### PR TITLE
Fix flaky util test

### DIFF
--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -1,4 +1,5 @@
 """User utils tests"""
+from email.utils import parseaddr
 from unittest.mock import patch
 
 import pytest
@@ -75,4 +76,6 @@ def test_ensure_active_user(mock_repair_faulty_edx_user, user):
 
 def test_format_recipient(user):
     """Verify that format_recipient correctly format's a user's name and email"""
-    assert format_recipient(user) == f"{user.name} <{user.email}>"
+    name, email = parseaddr(format_recipient(user))
+    assert name == user.name
+    assert email == user.email


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
This fixes a flaky test caused by the fact that python's `email.utils.formataddr` _conditionally_ quotes the address' name component if there's a character in there that needs to be escaped. This means that this test would fail a small portion of the time if the data generated for `User.name` contained a character that needed to be escaped, for example a period (`.`) in a person's salutation (e.g. "Mrs. Smith"). I updated the tests to instead parse the result and make sure they match the expected fields on `User`.

#### How should this be manually tested?
Tests should pass, if you want to try to reproduce this on `main` you can run `pytest users/utils_test.py -k test_format_recipient
` a few times and you should eventually hit a failure case. Running it repeatedly on this branch should always succeed.