### PR TITLE
added styling for header logo and sign-in/create account, hamburger links

### DIFF
--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -16,37 +16,38 @@ type Props = {
 
 const TopAppBar = ({ currentUser, location }: Props) => (
   <header className="header-holder">
-    <div className="container">
+    <div className="container-fluid">
       <nav
         className={`sub-nav navbar navbar-expand-md link-section ${
           currentUser.is_authenticated ? "nowrap login" : ""
         }`}
       >
         <div className="navbar-brand">
-          <a
-            href="https://web.mit.edu/"
-            rel="noopener noreferrer"
-            target="_blank"
-            className="mit-link"
-          />
+          <a href="https://mit.edu">
+            <img
+              src="/static/images/mit-logo.jpg"
+              className="site-logo"
+              alt={SETTINGS.site_name}
+            />
+          </a>
+          <div className="divider-large" />
           <a href={routes.root} className="mitx-online-link">
-            mitX Online
+            MITx Online
           </a>
         </div>
-        {currentUser.is_authenticated ? null : (
-          <button
-            className="navbar-toggler nav-opener"
-            type="button"
-            data-toggle="collapse"
-            data-target="#nav"
-            aria-controls="nav"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-          >
-            <span className="navbar-toggler-icon" />
-            Menu
-          </button>
-        )}
+        <button
+          className="navbar-toggler nav-opener collapsed"
+          type="button"
+          data-toggle="collapse"
+          data-target="#nav"
+          aria-controls="nav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span className="bar" />
+          <span className="bar" />
+          <span className="bar" />
+        </button>
         <ul
           id="nav"
           className={`${
@@ -54,15 +55,32 @@ const TopAppBar = ({ currentUser, location }: Props) => (
           } navbar-collapse px-0 justify-content-end`}
         >
           {currentUser.is_authenticated ? (
-            <li>
-              <UserMenu currentUser={currentUser} />
-            </li>
+            <React.Fragment>
+              <li>
+                <UserMenu currentUser={currentUser} />
+              </li>
+              {/* These menu lists will show/hide based on desktop/mobile screen. */}
+              <li className="authenticated-menu">
+                <MixedLink dest={routes.accountSettings} aria-label="Settings">
+                  Settings
+                </MixedLink>
+              </li>
+              <li className="authenticated-menu">
+                <MixedLink
+                  dest={routes.logout}
+                  className="button"
+                  aria-label="Sign Out"
+                >
+                  Sign Out
+                </MixedLink>
+              </li>
+            </React.Fragment>
           ) : (
             <React.Fragment>
               <li>
                 <MixedLink
                   dest={routes.login.begin}
-                  className="button"
+                  // className="button"
                   aria-label="Login"
                 >
                   Sign In

--- a/static/js/components/TopAppBar_test.js
+++ b/static/js/components/TopAppBar_test.js
@@ -51,19 +51,20 @@ describe("TopAppBar component", () => {
       )
     })
 
-    it("does not have a button to collapse the menu", () => {
-      assert.isNotOk(
+    it("have MixedLinks for login/registration for mobile view", () => {
+      assert.isOk(
         shallow(<TopAppBar currentUser={user} location={null} />)
-          .find("button")
+          .find("MixedLink")
           .exists()
       )
     })
 
-    it("does not have MixedLinks for login/registration", () => {
-      assert.isNotOk(
+    it("have two menu items with authenticated-menu class attributes", () => {
+      assert.equal(
         shallow(<TopAppBar currentUser={user} location={null} />)
-          .find("MixedLink")
-          .exists()
+          .find(".authenticated-menu")
+          .getElements().length,
+        2
       )
     })
   })

--- a/static/scss/top-app-bar.scss
+++ b/static/scss/top-app-bar.scss
@@ -1,14 +1,15 @@
 // sass-lint:disable mixins-before-declarations
 
 .header-holder {
-  padding: 20px 1px;
-
-  @include media-breakpoint-down(md) {
-    max-width: 100%;
-  }
+  padding: 10px 0;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14);
 
   .navbar {
     padding: 0;
+
+    @include media-breakpoint-down(sm) {
+      position: static;
+    }
   }
 
   .nowrap {
@@ -18,8 +19,8 @@
 
 .link-section.nowrap.login {
   ul {
+
     @include media-breakpoint-down(md) {
-      margin: 0;
       text-align: right;
 
       li {
@@ -38,18 +39,19 @@
 }
 
 .navbar-collapse {
+  margin: 0;
 
   li {
     letter-spacing: normal;
     display: inline-block;
     vertical-align: top;
-    font-size: 18px;
-    line-height: 25px;
-    font-weight: 500;
-    padding: 0 0 0 10px;
+    font-size: 16px;
+    line-height: 22px;
+    font-weight: 600;
+    padding: 0 0 0 25px;
 
     a {
-      padding: 5px 10px;
+      padding: 10px 16px;
       color: black;
       text-decoration: none;
       display: block;
@@ -59,52 +61,161 @@
       }
 
       &.button {
-        background: $primary;
+        @include media-breakpoint-up(md) {
+          background: $primary;
+          color: white;
+          border-radius: 3px;
+          box-shadow: inset 0 0 2px 0 rgba(255, 255, 255, 0.57);
+
+          &:hover {
+            background: black;
+          }
+        }
+      }
+    }
+  }
+
+  &.collapsing,
+  &.show {
+    display: flex;
+    @include media-breakpoint-down(sm) {
+      display: block;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    display: none;
+    position: absolute;
+    padding-top: 70px;
+    background: rgba(0, 0, 0, 0.91);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: 55px;
+    height: auto !important;
+    z-index: 999;
+
+    li {
+      display: block;
+      padding: 10px 0;
+      margin: 0 auto;
+      max-width: 170px;
+      text-align: left;
+
+      a {
         color: white;
+        font-size: 18px;
+        font-weight: 600;
+        line-height: 25px;
+        padding: 0;
+        margin-top: 5px;
 
         &:hover {
-          background: black;
+          color: white;
         }
       }
     }
   }
 }
 
-.navbar-collapse.collapsing,
-.navbar-collapse.show {
-  display: flex;
+.authenticated-menu {
+  display: none !important;
+
+  @include media-breakpoint-down(sm) {
+    display: block !important;
+  }
 }
 
 .site-logo {
-  width: 154px;
-  height: 47.5px;
+  width: 65px;
+  height: 35px;
+  @include media-breakpoint-down(sm) {
+    width: 46px;
+    height: 25px;
+  }
 }
 
-.navbar-toggler.nav-opener {
-  border: 1px solid $primary;
-  border-radius: 2px;
-  color: $primary;
-  margin: 5px 0 0;
-  padding: 8px 6px 6px;
+.navbar-brand {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
 
-  .navbar-toggler-icon {
-    width: 18px;
-    height: 15px;
-    display: inline-block;
-    border: 1px solid $primary;
-    border-width: 2px 0;
-    position: relative;
-    margin: -2px 5px 0 0;
-    vertical-align: top;
+  .mitx-online-link {
+    font-size: 24px;
+    color: black;
+    font-weight: bold;
+    line-height: 24px;
+    letter-spacing: 0;
 
-    &:after {
-      position: absolute;
-      left: 0;
-      right: 0;
-      content: "";
+    @include media-breakpoint-down(sm) {
+      font-size: 18px;
+      line-height: 18px;
+    }
+  }
+
+  .divider-large {
+    width: 1px;
+    height: 48px;
+    margin: 0 15px;
+    background: black;
+    @include media-breakpoint-down(sm) {
+      height: 34px;
+      margin: 0 8px;
+    }
+  }
+}
+
+.navbar-toggler {
+  position: relative;
+  width: 24px;
+  height: 24px;
+
+  ul {
+    cursor: pointer;
+  }
+
+  .bar {
+    // This series of .bar elements creates a hamburger menu that tranforms into an "X" when clicked
+    list-style: none;
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    transition: .5s;
+    background: black;
+    transform: translateY(-50%) rotate(0);
+    opacity: 1;
+  }
+
+  .bar:nth-child(1) {
+    top: 50%;
+    transform: translateY(-50%) rotate(45deg);
+  }
+
+  .bar:nth-child(2) {
+    opacity: 0;
+    margin-top: 1px;
+  }
+
+  .bar:nth-child(3) {
+    top: 50%;
+    transform: translateY(-50%) rotate(-45deg);
+  }
+
+  &.collapsed {
+    .bar:nth-child(1) {
+      top: 20%;
+      transform: none;
+    }
+
+    .bar:nth-child(2) {
       top: 50%;
-      border-top: 2px solid $primary;
-      margin: -1px 0 0;
+      opacity: 1;
+    }
+
+    .bar:nth-child(3) {
+      top: 80%;
+      transform: none;
     }
   }
 }

--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -50,6 +50,11 @@
 }
 
 .user-menu.dropdown {
+
+  @include media-breakpoint-down(sm) {
+    display: none;
+  }
+
   padding-left: 15px;
   padding-right: 15px;
 

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -34,3 +34,4 @@ $footer-border: #686461;
 $dc-background: #f2f2f2;
 $subtitle-color: #ff4a68;
 $sirocco: #758080;
+$brand-button-bg: #a41e34


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #21, fixes #23 

#### What's this PR do?
- Adds MIT Logo branding and redirection links
- Adds styling for `Sign in` and `Create Account` buttons
- Adds styling for top app bar overall
- Add styling for the hamburger icons and menus
- Adds overlay for the nav menu list
- Incorporates different menus for authenticated and non authenticated Desktop/Moblie

#### How should this be manually tested?
- Setup `mitxonline`
- Visit HomePage
- Make sure the design matches that of Invision UI mentioned in the ticket
- Make sure mobile design matches Invision UI mentioned in the ticket
- Make sure hamburger design and links match provided Invision UI in ticket
- Majorly, just make sure the acceptance criteria is met based on both the tickets mentioned

#### Where should the reviewer start?
- MITx Online setup and HomePage

#### Screenshots (if appropriate)

**Unauthenticated Desktop**
<img width="1440" alt="Screenshot 2021-07-29 at 4 05 27 PM" src="https://user-images.githubusercontent.com/34372316/127481653-804b3508-cad7-4683-be14-587138e76a5f.png">

**Authenticated Desktop**
<img width="1439" alt="Screenshot 2021-07-29 at 4 01 22 PM" src="https://user-images.githubusercontent.com/34372316/127481618-653b39aa-c812-489d-b894-decf04285d3b.png">

**Authenticated Desktop Menu**
<img width="1440" alt="Screenshot 2021-07-29 at 4 01 36 PM" src="https://user-images.githubusercontent.com/34372316/127481639-033c3c7c-ecb0-4521-9442-9a31b7830046.png">

**Hamburger mobile**
<img width="200" alt="Screenshot 2021-07-29 at 4 04 21 PM" src="https://user-images.githubusercontent.com/34372316/127481647-d804b5aa-7ea8-491e-8975-91e0540aae24.png">

**Unauthenticated mobile menu**
<img width="201" alt="Screenshot 2021-07-29 at 4 05 17 PM" src="https://user-images.githubusercontent.com/34372316/127481651-f072746b-2589-4e2c-829d-f6d61fa69a81.png">

**Authenticated mobile menu**
<img width="200" alt="Screenshot 2021-07-29 at 4 04 56 PM" src="https://user-images.githubusercontent.com/34372316/127481649-89baaaa3-f5fa-42db-930f-3a672afa00f1.png">
