### PR TITLE
Fix: forgot password regex failure fix and error message display

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -169,7 +169,7 @@ class CustomPasswordResetEmail(DjoserPasswordResetEmail):
                 headers={"Reply-To": settings.MITX_ONLINE_REPLY_TO_ADDRESS},
             )
             msg.attach_alternative(html_body, "text/html")
-            send_messages([msg])
+            send_messages([msg], raise_errors=True)
 
     def get_context_data(self):
         """Adds base_url to the template context"""

--- a/mail/exceptions.py
+++ b/mail/exceptions.py
@@ -14,3 +14,7 @@ class MultiEmailValidationError(Exception):
         """
         self.invalid_emails = invalid_emails
         super().__init__(msg)
+
+
+class EmailSendFailureException(Exception):
+    """Exception to mark the failure in sending an email"""

--- a/main/urls.py
+++ b/main/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     path("signin/password/", index, name="login-password"),
     re_path(r"^signin/forgot-password/$", index, name="password-reset"),
     re_path(
-        r"^signin/forgot-password/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
+        r"^signin/forgot-password/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$",
         index,
         name="password-reset-confirm",
     ),

--- a/main/views.py
+++ b/main/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 from django.urls import reverse
 
 
-def index(request):
+def index(request, **kwargs):
     """
     The index view. Display available programs
     """

--- a/static/scss/auth.scss
+++ b/static/scss/auth.scss
@@ -146,6 +146,10 @@
   .submit-row {
     margin-top: 25px;
   }
+
+  .error-label {
+    color: red;
+  }
 }
 
 .registration-page .auth-form {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#39 

#### What's this PR do?
- Updates the forgot-password API URL to match a regex of accurate length as of Django3
- Adds an error message for the user in case the API fails

#### How should this be manually tested?
- Setup, make sure the Django version is above 3 and visit `signin/forgot-password/`.
- Add dummy MAILGUN keys which will make the email API fail or forcefully throw an error from mail/API.
- Make sure that an error message is shown to the user
- Now configure the right MAILGUN creds and visit `signin/forgot-password/`
- Make sure that the user is able to reset the password correctly


#### Where should the reviewer start?
- Probably run an instance and verify the generated token length as mentioned in [here](https://github.com/mitodl/mitxonline/issues/39#issuecomment-889822686)
- Now, run this PR and make sure that the acceptance criteria mention in the ticket is met. 


#### Screenshots (if appropriate)
**Email Success Message**

<img width="603" alt="Screenshot 2021-07-30 at 5 11 48 PM" src="https://user-images.githubusercontent.com/34372316/127655673-7275a3aa-cfe0-4c25-a4f8-07d82717ae12.png">

**Email Error Message**
<img width="693" alt="Screenshot 2021-07-30 at 5 50 11 PM" src="https://user-images.githubusercontent.com/34372316/127655683-eaad76f9-79c6-45f3-b7de-661c26e973a3.png">
