### PR TITLE
Added API endpoint for creating user enrollments

### DIFF
--- a/cms/migrations/0004_add_hero_titles_image_chooser.py
+++ b/cms/migrations/0004_add_hero_titles_image_chooser.py
@@ -7,24 +7,41 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailimages', '0023_add_choose_permissions'),
-        ('cms', '0003_resourcepage'),
+        ("wagtailimages", "0023_add_choose_permissions"),
+        ("cms", "0003_resourcepage"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='homepage',
-            name='hero_subtitle',
-            field=models.CharField(blank=True, help_text='The subtitle text to display in the hero section of the home page.', max_length=255, null=True),
+            model_name="homepage",
+            name="hero_subtitle",
+            field=models.CharField(
+                blank=True,
+                help_text="The subtitle text to display in the hero section of the home page.",
+                max_length=255,
+                null=True,
+            ),
         ),
         migrations.AddField(
-            model_name='homepage',
-            name='hero_title',
-            field=models.CharField(blank=True, help_text='The title text to display in the hero section of the home page.', max_length=255, null=True),
+            model_name="homepage",
+            name="hero_title",
+            field=models.CharField(
+                blank=True,
+                help_text="The title text to display in the hero section of the home page.",
+                max_length=255,
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='homepage',
-            name='hero',
-            field=models.ForeignKey(blank=True, help_text='Main image displayed at the top of the home page. (The recommended dimensions for hero image are 1920x400)', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.image'),
+            model_name="homepage",
+            name="hero",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Main image displayed at the top of the home page. (The recommended dimensions for hero image are 1920x400)",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailimages.image",
+            ),
         ),
     ]

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -8,11 +8,11 @@ router = routers.SimpleRouter()
 router.register(r"programs", v1.ProgramViewSet, basename="programs_api")
 router.register(r"courses", v1.CourseViewSet, basename="courses_api")
 router.register(r"course_runs", v1.CourseRunViewSet, basename="course_runs_api")
+router.register(
+    r"enrollments", v1.UserEnrollmentsViewSet, basename="user-enrollments-api"
+)
 
 urlpatterns = [
     re_path(r"^api/v1/", include(router.urls)),
     re_path(r"^api/", include(router.urls)),
-    re_path(
-        r"^api/enrollments/", v1.UserEnrollmentsView.as_view(), name="user-enrollments"
-    ),
 ]

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -1,5 +1,5 @@
 """Course views verson 1"""
-from rest_framework import status, viewsets, generics
+from rest_framework import status, mixins, viewsets, generics
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -42,8 +42,10 @@ class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = CourseRun.objects.all()
 
 
-class UserEnrollmentsView(generics.ListAPIView):
-    """API view for user enrollments"""
+class UserEnrollmentsViewSet(
+    mixins.CreateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet
+):
+    """API view set for user enrollments"""
 
     serializer_class = CourseRunEnrollmentSerializer
     permission_classes = [IsAuthenticated]
@@ -56,4 +58,7 @@ class UserEnrollmentsView(generics.ListAPIView):
         )
 
     def get_serializer_context(self):
-        return {"include_page_fields": True}
+        if self.action == "list":
+            return {"include_page_fields": True}
+        else:
+            return {"user": self.request.user}

--- a/mail/api.py
+++ b/mail/api.py
@@ -299,9 +299,7 @@ def send_messages(messages, raise_errors=False):
             errored_emails.add(msg)
     if errored_emails:
         for email_msg in errored_emails:
-            log.error(
-                "Error sending email '%s' to %s", email_msg.subject, email_msg.to
-            )
+            log.error("Error sending email '%s' to %s", email_msg.subject, email_msg.to)
         if raise_errors:
             raise EmailSendFailureException()
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #4

#### What's this PR do?
Creates an API endpoint to add enrollments for the logged-in user

#### How should this be manually tested?
- Find or create a course run and note its id
- Open a shell and test out the endpoint:
    
    ```python
    RUN_ID = <your run id>
    USER_EMAIL = <your user email>

    import json
    from django.test.client import Client
    from django.contrib.auth import get_user_model
    User = get_user_model()
    #
    user = User.objects.get(email=USER_EMAIL)
    client = Client()
    client.force_login(user)
    resp = client.post(
        "/api/enrollments/",
        data=json.dumps({"run_id": RUN_ID})
        content_type="application/json",
        follow=True,
    )
    resp
    ```

The request should succeed, you should have a `CourseRunEnrollment` record created, and an attempt should be made to create the enrollment in edX.

If you make the request with an invalid run id, you should get a 400 with an error message in the response body.
