### PR TITLE
excluded .container class from .auth-page elements

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="wrapper">
+    <div class="product-page" id="wrapper">
       <section class="hero-block">
         <div class="container">
           <div class="content-row">

--- a/static/scss/product-details.scss
+++ b/static/scss/product-details.scss
@@ -1,217 +1,221 @@
 // sass-lint:disable mixins-before-declarations
-.container {
-  max-width: 1260px;
-  padding: 0 15px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
 
-.hero-block {
-  font-size: 20px;
-  line-height: 30px;
-  color: $black;
-  padding: 20px 0;
+.product-page {
 
-  @include media-breakpoint-up(md) {
-    font-size: 24px;
-    line-height: 36px;
+  .container {
+    max-width: 1260px;
+    padding: 0 15px;
+    box-sizing: border-box;
+    margin: 0 auto;
   }
 
-  @include media-breakpoint-up(lg) {
-    padding: 38px 0;
-  }
+  .hero-block {
+    font-size: 20px;
+    line-height: 30px;
+    color: $black;
+    padding: 20px 0;
 
-  .content-row {
-    @include media-breakpoint-up(lg) {
-      display: flex;
-      flex-flow: row wrap;
-      margin: 0 -15px;
+    @include media-breakpoint-up(md) {
+      font-size: 24px;
+      line-height: 36px;
     }
 
-    .content-col {
-      padding: 0 0 20px;
-      @include media-breakpoint-up(md) {
-        padding: 0 0 30px;
-      }
+    @include media-breakpoint-up(lg) {
+      padding: 38px 0;
+    }
+
+    .content-row {
       @include media-breakpoint-up(lg) {
-        width: calc(100% - 455px);
-        padding: 0 15px;
-        box-sizing: border-box;
+        display: flex;
+        flex-flow: row wrap;
+        margin: 0 -15px;
       }
 
-      &.video {
-        padding-bottom: 0;
+      .content-col {
+        padding: 0 0 20px;
+        @include media-breakpoint-up(md) {
+          padding: 0 0 30px;
+        }
         @include media-breakpoint-up(lg) {
-          width: 455px;
+          width: calc(100% - 455px);
           padding: 0 15px;
-          flex-shrink: 0;
+          box-sizing: border-box;
+        }
+
+        &.video {
+          padding-bottom: 0;
+          @include media-breakpoint-up(lg) {
+            width: 455px;
+            padding: 0 15px;
+            flex-shrink: 0;
+          }
         }
       }
     }
-  }
 
-  .video-holder {
-    background: $sirocco;
-    margin-top: 10px;
-    min-height: 200px;
+    .video-holder {
+      background: $sirocco;
+      margin-top: 10px;
+      min-height: 200px;
 
-    img {
-      display: block;
-      width: 100%;
-    }
-  }
-
-  .text-info {
-    @include media-breakpoint-up(lg) {
-      max-width: 625px;
-    }
-  }
-
-  p {
-    margin: 0 0 28px;
-  }
-}
-
-.info-block {
-  padding: 20px 0;
-  font-size: 14px;
-  line-height: 16px;
-  color: $black;
-
-  @include media-breakpoint-up(lg) {
-    padding: 30px 0;
-  }
-
-  .stats-row {
-    display: flex;
-    flex-flow: row wrap;
-    margin: 0 -8px;
-    align-items: baseline;
-
-    @include media-breakpoint-up(xl) {
-      margin: 0 -18px;
+      img {
+        display: block;
+        width: 100%;
+      }
     }
 
-    .stat-col {
-      margin: 0 8px 16px;
-      background: $very-light-gray;
-      border-radius: 3px;
-      overflow: hidden;
-      text-align: center;
-      display: flex;
-      flex-flow: column;
-      flex-grow: 1;
-      width: calc(50% - 16px);
-
+    .text-info {
       @include media-breakpoint-up(lg) {
-        width: auto;
-      }
-
-      @include media-breakpoint-up(xl) {
-        margin: 0 18px;
-        width: 180px;
-        flex-grow: inherit;
-      }
-
-      &.small {
-        font-size: 14px;
-        @include media-breakpoint-up(xl) {
-          width: 140px;
-        }
-      }
-
-      &.large {
-        flex-grow: 1;
-        text-align: left;
-        }
-      }
-
-    .text {
-      padding: 14px 20px;
-      width: 100%;
-      flex-grow: 1;
-      display: inline-block;
-      align-items: center;
-      justify-content: center;
-      box-sizing: border-box;
-      font-size: 14px;
-
-      p {
-        margin: 0;
-      }
-
-      a:link {
-        color: $link-blue;
-        text-decoration: underline;
+        max-width: 625px;
       }
     }
 
-    .title {
-      background-color: $sirocco;
-      font-weight: 500;
-      color: $tile-background;
-      text-align: center;
-      padding: 9px 8px;
-      width: 100%;
-      box-sizing: border-box;
-      height: 34px;
-      text-transform: uppercase;
+    p {
+      margin: 0 0 28px;
     }
   }
 
-  a {
+  .info-block {
+    padding: 20px 0;
+    font-size: 14px;
+    line-height: 16px;
     color: $black;
 
-    &:hover {
-      text-decoration: none;
+    @include media-breakpoint-up(lg) {
+      padding: 30px 0;
     }
-  }
-}
 
-.text-block {
-  color: $black;
-  padding: 20px 0;
+    .stats-row {
+      display: flex;
+      flex-flow: row wrap;
+      margin: 0 -8px;
+      align-items: baseline;
 
-  @include media-breakpoint-up(lg) {
-    padding: 30px 0;
-  }
+      @include media-breakpoint-up(xl) {
+        margin: 0 -18px;
+      }
 
-  p {
-    margin: 0 0 25px;
-  }
+      .stat-col {
+        margin: 0 8px 16px;
+        background: $very-light-gray;
+        border-radius: 3px;
+        overflow: hidden;
+        text-align: center;
+        display: flex;
+        flex-flow: column;
+        flex-grow: 1;
+        width: calc(50% - 16px);
 
-  .text-holder {
-    max-width: 1020px;
+        @include media-breakpoint-up(lg) {
+          width: auto;
+        }
+
+        @include media-breakpoint-up(xl) {
+          margin: 0 18px;
+          width: 180px;
+          flex-grow: inherit;
+        }
+
+        &.small {
+          font-size: 14px;
+          @include media-breakpoint-up(xl) {
+            width: 140px;
+          }
+        }
+
+        &.large {
+          flex-grow: 1;
+          text-align: left;
+          }
+        }
+
+      .text {
+        padding: 14px 20px;
+        width: 100%;
+        flex-grow: 1;
+        display: inline-block;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        font-size: 14px;
+
+        p {
+          margin: 0;
+        }
+
+        a:link {
+          color: $link-blue;
+          text-decoration: underline;
+        }
+      }
+
+      .title {
+        background-color: $sirocco;
+        font-weight: 500;
+        color: $tile-background;
+        text-align: center;
+        padding: 9px 8px;
+        width: 100%;
+        box-sizing: border-box;
+        height: 34px;
+        text-transform: uppercase;
+      }
+    }
 
     a {
+      color: $black;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+
+  .text-block {
+    color: $black;
+    padding: 20px 0;
+
+    @include media-breakpoint-up(lg) {
+      padding: 30px 0;
+    }
+
+    p {
+      margin: 0 0 25px;
+    }
+
+    .text-holder {
+      max-width: 1020px;
+
+      a {
+        font-weight: 700;
+        color: $black;
+      }
+    }
+
+    .more {
       font-weight: 700;
       color: $black;
     }
-  }
 
-  .more {
-    font-weight: 700;
-    color: $black;
-  }
+    ul:not(class) {
+      margin: 0 0 6px;
+      padding: 0;
+      list-style: none;
 
-  ul:not(class) {
-    margin: 0 0 6px;
-    padding: 0;
-    list-style: none;
+      li {
+        position: relative;
+        padding: 0 0 0 18px;
 
-    li {
-      position: relative;
-      padding: 0 0 0 18px;
-
-      &:before {
-        position: absolute;
-        left: 0;
-        top: 11px;
-        content: '';
-        background: $black;
-        width: 6px;
-        height: 6px;
-        border-radius: 100%;
+        &:before {
+          position: absolute;
+          left: 0;
+          top: 11px;
+          content: '';
+          background: $black;
+          width: 6px;
+          height: 6px;
+          border-radius: 100%;
+        }
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
relevant tickets #61 

#### What's this PR do?
Fixes styling issue on auth pages.

#### How should this be manually tested?
Steps for manual testing
- Open SingIn page and verify auth container Is of valid size.
- Open Forgot Password Page and verify auth container is of valid size.


#### Screenshots (if appropriate)
Desktop Screen Shots:

<img width="1549" alt="Screenshot 2021-08-06 at 4 00 49 PM" src="https://user-images.githubusercontent.com/87968618/128506575-c18a5f2c-c054-44b8-8089-a80355b30f60.png">

<img width="916" alt="Screenshot 2021-08-06 at 4 02 11 PM" src="https://user-images.githubusercontent.com/87968618/128506605-8fce7d60-de7b-4d7b-a5d5-9223dec1c5e8.png">

Mobile Screen Shots:

<img width="647" alt="Screenshot 2021-08-06 at 4 01 36 PM" src="https://user-images.githubusercontent.com/87968618/128506697-51434331-9f50-41e2-9fe0-16da42dcc000.png">
