### PR TITLE
Added dashboard message for users with no enrollments

### DIFF
--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -18,7 +18,7 @@ import { formatPrettyDate, parseDateString } from "../../lib/util"
 import { RunEnrollment } from "../../flow/courseTypes"
 
 type DashboardPageProps = {
-  enrollments: RunEnrollment
+  enrollments: RunEnrollment[]
 }
 
 export class DashboardPage extends React.Component<DashboardPageProps, void> {
@@ -77,7 +77,13 @@ export class DashboardPage extends React.Component<DashboardPageProps, void> {
         <div className="dashboard container">
           <h1>My Courses</h1>
           <div className="enrolled-items container">
-            {enrollments && enrollments.map(this.renderEnrolledItemCard)}
+            {enrollments && enrollments.length > 0 ? (
+              enrollments.map(this.renderEnrolledItemCard)
+            ) : (
+              <div className="enrolled-item row card p-3 p-sm-5 rounded-0">
+                Once you enroll in a course, you can find it listed here.
+              </div>
+            )}
           </div>
         </div>
       </DocumentTitle>

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -51,6 +51,21 @@ describe("DashboardPage", () => {
     })
   })
 
+  it("shows a message if the user has no enrollments", async () => {
+    const { inner } = await renderPage({
+      entities: {
+        enrollments: []
+      }
+    })
+    assert.isTrue(inner.find(".dashboard").exists())
+    const enrolledItems = inner.find(".enrolled-item")
+    assert.lengthOf(enrolledItems, 1)
+    assert.equal(
+      enrolledItems.at(0).text(),
+      "Once you enroll in a course, you can find it listed here."
+    )
+  })
+
   it("links to the courseware URL if that property is set on the course run", async () => {
     const exampleCoursewareUrl = "http://example.com/my-course"
     userEnrollments[0].run.courseware_url = exampleCoursewareUrl

--- a/static/js/flow/courseTypes.js
+++ b/static/js/flow/courseTypes.js
@@ -22,5 +22,5 @@ export type CourseRunDetail = BaseCourseRun & {
 }
 
 export type RunEnrollment = {
-  run: BaseCourseRun
+  run: CourseRunDetail
 }

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -23,7 +23,7 @@ body {
   font-family: Montserrat, "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   margin: 0;
   color: #000000;
-  background: linear-gradient(#ffffff, #f5f5f5);
+  background: linear-gradient(to bottom, #ffffff, #f5f5f5 200px);
 
   header {
     background-color: #ffffff;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #50

#### What's this PR do?
Adds dashboard message for users with no enrollments

#### How should this be manually tested?
Log in and navigate to the dashboard page with a user that has no enrollments

#### Any background context you want to provide?
- There is no course catalog, which is why the "Explore" links were left out
- The issue says to implement the user notification ("Account created!") in addition to this message in the body of the page, but that's going to be a bit more involved. I'm creating a separate issue for that and will link it to this one

#### Screenshots (if appropriate)
![ss 2021-08-06 at 16 28 07 ](https://user-images.githubusercontent.com/14932219/128573825-ee3f952f-208a-402c-9fe7-1ecfac9031b5.png)
![ss 2021-08-06 at 16 27 56 ](https://user-images.githubusercontent.com/14932219/128573828-9ab55070-6121-48aa-8f3c-593d7f3788d3.png)

