### PR TITLE
Added styling to pin footer to the bottom of the page

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -23,7 +23,10 @@ body {
   font-family: Montserrat, "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   margin: 0;
   color: #000000;
-  background: linear-gradient(to bottom, #ffffff, #f5f5f5 200px);
+  background: linear-gradient(to bottom, #ffffff, #f5f5f5 250px);
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
 
   header {
     background-color: #ffffff;
@@ -31,6 +34,7 @@ body {
   }
 
   .main-panel {
+    flex: 1;
     min-height: calc(100vh - 351px);
 
     // TODO: temporary fix for home page iamge size, please remove it after home page design


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots

#### What are the relevant tickets?
Closes #70

#### What's this PR do?
Adds styling to pin footer to the bottom of the page, whether there is enough content to push the footer down or not

#### How should this be manually tested?
View any page in the site and fill in/remove content to make sure that the footer is always at the bottom of the page

#### Screenshots (if appropriate)

Before:
![ss 2021-08-06 at 16 51 35 ](https://user-images.githubusercontent.com/14932219/128585972-d7a672c0-c86a-41bd-9713-4ff1ad0d94c7.png)

After:
![ss 2021-08-06 at 22 03 11 ](https://user-images.githubusercontent.com/14932219/128585963-4e48a34b-83ae-4133-83e7-3a77e80c6a46.png)

