### PR TITLE
changed image src to valid image

### DIFF
--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -239,7 +239,7 @@
 	            <tr>
 	                <td style="padding: 20px;">
                       {% block logo %}
-                      <img src="{{ base_url }}/static/images/mit-logo.png" width="160" height="80" alt="{{ site_name }}" style="height: auto; background: #ffffff; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #A31F34; margin-bottom: -10px;  margin-right: 10px;"/>
+                      <img src="{{ base_url }}/static/images/mit.png" width="160" height="80" alt="{{ site_name }}" style="height: auto; margin-bottom: -10px; margin-right: 10px;"/>
                       {% endblock %}
 	                </td>
 	            </tr>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
#### What are the relevant tickets?
ticket #62 

#### What's this PR do?
Changed image source url from mit-logo.png to mit.png as mit-logo.png is unavailable.

#### How should this be manually tested?
- Sign Up with a new user.
- Verify an image is visible in verification email.

#### Any background context you want to provide?
- mit-logo.png is unavailable however mid.png.So I moved forward with it. The the only difference
    between them is of size 

 - During testing on local dev environment the image is still not visible but that is due to gmail image proxy.
 It rewrites image src with its proxy server url and is unable to fetch the image from a local machine.
 It should be testable on RC or any deployed instance.

#### Screenshots (if appropriate)
Screent Shot:

<img width="916" alt="Screenshot 2021-08-10 at 3 51 11 PM" src="https://user-images.githubusercontent.com/87968618/128856064-2cef3476-1109-45e7-a550-414b8553000b.png">

