### PR TITLE
fix: made dashboard accessible only when authenticated

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -64,7 +64,8 @@ export class App extends React.Component<Props, void> {
               path={urljoin(match.url, String(routes.account.confirmEmail))}
               component={EmailConfirmPage}
             />
-            <Route
+            <PrivateRoute
+              exact
               path={urljoin(match.url, String(routes.dashboard))}
               component={DashboardPage}
             />


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#72 

#### What's this PR do?
- Makes the dashboard accessible to authenticated users only
- If the user visits `/dashboard` without login, he is redirected to the login page with `next` path to dashboard

#### How should this be manually tested?
- Make sure you are logged out
- Visit `/dashboard`
- You should be redirected to the login page with `signin/?next=dashboard` redirect
- Confirm that you are redirected to the dashboard when you signing now
