### PR TITLE
Fixed home page product URLs

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -93,7 +93,7 @@ class HomePage(Page):
                         "description": product_page.description,
                         "feature_image": product_page.feature_image,
                         "start_date": run.start_date if run is not None else None,
-                        "url_path": product_page.slug,
+                        "url_path": product_page.get_url(),
                     }
                 )
         return page_data


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A. Related to #38 

#### What's this PR do?
Fixes an incorrect assumption made in the initial implementation of the home page product section. That PR contained the assumption that the URL for a product page would always be the `slug` value, but that URL changed in this PR: #81.

#### How should this be manually tested?
Go to the home page in the CMS and add some featured products, publish, and visit the live home page. The product links should point to the correct URLs for the product detail pages (e.g.: `/courses/course-v1:first+course/`)
