### PR TITLE
Implemented enrollment and notification from product detail

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1,9 +1,11 @@
 """CMS model definitions"""
 import re
+from urllib.parse import quote_plus
 
 from django.conf import settings
 from django.db import models
 from django.http import Http404
+from django.urls import reverse
 from wagtail.admin.edit_handlers import (
     FieldPanel,
     StreamFieldPanel,
@@ -308,8 +310,25 @@ class CoursePage(ProductPage):
 
     def get_context(self, request, *args, **kwargs):
         first_unexpired_run = self.product.first_unexpired_run
+        is_enrolled = (
+            False
+            if (first_unexpired_run is None or not request.user.is_authenticated)
+            else (
+                first_unexpired_run.courserunenrollment_set.filter(
+                    user_id=request.user.id
+                ).exists()
+            )
+        )
+        sign_in_url = (
+            None
+            if request.user.is_authenticated
+            else f'{reverse("login")}?next={quote_plus(self.get_url())}'
+        )
         return {
             **super().get_context(request, *args, **kwargs),
+            "run": first_unexpired_run,
+            "is_enrolled": is_enrolled,
+            "sign_in_url": sign_in_url,
             "start_date": first_unexpired_run.start_date
             if first_unexpired_run
             else None,

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -34,9 +34,11 @@
         <div class="course-card">
           <img src="{% wagtail_img_src product.feature_image %}" alt="Featured course image">
           <div class="course-info">
-            <a href="{{ product.url_path }}">
-              <h2 class="course-card-title">{{ product.title }}</h2>
-            </a>
+            <h2 class="course-card-title">
+              <a href="{{ product.url_path }}">
+                {{ product.title }}
+              </a>
+            </h2>
             <div class="course-card-description">
               {{ product.description |richtext }}
             </div>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -19,7 +19,33 @@
               <div class="text">
                 <h1>{{ page.title }}</h1>
                 <p>{{ page.description |richtext }}</p>
-                <a href="#" class="action-btn">Enroll now</a>
+                {% if run %}
+                  {% if is_enrolled %}
+                    {% if run.courseware_url_path %}
+                      <a href="{{ run.courseware_url }}" class="action-btn" target="_blank" rel="noopener noreferrer">
+                        Enrolled &#10003;
+                      </a>
+                    {% else %}
+                      <div class="action-btn">
+                        Enrolled &#10003;
+                      </div>
+                    {% endif %}
+                  {% else %}
+                    {% if sign_in_url %}
+                      <a href="{{ sign_in_url }}" class="action-btn">
+                        Enroll now
+                      </a>
+                    {% else %}
+                      <form action="/enrollments/" method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="run" value="{{ run.id }}" />
+                        <button type="submit" class="action-btn">
+                          Enroll now
+                        </button>
+                      </form>
+                    {% endif %}
+                  {% endif %}
+                {% endif %}
               </div>
             </div>
             <div class="content-col video">

--- a/conftest.py
+++ b/conftest.py
@@ -8,3 +8,34 @@ from fixtures.common import *
 def default_settings(settings):
     """Set default settings for all tests"""
     settings.DISABLE_WEBPACK_LOADER_STATS = True
+
+
+def pytest_addoption(parser):
+    """Pytest hook that adds command line parameters"""
+    parser.addoption(
+        "--simple",
+        action="store_true",
+        help="Run tests only (no cov, warning output silenced)",
+    )
+
+
+def pytest_cmdline_main(config):
+    """Pytest hook that runs after command line options are parsed"""
+    if getattr(config.option, "simple") is True:
+        config.option.pylint = False
+        config.option.no_pylint = True
+
+
+def pytest_configure(config):
+    """Pytest hook to perform some initial configuration"""
+    if getattr(config.option, "simple") is True:
+        # NOTE: These plugins are already configured by the time the pytest_cmdline_main hook is run, so we can't
+        #       simply add/alter the command line options in that hook. This hook is being used to
+        #       reconfigure/unregister plugins that we can't change via the pytest_cmdline_main hook.
+        # Switch off coverage plugin
+        cov = config.pluginmanager.get_plugin("_cov")
+        cov.options.no_cov = True
+        # Remove warnings plugin to suppress warnings
+        if config.pluginmanager.has_plugin("warnings"):
+            warnings_plugin = config.pluginmanager.get_plugin("warnings")
+            config.pluginmanager.unregister(warnings_plugin)

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -11,6 +11,7 @@ from rest_framework.exceptions import ValidationError
 from cms.serializers import CoursePageSerializer
 from courses import models
 from courses.api import create_run_enrollments
+from main import features
 
 
 def _get_thumbnail_url(page):
@@ -248,7 +249,7 @@ class CourseRunEnrollmentSerializer(serializers.ModelSerializer):
         successful_enrollments, edx_request_success = create_run_enrollments(
             user,
             [run],
-            keep_failed_enrollments=True,
+            keep_failed_enrollments=features.is_enabled(features.IGNORE_EDX_FAILURES),
         )
         return successful_enrollments
 

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -1,5 +1,5 @@
 """Course API URL routes"""
-from django.urls import include, re_path
+from django.urls import include, re_path, path
 from rest_framework import routers
 
 from courses.views import v1
@@ -9,10 +9,11 @@ router.register(r"programs", v1.ProgramViewSet, basename="programs_api")
 router.register(r"courses", v1.CourseViewSet, basename="courses_api")
 router.register(r"course_runs", v1.CourseRunViewSet, basename="course_runs_api")
 router.register(
-    r"enrollments", v1.UserEnrollmentsViewSet, basename="user-enrollments-api"
+    r"enrollments", v1.UserEnrollmentsApiViewSet, basename="user-enrollments-api"
 )
 
 urlpatterns = [
     re_path(r"^api/v1/", include(router.urls)),
     re_path(r"^api/", include(router.urls)),
+    path("enrollments/", v1.create_enrollment_view, name="create-enrollment-via-form"),
 ]

--- a/main/constants.py
+++ b/main/constants.py
@@ -1,0 +1,5 @@
+USER_MSG_COOKIE_NAME = "user-message"
+# Max age value = number of seconds
+USER_MSG_COOKIE_MAX_AGE = 20
+USER_MSG_TYPE_ENROLLED = "enrolled"
+USER_MSG_TYPE_ENROLL_FAILED = "enroll-failed"

--- a/main/features.py
+++ b/main/features.py
@@ -1,0 +1,46 @@
+"""MITxOnline feature flags"""
+from functools import wraps
+
+from django.conf import settings
+
+
+IGNORE_EDX_FAILURES = "IGNORE_EDX_FAILURES"
+
+
+def is_enabled(name, default=None):
+    """
+    Returns True if the feature flag is enabled
+
+    Args:
+        name (str): feature flag name
+        default (bool): default value if not set in settings
+
+    Returns:
+        bool: True if the feature flag is enabled
+    """
+    return settings.FEATURES.get(name, default or settings.FEATURES_DEFAULT)
+
+
+def if_feature_enabled(name, default=None):
+    """
+    Wrapper that results in a no-op if the given feature isn't enabled, and otherwise
+    runs the wrapped function as normal.
+
+    Args:
+        name (str): Feature flag name
+        default (bool): default value if not set in settings
+    """
+
+    def if_feature_enabled_inner(func):  # pylint: disable=missing-docstring
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):  # pylint: disable=missing-docstring
+            if not is_enabled(name, default):
+                # If the given feature name is not enabled, do nothing (no-op).
+                return
+            else:
+                # If the given feature name is enabled, call the function and return as normal.
+                return func(*args, **kwargs)
+
+        return wrapped_func
+
+    return if_feature_enabled_inner

--- a/main/settings.py
+++ b/main/settings.py
@@ -656,6 +656,12 @@ if MITX_ONLINE_USE_S3:
         AWS_S3_CUSTOM_DOMAIN = "{dist}.cloudfront.net".format(dist=CLOUDFRONT_DIST)
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 
+FEATURES_DEFAULT = get_bool(
+    name="FEATURES_DEFAULT",
+    default=False,
+    dev_only=True,
+    description="The default value for all feature flags",
+)
 FEATURES = get_features()
 
 # Redis

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     {% include "partials/gtm_head.html" %}
-        <link rel="stylesheet" type="text/css"
-              href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700|Montserrat:300,400,500,600,700&display=swap"
-              media="all"/>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
-          media="none" onload="if(media!='all') media='all'">
+    <link rel="stylesheet" type="text/css"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700|Montserrat:300,400,500,600,700&display=swap"
+      media="all"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
+      media="none" onload="if(media!='all') media='all'">
     {% js_settings %}
     {% render_bundle 'style' %}
     <title>{% block title %}{% endblock %}</title>

--- a/openedx/constants.py
+++ b/openedx/constants.py
@@ -7,11 +7,14 @@ OPENEDX_PLATFORMS = (PLATFORM_EDX,)
 OPENEDX_PLATFORM_CHOICES = zip(OPENEDX_PLATFORMS, OPENEDX_PLATFORMS)
 EDX_ENROLLMENT_PRO_MODE = "no-id-professional"
 EDX_ENROLLMENT_AUDIT_MODE = "audit"
+EDX_DEFAULT_ENROLLMENT_MODE = EDX_ENROLLMENT_AUDIT_MODE
 PRO_ENROLL_MODE_ERROR_TEXTS = (
     "The [{}] course mode is expired or otherwise unavailable for course run".format(
-        EDX_ENROLLMENT_PRO_MODE
+        EDX_DEFAULT_ENROLLMENT_MODE
     ),
-    "Specified course mode '{}' unavailable for course".format(EDX_ENROLLMENT_PRO_MODE),
+    "Specified course mode '{}' unavailable for course".format(
+        EDX_DEFAULT_ENROLLMENT_MODE
+    ),
 )
 # The amount of minutes after creation that a openedx model record should be eligible for repair
 OPENEDX_REPAIR_GRACE_PERIOD_MINS = 5

--- a/static/js/components/NotificationContainer.js
+++ b/static/js/components/NotificationContainer.js
@@ -6,8 +6,14 @@ import { partial } from "ramda"
 import { Alert } from "reactstrap"
 
 import { removeUserNotification } from "../actions"
-import { newSetWith, newSetWithout, timeoutPromise } from "../lib/util"
-import { notificationTypeMap } from "./notifications"
+import {
+  firstNotNil,
+  newSetWith,
+  newSetWithout,
+  timeoutPromise
+} from "../lib/util"
+import { getNotificationAlertProps } from "../lib/notificationsApi"
+import { notificationTypeMap, TextNotification } from "./notifications"
 
 import type { UserNotificationMapping } from "../reducers/notifications"
 
@@ -56,12 +62,19 @@ export class NotificationContainer extends React.Component<Props, State> {
         {Object.keys(userNotifications).map((notificationKey, i) => {
           const dismiss = partial(this.onDismiss, [notificationKey])
           const notification = userNotifications[notificationKey]
-          const AlertBodyComponent = notificationTypeMap[notification.type]
+          const alertProps = getNotificationAlertProps(notification.type)
+          const color = firstNotNil([
+            notification.color,
+            alertProps.color,
+            "info"
+          ])
+          const AlertBodyComponent =
+            notificationTypeMap[notification.type] || TextNotification
 
           return (
             <Alert
               key={i}
-              color={notification.color || "info"}
+              color={color}
               className="rounded-0 border-0"
               isOpen={!hiddenNotifications.has(notificationKey)}
               toggle={dismiss}

--- a/static/js/components/notifications/index.js
+++ b/static/js/components/notifications/index.js
@@ -1,8 +1,5 @@
 // @flow
 import React from "react"
-
-import MixedLink from "../MixedLink"
-import { routes } from "../../lib/urls"
 import { ALERT_TYPE_TEXT } from "../../constants"
 
 import type { TextNotificationProps } from "../../reducers/notifications"

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -105,7 +105,13 @@ export const HIGHEST_EDUCATION_CHOICES = [
   "Other education"
 ]
 
+export const USER_MSG_COOKIE_NAME = "user-message"
+export const USER_MSG_TYPE_ENROLLED = "enrolled"
+export const USER_MSG_TYPE_ENROLL_FAILED = "enroll-failed"
+
 export const ALERT_TYPE_TEXT = "text"
+export const ALERT_TYPE_SUCCESS = "success"
+export const ALERT_TYPE_DANGER = "danger"
 
 // HTML title for different pages
 export const CHECKOUT_PAGE_TITLE = "Checkout"

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -23,14 +23,32 @@ import DashboardPage from "./pages/DashboardPage"
 
 import type { Match, Location } from "react-router"
 import type { CurrentUser } from "../flow/authTypes"
+import { getStoredUserMessage } from "../lib/notificationsApi"
 
 type Props = {
   match: Match,
   location: Location,
-  currentUser: ?CurrentUser
+  currentUser: ?CurrentUser,
+  addUserNotification: Function
 }
 
 export class App extends React.Component<Props, void> {
+  componentDidMount() {
+    const { addUserNotification } = this.props
+
+    const userMsg = getStoredUserMessage()
+    if (userMsg) {
+      addUserNotification({
+        "loaded-user-msg": {
+          type:  userMsg.type,
+          props: {
+            text: userMsg.text
+          }
+        }
+      })
+    }
+  }
+
   render() {
     const { match, currentUser, location } = this.props
 

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -1,18 +1,20 @@
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
-import { mergeRight } from "ramda"
 
 import App, { App as InnerApp } from "./App"
 import { routes } from "../lib/urls"
+import * as notificationsApi from "../lib/notificationsApi"
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { makeUser, makeUnusedCoupon } from "../factories/user"
 
 describe("Top-level App", () => {
-  let helper, renderPage
+  let helper, renderPage, getStoredUserMessageStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
+    getStoredUserMessageStub = helper.sandbox
+      .stub(notificationsApi, "getStoredUserMessage")
+      .returns(null)
     renderPage = helper.configureHOCRenderer(
       App,
       InnerApp,
@@ -35,5 +37,24 @@ describe("Top-level App", () => {
 
     assert.notExists(inner.find(".app").prop("children"))
     sinon.assert.calledWith(helper.handleRequestStub, "/api/users/me", "GET")
+  })
+
+  it("adds a user notification if a stored message is found in cookies", async () => {
+    const userMsg = {
+      type: "some-type",
+      text: "some text"
+    }
+    getStoredUserMessageStub.returns(userMsg)
+    const { store } = await renderPage()
+
+    const { ui } = store.getState()
+    assert.deepEqual(ui.userNotifications, {
+      "loaded-user-msg": {
+        type:  userMsg.type,
+        props: {
+          text: userMsg.text
+        }
+      }
+    })
   })
 })

--- a/static/js/containers/HeaderApp.js
+++ b/static/js/containers/HeaderApp.js
@@ -6,6 +6,7 @@ import { connectRequest } from "redux-query"
 import { createStructuredSelector } from "reselect"
 
 import users, { currentUserSelector } from "../lib/queries/users"
+import { getStoredUserMessage } from "../lib/notificationsApi"
 import { addUserNotification } from "../actions"
 
 import Header from "../components/Header"
@@ -20,6 +21,22 @@ type Props = {
 }
 
 export class HeaderApp extends React.Component<Props, void> {
+  componentDidMount() {
+    const { addUserNotification } = this.props
+
+    const userMsg = getStoredUserMessage()
+    if (userMsg) {
+      addUserNotification({
+        "loaded-user-msg": {
+          type:  userMsg.type,
+          props: {
+            text: userMsg.text
+          }
+        }
+      })
+    }
+  }
+
   render() {
     const { currentUser } = this.props
 

--- a/static/js/lib/notificationsApi.js
+++ b/static/js/lib/notificationsApi.js
@@ -1,0 +1,71 @@
+/* global SETTINGS: false */
+import { getCookie } from "./api"
+import {
+  ALERT_TYPE_DANGER,
+  ALERT_TYPE_SUCCESS,
+  USER_MSG_COOKIE_NAME,
+  USER_MSG_TYPE_ENROLL_FAILED,
+  USER_MSG_TYPE_ENROLLED
+} from "../constants"
+
+type UserMessage = {
+  type: string,
+  text: string
+}
+
+export function getStoredUserMessage(): UserMessage | null {
+  const userMsgValue = getCookie(USER_MSG_COOKIE_NAME)
+  if (!userMsgValue) {
+    return null
+  }
+  const userMsgObject = JSON.parse(decodeURIComponent(userMsgValue))
+  return parseStoredUserMessage(userMsgObject)
+}
+
+export function parseStoredUserMessage(
+  userMsgJson: Object
+): UserMessage | null {
+  const msgType = userMsgJson.type || null
+  if (!msgType) {
+    return null
+  }
+  let alertType, msgText
+  switch (msgType) {
+  case USER_MSG_TYPE_ENROLLED:
+    alertType = ALERT_TYPE_SUCCESS
+    msgText = userMsgJson.run
+      ? `Success! You've been enrolled in ${userMsgJson.run}.`
+      : null
+    break
+  case USER_MSG_TYPE_ENROLL_FAILED:
+    alertType = ALERT_TYPE_DANGER
+    msgText = `Something went wrong with your enrollment. Please contact support at ${
+      SETTINGS.support_email
+    }.`
+    break
+  default:
+    return null
+  }
+  if (!alertType || !msgText) {
+    return null
+  }
+  return {
+    type: alertType,
+    text: msgText
+  }
+}
+
+export const getNotificationAlertProps = (
+  notificationType: string
+): {
+  color?: string
+} => {
+  switch (notificationType) {
+  case ALERT_TYPE_SUCCESS:
+    return { color: ALERT_TYPE_SUCCESS }
+  case ALERT_TYPE_DANGER:
+    return { color: ALERT_TYPE_DANGER }
+  default:
+    return {}
+  }
+}

--- a/static/js/lib/notificationsApi_test.js
+++ b/static/js/lib/notificationsApi_test.js
@@ -1,0 +1,83 @@
+/* global SETTINGS: false */
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+
+import * as notificationsApi from "./notificationsApi"
+import * as api from "./api"
+import {
+  USER_MSG_COOKIE_NAME,
+  USER_MSG_TYPE_ENROLL_FAILED,
+  USER_MSG_TYPE_ENROLLED
+} from "../constants"
+import IntegrationTestHelper from "../util/integration_test_helper"
+
+describe("notifications API", () => {
+  let helper, getCookieStub
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    getCookieStub = helper.sandbox.stub(api, "getCookie")
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  describe("parseStoredUserMessage", () => {
+    it("returns null if given JSON without the expected properties", () => {
+      [{}, { type: null }, { type: "unrecognized" }].forEach(userMsgJson => {
+        assert.isNull(notificationsApi.parseStoredUserMessage(userMsgJson))
+      })
+    })
+
+    it("returns the correct message properties given an 'enrolled' message cookie value", () => {
+      assert.deepEqual(
+        notificationsApi.parseStoredUserMessage({
+          type: USER_MSG_TYPE_ENROLLED,
+          run:  "My Run"
+        }),
+        {
+          text: "Success! You've been enrolled in My Run.",
+          type: "success"
+        }
+      )
+    })
+
+    it("returns the correct message properties given an 'enroll failed' message cookie value", () => {
+      assert.deepEqual(
+        notificationsApi.parseStoredUserMessage({
+          type: USER_MSG_TYPE_ENROLL_FAILED
+        }),
+        {
+          text: `Something went wrong with your enrollment. Please contact support at ${
+            SETTINGS.support_email
+          }.`,
+          type: "danger"
+        }
+      )
+    })
+  })
+
+  describe("getStoredUserMessage", () => {
+    it("returns null if the cookie is not found", () => {
+      getCookieStub.returns(null)
+      const msg = notificationsApi.getStoredUserMessage()
+      assert.isNull(msg)
+      sinon.assert.calledWith(getCookieStub, USER_MSG_COOKIE_NAME)
+    })
+
+    it("returns a parsed message from the cookie value", () => {
+      // Decoded value: {type: "enrolled", run: "Course 2 Run 1"}
+      const encodedJsonCookieValue =
+        "%7B%22type%22%3A %22enrolled%22%2C %22run%22%3A %22Course 2 Run 1%22%7D"
+      getCookieStub.returns(encodedJsonCookieValue)
+      const msg = notificationsApi.getStoredUserMessage()
+      assert.deepEqual(msg, {
+        text: "Success! You've been enrolled in Course 2 Run 1.",
+        type: "success"
+      })
+      sinon.assert.calledWith(getCookieStub, USER_MSG_COOKIE_NAME)
+    })
+  })
+})

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -7,6 +7,7 @@ import {
   curry,
   defaultTo,
   either,
+  find,
   isEmpty,
   isNil,
   lensPath,
@@ -49,6 +50,7 @@ export const isEmptyText = compose(
 )
 
 export const notNil = complement(isNil)
+export const firstNotNil = find(notNil)
 
 export const goBackAndHandleEvent = curry((history, e) => {
   e.preventDefault()

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -11,6 +11,7 @@ import {
   isEmptyText,
   preventDefaultAndInvoke,
   notNil,
+  firstNotNil,
   truncate,
   getTokenFromUrl,
   makeUUID,
@@ -105,6 +106,16 @@ describe("utility functions", () => {
       ["abc", true]
     ].forEach(([val, exp]) => {
       assert.equal(notNil(val), exp)
+    })
+  })
+
+  it("firstNotNil works as expected", () => {
+    [
+      [["value"], "value"],
+      [[null, undefined, "value"], "value"],
+      [[null, 123, null], 123]
+    ].forEach(([val, exp]) => {
+      assert.equal(firstNotNil(val), exp)
     })
   })
 

--- a/static/scss/notification.scss
+++ b/static/scss/notification.scss
@@ -14,7 +14,7 @@
   .alert {
     margin-bottom: 0;
 
-    &.alert-info, &.alert-danger {
+    &.alert-info, &.alert-danger, &.alert-success {
       color: white;
 
       a.alert-link, .close {
@@ -41,6 +41,10 @@
 
     &.alert-danger {
       background-color: $primary;
+    }
+
+    &.alert-success {
+      background-color: $success;
     }
   }
 

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -3,7 +3,7 @@ $static-path: '/static';
 $primary: #a31f34;
 $gray: #363636;
 $gray-85: #d9d9d9;
-$success: #869ca6;
+$success: #28977e;
 
 $light-gray: #8a8b8c;
 $very-light-gray: #f5f5f5;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #34

#### What's this PR do?
- Allows users to enroll in course runs from the product detail page.
- Brings feature flag handling up to speed w/ other projects, and adds the `IGNORE_EDX_FAILURES` feature flag, which allows the app to work with enrollments without needing a working edX instance with the correct course runs seeded.
- Adds a mechanism for showing user notifications that originate from outside of the React app context (in this case, the mechanism is used to show a success message when the enrollment succeeds, and it should be applicable for showing a success message when a user first authenticates – #69)

#### How should this be manually tested?
This can be tested with or without an edX instance running with matching course runs in its database. To test _without_ edX, you can set `FEATURE_IGNORE_EDX_FAILURES=True` in your `.env`

1. Set up an enrollable course run. Make sure its parent course has a CMS page, and that you aren't currently enrolled in the run
2. Navigate to the course detail page
3. Click "Enroll"

You should be redirected to the dashboard page, and the "Success!" message in the above screenshot should be shown. On the backend, an API call should have been made to edX to enroll the user in the course with `audit` mode, and a `CourseRunEnrollment` record should be created if the enrollment in edX was successful, or if you have the above feature flag turned on.

After that, visit the course detail page again. The button should say "Enrolled", and if the course run has a courseware URL set, the button should link to that course in edX.

If you're logged out, the "Enrolled" button should redirect you to the login page, which should then redirect you back to the course detail page after you've logged in

#### Screenshots (if appropriate)
<img width="1094" alt="ss 2021-08-13 at 16 50 49 " src="https://user-images.githubusercontent.com/14932219/129422286-ec48d29e-ca64-43a0-a554-673ac2a9e067.png">
<img width="674" alt="ss 2021-08-13 at 16 51 33 " src="https://user-images.githubusercontent.com/14932219/129422296-12b736c2-7287-4c38-abff-d9b7183109da.png">
