### PR TITLE
Fixed  SignIn and Create Account style regression

### DIFF
--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -104,6 +104,20 @@ const TopAppBar = ({ currentUser, location }: Props) => (
                   Create Account
                 </MixedLink>
               </li>
+              <li>
+                <MixedLink dest={routes.login.begin} aria-label="Login">
+                  Sign In
+                </MixedLink>
+              </li>
+              <li>
+                <MixedLink
+                  dest={routes.register.begin}
+                  className="button"
+                  aria-label="Login"
+                >
+                  Create Account
+                </MixedLink>
+              </li>
             </React.Fragment>
           )}
         </ul>

--- a/static/scss/top-app-bar.scss
+++ b/static/scss/top-app-bar.scss
@@ -75,6 +75,10 @@
     }
   }
 
+  li[data-toggle="collapse"] {
+    display: none;
+  }
+
   &.collapsing,
   &.show {
     display: flex;
@@ -96,6 +100,10 @@
     z-index: 999;
 
     li {
+      display: none;
+    }
+
+    li[data-toggle="collapse"] {
       display: block;
       padding: 10px 0;
       margin: 0 auto;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots  
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Tickets #83 

#### What's this PR do?
Fixes the following problems:
        - The open/close animation on signIn and Create Account button.
        - The overlay on mobile view opening, on clicking signIn create button.

#### How should this be manually tested?
Follow the bellow steps to manually test PR:
        - Open home page and press sign in and/or create account buttons
        - Verify they do not show open/close animation.
        - Change screen to mobile view.
        - verify overlay is not open 

#### Screenshots (if appropriate)
Following are the relevant Screen shots

Desktop Screen Shot
<img width="1440" alt="Screenshot 2021-08-17 at 5 04 39 PM" src="https://user-images.githubusercontent.com/87968618/129725363-3356cce2-4883-4990-bbd1-8534e83f67ad.png">
      
Mobile Screen Shot
<img width="370" alt="Screenshot 2021-08-17 at 5 06 45 PM" src="https://user-images.githubusercontent.com/87968618/129725725-0fcc1d6c-0359-4d29-bb13-366a04dd839d.png">


