### PR TITLE
Fixed issues with register API and recaptcha (#111)

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -35,6 +35,7 @@ def get_js_settings(request: HttpRequest):
         "environment": settings.ENVIRONMENT,
         "public_path": webpack_public_path(request),
         "release_version": settings.VERSION,
+        "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
         "sentry_dsn": remove_password_from_url(settings.SENTRY_DSN),
         "support_email": settings.EMAIL_SUPPORT,
         "site_name": settings.SITE_NAME,

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -1,6 +1,9 @@
 """Utils tests"""
+from mitol.common.utils.urls import remove_password_from_url
+from mitol.common.utils.webpack import webpack_public_path
+
 from main.models import AuditModel
-from main.utils import get_field_names
+from main.utils import get_field_names, get_js_settings
 
 
 def test_get_field_names():
@@ -13,4 +16,27 @@ def test_get_field_names():
         "acting_user",
         "created_on",
         "updated_on",
+    }
+
+
+def test_get_js_settings(settings, rf):
+    """Test get_js_settings"""
+    settings.GA_TRACKING_ID = "fake"
+    settings.ENVIRONMENT = "test"
+    settings.VERSION = "4.5.6"
+    settings.EMAIL_SUPPORT = "support@text.com"
+    settings.USE_WEBPACK_DEV_SERVER = False
+    settings.RECAPTCHA_SITE_KEY = "fake_key"
+
+    request = rf.get("/")
+
+    assert get_js_settings(request) == {
+        "gaTrackingID": "fake",
+        "public_path": webpack_public_path(request),
+        "environment": settings.ENVIRONMENT,
+        "sentry_dsn": remove_password_from_url(settings.SENTRY_DSN),
+        "release_version": settings.VERSION,
+        "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
+        "support_email": settings.EMAIL_SUPPORT,
+        "site_name": settings.SITE_NAME,
     }

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,5 @@ env =
   OPENEDX_API_CLIENT_SECRET=fake_client_secret
   OPENEDX_API_KEY=test-openedx-api-key
   SENTRY_DSN=
+  RECAPTCHA_SITE_KEY=
+  RECAPTCHA_SECRET_KEY=


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #111 

#### What's this PR do?
This updates `get_js_settings` to return the recaptcha key since all of the other code expects it to be there.

#### How should this be manually tested?
- Configure a V2 recaptch key (https://www.google.com/recaptcha/admin/create)
- In `.env`, set `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY` based on the values the admin console gives you.
- Got to the create account page, the recaptcha should render and you should be able to submit the form and receive a confirmation email.