### PR TITLE
Added setting to avoid name collisions in Wagtail

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,6 +35,10 @@
       "description": "Enables querystring auth for S3 urls",
       "required": false
     },
+    "AWS_S3_FILE_OVERWRITE": {
+      "description": "Django Storages setting. By default files with the same name will overwrite each other. Set this to False to have extra characters appended.",
+      "required": false
+    },
     "AWS_SECRET_ACCESS_KEY": {
       "description": "AWS Secret Key for S3 storage.",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -642,6 +642,16 @@ AWS_QUERYSTRING_AUTH = get_bool(
     default=False,
     description="Enables querystring auth for S3 urls",
 )
+AWS_S3_FILE_OVERWRITE = get_bool(
+    name="AWS_S3_FILE_OVERWRITE",
+    # Django Storages defaults this setting to True, but our desired default is False to avoid name collisions in
+    # files uploaded in the CMS.
+    default=False,
+    description=(
+        "Django Storages setting. By default files with the same name will overwrite each other. "
+        "Set this to False to have extra characters appended."
+    ),
+)
 # Provide nice validation of the configuration
 if MITX_ONLINE_USE_S3 and (
     not AWS_ACCESS_KEY_ID or not AWS_SECRET_ACCESS_KEY or not AWS_STORAGE_BUCKET_NAME


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] ~~Opened issue for DevOps regarding necessary configuration changes to deployed environments~~ N/A - defaulting this setting to `False` which what we want for all envs

#### What are the relevant tickets?
Fixes #108

#### What's this PR do?
Adds a setting to prevent name collisions for uploaded files (especially critical for files uploaded in Wagtail)

#### How should this be manually tested?
*NOTE:* To get this working I couldn't use my existing database, which had a bunch of CMS data from 

- Copy `AWS_` settings from RC and set `MITX_ONLINE_USE_S3=True` in your `.env`
- Run the app, and upload an image, then upload the same image again
- Navigate to the detail page for each of those images in Wagtail. Under "File:" the first image should have the same filename as the file you uploaded, and the second one should have an alphanumeric suffix attached

<img width="642" alt="ss 2021-08-20 at 17 53 46 " src="https://user-images.githubusercontent.com/14932219/130302662-16f507bd-bc62-40a2-a10e-217a70b15ee9.png">
