### PR TITLE
Fixed CMS migrations, added startup command to configure Wagtail

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -1,14 +1,17 @@
 """API functionality for the CMS app"""
 import logging
+from typing import Tuple
 from urllib.parse import urljoin, urlencode
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+
 from django.utils.text import slugify
 from wagtail.core.blocks import StreamValue
 from wagtail.core.models import Page, Site
 
 from cms import models as cms_models
+from cms.exceptions import WagtailSpecificPageError
 
 log = logging.getLogger(__name__)
 DEFAULT_HOMEPAGE_PROPS = dict(
@@ -17,79 +20,98 @@ DEFAULT_HOMEPAGE_PROPS = dict(
     hero_subtitle="Enim ad minim veniam, quis nostrud exercitation",
 )
 DEFAULT_SITE_PROPS = dict(hostname="localhost", port=80)
+COURSE_INDEX_PAGE_PROPERTIES = dict(title="Courses")
+RESOURCE_PAGE_TITLES = [
+    "About Us",
+    "Terms of Service",
+    "Privacy Policy",
+    "Honor Code",
+]
+RESOURCE_PAGE_SLUGS = [slugify(title) for title in RESOURCE_PAGE_TITLES]
 
 
-def get_or_create_resource_page(title, parent):
-    """Get/Create a resource page with the given title under the parent page"""
-    resource = cms_models.ResourcePage.objects.filter(slug=slugify(title)).first()
-    if not resource:
-        resource = cms_models.ResourcePage(
-            slug=slugify(title),
-            title=title,
-            content=StreamValue(
-                "content",
-                [
-                    {
-                        "type": "content",
-                        "value": {
-                            "heading": title,
-                            "detail": f"<p>Stock {title.lower()} page.</p>",
-                        },
-                    }
-                ],
-                is_lazy=True,
-            ),
-        )
-        parent.add_child(instance=resource)
-    return resource
-
-
-def get_home_page():
+def get_home_page(raise_if_missing=True, check_specific=False) -> Page:
     """
     Returns an instance of the home page (all of our Wagtail pages are expected to be descendants of this home page)
 
     Returns:
         Page: The home page object
     """
-    return Page.objects.get(
-        content_type=ContentType.objects.get_for_model(cms_models.HomePage)
+    home_page = Page.objects.filter(
+        content_type=ContentType.objects.get_for_model(cms_models.HomePage), live=True
+    ).first()
+    if raise_if_missing is True and home_page is None:
+        raise Page.DoesNotExist
+    if check_specific and home_page is not None:
+        try:
+            home_page.get_specific()
+        except cms_models.HomePage.DoesNotExist as exc:
+            raise WagtailSpecificPageError(
+                spec_page_cls=cms_models.HomePage, page_obj=home_page
+            ) from exc
+    return home_page
+
+
+def _create_resource_page(title: str) -> cms_models.ResourcePage:
+    """Creates a resource page with the given title under the parent page"""
+    return cms_models.ResourcePage(
+        slug=slugify(title),
+        title=title,
+        content=StreamValue(
+            "content",
+            [
+                {
+                    "type": "content",
+                    "value": {
+                        "heading": title,
+                        "detail": f"<p>Stock {title.lower()} page.</p>",
+                    },
+                }
+            ],
+            is_lazy=True,
+        ),
     )
 
 
-def ensure_resource_pages():
+def ensure_resource_pages() -> None:
     """
-    Ensures that all the following resource pages exists
-    (About Us / Terms of Service / Privacy Policy / Honor Code)
+    Ensures that a set of specific resource pages exist in some basic form
     """
-    home_page = Page.objects.filter(
-        content_type=ContentType.objects.get_for_model(cms_models.HomePage)
-    ).first()
-    get_or_create_resource_page("About Us", parent=home_page)
-    get_or_create_resource_page("Terms of Service", parent=home_page)
-    get_or_create_resource_page("Privacy Policy", parent=home_page)
-    get_or_create_resource_page("Honor Code", parent=home_page)
+    home_page = get_home_page()
+    resource_pages_qset = cms_models.ResourcePage.objects.filter(
+        slug__in=RESOURCE_PAGE_SLUGS
+    )
+    if resource_pages_qset.count() == len(RESOURCE_PAGE_SLUGS):
+        return
+    existing_resource_titles = set(resource_pages_qset.values_list("title", flat=True))
+    missing_resource_titles = set(RESOURCE_PAGE_TITLES) - existing_resource_titles
+    for resource_page_title in missing_resource_titles:
+        resource_page = _create_resource_page(resource_page_title)
+        home_page.add_child(instance=resource_page)
+        resource_page.save_revision().publish()
 
 
-def ensure_home_page_and_site():
+def ensure_home_page_and_site() -> Tuple[cms_models.HomePage, Site]:
     """
     Ensures that Wagtail is configured with a home page of the right type, and that
     the home page is configured as the default site.
     """
     site = Site.objects.filter(is_default_site=True).first()
-    valid_home_page = Page.objects.filter(
-        content_type=ContentType.objects.get_for_model(cms_models.HomePage)
-    ).first()
+    home_page = get_home_page(raise_if_missing=False, check_specific=True)
     root = Page.objects.get(depth=1)
-    if valid_home_page is None:
-        valid_home_page = cms_models.HomePage(**DEFAULT_HOMEPAGE_PROPS)
-        root.add_child(instance=valid_home_page)
-        valid_home_page.refresh_from_db()
+    if home_page is None:
+        home_page = cms_models.HomePage(**DEFAULT_HOMEPAGE_PROPS)
+        root.add_child(instance=home_page)
+        home_page.refresh_from_db()
+        specific_home_page = home_page
+    else:
+        specific_home_page = home_page.specific
     if site is None:
         Site.objects.create(
-            is_default_site=True, root_page=valid_home_page, **DEFAULT_SITE_PROPS
+            is_default_site=True, root_page=home_page, **DEFAULT_SITE_PROPS
         )
-    elif site.root_page is None or site.root_page != valid_home_page:
-        site.root_page = valid_home_page
+    elif site.root_page is None or site.root_page != home_page:
+        site.root_page = home_page
         site.save()
         log.info("Updated site: %s", site)
     wagtail_default_home_page = Page.objects.filter(
@@ -97,9 +119,32 @@ def ensure_home_page_and_site():
     ).first()
     if wagtail_default_home_page is not None:
         wagtail_default_home_page.delete()
+    return specific_home_page, site
 
 
-def get_wagtail_img_src(image_obj):
+def ensure_product_index() -> cms_models.CourseIndexPage:
+    """
+    Ensures that an index page has been created for each type of product, and that all product pages are
+    nested under it.
+    """
+    home_page = get_home_page()
+    course_index = Page.objects.filter(
+        content_type=ContentType.objects.get_for_model(cms_models.CourseIndexPage)
+    ).first()
+    if not course_index:
+        course_index = cms_models.CourseIndexPage(**COURSE_INDEX_PAGE_PROPERTIES)
+        home_page.add_child(instance=course_index)
+        course_index.save_revision().publish()
+    # Move course detail pages to be children of the course index pages
+    for page_id in cms_models.CoursePage.objects.exclude(
+        path__startswith=course_index.path
+    ).values_list("id", flat=True):
+        page = Page.objects.get(id=page_id)
+        page.move(course_index, "last-child")
+    return course_index
+
+
+def get_wagtail_img_src(image_obj) -> str:
     """Returns the image source URL for a Wagtail Image object"""
     return (
         "{url}?{qs}".format(

--- a/cms/commands_test.py
+++ b/cms/commands_test.py
@@ -1,0 +1,19 @@
+"""Tests for CMS management commands"""
+from django.core.management import call_command
+
+
+def test_configure_wagtail(mocker):
+    """The 'configure_wagtail' command should call specific API methods to configure Wagtail"""
+    patched_ensure_home_page = mocker.patch(
+        "cms.management.commands.configure_wagtail.ensure_home_page_and_site"
+    )
+    patched_ensure_resource_pages = mocker.patch(
+        "cms.management.commands.configure_wagtail.ensure_resource_pages"
+    )
+    patched_ensure_product_index = mocker.patch(
+        "cms.management.commands.configure_wagtail.ensure_product_index"
+    )
+    call_command("configure_wagtail")
+    patched_ensure_home_page.assert_called_once()
+    patched_ensure_resource_pages.assert_called_once()
+    patched_ensure_product_index.assert_called_once()

--- a/cms/conftest.py
+++ b/cms/conftest.py
@@ -1,0 +1,24 @@
+"""Fixtures for CMS test suite"""
+from types import SimpleNamespace
+
+import pytest
+
+from cms.api import ensure_home_page_and_site, ensure_product_index
+
+
+@pytest.fixture()
+def configured_wagtail_home():
+    """Fixture that ensures the site and home page are correctly configured"""
+    home_page, site = ensure_home_page_and_site()
+    return SimpleNamespace(home_page=home_page, site=site)
+
+
+@pytest.fixture()
+def fully_configured_wagtail(configured_wagtail_home):
+    """Fixture that ensures the site home page, and index pages are correctly configured"""
+    course_index_page = ensure_product_index()
+    return SimpleNamespace(
+        home_page=configured_wagtail_home.home_page,
+        site=configured_wagtail_home.site,
+        course_index_page=course_index_page,
+    )

--- a/cms/exceptions.py
+++ b/cms/exceptions.py
@@ -1,0 +1,19 @@
+"""Custom exceptions for Wagtail"""
+
+from django.db import DataError
+
+
+class WagtailSpecificPageError(DataError):
+    def __init__(self, spec_page_cls, page_obj, msg=None):
+        self.spec_page_cls = spec_page_cls
+        self.page_obj = page_obj
+        if msg is None:
+            msg = (
+                "Wagtail data corrupted. A Page object exists (id: {}), but does not have an equivalent "
+                "object for the specific page class ({}).\n"
+                "Either the Page object(s) need to be manually deleted from the database, or all Wagtail "
+                "migrations need re-ran from zero.".format(
+                    self.page_obj.id, self.spec_page_cls
+                )
+            )
+        super().__init__(msg)

--- a/cms/factories.py
+++ b/cms/factories.py
@@ -13,9 +13,22 @@ class HomePageFactory(wagtail_factories.PageFactory):
     """HomePage factory class"""
 
     hero = factory.SubFactory(wagtail_factories.ImageFactory)
+    title = "Home Page"
 
     class Meta:
         model = HomePage
+
+
+class CourseIndexPageFactory(wagtail_factories.PageFactory):
+    """CourseIndexPage factory class"""
+
+    title = "Courses"
+    parent = LazyAttribute(
+        lambda _: HomePage.objects.first() or HomePageFactory.create()
+    )
+
+    class Meta:
+        model = CourseIndexPage
 
 
 class CoursePageFactory(wagtail_factories.PageFactory):
@@ -25,7 +38,9 @@ class CoursePageFactory(wagtail_factories.PageFactory):
     feature_image = factory.SubFactory(wagtail_factories.ImageFactory)
     course = factory.SubFactory(CourseFactory)
     slug = fuzzy.FuzzyText(prefix="my-page-")
-    parent = LazyAttribute(lambda _: CourseIndexPage.objects.first())
+    parent = LazyAttribute(
+        lambda _: CourseIndexPage.objects.first() or CourseIndexPageFactory.create()
+    )
 
     class Meta:
         model = CoursePage

--- a/cms/management/commands/configure_wagtail.py
+++ b/cms/management/commands/configure_wagtail.py
@@ -1,7 +1,11 @@
 """Ensures that all appropriate changes have been made to Wagtail that will make the site navigable."""
 from django.core.management.base import BaseCommand
 
-from cms.api import ensure_home_page_and_site, ensure_resource_pages
+from cms.api import (
+    ensure_home_page_and_site,
+    ensure_resource_pages,
+    ensure_product_index,
+)
 
 
 class Command(BaseCommand):
@@ -11,4 +15,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         ensure_home_page_and_site()
+        ensure_product_index()
         ensure_resource_pages()

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -21,7 +21,7 @@ def test_resource_page_site_name(settings, mocker):
     assert page.get_context(mocker.Mock())["site_name"] == settings.SITE_NAME
 
 
-def test_custom_detail_page_urls():
+def test_custom_detail_page_urls(fully_configured_wagtail):
     """Verify that course detail pages return our custom URL path"""
     readable_id = "some:readable-id"
     course_pages = CoursePageFactory.create_batch(
@@ -30,7 +30,7 @@ def test_custom_detail_page_urls():
     assert course_pages[0].get_url() == "/courses/{}/".format(readable_id)
 
 
-def test_custom_detail_page_urls_handled():
+def test_custom_detail_page_urls_handled(fully_configured_wagtail):
     """Verify that custom URL paths for our course pages are served by the standard Wagtail view"""
     readable_id = "some:readable-id"
     CoursePageFactory.create(course__readable_id=readable_id)
@@ -51,6 +51,7 @@ def test_custom_detail_page_urls_handled():
 )
 def test_course_page_context(
     user,
+    fully_configured_wagtail,
     is_authenticated,
     has_unexpired_run,
     enrolled,

--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -6,6 +6,7 @@ from cms.api import get_wagtail_img_src
 from courses.constants import DEFAULT_COURSE_IMG_PATH
 from django.templatetags.static import static
 
+
 class CoursePageSerializer(serializers.ModelSerializer):
     """Course page model serializer"""
 

--- a/cms/templatetags_test.py
+++ b/cms/templatetags_test.py
@@ -25,9 +25,7 @@ def test_wagtail_img_src(mocker, settings):
 def test_featured_img_src(mocker, settings):
     """featured_img_src should return the correct image URL if found else return the Default one"""
     image = ImageFactory()
-    product = CoursePageFactory.create(
-        feature_image=image
-    )
+    product = CoursePageFactory.create(feature_image=image)
     fake_src_value = "http://example.com"
     mocker.patch(
         "cms.templatetags.feature_img_src.get_wagtail_img_src",
@@ -38,4 +36,4 @@ def test_featured_img_src(mocker, settings):
 
     # Now when feature_image is not set.
     img_src = feature_img_src(None)
-    assert img_src == '/static/' + DEFAULT_COURSE_IMG_PATH
+    assert img_src == "/static/" + DEFAULT_COURSE_IMG_PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --noinput &&
+      python3 manage.py configure_wagtail &&
       uwsgi uwsgi.ini --honour-stdin'
     stdin_open: true
     tty: true


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
- Changes the existing CMS data migration for setting up course index page etc. to be a no-op in favor of using the `configure_wagtail` command exclusively.
- Changes our app configuration so that the `configure_wagtail` command is run immediately after the `migrate` command, both for local development (via `docker-compose.yml`) and deployment (via [`app.json`](https://devcenter.heroku.com/articles/app-json-schema)).

#### How should this be manually tested?
Running the management command and making sure it completes successfully is a good start. 

Beyond that, the purpose of this command is to ensure that all of the Wagtail objects we care about are in the database, so the best way to test is with a fresh database. You can run the command with a fresh db and ensure that it succeeds – our custom home page is set up as the site root, a course index page exists as a child of that home page, and basic resource pages have been added.

#### Any background context you want to provide?
- I was made aware of the need for this change when my database got stuck in a bad state w/ cms migrations. Hacking my way through that and remembering the hardships we had with cms data migrations in xpro, it was pretty clear that we needed an alternate solution for getting Wagtail configured correctly and automatically.
- For any future steps that we need to take to ensure that Wagtail is configured correctly, we will not use data migrations anymore once this merges. We will just add to the `configure_wagtail` management command.

