### PR TITLE
fix(Accessibility): added missing SITE_NAME to context to fix head titles

### DIFF
--- a/main/context_processors.py
+++ b/main/context_processors.py
@@ -17,3 +17,12 @@ def api_keys(request):
             "GTM_TRACKING_ID": settings.GTM_TRACKING_ID,
         }
     }
+
+
+def configuration_context(request):
+    """
+    Configuration context for django templates.
+    """
+    return {
+        "site_name": settings.SITE_NAME,
+    }

--- a/main/settings.py
+++ b/main/settings.py
@@ -234,6 +234,7 @@ TEMPLATES = [
                 "social_django.context_processors.backends",
                 "social_django.context_processors.login_redirect",
                 "main.context_processors.api_keys",
+                "main.context_processors.configuration_context"
             ]
         },
     }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#148 

#### What's this PR do?
- Adds the missing `SITE_NAME` config variable from the Django templates
- Fixes the head titles of the pages using the site name

#### How should this be manually tested?
- Visit the home page of the web and see the head title is the one set in the `SITE_NAME` variable 
- Visit the product page and check that the head title is `{Page Name} | {Site Name}`
- Generally, other pages could also be checked to verify this change

#### Where should the reviewer start?
Home Page

#### Screenshots (if appropriate)
**Note:** For the **Before** screenshot you can visit the associated ticket

**Home Page Head**
<img width="1440" alt="Screenshot 2021-09-07 at 4 54 01 PM" src="https://user-images.githubusercontent.com/34372316/132340387-5b7ee8fa-d058-434b-99e8-737293aa0b62.png">

**Product Page Head**
<img width="1437" alt="Screenshot 2021-09-07 at 4 53 50 PM" src="https://user-images.githubusercontent.com/34372316/132340368-3ef0a04d-4c59-4d3e-b0b5-2e149e824d9a.png">
