### PR TITLE
fix: accessibility issues on homepage

### DIFF
--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -15,10 +15,10 @@
   <div class="container hero-content">
     <div class="hero-title">
       {% if page.hero_title %}
-        <h1>{{ page.hero_title }}</h1>
+        <h2>{{ page.hero_title }}</h2>
       {% endif %}
       {% if page.hero_subtitle %}
-        <h2>{{ page.hero_subtitle }}</h2>
+        <h3>{{ page.hero_subtitle }}</h3>
       {% endif %}
     </div>
   </div>
@@ -33,7 +33,7 @@
       <li>
         <div class="course-card highlight-card">
           <a href="{{ product.url_path }}" class="course-card-link">
-            <img src="{% feature_img_src product.feature_image %}" alt="Featured course image">
+            <img src="{% feature_img_src product.feature_image %}" alt="">
             <div class="course-info">
               <h2 class="course-card-title">
                   {{ product.title }}

--- a/static/scss/home.scss
+++ b/static/scss/home.scss
@@ -19,7 +19,7 @@
     padding: 20px;
   }
 
-  h1 {
+  h2 {
     color: white;
     font-weight: 600;
     font-size: 48px;
@@ -32,7 +32,7 @@
     }
   }
 
-  h2 {
+  h3 {
     color: $subtitle-color;
     font-weight: 600;
     font-size: 36px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#155 

#### What's this PR do?
- Removes multiple `h1` tags from the homepage and keeps only now `h1`
- Removed the `alt` text from the course list on the homepage since the cards are now decorative and won't need repetitive alt names.

**Note:**
There are currently 2 `H1` elements on the Home Page. `1) Hero title` `(2 Courses Heading`. To keep only one H1 we had alternate options:
1) We already had a customized style for Hero Title's `h1` on the home page and just changing it to `h2` would let us do the job that we needed.
2) We replace `h1` with any other `h tag` in the courses heading and add a relevant style for the CSS.

I followed the approach in `point#1` since we are trying to keep common styling for all of our `h1 elements` in all the pages and the course list heading is one of them following the style from the common. So instead of updating it, I've updated the hero title's h1 which was already using a custom styling.

#### How should this be manually tested?
- Visit the home page and check there is only one H1
- Visit the home page and check that course cards have empty `alt` value for the images

#### Where should the reviewer start?
- Home Page
