### PR TITLE
fix user name font weight in user menu

### DIFF
--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -68,6 +68,7 @@
   .dropdown-toggle {
     max-width: 100%;
     padding: 0px;
+    font-weight: 600;
 
     &:after {
       border: 2px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
NA

#### What's this PR do?
fix user name font weight in user menu

#### How should this be manually tested?
Just see the desktop user menu and see the user name there

#### Screenshots (if appropriate)

**NOW**

<img width="1436" alt="Screenshot 2021-09-09 at 13 15 50" src="https://user-images.githubusercontent.com/4043989/132649380-635b4edf-67fb-4f15-8c4c-a999da339720.png">

**BEFORE**

<img width="1440" alt="Screenshot 2021-09-09 at 13 16 15" src="https://user-images.githubusercontent.com/4043989/132649415-583e175f-aff6-4a14-a2ab-fed13faa3ace.png">
