### PR TITLE
Pull courserun title, dates from studio

### DIFF
--- a/app.json
+++ b/app.json
@@ -64,11 +64,11 @@
       "required": false
     },
     "CRON_COURSERUN_SYNC_DAYS": {
-      "description": "'day_of_week' value for 'sync-courseruns-data' scheduled task (default will run once a day).",
+      "description": "day_of_week' value for scheduled task to sync course run data (by default, it will run each day of the week).",
       "required": false
     },
     "CRON_COURSERUN_SYNC_HOURS": {
-      "description": "'hours' value for the 'sync-courseruns-data' scheduled task (defaults to midnight)",
+      "description": "'hours' value for scheduled task to sync course run data (by default, it will run at midnight",
       "required": false
     },
     "CSRF_TRUSTED_ORIGINS": {

--- a/app.json
+++ b/app.json
@@ -63,6 +63,14 @@
       "description": "The Cloundfront distribution to use for static assets",
       "required": false
     },
+    "CRON_COURSERUN_SYNC_DAYS": {
+      "description": "'day_of_week' value for 'sync-courseruns-data' scheduled task (default will run once a day).",
+      "required": false
+    },
+    "CRON_COURSERUN_SYNC_HOURS": {
+      "description": "'hours' value for the 'sync-courseruns-data' scheduled task (defaults to midnight)",
+      "required": false
+    },
     "CSRF_TRUSTED_ORIGINS": {
       "description": "Comma separated string of trusted domains that should be CSRF exempt",
       "required": false

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -1,0 +1,22 @@
+"""
+Tasks for the courses app
+"""
+
+from django.db.models import Q
+from mitol.common.utils.datetime import now_in_utc
+
+from courses.api import sync_course_runs
+from courses.models import CourseRun
+from main.celery import app
+
+
+@app.task
+def sync_course_runs_data():
+    """
+    Task to sync titles and dates for course runs from edX.
+    """
+    now = now_in_utc()
+    runs = CourseRun.objects.live().filter(Q(expiration_date__isnull=True) | Q(expiration_date__gt=now))
+
+    # `sync_course_runs` logs internally so no need to capture/output the returned values
+    sync_course_runs(runs)

--- a/main/settings.py
+++ b/main/settings.py
@@ -719,12 +719,12 @@ CELERY_TIMEZONE = "UTC"
 CRON_COURSERUN_SYNC_HOURS = get_string(
     name="CRON_COURSERUN_SYNC_HOURS",
     default=0,
-    description="'hours' value for the 'sync-courseruns-data' scheduled task (defaults to midnight)",
+    description="'hours' value for scheduled task to sync course run data (by default, it will run at midnight",
 )
 CRON_COURSERUN_SYNC_DAYS = get_string(
     name="CRON_COURSERUN_SYNC_DAYS",
-    default=None,
-    description="'day_of_week' value for 'sync-courseruns-data' scheduled task (default will run once a day).",
+    default="*",
+    description="day_of_week' value for scheduled task to sync course run data (by default, it will run each day of the week).",
 )
 RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY = get_int(
     name="RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY",
@@ -755,7 +755,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(
             minute=0,
             hour=CRON_COURSERUN_SYNC_HOURS,
-            day_of_week=CRON_COURSERUN_SYNC_DAYS or "*",
+            day_of_week=CRON_COURSERUN_SYNC_DAYS,
             day_of_month="*",
             month_of_year="*",
         ),

--- a/main/settings.py
+++ b/main/settings.py
@@ -716,6 +716,16 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TIMEZONE = "UTC"
+CRON_COURSERUN_SYNC_HOURS = get_string(
+    name="CRON_COURSERUN_SYNC_HOURS",
+    default=0,
+    description="'hours' value for the 'sync-courseruns-data' scheduled task (defaults to midnight)",
+)
+CRON_COURSERUN_SYNC_DAYS = get_string(
+    name="CRON_COURSERUN_SYNC_DAYS",
+    default=None,
+    description="'day_of_week' value for 'sync-courseruns-data' scheduled task (default will run once a day).",
+)
 RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY = get_int(
     name="RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY",
     default=60 * 30,
@@ -738,6 +748,16 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": OffsettingSchedule(
             run_every=timedelta(seconds=REPAIR_OPENEDX_USERS_FREQUENCY),
             offset=timedelta(seconds=REPAIR_OPENEDX_USERS_OFFSET),
+        ),
+    },
+    "sync-courseruns-data": {
+        "task": "courses.tasks.sync_courseruns_data",
+        "schedule": crontab(
+            minute=0,
+            hour=CRON_COURSERUN_SYNC_HOURS,
+            day_of_week=CRON_COURSERUN_SYNC_DAYS or "*",
+            day_of_month="*",
+            month_of_year="*",
         ),
     },
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
fixes #106 

#### What's this PR do?
Pull courserun title, dates from studio

#### How should this be manually tested?
- make a course / course run with same courseware_id both on MIT xOnline and edx-platform  e.g `course-v1:edX+DemoX+Demo_Course`
- then run management command / celery tasks to run the syncs of data
- `docker-compose exec web python manage.py sync_courserun --run=course-v1:edX+DemoX+Demo_Course`
- `courses.tasks.sync_course_runs_data`
- for further details see the attached screenshots

#### Screenshots (if appropriate)

**THROUGH MANAGEMENT COMMAND**

<img width="723" alt="Screenshot 2021-09-10 at 19 27 04" src="https://user-images.githubusercontent.com/4043989/132869451-2e3951a0-c19f-4e78-a85e-2f0fa2944cdd.png">

**THROUGH CELERY TASK (CALLING MANUALLY / SCHEDULED)**

<img width="1440" alt="Screenshot 2021-09-10 at 19 22 21" src="https://user-images.githubusercontent.com/4043989/132869447-a0101875-f4e2-4492-a44c-b44116fd906e.png">

**BEFORE SYNCING**

<img width="1440" alt="Screenshot 2021-09-10 at 19 18 33" src="https://user-images.githubusercontent.com/4043989/132869424-3783ead8-7e16-40fb-85de-c1146a8dad60.png">

**AFTER SYNCING**

<img width="1440" alt="Screenshot 2021-09-10 at 19 18 50" src="https://user-images.githubusercontent.com/4043989/132869438-e85b4661-93ab-43c8-aec2-19b324a0b699.png">
