### PR TITLE
Updated Forgot Password flow in case of email does not exist.

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -812,7 +812,7 @@ DJOSER = {
     "SET_PASSWORD_RETYPE": False,
     "LOGOUT_ON_PASSWORD_CHANGE": False,
     "PASSWORD_RESET_CONFIRM_RETYPE": True,
-    "PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND": True,
+    "PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND": False,
     "EMAIL": {"password_reset": "authentication.views.CustomPasswordResetEmail"},
     "SERIALIZERS": {
         "password_reset": "authentication.serializers.CustomSendEmailResetSerializer"


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
ticket #56 

#### What's this PR do?
Updated Djoser setting to send a 200 response in case an email does not exist in Forgot Password Form.

#### How should this be manually tested?
 - Create an Account  with a valid email.
 - Enter Email in the First SignIn step
 - On the `Enter Password Page` click forgot password
 - Enter Invalid email and verify no email is sent

