### PR TITLE
fix: accessibility fixes for Product Detail page and dashboard

### DIFF
--- a/authentication/templates/profile.html
+++ b/authentication/templates/profile.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block content %}
-<div id="login-page">
+<div id="profile-page">
   <h2>Profile</h2>
   <form method="post" action="{% url 'social:complete' 'email' %}">
     {% csrf_token %}

--- a/authentication/templates/register.html
+++ b/authentication/templates/register.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block content %}
-<div id="login-page">
+<div id="register-page">
   <h2>Register</h2>
   <form method="post" action="{% url 'social:complete' 'email' %}">
     {% csrf_token %}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -140,7 +140,7 @@
                 <div class="member-card highlight-card">
                   <img src="{% wagtail_img_src member.value.image %}" alt="{{ member.name }}">
                   <div class="member-info">
-                    <h4 class="name">{{ member.value.name }}</h4>
+                    <h3 class="name">{{ member.value.name }}</h3>
                     <div class="description">{{ member.value.description }}</div>
                   </div>
                 </div>

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -68,7 +68,7 @@ export class DashboardPage extends React.Component<DashboardPageProps, void> {
           )}
         </div>
         <div className="col-12 col-sm p-3 p-sm-0">
-          <h4 className="mb-3">{title}</h4>
+          <h2 className="mb-3">{title}</h2>
           <div className="detail">{startDateDescription}</div>
         </div>
       </div>
@@ -88,7 +88,7 @@ export class DashboardPage extends React.Component<DashboardPageProps, void> {
                 enrollments.map(this.renderEnrolledItemCard)
               ) : (
                 <div className="card no-enrollments p-3 p-sm-5 rounded-0">
-                  <h4>Enroll Now</h4>
+                  <h2>Enroll Now</h2>
                   <p>
                     You are not enrolled in any courses yet. Please{" "}
                     <a href={routes.root}>browse our courses</a>.

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -46,7 +46,7 @@ describe("DashboardPage", () => {
     userEnrollments.forEach((userEnrollment, i) => {
       const enrolledItem = enrolledItems.at(i)
       assert.equal(
-        enrolledItem.find("h4").text(),
+        enrolledItem.find("h2").text(),
         userEnrollment.run.course.title
       )
     })
@@ -91,7 +91,7 @@ describe("DashboardPage", () => {
         expCourseLink
       )
       if (expCourseLink) {
-        const linkedTitle = enrolledItems.at(0).find("h4")
+        const linkedTitle = enrolledItems.at(0).find("h2")
         assert.equal(linkedTitle.find("a").prop("href"), exampleCoursewareUrl)
       }
     })

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -21,7 +21,7 @@ $featureImgMobileWidth: 343px;
       }
     }
 
-    h4 a {
+    h2 a {
       text-decoration: underline;
     }
 

--- a/static/scss/product-faculty-members.scss
+++ b/static/scss/product-faculty-members.scss
@@ -39,13 +39,13 @@
         .description {
           p {
             margin: 0;
-            color: $light-gray;
+            color: $label-subtitle;
           }
         }
       }
 
       &:hover {
-        h4 {
+        h3 {
           color: $brand-button-bg;
         }
       }

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -34,5 +34,5 @@ $footer-border: #686461;
 
 $dc-background: #f2f2f2;
 $subtitle-color: #ff4a68;
-$sirocco: #758080;
+$sirocco: #465a5b;
 $brand-button-bg: #a41e34


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#171 

#### What's this PR do?
- Fixes the accessibility on the Product detail page
- Fixes accessibility on the Dashboard page

**Note for Reviewer:**
- Lighthouse complains about descending order of headings to be followed for accessibility e.g. `h1->h2->h3...` But in our case, we were using `h1` and then directly `h4` so i had to make our design use the heading tag in order and for that, i had to override the style of `h4` as `h2` in the specific classes to keep the design intact as well as resolve accessibility issues by LightHouse. I'm aware of using the common `h2` style but using `h2` here as is was a notable difference
- The second complaint was the color contrast so least possible color to fix the issue in tiles.

#### How should this be manually tested?
- Open the dashboard page and check the accessibility and design. There should be no accessibility errors for that specific page and there should be no notable design changes
- Verify the same as above on the Product detail page.


#### Screenshots (if appropriate)
**Tiles Before**
<img width="976" alt="Screenshot 2021-09-17 at 1 32 56 PM" src="https://user-images.githubusercontent.com/34372316/133751745-4f5d5ad9-9dc3-4c05-90f9-14509a2127f9.png">

**Tiles After**
<img width="984" alt="Screenshot 2021-09-17 at 1 33 05 PM" src="https://user-images.githubusercontent.com/34372316/133751784-11395249-6d73-4827-a20f-e17cd0c89261.png">


**Dashboard Before**
<img width="1440" alt="Screenshot 2021-09-17 at 1 35 43 PM" src="https://user-images.githubusercontent.com/34372316/133752043-84315acb-6460-42f7-8bc1-d536b1f3ad9b.png">

**Dashboard After**
<img width="1439" alt="Screenshot 2021-09-17 at 1 35 55 PM" src="https://user-images.githubusercontent.com/34372316/133752081-926b3194-dbb0-49df-b73b-fe2bf08797db.png">

**Faculty Before**
<img width="748" alt="Screenshot 2021-09-17 at 1 37 54 PM" src="https://user-images.githubusercontent.com/34372316/133752369-961787ae-bb76-4c3b-b227-c9c44cdfdc7a.png">

**Faculty After**
<img width="738" alt="Screenshot 2021-09-17 at 1 38 07 PM" src="https://user-images.githubusercontent.com/34372316/133752416-7bfabe00-88da-4abc-860e-0e417018746a.png">

