### PR TITLE
Fixed user menu visibility regression

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -42,7 +42,7 @@ body {
     }
 
     .mobile-menu {
-      @include media-breakpoint-down(xs) {
+      @include media-breakpoint-down(sm) {
         display: block;
       }
 

--- a/static/scss/user-menu.scss
+++ b/static/scss/user-menu.scss
@@ -27,8 +27,7 @@
   .dropdown-item {
     display: flex;
     align-items: center;
-    font-family: Roboto;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 500;
     color: $black;
     line-height: 14px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #174 

#### What's this PR do?
- Fixes user menu regression where overlay menu options were not visible in tablet widths
- Fixes faulty font definition for user menu in desktop width. The designs specify the same font family as all the other text on the site at slightly larger size

#### How should this be manually tested?
Set your browser window to "sm" width (≥ 576px, < 768px) and open the user menu (hamburger at the top right). Options should be visible.

#### Screenshots (if appropriate)
![ss 2021-09-10 at 11 03 03 ](https://user-images.githubusercontent.com/14932219/132883426-2388a443-5d67-4cd6-bc21-e1fc62308558.png)
![ss 2021-09-10 at 11 03 16 ](https://user-images.githubusercontent.com/14932219/132883432-ca9b99e8-e977-47eb-8145-0788ff993eb6.png)

