### PR TITLE
Fixed 'enrolled' UI on product detail page

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -23,7 +23,7 @@
                 {% if run %}
                   {% if is_enrolled %}
                     {% if run.courseware_url_path and can_access_edx_course %}
-                      <a href="{{ run.courseware_url }}" class="btn btn-primary btn-gradient-red highlight" target="_blank" rel="noopener noreferrer">
+                      <a href="{{ run.courseware_url }}" class="btn btn-primary btn-gradient-red highlight outline" target="_blank" rel="noopener noreferrer">
                         Enrolled &#10003;
                       </a>
                     {% else %}

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -245,7 +245,7 @@ def test_course_run_not_beyond_enrollment(
 
 
 @pytest.mark.parametrize(
-    "start_delta, end_delta, exp_result",
+    "start_delta, end_delta, expected_result",
     [
         [-1, 2, True],
         [-1, None, True],
@@ -253,7 +253,7 @@ def test_course_run_not_beyond_enrollment(
         [-2, -1, False],
     ],
 )
-def test_course_run_in_progress(start_delta, end_delta, exp_result):
+def test_course_run_in_progress(start_delta, end_delta, expected_result):
     """
     Test that CourseRun.is_in_progress returns the correct value based on the start and end dates
     """
@@ -266,7 +266,7 @@ def test_course_run_in_progress(start_delta, end_delta, exp_result):
             end_date=end_date,
             expiration_date=now + timedelta(days=10),
         ).is_in_progress
-        is exp_result
+        is expected_result
     )
 
 

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -103,6 +103,17 @@ a.link-button {
       opacity: 0.8;
     }
   }
+
+  &.outline {
+    background-image: none;
+    background-color: #ffffff;
+    color: $brand-lighter-bg;
+    border: 2px solid $brand-lighter-bg;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
 }
 
 .btn-gradient-red {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #184 

#### What's this PR do?
- Changes the styling of the enroll button in the product detail page if you are already enrolled. The new styling more clearly indicates that it isn't an action button, and it follows the same sort of approach that xpro uses
- Updates the logic of the button so that it only links to the edX course if you are enrolled _and_ the course is active (start date in the past, end date in the future). 

#### How should this be manually tested?
Test the page with a course run with start/end dates in the states described above

#### Screenshots (if appropriate)
![ss 2021-09-13 at 20 26 46 ](https://user-images.githubusercontent.com/14932219/133180084-7dca504c-14f2-46b4-a7a2-31fc2468424d.png)
