### PR TITLE
Add privacy policy and terms of service links to register page

### DIFF
--- a/static/js/components/forms/RegisterEmailForm.js
+++ b/static/js/components/forms/RegisterEmailForm.js
@@ -9,6 +9,7 @@ import ScaledRecaptcha from "../ScaledRecaptcha"
 import { EmailInput } from "./elements/inputs"
 import FormError from "./elements/FormError"
 import { emailFieldValidation } from "../../lib/validation"
+import { routes } from "../../lib/urls"
 
 const emailValidation = yup.object().shape({
   email:     emailFieldValidation,
@@ -45,6 +46,15 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
             component={EmailInput}
           />
           <ErrorMessage name="email" component={FormError} />
+          <p className="policy-consent">
+            By creating an account I agree to the{" "}
+            <a href={routes.informationLinks.termsOfService}>
+              Terms of Service
+            </a>
+            {" and "}
+            <a href={routes.informationLinks.privacyPolicy}>Privacy Policy</a>
+            {"."}
+          </p>
         </div>
         {SETTINGS.recaptchaKey ? (
           <div className="form-group">

--- a/static/js/components/forms/RegisterEmailForm.js
+++ b/static/js/components/forms/RegisterEmailForm.js
@@ -48,11 +48,21 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
           <ErrorMessage name="email" component={FormError} />
           <p className="py-2">
             By creating an account I agree to the{" "}
-            <a href={routes.informationLinks.termsOfService}>
+            <a
+              href={routes.informationLinks.termsOfService}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Terms of Service
             </a>
             {" and "}
-            <a href={routes.informationLinks.privacyPolicy}>Privacy Policy</a>
+            <a
+              href={routes.informationLinks.privacyPolicy}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Privacy Policy
+            </a>
             {"."}
           </p>
         </div>

--- a/static/js/components/forms/RegisterEmailForm.js
+++ b/static/js/components/forms/RegisterEmailForm.js
@@ -46,7 +46,7 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
             component={EmailInput}
           />
           <ErrorMessage name="email" component={FormError} />
-          <p className="policy-consent">
+          <p className="py-2">
             By creating an account I agree to the{" "}
             <a href={routes.informationLinks.termsOfService}>
               Terms of Service

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -36,5 +36,10 @@ export const routes = {
 
   account: include("/account/", {
     confirmEmail: "confirm-email"
+  }),
+
+  informationLinks: include("", {
+    termsOfService: "terms-of-service",
+    privacyPolicy:  "privacy-policy"
   })
 }

--- a/static/scss/auth.scss
+++ b/static/scss/auth.scss
@@ -242,8 +242,3 @@
   width: 50px;
   height: 50px;
 }
-
-.policy-consent {
-  font-size: 14px;
-  padding: 8px 0;
-}

--- a/static/scss/auth.scss
+++ b/static/scss/auth.scss
@@ -242,3 +242,8 @@
   width: 50px;
   height: 50px;
 }
+
+.policy-consent {
+  font-size: 14px;
+  padding: 8px 0;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes #197 

#### What's this PR do?
- Adds a privacy policy and terms of service links on the `Create Account` page

#### How should this be manually tested?
- Visit `/create-account/` and verify that you can see the privacy policy and terms of service links there.

#### Screenshots (if appropriate)

**Desktop Normal Mode**
<img width="696" alt="Screenshot 2021-09-16 at 7 13 20 PM" src="https://user-images.githubusercontent.com/34372316/133628409-62dae17c-2d1b-4a37-9e94-0c1663112f92.png">

**Mobile Normal Mode**
<img width="311" alt="Screenshot 2021-09-16 at 7 14 10 PM" src="https://user-images.githubusercontent.com/34372316/133628478-c8d25743-8990-4679-a8c4-e2a7fb62822b.png">

**Desktop Error Mode**
<img width="698" alt="Screenshot 2021-09-16 at 7 13 35 PM" src="https://user-images.githubusercontent.com/34372316/133628601-af832b9b-7704-4001-928c-992e6c86229a.png">

**Mobile Error Mode**
<img width="314" alt="Screenshot 2021-09-16 at 7 13 51 PM" src="https://user-images.githubusercontent.com/34372316/133628684-4dbf46a7-5742-4f6e-9086-40f7bdbaea01.png">

