### PR TITLE
Allowed admins/editors to access closed edX courses

### DIFF
--- a/cms/constants.py
+++ b/cms/constants.py
@@ -1,3 +1,4 @@
 """CMS app constants"""
 
 COURSE_INDEX_SLUG = "courses"
+CMS_EDITORS_GROUP_NAME = "Editors"

--- a/cms/models.py
+++ b/cms/models.py
@@ -28,7 +28,7 @@ from cms.blocks import ResourceBlock, PriceBlock, FacultyBlock
 
 from modelcluster.fields import ParentalKey
 
-from cms.constants import COURSE_INDEX_SLUG
+from cms.constants import COURSE_INDEX_SLUG, CMS_EDITORS_GROUP_NAME
 
 log = logging.getLogger()
 
@@ -372,14 +372,17 @@ class CoursePage(ProductPage):
             if request.user.is_authenticated
             else f'{reverse("login")}?next={quote_plus(self.get_url())}'
         )
+        start_date = first_unexpired_run.start_date if first_unexpired_run else None
+        can_access_edx_course = first_unexpired_run is not None and (
+            first_unexpired_run.is_in_progress or request.user.is_editor
+        )
         return {
             **super().get_context(request, *args, **kwargs),
             "run": first_unexpired_run,
             "is_enrolled": is_enrolled,
             "sign_in_url": sign_in_url,
-            "start_date": first_unexpired_run.start_date
-            if first_unexpired_run
-            else None,
+            "start_date": start_date,
+            "can_access_edx_course": can_access_edx_course,
         }
 
     content_panels = [

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -22,7 +22,7 @@
                 {{ page.description | richtext }}
                 {% if run %}
                   {% if is_enrolled %}
-                    {% if run.courseware_url_path %}
+                    {% if run.courseware_url_path and can_access_edx_course %}
                       <a href="{{ run.courseware_url }}" class="btn btn-primary btn-gradient-red highlight" target="_blank" rel="noopener noreferrer">
                         Enrolled &#10003;
                       </a>

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -97,6 +97,13 @@ class CourseRunFactory(DjangoModelFactory):
         past_enrollment_end = factory.Trait(
             enrollment_end=factory.Faker("past_datetime", tzinfo=pytz.utc)
         )
+        in_progress = factory.Trait(
+            start_date=factory.Faker("past_datetime", tzinfo=pytz.utc),
+            end_date=factory.Faker("future_datetime", tzinfo=pytz.utc),
+        )
+        in_future = factory.Trait(
+            start_date=factory.Faker("future_datetime", tzinfo=pytz.utc), end_date=None
+        )
 
 
 class BlockedCountryFactory(DjangoModelFactory):

--- a/courses/models.py
+++ b/courses/models.py
@@ -397,6 +397,18 @@ class CourseRun(TimestampedModel):
         return not self.is_past and self.is_not_beyond_enrollment
 
     @property
+    def is_in_progress(self) -> bool:
+        """
+        Returns True if the course run has started and has not yet ended
+        """
+        now = now_in_utc()
+        return (
+            self.start_date is not None
+            and self.start_date <= now
+            and (self.end_date is None or self.end_date > now)
+        )
+
+    @property
     def courseware_url(self):
         """
         Full URL for this CourseRun as it exists in the courseware

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -245,6 +245,32 @@ def test_course_run_not_beyond_enrollment(
 
 
 @pytest.mark.parametrize(
+    "start_delta, end_delta, exp_result",
+    [
+        [-1, 2, True],
+        [-1, None, True],
+        [None, 2, False],
+        [-2, -1, False],
+    ],
+)
+def test_course_run_in_progress(start_delta, end_delta, exp_result):
+    """
+    Test that CourseRun.is_in_progress returns the correct value based on the start and end dates
+    """
+    now = now_in_utc()
+    start_date = None if start_delta is None else now + timedelta(days=start_delta)
+    end_date = None if end_delta is None else now + timedelta(days=end_delta)
+    assert (
+        CourseRunFactory.create(
+            start_date=start_date,
+            end_date=end_date,
+            expiration_date=now + timedelta(days=10),
+        ).is_in_progress
+        is exp_result
+    )
+
+
+@pytest.mark.parametrize(
     "end_days,enroll_days,expected", [[-1, 1, False], [1, -1, False], [1, 1, True]]
 )
 def test_course_run_unexpired(end_days, enroll_days, expected):

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -16,21 +16,26 @@ import {
   enrollmentsQuery,
   enrollmentsQueryKey
 } from "../../lib/queries/enrollment"
+import { currentUserSelector } from "../../lib/queries/users"
 import { isLinkableCourseRun } from "../../lib/courseApi"
 import { formatPrettyDate, parseDateString } from "../../lib/util"
 import { routes } from "../../lib/urls"
 
 import type { RunEnrollment } from "../../flow/courseTypes"
+import type { CurrentUser } from "../../flow/authTypes"
 
 type DashboardPageProps = {
   enrollments: RunEnrollment[],
+  currentUser: CurrentUser,
   isLoading: boolean
 }
 
 export class DashboardPage extends React.Component<DashboardPageProps, void> {
   renderEnrolledItemCard(enrollment: RunEnrollment) {
+    const { currentUser } = this.props
+
     let startDate, startDateDescription
-    const title = isLinkableCourseRun(enrollment.run) ? (
+    const title = isLinkableCourseRun(enrollment.run, currentUser) ? (
       <a
         href={enrollment.run.courseware_url}
         target="_blank"
@@ -85,7 +90,7 @@ export class DashboardPage extends React.Component<DashboardPageProps, void> {
             <h1>My Courses</h1>
             <div className="enrolled-items">
               {enrollments && enrollments.length > 0 ? (
-                enrollments.map(this.renderEnrolledItemCard)
+                enrollments.map(this.renderEnrolledItemCard.bind(this))
               ) : (
                 <div className="card no-enrollments p-3 p-sm-5 rounded-0">
                   <h2>Enroll Now</h2>
@@ -105,6 +110,7 @@ export class DashboardPage extends React.Component<DashboardPageProps, void> {
 
 const mapStateToProps = createStructuredSelector({
   enrollments: enrollmentsSelector,
+  currentUser: currentUserSelector,
   isLoading:   pathOr(true, ["queries", enrollmentsQueryKey, "isPending"])
 })
 

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -27,7 +27,8 @@ describe("DashboardPage", () => {
       InnerDashboardPage,
       {
         entities: {
-          enrollments: userEnrollments
+          enrollments: userEnrollments,
+          currentUser: currentUser
         }
       },
       {}

--- a/static/js/factories/user.js
+++ b/static/js/factories/user.js
@@ -32,6 +32,7 @@ export const makeUser = (username: ?string): LoggedInUser => ({
   name:             casual.full_name,
   is_anonymous:     false,
   is_authenticated: true,
+  is_editor:        false,
   created_on:       casual.moment.format(),
   updated_on:       casual.moment.format(),
   profile:          {

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -90,7 +90,8 @@ export type AnonymousUser = {
 
 export type LoggedInUser = {
   is_anonymous: false,
-  is_authenticated: true
+  is_authenticated: true,
+  is_editor: boolean
 } & User
 
 export type CurrentUser = AnonymousUser | LoggedInUser

--- a/static/js/lib/courseApi.js
+++ b/static/js/lib/courseApi.js
@@ -2,18 +2,26 @@
 /* global SETTINGS:false */
 import moment from "moment"
 import { isNil } from "ramda"
+
 import { notNil } from "./util"
 
 import type Moment from "moment"
-import type { RunEnrollment } from "../flow/courseTypes"
+import type { CourseRunDetail } from "../flow/courseTypes"
+import type { CurrentUser } from "../flow/authTypes"
 
 export const isLinkableCourseRun = (
-  run: RunEnrollment,
+  run: CourseRunDetail,
+  currentUser: CurrentUser,
   dtNow?: Moment
 ): boolean => {
+  if (isNil(run.courseware_url)) {
+    return false
+  }
+  if (!currentUser.is_anonymous && currentUser.is_editor) {
+    return true
+  }
   const now = dtNow || moment()
   return (
-    notNil(run.courseware_url) &&
     notNil(run.start_date) &&
     moment(run.start_date).isBefore(now) &&
     (isNil(run.end_date) || moment(run.end_date).isAfter(now))

--- a/users/factories.py
+++ b/users/factories.py
@@ -20,6 +20,8 @@ class UserFactory(DjangoModelFactory):
     email = FuzzyText(suffix="@example.com")
     name = Faker("name")
     password = FuzzyText(length=8)
+    is_superuser = False
+    is_staff = False
 
     is_active = True
 

--- a/users/models.py
+++ b/users/models.py
@@ -15,6 +15,7 @@ from mitol.common.utils import now_in_utc
 
 # Defined in edX Profile model
 from users.constants import USERNAME_MAX_LEN
+from cms.constants import CMS_EDITORS_GROUP_NAME
 
 MALE = "m"
 FEMALE = "f"
@@ -158,6 +159,15 @@ class User(AbstractBaseUser, TimestampedModel, PermissionsMixin):
     def get_full_name(self):
         """Returns the user's fullname"""
         return self.name
+
+    @property
+    def is_editor(self) -> bool:
+        """Returns True if the user has editor permissions for the CMS"""
+        return (
+            self.is_superuser
+            or self.is_staff
+            or self.groups.filter(name=CMS_EDITORS_GROUP_NAME).exists()
+        )
 
     def __str__(self):
         """Str representation for the user"""

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -157,6 +157,7 @@ class UserSerializer(serializers.ModelSerializer):
             "legal_address",
             "is_anonymous",
             "is_authenticated",
+            "is_editor",
             "created_on",
             "updated_on",
         )
@@ -164,6 +165,7 @@ class UserSerializer(serializers.ModelSerializer):
             "username",
             "is_anonymous",
             "is_authenticated",
+            "is_editor",
             "created_on",
             "updated_on",
         )

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -83,6 +83,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, show_enrollment_code
             },
             "is_anonymous": False,
             "is_authenticated": True,
+            "is_editor": False,
             "created_on": drf_datetime(user.created_on),
             "updated_on": drf_datetime(user.updated_on),
         }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #190 

#### What's this PR do?
Allows admins and editors access edX courses from mitxonline even if the course run is not in progress

#### How should this be manually tested?
These scenarios all require you to be enrolled in the course run you're testing. You'll be checking all of these scenarios in (1) the dashboard, and (2) the product detail page "Enrolled" text.

An "editor" in this case is someone who is not a superuser/staff, but has access to Wagtail, which is granted by adding the "Editors" group to the user, which can be done in the user record in Django admin ("Permissions" section)

- Set the course run to have a future start date, and set your user to be non-superuser/staff, and non-editor. The dashboard and product detail pages should _not_ link you to the course in edX
- Set the course run to have a current start date and future end date. The dashboard and product detail pages _should_  link you to the course in edX
- Set the course run to have a future start date again, then configure your user to be any one of the following: (1) a superuser, (2) staff, and (3) an editor. The dashboard and product detail pages _should_  link you to the course in edX
