### PR TITLE
Fixed logout link

### DIFF
--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -83,9 +83,9 @@ const UserMenu = ({ currentUser, useScreenOverlay }: Props) => {
           </MixedLink>
         </li>
         <li {...menuChildProps.li || {}}>
-          <MixedLink dest={routes.logout} aria-label="Sign Out">
+          <a href={routes.logout} aria-label="Sign Out">
             Sign Out
-          </MixedLink>
+          </a>
         </li>
       </ul>
     </div>

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -10,18 +10,18 @@ import { makeUser } from "../factories/user"
 describe("UserMenu component", () => {
   const user = makeUser()
   it("has the correct number of menu links", () => {
-    assert.isOk(
-      shallow(<UserMenu currentUser={user} useScreenOverlay={false} />)
-        .find("MixedLink")
-        .exists()
+    const userMenu = shallow(
+      <UserMenu currentUser={user} useScreenOverlay={false} />
     )
+    assert.lengthOf(userMenu.find("MixedLink"), 3)
+    assert.lengthOf(userMenu.find("a"), 1)
   })
 
-  it("has the correct number of menu links in the mobile view", () => {
-    assert.equal(
+  it("has the correct class applied to menu items in the mobile view", () => {
+    assert.lengthOf(
       shallow(<UserMenu currentUser={user} useScreenOverlay={true} />).find(
         ".authenticated-menu"
-      ).length,
+      ),
       4
     )
   })
@@ -29,9 +29,9 @@ describe("UserMenu component", () => {
   it("has a link to logout", () => {
     assert.equal(
       shallow(<UserMenu currentUser={user} useScreenOverlay={false} />)
-        .find("MixedLink")
-        .at(3)
-        .prop("dest"),
+        .find("a")
+        .at(0)
+        .prop("href"),
       routes.logout
     )
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A - Fixes bug introduced by #135 

#### What's this PR do?
Fixes logout link in pages that are fully rendered by React (as opposed to Wagtail pages that only have a React header)

#### How should this be manually tested?
- Log in
- Visit `/dashboard/`, `/profile/`, or any other non-CMS page and click the logout link in the user menu. It should work.
- Visit any CMS page (home, product detail). The logout link should work on those too
