### PR TITLE
fix retry_edx_enrollment management command

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -33,7 +33,6 @@ from openedx.constants import (
     PRO_ENROLL_MODE_ERROR_TEXTS,
 )
 
-# from courses.models import CourseRunEnrollment
 from openedx.exceptions import (
     EdxApiEnrollErrorException,
     NoEdxApiAuthError,
@@ -526,10 +525,8 @@ def retry_failed_edx_enrollments():
     Returns:
         list of CourseRunEnrollment: All CourseRunEnrollments that were successfully retried
     """
-    log.error("retry_failed_edx_enrollments() requires the courses app")
-    return []
     now = now_in_utc()
-    failed_run_enrollments = CourseRunEnrollment.objects.select_related(
+    failed_run_enrollments = courses.models.CourseRunEnrollment.objects.select_related(
         "user", "run"
     ).filter(
         user__is_active=True,

--- a/openedx/management/commands/retry_edx_enrollment.py
+++ b/openedx/management/commands/retry_edx_enrollment.py
@@ -7,7 +7,7 @@ from django.core.management import BaseCommand
 from openedx.api import enroll_in_edx_course_runs
 from users.api import fetch_users
 
-# from courses.models import CourseRunEnrollment
+from courses.models import CourseRunEnrollment
 
 User = get_user_model()
 
@@ -44,7 +44,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Run the command"""
-        raise NotImplemented("This command requires the course application")
         enrollment_filter = {}
         if not options["force"]:
             enrollment_filter["edx_enrolled"] = False


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes #204 

#### What's this PR do?
fix retry_edx_enrollment management command

#### How should this be manually tested?
Just run the command command
`docker-compose exec web python manage.py retry_edx_enrollment --run=course-v1:edX+DemoX+Demo_Course <user_email>`

#### Any background context you want to provide?
It seems like everything already in place but commented out that I have addressed in my PR. I don't have configured edx-platform so I could not test it.