### PR TITLE
Fixed 'enrolled' UI regression

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -27,7 +27,7 @@
                         Enrolled &#10003;
                       </a>
                     {% else %}
-                      <div class="btn btn-primary btn-gradient-red highlight">
+                      <div class="btn btn-primary btn-gradient-red highlight outline">
                         Enrolled &#10003;
                       </div>
                     {% endif %}


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A - fixes issue with #187 

#### What's this PR do?
Fixes the 'enrolled' UI on the product detail page for non-admin users that are enrolled in a future course run

#### How should this be manually tested?
- Log in with a non-admin, non-editor user
- Enroll in a course run that has a future start date
- Visit the dashboard page

The "enrolled" UI should look like the screenshot in PR #187

#### Any background context you want to provide?
#187 was rebased several times and it looks like that css class was removed by accident

#### Screenshots (if appropriate)
![ss 2021-09-13 at 20 26 46 ](https://user-images.githubusercontent.com/14932219/133180084-7dca504c-14f2-46b4-a7a2-31fc2468424d.png)
