### PR TITLE
Removed username from profile edit form

### DIFF
--- a/static/js/components/forms/EditProfileForm.js
+++ b/static/js/components/forms/EditProfileForm.js
@@ -30,7 +30,7 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => (
           setFieldValue={setFieldValue}
           setFieldTouched={setFieldTouched}
           values={values}
-          includePassword={false}
+          isNewAccount={false}
         />
         <div className="row submit-row no-gutters justify-content-end">
           <button

--- a/static/js/components/forms/ProfileFormFields.js
+++ b/static/js/components/forms/ProfileFormFields.js
@@ -10,11 +10,13 @@ import {
   EMPLOYMENT_INDUSTRY,
   EMPLOYMENT_LEVEL,
   EMPLOYMENT_SIZE,
-  HIGHEST_EDUCATION_CHOICES,
-  USERNAME_LENGTH
+  HIGHEST_EDUCATION_CHOICES
 } from "../../constants"
 import FormError from "./elements/FormError"
-import { newPasswordFieldValidation } from "../../lib/validation"
+import {
+  newPasswordFieldValidation,
+  usernameFieldValidation
+} from "../../lib/validation"
 
 const US_ALPHA_2 = "US"
 const CA_ALPHA_2 = "CA"
@@ -38,13 +40,6 @@ export const legalAddressValidation = yup.object().shape({
     .trim()
     .required()
     .min(2),
-  username: yup
-    .string()
-    .label("Username")
-    .trim()
-    .required()
-    .min(3)
-    .max(USERNAME_LENGTH),
   legal_address: yup.object().shape({
     first_name: yup
       .string()
@@ -66,8 +61,9 @@ export const legalAddressValidation = yup.object().shape({
   })
 })
 
-export const passwordValidation = yup.object().shape({
-  password: newPasswordFieldValidation
+export const newAccountValidation = yup.object().shape({
+  password: newPasswordFieldValidation,
+  username: usernameFieldValidation
 })
 
 export const profileValidation = yup.object().shape({
@@ -98,12 +94,12 @@ type LegalAddressProps = {
   setFieldValue: Function,
   setFieldTouched: Function,
   values: Object,
-  includePassword: boolean
+  isNewAccount: boolean
 }
 
 export const LegalAddressFields = ({
   countries,
-  includePassword
+  isNewAccount
 }: LegalAddressProps) => (
   <React.Fragment>
     <div className="form-group">
@@ -164,49 +160,54 @@ export const LegalAddressFields = ({
       />
       <ErrorMessage name="name" id="nameError" component={FormError} />
     </div>
-    <div className="form-group">
-      <label htmlFor="username" className="row">
-        <div className="col-auto font-weight-bold">
-          Public Username<span className="required">*</span>
+    {isNewAccount ? (
+      <React.Fragment>
+        <div className="form-group">
+          <label htmlFor="username" className="row">
+            <div className="col-auto font-weight-bold">
+              Public Username<span className="required">*</span>
+            </div>
+            <div className="col-auto subtitle">
+              Name that will identify you in courses
+            </div>
+          </label>
+          <Field
+            type="text"
+            name="username"
+            className="form-control"
+            autoComplete="username"
+            id="username"
+            aria-describedby="usernameError"
+          />
+          <ErrorMessage
+            name="username"
+            id="usernameError"
+            component={FormError}
+          />
         </div>
-        <div className="col-auto subtitle">
-          Name that will identify you in courses
+        <div className="form-group">
+          <label htmlFor="password" className="font-weight-bold">
+            Password<span className="required">*</span>
+          </label>
+          <Field
+            type="password"
+            name="password"
+            id="password"
+            aria-describedby="passwordError"
+            className="form-control"
+          />
+          <ErrorMessage
+            name="password"
+            id="passwordError"
+            component={FormError}
+          />
+          <div className="label-secondary">
+            Passwords must contain at least 8 characters and at least 1 number
+            and 1 letter.
+          </div>
         </div>
-      </label>
-      <Field
-        type="text"
-        name="username"
-        className="form-control"
-        autoComplete="username"
-        id="username"
-        aria-describedby="usernameError"
-      />
-      <ErrorMessage name="username" id="usernameError" component={FormError} />
-    </div>
-    {includePassword ? (
-      <div className="form-group">
-        <label htmlFor="password" className="font-weight-bold">
-          Password<span className="required">*</span>
-        </label>
-        <Field
-          type="password"
-          name="password"
-          id="password"
-          aria-describedby="passwordError"
-          className="form-control"
-        />
-        <ErrorMessage
-          name="password"
-          id="passwordError"
-          component={FormError}
-        />
-        <div className="label-secondary">
-          Passwords must contain at least 8 characters and at least 1 number and
-          1 letter.
-        </div>
-      </div>
+      </React.Fragment>
     ) : null}
-
     <div className="form-group">
       <label htmlFor="legal_address.country" className="font-weight-bold">
         Country<span className="required">*</span>

--- a/static/js/components/forms/RegisterDetailsForm.js
+++ b/static/js/components/forms/RegisterDetailsForm.js
@@ -3,7 +3,7 @@ import React from "react"
 import { Formik, Form } from "formik"
 
 import {
-  passwordValidation,
+  newAccountValidation,
   legalAddressValidation,
   LegalAddressFields
 } from "./ProfileFormFields"
@@ -29,7 +29,7 @@ const INITIAL_VALUES = {
 const RegisterDetailsForm = ({ onSubmit, countries }: Props) => (
   <Formik
     onSubmit={onSubmit}
-    validationSchema={legalAddressValidation.concat(passwordValidation)}
+    validationSchema={legalAddressValidation.concat(newAccountValidation)}
     initialValues={INITIAL_VALUES}
     render={({ isSubmitting, setFieldValue, setFieldTouched, values }) => (
       <Form>
@@ -38,7 +38,7 @@ const RegisterDetailsForm = ({ onSubmit, countries }: Props) => (
           setFieldValue={setFieldValue}
           setFieldTouched={setFieldTouched}
           values={values}
-          includePassword={true}
+          isNewAccount={true}
         />
         <div className="row submit-row no-gutters justify-content-end">
           <button

--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -58,6 +58,11 @@ describe("RegisterDetailsForm", () => {
     ["username", "", "Username is a required field"],
     ["username", "  ", "Username is a required field"],
     ["username", "ab", "Username must be at least 3 characters"],
+    [
+      "username",
+      "0123456789012345678901234567890",
+      "Username must be at most 30 characters"
+    ],
     ["username", "ábc-dèf-123", null],
     ["legal_address.first_name", "", "First Name is a required field"],
     ["legal_address.last_name", "", "Last Name is a required field"]

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -1,6 +1,8 @@
 // @flow
 import * as yup from "yup"
 
+import { USERNAME_LENGTH } from "../constants"
+
 // Field validations
 
 export const emailFieldValidation = yup
@@ -14,6 +16,14 @@ export const passwordFieldValidation = yup
   .label("Password")
   .required()
   .min(8)
+
+export const usernameFieldValidation = yup
+  .string()
+  .label("Username")
+  .trim()
+  .required()
+  .min(3)
+  .max(USERNAME_LENGTH)
 
 export const newPasswordFieldValidation = passwordFieldValidation.matches(
   /^(?=.*[0-9])(?=.*[a-zA-Z]).*$/,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A - Fixes an oversight from #202 

#### What's this PR do?
Removes the username field from the edit profile form. The username should only be in the form if a new account is being created (just like the password field)

#### How should this be manually tested?
- Create a new account. The register details page should have username and password, and submitting the form should successfully create the user
- Edit a user profile. The username and password fields should be omitted, and saving the form should successfully apply changes to the relevant user fields

#### Screenshots (if appropriate)
![ss 2021-09-22 at 11 38 48 ](https://user-images.githubusercontent.com/14932219/134385717-33eb150d-7502-4ee6-abad-1d7ef6cbf916.png)

