### PR TITLE
Fixed logged-out bug on product detail page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -373,8 +373,10 @@ class CoursePage(ProductPage):
             else f'{reverse("login")}?next={quote_plus(self.get_url())}'
         )
         start_date = first_unexpired_run.start_date if first_unexpired_run else None
-        can_access_edx_course = first_unexpired_run is not None and (
-            first_unexpired_run.is_in_progress or request.user.is_editor
+        can_access_edx_course = (
+            request.user.is_authenticated
+            and first_unexpired_run is not None
+            and (first_unexpired_run.is_in_progress or request.user.is_editor)
         )
         return {
             **super().get_context(request, *args, **kwargs),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A - fixes bug related to #207 

#### What's this PR do?
Fixes an bug where a user visiting the product detail page without logging in could cause a server error

#### How should this be manually tested?
In a logged-out session, visit the product detail page for a course. Test with a course that has an in-progress course run, and one with its next course run starting in the future. In both cases you should see the normal product detail page with no errors.
