### PR TITLE
Added username whitespace trimming and case-insensitive unique validation

### DIFF
--- a/authentication/api_test.py
+++ b/authentication/api_test.py
@@ -16,33 +16,6 @@ def test_create_user_session(user):
     assert session.session_key is not None
 
 
-def test_create_user_with_generated_username(mocker, valid_address_dict):
-    """
-    Integration test to assert that create_user_with_generated_username tries to find an available
-    username and try again to save a User if there was a username collision
-    """
-    username = "testuser"
-    # Create a user with the desired username before calling the function so we get a collision
-    UserFactory.create(username=username)
-    data = {
-        "username": username,
-        "email": "test@example.com",
-        "name": "Test User",
-        "legal_address": valid_address_dict,
-        "password": "fakepassword",
-    }
-    serializer = UserSerializer(data=data)
-    serializer.is_valid()
-    patched_find_username = mocker.patch(
-        "authentication.api.find_available_username", return_value="testuser1"
-    )
-
-    created_user = api.create_user_with_generated_username(serializer, username)
-    patched_find_username.assert_called_once_with(username)
-    assert created_user is not None
-    assert created_user.username == patched_find_username.return_value
-
-
 def test_create_user_reattempt(mocker):
     """
     Test that create_user_with_generated_username reattempts User creation multiple times when

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -107,7 +107,6 @@ def create_user_via_email(
 
     data["email"] = kwargs.get("email", kwargs.get("details", {}).get("email"))
     serializer = UserSerializer(data=data, context=context)
-    username = data["username"]
 
     if not serializer.is_valid():
         raise RequirePasswordAndPersonalInfoException(
@@ -118,11 +117,12 @@ def create_user_via_email(
         )
 
     try:
-        created_user = serializer.save(username=username)
+        created_user = serializer.save()
     except IntegrityError:
         # 'email' and 'username' are the only unique fields that can be supplied by the user at this point, and a user
         # cannot reach this point of the auth flow without a unique email, so we know that the IntegrityError is caused
         # by the username not being unique.
+        username = data["username"]
         raise RequirePasswordAndPersonalInfoException(
             backend,
             current_partial,

--- a/cms/migrations/0013_feature_img_aspect_ratio.py
+++ b/cms/migrations/0013_feature_img_aspect_ratio.py
@@ -7,14 +7,21 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailimages', '0023_add_choose_permissions'),
-        ('cms', '0012_product_description_help_text'),
+        ("wagtailimages", "0023_add_choose_permissions"),
+        ("cms", "0012_product_description_help_text"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='coursepage',
-            name='feature_image',
-            field=models.ForeignKey(blank=True, help_text='Image that will be used where the course is featured or linked. (The recommended dimensions for the image are 375x244)', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.image'),
+            model_name="coursepage",
+            name="feature_image",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Image that will be used where the course is featured or linked. (The recommended dimensions for the image are 375x244)",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailimages.image",
+            ),
         ),
     ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #242 

#### What's this PR do?
Trims whitespace around usernames during account creation, and performs a case-insensitive match for existing usernames

#### How should this be manually tested?
- Create an account, and input a unique username with spaces around it. The saved User should have a username with whitespace trimmed
- Create an account, and input a username that matches an existing user, but change the case of some/all of the letters. You should see an error message indicating that the username already exists
