### PR TITLE
Load enrollment status dynamically in product detail page

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -20,33 +20,8 @@
                 <h1>{{ page.title }}</h1>
                 {# Description field contents are already rendered wrapped in a <p> tag #}
                 {{ page.description | richtext }}
-                {% if run %}
-                  {% if is_enrolled %}
-                    {% if run.courseware_url_path and can_access_edx_course %}
-                      <a href="{{ run.courseware_url }}" class="btn btn-primary btn-gradient-red highlight outline" target="_blank" rel="noopener noreferrer">
-                        Enrolled &#10003;
-                      </a>
-                    {% else %}
-                      <div class="btn btn-primary btn-gradient-red highlight outline">
-                        Enrolled &#10003;
-                      </div>
-                    {% endif %}
-                  {% else %}
-                    {% if sign_in_url %}
-                      <a href="{{ sign_in_url }}" class="btn btn-primary btn-gradient-red highlight">
-                        Enroll now
-                      </a>
-                    {% else %}
-                      <form action="/enrollments/" method="post">
-                        {% csrf_token %}
-                        <input type="hidden" name="run" value="{{ run.id }}" />
-                        <button type="submit" class="btn btn-primary btn-gradient-red highlight">
-                          Enroll now
-                        </button>
-                      </form>
-                    {% endif %}
-                  {% endif %}
-                {% endif %}
+                <input id="courseId" type="hidden" value="{{page.course.readable_id}}" />
+                <div id="productDetailEnrollment"></div>
               </div>
             </div>
             {% if page.video_url %}

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -76,6 +76,15 @@ class CourseRunSerializer(BaseCourseRunSerializer):
         model = models.CourseRun
         fields = BaseCourseRunSerializer.Meta.fields
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if self.context and self.context.get("include_enrolled_flag"):
+            return {
+                **data,
+                **{"is_enrolled": getattr(instance, "user_enrollments", 0) > 0},
+            }
+        return data
+
 
 class CourseSerializer(serializers.ModelSerializer):
     """Course model serializer - also serializes child course runs"""

--- a/static/js/containers/ProductDetailEnrollApp.js
+++ b/static/js/containers/ProductDetailEnrollApp.js
@@ -1,0 +1,97 @@
+// @flow
+import React, { Fragment } from "react"
+import { createStructuredSelector } from "reselect"
+import { pathOr } from "ramda"
+import { compose } from "redux"
+import { connect } from "react-redux"
+import { connectRequest } from "redux-query"
+
+import Loader from "../components/Loader"
+import { routes } from "../lib/urls"
+import { EnrollmentFlaggedCourseRun } from "../flow/courseTypes"
+import {
+  courseRunsSelector,
+  courseRunsQuery,
+  courseRunsQueryKey
+} from "../lib/queries/courseRuns"
+
+import { getCookie } from "../lib/api"
+
+type Props = {
+  courseId: string,
+  isLoading: ?boolean,
+  courseRuns: ?Array<EnrollmentFlaggedCourseRun>,
+  status: ?number
+}
+export class ProductDetailEnrollApp extends React.Component<Props> {
+  render() {
+    const { courseRuns, isLoading, status } = this.props
+    const csrfToken = getCookie("csrftoken")
+    const run = courseRuns ? courseRuns[0] : null
+
+    return (
+      // $FlowFixMe: isLoading null or undefined
+      <Loader isLoading={isLoading}>
+        {run && run.is_enrolled ? (
+          <Fragment>
+            {run.courseware_url ? (
+              <a
+                href={run.courseware_url}
+                className="btn btn-primary btn-gradient-red highlight outline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Enrolled &#10003;
+              </a>
+            ) : (
+              <div className="btn btn-primary btn-gradient-red highlight outline">
+                Enrolled &#10003;
+              </div>
+            )}
+          </Fragment>
+        ) : (
+          <Fragment>
+            {status === 403 ? (
+              <a
+                href={routes.login}
+                className="btn btn-primary btn-gradient-red highlight"
+              >
+                Enroll now
+              </a>
+            ) : (
+              <Fragment>
+                <form action="/enrollments/" method="post">
+                  <input
+                    type="hidden"
+                    name="csrfmiddlewaretoken"
+                    value={csrfToken}
+                  />
+                  <input type="hidden" name="run" value={run ? run.id : ""} />
+                  <button
+                    type="submit"
+                    className="btn btn-primary btn-gradient-red highlight"
+                  >
+                    Enroll now
+                  </button>
+                </form>
+              </Fragment>
+            )}
+          </Fragment>
+        )}
+      </Loader>
+    )
+  }
+}
+
+const mapStateToProps = createStructuredSelector({
+  courseRuns: courseRunsSelector,
+  isLoading:  pathOr(true, ["queries", courseRunsQueryKey, "isPending"]),
+  status:     pathOr(null, ["queries", courseRunsQueryKey, "status"])
+})
+
+const mapPropsToConfig = props => [courseRunsQuery(props.courseId)]
+
+export default compose(
+  connect(mapStateToProps),
+  connectRequest(mapPropsToConfig)
+)(ProductDetailEnrollApp)

--- a/static/js/containers/ProductDetailEnrollApp_test.js
+++ b/static/js/containers/ProductDetailEnrollApp_test.js
@@ -1,0 +1,104 @@
+// @flow
+import { assert } from "chai"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import ProductDetailEnrollApp, {
+  ProductDetailEnrollApp as InnerProductDetailEnrollApp
+} from "./ProductDetailEnrollApp"
+
+import { courseRunsSelector } from "../lib/queries/courseRuns"
+import {
+  makeCourseRunDetail,
+  makeCourseRunEnrollment
+} from "../factories/course"
+
+describe("ProductDetailEnrollApp", () => {
+  let helper, renderPage
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+
+    renderPage = helper.configureHOCRenderer(
+      ProductDetailEnrollApp,
+      InnerProductDetailEnrollApp,
+      {},
+      {}
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("renders a Loader component", async () => {
+    const { inner } = await renderPage({
+      queries: {
+        courseRuns: {
+          isPending: true
+        }
+      }
+    })
+
+    assert.isTrue(inner.props().isLoading)
+    const loader = inner.find("Loader")
+    assert.isOk(loader.exists())
+    assert.isTrue(loader.props().isLoading)
+  })
+
+  it("checks for enroll now button", async () => {
+    const courseRun = makeCourseRunDetail()
+    const { inner } = await renderPage(
+      {
+        entities: {
+          courseRuns: [courseRun]
+        },
+        queries: {
+          courseRuns: {
+            isPending: false,
+            status:    200
+          }
+        }
+      },
+      {}
+    )
+    assert.equal(
+      inner
+        .find("button")
+        .at(0)
+        .text(),
+      "Enroll now"
+    )
+  })
+
+  it("checks for enrolled button", async () => {
+    const userEnrollment = makeCourseRunEnrollment()
+    const expectedResponse = {
+      ...userEnrollment.run,
+      is_enrolled: true
+    }
+
+    const { inner, store } = await renderPage(
+      {
+        entities: {
+          courseRuns: [expectedResponse]
+        },
+        queries: {
+          courseRuns: {
+            isPending: false,
+            status:    200
+          }
+        }
+      },
+      {}
+    )
+
+    assert.equal(
+      inner
+        .find("a")
+        .at(0)
+        .text(),
+      "Enrolled ✓"
+    )
+    assert.equal(courseRunsSelector(store.getState())[0], expectedResponse)
+  })
+})

--- a/static/js/entry/header.js
+++ b/static/js/entry/header.js
@@ -8,6 +8,7 @@ import { createBrowserHistory } from "history"
 import configureStore from "../store/configureStore"
 import { AppTypeContext, MIXED_APP_CONTEXT } from "../contextDefinitions"
 import HeaderApp from "../containers/HeaderApp"
+import ProductDetailEnrollApp from "../containers/ProductDetailEnrollApp"
 // Object.entries polyfill
 import entries from "object.entries"
 
@@ -39,4 +40,25 @@ const renderHeader = () => {
   )
 }
 
+const renderEnrollSection = (courseId, element, reduxStore) => {
+  ReactDOM.render(
+    <AppContainer>
+      <Provider store={reduxStore}>
+        <ProductDetailEnrollApp courseId={courseId} />
+      </Provider>
+    </AppContainer>,
+    element
+  )
+}
+
 renderHeader()
+
+document.addEventListener("DOMContentLoaded", function() {
+  const enrollSectionEl = document.getElementById("productDetailEnrollment")
+  const courseIdEl = document.getElementById("courseId")
+  if (enrollSectionEl && courseIdEl) {
+    const productDetailStore = configureStore()
+    const courseId = courseIdEl.value
+    renderEnrollSection(courseId, enrollSectionEl, productDetailStore)
+  }
+})

--- a/static/js/flow/courseTypes.js
+++ b/static/js/flow/courseTypes.js
@@ -17,6 +17,11 @@ export type BaseCourseRun = {
   id: number
 }
 
+export type EnrollmentFlaggedCourseRun = BaseCourseRun & {
+  expiration_date: ?string,
+  is_enrolled: boolean
+}
+
 export type CourseRunDetail = BaseCourseRun & {
   course: CourseDetail
 }

--- a/static/js/lib/queries/courseRuns.js
+++ b/static/js/lib/queries/courseRuns.js
@@ -1,0 +1,18 @@
+import { pathOr } from "ramda"
+
+import { nextState } from "./util"
+
+export const courseRunsSelector = pathOr(null, ["entities", "courseRuns"])
+
+export const courseRunsQueryKey = "courseRuns"
+
+export const courseRunsQuery = (courseKey: string = "") => ({
+  queryKey:  courseRunsQueryKey,
+  url:       `/api/course_runs/?relevant_to=${encodeURIComponent(courseKey)}`,
+  transform: json => ({
+    courseRuns: json
+  }),
+  update: {
+    courseRuns: nextState
+  }
+})

--- a/static/js/lib/queries/courseRuns_test.js
+++ b/static/js/lib/queries/courseRuns_test.js
@@ -1,0 +1,15 @@
+// @flow
+import { assert } from "chai"
+
+import { courseRunsSelector } from "./courseRuns"
+
+describe("courseRuns reducers", () => {
+  describe("courseRunsSelector", () => {
+    it("should return the courseRuns state", () => {
+      const courseRuns = {
+        key: "value"
+      }
+      assert.equal(courseRunsSelector({ entities: { courseRuns } }), courseRuns)
+    })
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #253 

#### What's this PR do?
Load enrollment status dynamically in product detail page

#### How should this be manually tested?
Just visit the course / product page

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2021-10-18 at 17 13 32" src="https://user-images.githubusercontent.com/4043989/137735188-cc3241f3-a307-48d2-8a7a-96f1035a3a33.png">
<img width="1440" alt="Screenshot 2021-10-18 at 17 13 45" src="https://user-images.githubusercontent.com/4043989/137735210-f454ed44-4a23-48b7-9b0f-ecdaf1122619.png">
<img width="1440" alt="Screenshot 2021-10-18 at 17 13 59" src="https://user-images.githubusercontent.com/4043989/137735211-d0848891-a32f-48be-8b10-8b72fb27e891.png">

