### PR TITLE
Restrict user to use accented characters in username

### DIFF
--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -63,7 +63,11 @@ describe("RegisterDetailsForm", () => {
       "0123456789012345678901234567890",
       "Username must be at most 30 characters"
     ],
-    ["username", "ábc-dèf-123", null],
+    [
+      "username",
+      "ábc-dèf-123",
+      "Username can only contain letters, numbers and the following characters: @_+-"
+    ],
     ["legal_address.first_name", "", "First Name is a required field"],
     ["legal_address.last_name", "", "Last Name is a required field"]
   ].forEach(([name, value, errorMessage]) => {

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -22,6 +22,10 @@ export const usernameFieldValidation = yup
   .label("Username")
   .trim()
   .required()
+  .matches(
+    /^[A-Za-z0-9.@_+-]+$/,
+    "Username can only contain letters, numbers and the following characters: @_+-"
+  )
   .min(3)
   .max(USERNAME_LENGTH)
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -28,9 +28,9 @@ USER_GIVEN_NAME_RE = re.compile(
     """,
     flags=re.I | re.VERBOSE | re.MULTILINE,
 )
-USERNAME_RE_PARTIAL = r"[\w .@_+-]+"
+USERNAME_RE_PARTIAL = r"[A-Za-z0-9.@_+-]+"
 USERNAME_RE = re.compile(fr"(?P<username>{USERNAME_RE_PARTIAL})")
-USERNAME_ERROR_MSG = "Username can only contain letters, numbers, spaces, and the following characters: @_+-"
+USERNAME_ERROR_MSG = "Username can only contain letters, numbers and the following characters: @_+-"
 
 
 class LegalAddressSerializer(serializers.ModelSerializer):

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -140,7 +140,7 @@ def test_update_user_email(
     "new_username, expect_valid, expect_saved_username",
     [
         [f"{USERNAME}-1", True, f"{USERNAME}-1"],
-        [" My-Üsérname 1 ", True, "My-Üsérname 1"],
+        [" My-Üsérname 1 ", False, "My-Üsérname 1"],
         ["my>usern@me>1", False, None],
         [f"   {USERNAME.upper()}  ", False, None],
     ],


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #259 

#### What's this PR do?
(Required)

#### How should this be manually tested?
Create a user with username that may have accented characters in it e.g. `önlínê-user`. The system should not allow it.


##### NOTE: 

~~- I did not update the message `Username can only contain letters, numbers, spaces, and the following characters: @_+-` , seems of enough but if needs to modify then let me know.~~
