### PR TITLE
Fixing: 'Enroll now' button appears when 'Enrollment start' date is in the future

### DIFF
--- a/static/js/containers/ProductDetailEnrollApp.js
+++ b/static/js/containers/ProductDetailEnrollApp.js
@@ -16,6 +16,8 @@ import {
   courseRunsQueryKey
 } from "../lib/queries/courseRuns"
 
+import { isWithinEnrollmentPeriod } from "../lib/courseApi"
+
 import { getCookie } from "../lib/api"
 
 type Props = {
@@ -60,7 +62,7 @@ export class ProductDetailEnrollApp extends React.Component<Props> {
               >
                 Enroll now
               </a>
-            ) : run && now.isAfter(moment(run.enrollment_start)) ? (
+            ) : run && isWithinEnrollmentPeriod(run) ? (
               <Fragment>
                 <form action="/enrollments/" method="post">
                   <input

--- a/static/js/containers/ProductDetailEnrollApp.js
+++ b/static/js/containers/ProductDetailEnrollApp.js
@@ -60,8 +60,7 @@ export class ProductDetailEnrollApp extends React.Component<Props> {
               >
                 Enroll now
               </a>
-            ) : run && 
-                now.isAfter(moment(run.enrollment_start)) ? (
+            ) : run && now.isAfter(moment(run.enrollment_start)) ? (
               <Fragment>
                 <form action="/enrollments/" method="post">
                   <input
@@ -78,7 +77,7 @@ export class ProductDetailEnrollApp extends React.Component<Props> {
                   </button>
                 </form>
               </Fragment>
-            ): null }
+            ) : null}
           </Fragment>
         )}
       </Loader>

--- a/static/js/containers/ProductDetailEnrollApp.js
+++ b/static/js/containers/ProductDetailEnrollApp.js
@@ -5,6 +5,7 @@ import { pathOr } from "ramda"
 import { compose } from "redux"
 import { connect } from "react-redux"
 import { connectRequest } from "redux-query"
+import moment from "moment"
 
 import Loader from "../components/Loader"
 import { routes } from "../lib/urls"
@@ -28,6 +29,7 @@ export class ProductDetailEnrollApp extends React.Component<Props> {
     const { courseRuns, isLoading, status } = this.props
     const csrfToken = getCookie("csrftoken")
     const run = courseRuns ? courseRuns[0] : null
+    const now = moment()
 
     return (
       // $FlowFixMe: isLoading null or undefined
@@ -58,7 +60,8 @@ export class ProductDetailEnrollApp extends React.Component<Props> {
               >
                 Enroll now
               </a>
-            ) : (
+            ) : run && 
+                now.isAfter(moment(run.enrollment_start)) ? (
               <Fragment>
                 <form action="/enrollments/" method="post">
                   <input
@@ -75,7 +78,7 @@ export class ProductDetailEnrollApp extends React.Component<Props> {
                   </button>
                 </form>
               </Fragment>
-            )}
+            ): null }
           </Fragment>
         )}
       </Loader>

--- a/static/js/containers/ProductDetailEnrollApp_test.js
+++ b/static/js/containers/ProductDetailEnrollApp_test.js
@@ -12,10 +12,12 @@ import {
   makeCourseRunEnrollment
 } from "../factories/course"
 
+import * as courseApi from "../lib/courseApi"
+
 import moment from "moment"
 
 describe("ProductDetailEnrollApp", () => {
-  let helper, renderPage
+  let helper, renderPage, isWithinEnrollmentPeriodStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -25,6 +27,11 @@ describe("ProductDetailEnrollApp", () => {
       InnerProductDetailEnrollApp,
       {},
       {}
+    )
+
+    isWithinEnrollmentPeriodStub = helper.sandbox.stub(
+      courseApi,
+      "isWithinEnrollmentPeriod"
     )
   })
 
@@ -49,6 +56,7 @@ describe("ProductDetailEnrollApp", () => {
 
   it("checks for enroll now button", async () => {
     const courseRun = makeCourseRunDetail()
+    isWithinEnrollmentPeriodStub.returns(true)
     const { inner } = await renderPage(
       {
         entities: {
@@ -74,8 +82,7 @@ describe("ProductDetailEnrollApp", () => {
 
   it("checks for enroll now button should not appear if enrollment start in future", async () => {
     const courseRun = makeCourseRunDetail()
-    courseRun.enrollment_start = moment().add(1, "M")
-    courseRun.enrollment_end = moment().add(10, "M")
+    isWithinEnrollmentPeriodStub.returns(false)
     const { inner } = await renderPage(
       {
         entities: {
@@ -101,8 +108,7 @@ describe("ProductDetailEnrollApp", () => {
 
   it("checks for enroll now button should appear if enrollment start not in future", async () => {
     const courseRun = makeCourseRunDetail()
-    courseRun.enrollment_start = moment().add(-1, "M")
-    courseRun.enrollment_end = moment().add(10, "M")
+    isWithinEnrollmentPeriodStub.returns(true)
     const { inner } = await renderPage(
       {
         entities: {

--- a/static/js/containers/ProductDetailEnrollApp_test.js
+++ b/static/js/containers/ProductDetailEnrollApp_test.js
@@ -99,6 +99,34 @@ describe("ProductDetailEnrollApp", () => {
     )
   })
 
+  it("checks for enroll now button should appear if enrollment start not in future", async () => {
+    const courseRun = makeCourseRunDetail()
+    courseRun.enrollment_start = moment().add(-1, "M")
+    courseRun.enrollment_end = moment().add(10, "M")
+    const { inner } = await renderPage(
+      {
+        entities: {
+          courseRuns: [courseRun]
+        },
+        queries: {
+          courseRuns: {
+            isPending: false,
+            status:    200
+          }
+        }
+      },
+      {}
+    )
+
+    assert.equal(
+      inner
+        .find("button")
+        .at(0)
+        .text(),
+      "Enroll now"
+    )
+  })
+
   it("checks for enrolled button", async () => {
     const userEnrollment = makeCourseRunEnrollment()
     const expectedResponse = {

--- a/static/js/containers/ProductDetailEnrollApp_test.js
+++ b/static/js/containers/ProductDetailEnrollApp_test.js
@@ -12,6 +12,8 @@ import {
   makeCourseRunEnrollment
 } from "../factories/course"
 
+import moment from "moment"
+
 describe("ProductDetailEnrollApp", () => {
   let helper, renderPage
 
@@ -67,6 +69,33 @@ describe("ProductDetailEnrollApp", () => {
         .at(0)
         .text(),
       "Enroll now"
+    )
+  })
+
+  it("checks for enroll now button should not appear if enrollment start in future", async () => {
+    const courseRun = makeCourseRunDetail()
+    courseRun.enrollment_start = moment().add(1, "M")
+    courseRun.enrollment_end = moment().add(10, "M")
+    const { inner } = await renderPage(
+      {
+        entities: {
+          courseRuns: [courseRun]
+        },
+        queries: {
+          courseRuns: {
+            isPending: false,
+            status:    200
+          }
+        }
+      },
+      {}
+    )
+
+    assert.isNotOk(
+      inner
+        .find("button")
+        .at(0)
+        .exists()
     )
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #274 

#### What's this PR do?
The Enroll now button should only appear if there is a course that is currently open for enrolment and `enrolment start < current date`

#### How should this be manually tested?
- Create course run with start_date in future.
- visit the course page.
- Enroll now button should not be appeared.
