### PR TITLE
Prevented unenrollment for runs with expired enrollment period

### DIFF
--- a/static/js/lib/courseApi.js
+++ b/static/js/lib/courseApi.js
@@ -27,3 +27,14 @@ export const isLinkableCourseRun = (
     (isNil(run.end_date) || moment(run.end_date).isAfter(now))
   )
 }
+
+export const isWithinEnrollmentPeriod = (run: CourseRunDetail): boolean => {
+  const enrollStart = run.enrollment_start ? moment(run.enrollment_start) : null
+  const enrollEnd = run.enrollment_end ? moment(run.enrollment_end) : null
+  const now = moment()
+  return (
+    !!enrollStart &&
+    now.isAfter(enrollStart) &&
+    (isNil(enrollEnd) || now.isBefore(enrollEnd))
+  )
+}

--- a/static/js/lib/courseApi_test.js
+++ b/static/js/lib/courseApi_test.js
@@ -1,6 +1,6 @@
 /* global SETTINGS: false */
 // @flow
-import { isLinkableCourseRun } from "./courseApi"
+import { isLinkableCourseRun, isWithinEnrollmentPeriod } from "./courseApi"
 import { assert } from "chai"
 import moment from "moment"
 
@@ -13,6 +13,9 @@ import type { LoggedInUser } from "../flow/authTypes"
 describe("Course API", () => {
   const past = moment()
       .add(-10, "days")
+      .toISOString(),
+    farPast = moment()
+      .add(-50, "days")
       .toISOString(),
     future = moment()
       .add(10, "days")
@@ -60,5 +63,21 @@ describe("Course API", () => {
         })
       }
     )
+  })
+
+  describe("isWithinEnrollmentPeriod", () => {
+    [
+      [past, future, "active enrollment period", true],
+      [past, null, "active enrollment period with no end", true],
+      [null, null, "null enrollment start", false],
+      [farPast, past, "past enrollment period", false],
+      [future, farFuture, "future enrollment period", false]
+    ].forEach(([enrollStart, enrollEnd, desc, expResult]) => {
+      it(`returns ${String(expResult)} with ${desc}`, () => {
+        courseRun.enrollment_start = enrollStart
+        courseRun.enrollment_end = enrollEnd
+        assert.equal(isWithinEnrollmentPeriod(courseRun), expResult)
+      })
+    })
   })
 })

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -141,10 +141,17 @@ a.link-button {
   }
 }
 
-button.unstyled {
+button.unstyled,
+button.btn-secondary.unstyled {
   border: none;
   background-color: inherit;
+  color: inherit;
   padding: 0;
+
+  &:hover, &:active, &:not(:disabled):not(.disabled):active {
+    background-color: inherit;
+    color: inherit;
+  }
 }
 
 .link-light-blue {
@@ -230,13 +237,13 @@ button.unstyled {
   margin-top: 25px;
 }
 
-ul.dropdown-menu {
+.dropdown-menu {
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.5), 0 13px 11px 8px rgba(0,0,0,0.12);
   border-color: $white-smoke;
   border-radius: 0;
   padding: 10px 15px;
 
-  li.dropdown-item {
+  .dropdown-item {
     display: block;
     padding: 7px 0;
     font-size: 16px;

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -68,6 +68,10 @@ $featureImgMobileHeight: 223px;
     // Setting height so the button element doesn't expand to cover the full height of the row
     height: $material-icon-height;
   }
+
+  .unenroll-denied-msg .tooltip {
+    width: 250px;
+  }
 }
 
 .dashboard h1 {

--- a/static/scss/notification.scss
+++ b/static/scss/notification.scss
@@ -75,3 +75,30 @@
    }
  }
 }
+
+.dropdown {
+  .tooltip.show {
+    display: none;
+  }
+
+  &.show {
+    .tooltip.show {
+      display: inherit;
+    }
+  }
+}
+
+.tooltip {
+  &.show {
+    opacity: 0.95;
+  }
+
+  .tooltip-inner,
+  .tooltip-arrow {
+    background-color: $gray;
+  }
+
+  &.bs-tooltip-bottom .arrow::before {
+    border-bottom-color: $gray;
+  }
+}

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -23,7 +23,6 @@ $tiles-background: rgba(53, 53, 53, 97);
 $tab-color: #c2c0bf;
 $label-subtitle: #666666;
 $gray-bg: #ebebeb;
-$darker-grey-bg: #2c2a29;
 $catalog-text: #909090;
 $detail-grid-border-color: #b4b4b4;
 $featured-banner-background: #a32034;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #284

#### What's this PR do?
Prevents unenrollment for runs with expired enrollment period

#### How should this be manually tested?

- Enroll in at least 2 course runs for some user
- Check that the "unenroll" buttons in the dashboard still work if the course runs are within their enrollment period
- Set both course runs to have expired or future enrollment periods
- Check that the "unenroll" buttons are deactivated, and that there is a tooltip like the one shown in the screenshots when you try to hover/click it
  - Also check the mobile view to make sure the tooltip shows up and looks good

#### Screenshots (if appropriate)
![ss 2021-11-05 at 17 35 47 ](https://user-images.githubusercontent.com/14932219/140586067-d3326fee-bc7b-4ab6-b269-d55d05f30e1f.png)
![ss 2021-11-05 at 17 35 34 ](https://user-images.githubusercontent.com/14932219/140586070-f5d0affa-1d81-4618-b206-64e52d544134.png)

