### PR TITLE
Fixed tooltip behavior when enrollment period is active

### DIFF
--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -206,20 +206,22 @@ export class DashboardPage extends React.Component<
                       Unenroll
                     </DropdownItem>
                   </span>
-                  <Tooltip
-                    delay={0}
-                    placement="bottom-end"
-                    target={`unenrollButtonWrapper-${enrollment.id}`}
-                    container={`enrollmentDropdown-${enrollment.id}`}
-                    className="unenroll-denied-msg"
-                    isOpen={this.isActiveEnrollMsgId(enrollment.id)}
-                    toggle={this.toggleActiveEnrollMsgId(enrollment.id).bind(
-                      this
-                    )}
-                  >
-                    The enrollment period for this course has ended. If you'd
-                    like to unenroll, please contact support.
-                  </Tooltip>
+                  {!unenrollEnabled && (
+                    <Tooltip
+                      delay={0}
+                      placement="bottom-end"
+                      target={`unenrollButtonWrapper-${enrollment.id}`}
+                      container={`enrollmentDropdown-${enrollment.id}`}
+                      className="unenroll-denied-msg"
+                      isOpen={this.isActiveEnrollMsgId(enrollment.id)}
+                      toggle={this.toggleActiveEnrollMsgId(enrollment.id).bind(
+                        this
+                      )}
+                    >
+                      The enrollment period for this course has ended. If you'd
+                      like to unenroll, please contact support.
+                    </Tooltip>
+                  )}
                 </DropdownMenu>
               </Dropdown>
             </div>

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -181,26 +181,37 @@ describe("DashboardPage", () => {
       })
     })
   })
+  ;[
+    [true, "enables the unenroll button and renders no tooltip"],
+    [false, "disables the unenroll button and renders tooltip"]
+  ].forEach(([isEnrollable, desc]) => {
+    it(`${desc} if the enrollment period ${isIf(
+      isEnrollable
+    )} active`, async () => {
+      const enrollmentIndex = 0
+      const enrollment = userEnrollments[enrollmentIndex]
+      isWithinEnrollmentPeriodStub.returns(isEnrollable)
 
-  it("disables the unenroll button if the enrollment period has expired", async () => {
-    const enrollmentIndex = 0
-    const enrollment = userEnrollments[enrollmentIndex]
-    isWithinEnrollmentPeriodStub.returns(false)
-
-    const { inner } = await renderPage()
-    const enrolledItem = inner.find(".enrolled-item").at(enrollmentIndex)
-    const unenrollBtn = enrolledItem.find("Dropdown DropdownItem").at(0)
-    assert.isTrue(unenrollBtn.prop("disabled"))
-    sinon.assert.calledWith(isWithinEnrollmentPeriodStub, enrollment.run)
-    // Check that the button has a wrapper element that the tooltip can use
-    const btnWrapper = unenrollBtn.parent()
-    assert.equal(btnWrapper.type(), "span")
-    const wrapperId = btnWrapper.prop("id")
-    // Check that the tooltip correctly refers to the wrapper
-    const tooltip = enrolledItem.find("Tooltip")
-    assert.isTrue(tooltip.exists())
-    // Our component library just requires a tooltip to refer to the id of the target element
-    // in the "target" attribute, then takes care of the rest.
-    assert.equal(tooltip.prop("target"), wrapperId)
+      const { inner } = await renderPage()
+      const enrolledItem = inner.find(".enrolled-item").at(enrollmentIndex)
+      const unenrollBtn = enrolledItem.find("Dropdown DropdownItem").at(0)
+      assert.equal(
+        unenrollBtn.prop("disabled"),
+        isEnrollable ? undefined : true
+      )
+      sinon.assert.calledWith(isWithinEnrollmentPeriodStub, enrollment.run)
+      const tooltip = enrolledItem.find("Tooltip")
+      assert.equal(tooltip.exists(), !isEnrollable)
+      if (!isEnrollable) {
+        // Check that the button has a wrapper element that the tooltip can use
+        const btnWrapper = unenrollBtn.parent()
+        assert.equal(btnWrapper.type(), "span")
+        const wrapperId = btnWrapper.prop("id")
+        // Check that the tooltip correctly refers to the wrapper.
+        // Our component library just requires a tooltip to refer to the id of the target element
+        // in the "target" attribute, then takes care of the rest.
+        assert.equal(tooltip.prop("target"), wrapperId)
+      }
+    })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes bug related to #287 

#### What's this PR do?
Prevents the unenrollment period tooltip from showing up when the course run's enrollment period is active

#### How should this be manually tested?
Bring up the dot menu for an enrolled course run in your dashboard. If the enrollment period is active for that run, then the unenroll button should be enabled and there should not be a tooltip on hover/click
