### PR TITLE
Course product pages: If no Video URL is set, display the Feature Image

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -24,7 +24,7 @@
                 <div id="productDetailEnrollment"></div>
               </div>
             </div>
-            <div class="content-col video">
+            <div class="content-col hero-media">
               {% if page.video_url %}
               <video-js
                 class="vjs-default-skin vjs-big-play-centered"

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static wagtail_img_src render_bundle  %}
+{% load static wagtail_img_src render_bundle feature_img_src %}
 {% load wagtailcore_tags wagtailembeds_tags %}
 
 {% block title %}{{ page.title }} | {{ site_name }}{% endblock %}
@@ -24,17 +24,19 @@
                 <div id="productDetailEnrollment"></div>
               </div>
             </div>
-            {% if page.video_url %}
-              <div class="content-col video">
-                <video-js
-                  class="vjs-default-skin vjs-big-play-centered" 
-                  controls 
-                  data-setup="{{page.video_player_config}}"
-                  preload='metadata'
-                >
-                </video-js>
-              </div>
-            {% endif %}
+            <div class="content-col video">
+              {% if page.video_url %}
+              <video-js
+                class="vjs-default-skin vjs-big-play-centered"
+                controls
+                data-setup="{{page.video_player_config}}"
+                preload="metadata"
+              >
+              </video-js>
+              {% else %}
+              <img src="{% feature_img_src page.feature_image %}" alt="{{ page.title }}">
+              {% endif %}
+            </div>
           </div>
         </div>
       </section>

--- a/static/scss/product-details.scss
+++ b/static/scss/product-details.scss
@@ -74,7 +74,7 @@
           width: 100%;
         }
 
-        &.video {
+        &.hero-media {
           padding-bottom: 0;
 
           @include media-breakpoint-down(md) {

--- a/static/scss/product-details.scss
+++ b/static/scss/product-details.scss
@@ -86,6 +86,15 @@
             padding: 6px 15px;
             flex-shrink: 0;
           }
+
+          img, .video-js {
+            width: 100%;
+            height: 217px;
+
+            @include media-breakpoint-up(md) {
+              height: 263px;
+            }
+          }
         }
 
         .text {
@@ -99,13 +108,6 @@
     }
 
     .video-js {
-      width: 100%;
-      height: 217px;
-
-      @include media-breakpoint-up(md) {
-        height: 263px;
-      }
-
       .vjs-big-play-button {
         background: black;
         opacity: 0.8;

--- a/static/scss/product-details.scss
+++ b/static/scss/product-details.scss
@@ -90,6 +90,7 @@
           img, .video-js {
             width: 100%;
             height: 217px;
+            object-fit: cover;
 
             @include media-breakpoint-up(md) {
               height: 263px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #296

#### What's this PR do?
Course product pages: If no Video URL is set, display the Feature Image

#### How should this be manually tested?
Add course on wagtail but without video but only feature image and it should be shown on video place if video not available

#### Screenshots (if appropriate)
<img width="1439" alt="Screenshot 2021-11-17 at 15 04 38" src="https://user-images.githubusercontent.com/4043989/142180083-e5522896-2d01-4a28-b34c-03dfff07805d.png">
<img width="1440" alt="Screenshot 2021-11-17 at 15 04 26" src="https://user-images.githubusercontent.com/4043989/142180061-5dac4a6d-2f77-456e-bd36-f01171278a8a.png">
<img width="1439" alt="Screenshot 2021-11-17 at 15 05 01" src="https://user-images.githubusercontent.com/4043989/142180090-21616426-4fc3-4c40-9365-32f5e04b070d.png">
