### PR TITLE
Adding product subsystem apis

### DIFF
--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -1,0 +1,18 @@
+from factory import fuzzy, SubFactory
+from factory.django import DjangoModelFactory
+import faker
+
+from courses.factories import CourseRunFactory
+from ecommerce import models
+
+FAKE = faker.Factory.create()
+
+
+class ProductFactory(DjangoModelFactory):
+    purchasable_object = SubFactory(CourseRunFactory)
+    price = fuzzy.FuzzyDecimal(1, 2000, precision=2)
+    description = FAKE.sentence(nb_words=4)
+    is_active = True
+
+    class Meta:
+        model = models.Product

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -1,0 +1,66 @@
+"""
+MITxOnline ecommerce serializers
+"""
+from rest_framework import serializers
+
+from ecommerce import models
+from courses.models import CourseRun, ProgramRun
+
+
+class ProgramRunProductPurchasableObjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProgramRun
+        fields = [
+            "id",
+            "run_tag",
+            "start_date",
+            "end_date",
+        ]
+
+
+class CourseRunProductPurchasableObjectSerializer(serializers.ModelSerializer):
+    course = serializers.SerializerMethodField()
+    readable_id = serializers.CharField(source="text_id")
+
+    def get_course(self, instance):
+        return {"id": instance.course.id, "title": instance.course.title}
+
+    class Meta:
+        model = CourseRun
+        fields = [
+            "id",
+            "title",
+            "run_tag",
+            "start_date",
+            "end_date",
+            "course",
+            "readable_id",
+            "enrollment_start",
+            "enrollment_end",
+        ]
+
+
+class ProductPurchasableObjectField(serializers.RelatedField):
+    def to_representation(self, value):
+        """Serialize the purchasable object using a serializer that matches the model type (either a Program Run or a Course Run)"""
+        if isinstance(value, ProgramRun):
+            return ProgramRunProductPurchasableObjectSerializer(instance=value).data
+        elif isinstance(value, CourseRun):
+            return CourseRunProductPurchasableObjectSerializer(instance=value).data
+        raise Exception(
+            "Unexpected to find type for Product.purchasable_object:", value.__class__
+        )
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    purchasable_object = ProductPurchasableObjectField(read_only=True)
+
+    class Meta:
+        fields = [
+            "id",
+            "price",
+            "description",
+            "purchasable_object",
+            "is_active",
+        ]
+        model = models.Product

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,0 +1,60 @@
+import pytest
+from main.test_utils import assert_drf_json_equal, drf_datetime
+
+from courses.factories import (
+    CourseRunFactory,
+    ProgramFactory,
+    ProgramRunFactory,
+)
+
+from ecommerce.serializers import (
+    ProductSerializer,
+    CourseRunProductPurchasableObjectSerializer,
+    ProgramRunProductPurchasableObjectSerializer,
+)
+from ecommerce.factories import ProductFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_product_course_serializer(mock_context):
+    """
+    Tests serialization of a product that has an associated course.
+    """
+    program = ProgramFactory.create()
+    run = CourseRunFactory.create(course__program=program)
+    product = ProductFactory.create(purchasable_object=run)
+    product_serialized = ProductSerializer(instance=product).data
+    run_serialized = CourseRunProductPurchasableObjectSerializer(instance=run).data
+
+    assert_drf_json_equal(
+        product_serialized,
+        {
+            "description": product.description,
+            "id": product.id,
+            "is_active": product.is_active,
+            "price": str(product.price),
+            "purchasable_object": run_serialized,
+        },
+    )
+
+
+def test_product_program_serializer(mock_context):
+    """
+    Tests serialization of a product that has an associated program.
+    """
+    run = ProgramRunFactory.create()
+    product = ProductFactory.create(purchasable_object=run)
+    product_serialized = ProductSerializer(instance=product).data
+    run_serialized = ProgramRunProductPurchasableObjectSerializer(instance=run).data
+
+    assert_drf_json_equal(
+        product_serialized,
+        {
+            "description": product.description,
+            "id": product.id,
+            "is_active": product.is_active,
+            "price": str(product.price),
+            "purchasable_object": run_serialized,
+        },
+    )

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -1,0 +1,14 @@
+from django.urls import include, re_path, path
+from rest_framework import routers
+
+""" TODO: clean this up later (make the views look more like the courses one) """
+from ecommerce.views.v0 import ProductViewSet
+
+router = routers.SimpleRouter()
+
+router.register(r"products", ProductViewSet, basename="products_api")
+
+urlpatterns = [
+    re_path(r"^api/v0/", include(router.urls)),
+    re_path(r"^api/", include(router.urls)),
+]

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -1,0 +1,86 @@
+"""
+MITxOnline ecommerce views
+"""
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.pagination import LimitOffsetPagination
+from django.db.models import Q, Count
+from mitol.common.utils import now_in_utc
+
+from courses.models import (
+    CourseRun,
+    Course,
+    Program,
+    ProgramRun,
+)
+
+from ecommerce.serializers import ProductSerializer
+from ecommerce.models import Product
+
+
+class ProductsPagination(LimitOffsetPagination):
+    default_limit = 2
+    limit_query_param = "l"
+    offset_query_param = "o"
+    max_limit = 50
+
+
+class ProductViewSet(ReadOnlyModelViewSet):
+    serializer_class = ProductSerializer
+    pagination_class = ProductsPagination
+
+    def get_queryset(self):
+        now = now_in_utc()
+
+        unenrollable_courserun_ids = CourseRun.objects.filter(
+            enrollment_end__lt=now
+        ).values_list("id", flat=True)
+
+        unenrollable_course_ids = (
+            Course.objects.annotate(
+                num_runs=Count(
+                    "courseruns", filter=~Q(courseruns__in=unenrollable_courserun_ids)
+                )
+            )
+            .filter(num_runs=0)
+            .values_list("id", flat=True)
+        )
+
+        unenrollable_program_ids = (
+            Program.objects.annotate(
+                valid_runs=Count(
+                    "programruns",
+                    filter=Q(programruns__end_date__gt=now)
+                    | Q(programruns__end_date=None),
+                )
+            )
+            .filter(
+                Q(programruns__isnull=True)
+                | Q(valid_runs=0)
+                | Q(courses__in=unenrollable_course_ids)
+            )
+            .values_list("id", flat=True)
+            .distinct()
+        )
+
+        unenrollable_programrun_ids = ProgramRun.objects.filter(
+            Q(program__in=unenrollable_program_ids) | Q(end_date__lt=now)
+        )
+
+        return (
+            Product.objects.exclude(
+                (
+                    Q(object_id__in=unenrollable_courserun_ids)
+                    & Q(content_type__model="courserun")
+                )
+                | (
+                    Q(object_id__in=unenrollable_programrun_ids)
+                    & Q(content_type__model="programrun")
+                )
+            )
+            .exclude(is_active__exact=False)
+            .select_related("content_type")
+            .prefetch_related("purchasable_object")
+        )

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1,0 +1,37 @@
+import pytest
+import random
+from main.test_utils import assert_drf_json_equal
+from django.urls import reverse
+import operator as op
+
+from ecommerce.serializers import (
+    ProductSerializer,
+)
+from ecommerce.factories import ProductFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture()
+def products():
+    return ProductFactory.create_batch(5)
+
+
+def test_list_products(user_drf_client, products):
+    resp = user_drf_client.get(reverse("products_api-list"), {"l": 10, "o": 0})
+    resp_products = sorted(resp.json()["results"], key=op.itemgetter("id"))
+
+    assert len(resp_products) == len(products)
+
+    for product, resp_product in zip(products, resp_products):
+        assert_drf_json_equal(resp_product, ProductSerializer(product).data)
+
+
+def test_get_products(user_drf_client, products):
+    product = products[random.randrange(0, len(products))]
+
+    resp = user_drf_client.get(
+        reverse("products_api-detail", kwargs={"pk": product.id})
+    )
+
+    assert_drf_json_equal(resp.json(), ProductSerializer(product).data)

--- a/main/urls.py
+++ b/main/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
     path("", include("mail.urls")),
     path("", include("users.urls")),
     path("", include("courses.urls")),
+    path("", include("ecommerce.urls")),
     re_path(r"^dashboard/", index, name="user-dashboard"),
     # social django needs to be here to preempt the login
     path("", include("social_django.urls", namespace="social")),


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested

#### What are the relevant tickets?
#305 

#### What's this PR do?
Adds in the REST API for Product retrieval (and adds the scaffolding for that)

#### How should this be manually tested?
Use the standard DRF API explorer (go to /api/v0/products, etc.) once at least one Product has been created (via dj-admin)
pytest tests should also pass