### PR TITLE
fix: enable dashboard course link when end date is in past

### DIFF
--- a/static/js/lib/courseApi.js
+++ b/static/js/lib/courseApi.js
@@ -21,11 +21,7 @@ export const isLinkableCourseRun = (
     return true
   }
   const now = dtNow || moment()
-  return (
-    notNil(run.start_date) &&
-    moment(run.start_date).isBefore(now) &&
-    (isNil(run.end_date) || moment(run.end_date).isAfter(now))
-  )
+  return notNil(run.start_date) && moment(run.start_date).isBefore(now)
 }
 
 export const isWithinEnrollmentPeriod = (run: CourseRunDetail): boolean => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#346 

**Reviewer Note:** There were multiple conditions for a course to have the edX link from which one was that if a user has `is_editor` role he'd be able to see the course without any conditions except the edX's course URL has been added. For, other users we had a check on the end date to either `be empty or be in future`. I just removed that.


#### What's this PR do?
- Removes course end date check for adding enrolled course link to edX, since we won't need that check for a course to have a link in the dashboard.

#### How should this be manually tested?
- Follow the instructions on #346, to set up the enrollment. Make sure the acceptance criteria marked in the ticket fulfills.

#### Screenshots (if appropriate)
When Enrolled course end date is in past.
<img width="1212" alt="Screenshot 2021-12-23 at 4 35 33 AM" src="https://user-images.githubusercontent.com/34372316/147166959-34f88f9d-2502-4477-a4f2-3457470885ef.png">

