### PR TITLE
Add readable id in searchable fields of wagtail

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -24,6 +24,7 @@ from wagtail.images.models import Image
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.embeds.embeds import get_embed
 from wagtail.embeds.exceptions import EmbedException
+from wagtail.search import index
 
 from cms.blocks import ResourceBlock, PriceBlock, FacultyBlock
 from cms.constants import COURSE_INDEX_SLUG, CMS_EDITORS_GROUP_NAME
@@ -344,6 +345,12 @@ class CoursePage(ProductPage):
         "courses.Course", null=True, on_delete=models.SET_NULL, related_name="page"
     )
 
+    search_fields = Page.search_fields + [
+        index.RelatedFields('course', [
+            index.SearchField('readable_id', partial_match=True),
+        ])
+    ]
+
     @property
     def product(self):
         """Gets the product associated with this page"""
@@ -351,9 +358,9 @@ class CoursePage(ProductPage):
 
     template = "product_page.html"
 
-    def get_admin_display_title(self): 
-        """Gets the title of the course in the speacified format"""
-        return str(self.course)
+    def get_admin_display_title(self):
+        """Gets the title of the course in the specified format"""
+        return f"{self.course.readable_id} | {self.title}"
 
     def get_context(self, request, *args, **kwargs):
         relevant_run = get_user_relevant_course_run(

--- a/main/settings.py
+++ b/main/settings.py
@@ -141,6 +141,7 @@ INSTALLED_APPS = (
     # WAGTAIL
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
+    "wagtail.contrib.postgres_search",
     "wagtail.embeds",
     "wagtail.sites",
     "wagtail.users",
@@ -618,6 +619,13 @@ SITE_NAME = get_string(
     description="Name of the site. e.g MIT mitX Online",
 )
 WAGTAIL_SITE_NAME = SITE_NAME
+
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.contrib.postgres_search.backend',
+        'ATOMIC_REBUILD': True,
+    },
+}
 
 MEDIA_ROOT = get_string(
     name="MEDIA_ROOT",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Migrations (Wagtail Search App's)
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#351 

**Additional Note - Reviewer Note**
- While working on this, I also noticed that instead of showing the title from `CoursePage` model of wagtail, we were showing the title of the `Course` model from `courses` app. So I fixed that as well. This means updating the title of a course in `/cms/pages` should be displayed everywhere instead of the title from the Course model(Can be changed in Django Admin).
- The wagtail index search doesn't update the index of the related keys automatically, so in the case when you update the readable id of a course manually from admin after the course has been added in CMS, you'll need to run `./manage.py wagtail_update_index` so that the related `readable_id` index updates

#### What's this PR do?
- Adds the readable id to be part of search in wagtail

#### How should this be manually tested?
- Search any course with the readable id instead of title and you should see the matching course in the list
- Search a course by title, it should be returned in the search results

#### Any background context you want to provide?
- Readable id was added in `admin_display_title` in one of recent PR(https://github.com/mitodl/mitxonline/pull/336), where we formatted the course pages display title in addition with readable id. 

#### Screenshots (if appropriate)
<img width="1333" alt="Screenshot 2022-01-04 at 2 04 46 PM" src="https://user-images.githubusercontent.com/34372316/148035842-a82c3c90-887a-4a3a-aa0e-a43b20d1f2d7.png">
<img width="1277" alt="Screenshot 2022-01-04 at 2 05 03 PM" src="https://user-images.githubusercontent.com/34372316/148035847-a7870a29-c76e-4306-90fa-42220088a5aa.png">
