### PR TITLE
allow to unenroll even after the enrollment period has past

### DIFF
--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -35,10 +35,7 @@ import {
   courseEmailsSubscriptionMutation
 } from "../../lib/queries/enrollment"
 import { currentUserSelector } from "../../lib/queries/users"
-import {
-  isLinkableCourseRun,
-  isWithinEnrollmentPeriod
-} from "../../lib/courseApi"
+import { isLinkableCourseRun } from "../../lib/courseApi"
 import {
   formatPrettyDateTimeAmPmTz,
   isSuccessResponse,

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -65,7 +65,6 @@ type DashboardPageProps = {
 type DashboardPageState = {
   submittingEnrollmentId: number | null,
   activeMenuIds: number[],
-  activeEnrollMsgIds: number[],
   emailSettingsModalVisibility: boolean[]
 }
 
@@ -76,7 +75,6 @@ export class DashboardPage extends React.Component<
   state = {
     submittingEnrollmentId:       null,
     activeMenuIds:                [],
-    activeEnrollMsgIds:           [],
     emailSettingsModalVisibility: []
   }
 
@@ -98,10 +96,6 @@ export class DashboardPage extends React.Component<
     return !!this.state.activeMenuIds.find(id => id === itemId)
   }
 
-  isActiveEnrollMsgId(itemId: number): boolean {
-    return !!this.state.activeEnrollMsgIds.find(id => id === itemId)
-  }
-
   toggleActiveMenuId(itemId: number) {
     return () => {
       const isActive = this.isActiveMenuId(itemId)
@@ -109,17 +103,6 @@ export class DashboardPage extends React.Component<
         activeMenuIds: isActive
           ? without([itemId], this.state.activeMenuIds)
           : [...this.state.activeMenuIds, itemId]
-      })
-    }
-  }
-
-  toggleActiveEnrollMsgId(itemId: number) {
-    return () => {
-      const isActive = this.isActiveEnrollMsgId(itemId)
-      this.setState({
-        activeEnrollMsgIds: isActive
-          ? without([itemId], this.state.activeEnrollMsgIds)
-          : [...this.state.activeEnrollMsgIds, itemId]
       })
     }
   }
@@ -267,7 +250,7 @@ export class DashboardPage extends React.Component<
     const { currentUser } = this.props
     const { submittingEnrollmentId } = this.state
 
-    let startDate, startDateDescription, onUnenrollClick, unenrollEnabled
+    let startDate, startDateDescription
     const title = isLinkableCourseRun(enrollment.run, currentUser) ? (
       <a
         href={enrollment.run.courseware_url}
@@ -291,13 +274,7 @@ export class DashboardPage extends React.Component<
         </span>
       )
     }
-    if (isWithinEnrollmentPeriod(enrollment.run)) {
-      onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
-      unenrollEnabled = true
-    } else {
-      onUnenrollClick = () => {}
-      unenrollEnabled = false
-    }
+    const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
 
     return (
       <div
@@ -331,10 +308,6 @@ export class DashboardPage extends React.Component<
                     <DropdownItem
                       className="unstyled d-block"
                       onClick={onUnenrollClick}
-                      {...(!unenrollEnabled ||
-                      enrollment.id === submittingEnrollmentId
-                        ? { disabled: true }
-                        : {})}
                     >
                       Unenroll
                     </DropdownItem>
@@ -350,22 +323,6 @@ export class DashboardPage extends React.Component<
                     </DropdownItem>
                     {this.renderEmailSettingsDialog(enrollment)}
                   </span>
-                  {!unenrollEnabled && (
-                    <Tooltip
-                      delay={0}
-                      placement="bottom-end"
-                      target={`unenrollButtonWrapper-${enrollment.id}`}
-                      container={`enrollmentDropdown-${enrollment.id}`}
-                      className="unenroll-denied-msg"
-                      isOpen={this.isActiveEnrollMsgId(enrollment.id)}
-                      toggle={this.toggleActiveEnrollMsgId(enrollment.id).bind(
-                        this
-                      )}
-                    >
-                      The enrollment period for this course has ended. If you'd
-                      like to unenroll, please contact support.
-                    </Tooltip>
-                  )}
                 </DropdownMenu>
               </Dropdown>
             </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #403

#### What's this PR do?
allow to unenroll even after the enrollment period has past

#### How should this be manually tested?
Just enroll in a course and set enrollment end date in the past that should still allow you to unenroll the course

#### Screenshots (if appropriate)

**NOW**

<img width="1440" alt="Screenshot 2022-02-10 at 17 45 09" src="https://user-images.githubusercontent.com/4043989/153412029-112cadf1-e411-4444-82c8-a7fb6ee1c28c.png">
<img width="1440" alt="Screenshot 2022-02-10 at 17 46 24" src="https://user-images.githubusercontent.com/4043989/153412044-435d0552-cab8-4a47-99d2-cb06fe311487.png">

**BEFORE**

<img width="1440" alt="Screenshot 2022-02-10 at 17 44 13" src="https://user-images.githubusercontent.com/4043989/153411987-d5d5ce10-4a6a-4ecd-8ad5-300fdaf71329.png">

