### PR TITLE
Removing import for turtle in models

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -1,4 +1,3 @@
-from turtle import st
 from django.conf import settings
 from django.db import models
 from django.contrib.auth import get_user_model


### PR DESCRIPTION
#### Pre-Flight checklist

- [X ] Testing
  - [X ] Code is tested

#### What are the relevant tickets?
none

#### What's this PR do?
Removes "turtle" library from the models.

#### Any background context you want to provide?
This triggered a deploy failure in Heroku for rc.
