### PR TITLE
Fixing wrapping issue with long course titles (#426)

### DIFF
--- a/static/js/containers/pages/checkout/CartPage.js
+++ b/static/js/containers/pages/checkout/CartPage.js
@@ -84,8 +84,8 @@ export class CartPage extends React.Component<Props> {
         <div className="row d-flex flex-sm-columm p-md-3">
           <div className="img-container">{courseImage}</div>
 
-          <div className="flex-grow-1 mx-3 d-sm-flex flex-column">
-            <h5 className="mt-2">{title}</h5>
+          <div className="flex-grow-1 d-sm-flex flex-column w-50 mx-3">
+            <h5 className="">{title}</h5>
             <div className="detail">
               {readableId}
               <br />


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#426 

#### What's this PR do?
Fixes #426 

#### How should this be manually tested?
On RC, add 14.750x to the cart. The title should now wrap instead of spilling out. 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/945611/155538110-8beadd15-a240-4fa0-8ceb-9fa5c87b5e4b.png)

![image](https://user-images.githubusercontent.com/945611/155538208-939953a7-0a42-4d53-9750-e948c5c3cf0c.png)
