### PR TITLE
Fixed 500 and 404 error pages

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -25,6 +25,9 @@ from wagtail.documents import urls as wagtaildocs_urls
 
 from main.views import cms_signin_redirect_to_site_signin, index
 
+handler500 = "main.views.handler500"
+handler404 = "main.views.handler404"
+
 urlpatterns = [
     # NOTE: we only bring in base_urlpatterns so applications can only be created via django-admin
     path(

--- a/main/views.py
+++ b/main/views.py
@@ -2,7 +2,9 @@
 mitx_online views
 """
 from django.contrib.auth.views import redirect_to_login
+from django.http import HttpResponseNotFound, HttpResponseServerError
 from django.shortcuts import render
+from django.template.loader import render_to_string
 from django.urls import reverse
 
 
@@ -10,11 +12,20 @@ def index(request, **kwargs):
     """
     The index view. Display available programs
     """
-
     return render(
         request,
         "index.html",
     )
+
+
+def handler404(request, exception):  # pylint: disable=unused-argument
+    """404: NOT FOUND ERROR handler"""
+    return HttpResponseNotFound(render_to_string("404.html", request=request))
+
+
+def handler500(request):
+    """500 INTERNAL SERVER ERROR handler"""
+    return HttpResponseServerError(render_to_string("500.html", request=request))
 
 
 def cms_signin_redirect_to_site_signin(request):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #302 

#### What's this PR do?
This fixes an error where for a 500 page, django does not pass `request` to the template context, which in turn causes the 500 page to error itself.

#### How should this be manually tested?
On the main branch, set `DEBUG: false` for the web container in `docker-compose.override.yml`. Put a `raise Exception()` in `main.views.index` and try to load the dashboard. You should see a 502 Bad Gateway from nginx.

Now, perform the same test on this branch, you should see a django served 500 page that is nicely styled.
