### PR TITLE
Updating payment_gateway to 1.2.2, fixing some usage errors

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ mitol-django-common~=2.1.0
 mitol-django-mail~=3.0.1
 mitol-django-authentication~=1.3.1
 mitol-django-openedx~=1.0.0
-mitol-django-payment-gateway~=1.2.1
+mitol-django-payment-gateway~=1.2.2
 newrelic
 pyOpenSSL
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -233,7 +233,7 @@ mitol-django-mail==3.0.1
     #   mitol-django-authentication
 mitol-django-openedx==1.0.0
     # via -r requirements.in
-mitol-django-payment-gateway==1.2.1
+mitol-django-payment-gateway==1.2.2
     # via -r requirements.in
 newrelic==6.4.1.158
     # via -r requirements.in


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
none atm

#### What's this PR do?
Updates the mitol-django-payment-gateway dependency to the latest, which fixes a bug in processor response decoding. Also fixes some spots where the app was decoding responses incorrectly.

#### How should this be manually tested?
Run a transaction through - you should be ultimately redirected back into the DRF viewer (since there's no where to go quite yet when the transaction is done) and the appropriate action should be taken for the order that was created.
