### PR TITLE
Add order history screen

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -224,6 +224,14 @@ class Line(TimestampedModel):
     quantity = models.PositiveIntegerField()
 
     @property
+    def item_description(self):
+        return self.product_version.field_dict["description"]
+
+    @property
+    def content_type(self):
+        return self.product_version.field_dict["content_type"]
+
+    @property
     def unit_price(self):
         """Return the price of the product"""
         return self.product_version.field_dict["price"]

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -1,6 +1,7 @@
 """
 MITxOnline ecommerce serializers
 """
+from this import d
 from rest_framework import serializers
 
 from ecommerce import models
@@ -8,6 +9,7 @@ from courses.models import CourseRun, ProgramRun, Course
 from ecommerce.models import Basket, Product, BasketItem
 
 from cms.serializers import CoursePageSerializer
+from users.serializers import UserSerializer
 
 
 class ProgramRunProductPurchasableObjectSerializer(serializers.ModelSerializer):
@@ -173,3 +175,61 @@ class OrderSerializer(serializers.ModelSerializer):
             "lines",
         ]
         model = models.Order
+
+
+class LineSerializer(serializers.ModelSerializer):
+    product = serializers.SerializerMethodField()
+
+    def get_product(self, instance):
+        product = models.Product.objects.get(
+            pk=instance.product_version.field_dict["id"]
+        )
+
+        return ProductSerializer(instance=product).data
+
+    class Meta:
+        fields = [
+            "quantity",
+            "item_description",
+            "content_type",
+            "unit_price",
+            "total_price",
+            "id",
+            "product",
+        ]
+        model = models.Line
+
+
+class OrderHistorySerializer(serializers.ModelSerializer):
+    titles = serializers.SerializerMethodField()
+    lines = LineSerializer(many=True)
+
+    def get_titles(self, instance):
+        titles = []
+
+        for line in instance.lines.all():
+            product = models.Product.objects.get(
+                pk=line.product_version.field_dict["id"]
+            )
+            if product.content_type.model == "courserun":
+                titles.append(product.purchasable_object.course.title)
+            elif product.content_type.model == "programrun":
+                titles.append(product.description)
+            else:
+                titles.append(f"No Title - {product.id}")
+
+        return titles
+
+    class Meta:
+        fields = [
+            "id",
+            "state",
+            "reference_number",
+            "purchaser",
+            "total_price_paid",
+            "lines",
+            "created_on",
+            "titles",
+        ]
+        model = models.Order
+        depth = 1

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -16,6 +16,7 @@ from ecommerce.views.v0 import (
     CheckoutTestStepTwoView,
     CheckoutDecodeResponseView,
     CheckoutProductView,
+    OrderHistoryViewSet,
 )
 
 
@@ -29,6 +30,7 @@ frontend_router = SimpleRouter()
 
 router.register(r"products", ProductViewSet, basename="products_api")
 router.register(r"checkout", CheckoutApiViewSet, basename="checkout_api")
+router.register(r"orders/history", OrderHistoryViewSet, basename="orderhistory_api")
 
 frontend_router.register(r"checkout", CheckoutViewSet, basename="checkout")
 

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -46,6 +46,7 @@ from courses.models import (
 )
 
 from ecommerce.serializers import (
+    OrderHistorySerializer,
     ProductSerializer,
     BasketSerializer,
     BasketItemSerializer,
@@ -69,6 +70,13 @@ from ecommerce.discounts import DiscountType
 
 class ProductsPagination(LimitOffsetPagination):
     default_limit = 2
+    limit_query_param = "l"
+    offset_query_param = "o"
+    max_limit = 50
+
+
+class OrderHistoryPagination(LimitOffsetPagination):
+    default_limit = 10
     limit_query_param = "l"
     offset_query_param = "o"
     max_limit = 50
@@ -621,6 +629,15 @@ class CheckoutDecodeResponseView(TemplateView):
                 "full_response": request.POST,
             },
         )
+
+
+class OrderHistoryViewSet(ReadOnlyModelViewSet):
+    serializer_class = OrderHistorySerializer
+    pagination_class = OrderHistoryPagination
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return Order.objects.filter(purchaser=self.request.user).all()
 
 
 """

--- a/main/urls.py
+++ b/main/urls.py
@@ -66,6 +66,7 @@ urlpatterns = [
     path("profile/edit/", index, name="edit-profile"),
     re_path(r"^account-settings/", index, name="account-settings"),
     re_path(r"^cart/.*", index, name="cart"),
+    re_path(r"^orders/history/.*", index, name="order-history"),
     # Wagtail
     re_path(
         r"^cms/login", cms_signin_redirect_to_site_signin, name="wagtailadmin_login"

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -142,3 +142,5 @@ export const ACCOUNT_SETTINGS_PAGE_TITLE = "Account Settings"
 export const EMAIL_CONFIRM_PAGE_TITLE = "Confirm Email Change"
 
 export const CART_DISPLAY_PAGE_TITLE = "Checkout"
+
+export const ORDER_HISTORY_DISPLAY_PAGE_TITLE = "Order History"

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -26,6 +26,7 @@ import EmailConfirmPage from "./pages/settings/EmailConfirmPage"
 import DashboardPage from "./pages/DashboardPage"
 
 import CartPage from "./pages/checkout/CartPage"
+import OrderHistory from "./pages/checkout/OrderHistory"
 
 import type { Match, Location } from "react-router"
 import type { CurrentUser } from "../flow/authTypes"
@@ -96,6 +97,10 @@ export class App extends React.Component<Props, void> {
             <Route
               path={urljoin(match.url, String(routes.cart))}
               component={CartPage}
+            />
+            <Route
+              path={urljoin(match.url, String(routes.orderHistory))}
+              component={OrderHistory}
             />
           </Switch>
         </div>

--- a/static/js/containers/pages/checkout/OrderHistory.js
+++ b/static/js/containers/pages/checkout/OrderHistory.js
@@ -1,0 +1,113 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import DocumentTitle from "react-document-title"
+import { ORDER_HISTORY_DISPLAY_PAGE_TITLE } from "../../../constants"
+import { compose } from "redux"
+import { connect } from "react-redux"
+import { connectRequest } from "redux-query"
+import { partial, pathOr, without } from "ramda"
+
+import Loader from "../../../components/Loader"
+
+import { createStructuredSelector } from "reselect"
+import {
+  orderHistoryQuery,
+  orderHistoryQueryKey,
+  orderHistorySelector
+} from "../../../lib/queries/cart"
+
+import type { RouterHistory } from "react-router"
+import moment from "moment"
+import { formatPrettyDateTimeAmPmTz, parseDateString } from "../../../lib/util"
+import { Button } from "reactstrap"
+import type { PaginatedOrderHistory } from "../../../flow/cartTypes"
+
+type Props = {
+  history: RouterHistory,
+  isLoading: boolean,
+  orderHistory: PaginatedOrderHistory
+}
+
+export class OrderHistory extends React.Component<Props> {
+  renderOrderCard(order: Object) {
+    const orderTitle =
+      order.titles.length > 0 ? order.titles.join("<br />") : <em>No Items</em>
+    const orderDate = formatPrettyDateTimeAmPmTz(
+      parseDateString(order.created_on)
+    )
+
+    return (
+      <div className="row d-flex p-3 my-0 bg-light">
+        <div className="col">{orderTitle}</div>
+        <div className="col">{orderDate}</div>
+        <div className="col">{order.total_price_paid}</div>
+        <div className="col">{order.reference_number}</div>
+        <div className="col">View</div>
+      </div>
+    )
+  }
+  render() {
+    const { orderHistory, isLoading } = this.props
+
+    return (
+      <DocumentTitle
+        title={`${SETTINGS.site_name} | ${ORDER_HISTORY_DISPLAY_PAGE_TITLE}`}
+      >
+        <Loader isLoading={isLoading}>
+          <div className="std-page-body cart container">
+            <div className="row">
+              <div className="col-12 d-flex justify-content-between">
+                <h1 className="flex-grow-1">Order History</h1>
+              </div>
+            </div>
+
+            <div className="row d-flex p-3 mt-4 bg-light border-bottom border-2 border-dark">
+              <div className="col">
+                <strong>Items</strong>
+              </div>
+              <div className="col">
+                <strong>Date placed</strong>
+              </div>
+              <div className="col">
+                <strong>Total cost</strong>
+              </div>
+              <div className="col">
+                <strong>Order number</strong>
+              </div>
+              <div className="col">
+                <strong>Order details</strong>
+              </div>
+            </div>
+            {orderHistory && orderHistory.results.length > 0
+              ? orderHistory.results.map(this.renderOrderCard.bind(this))
+              : null}
+            <div className="row d-flex p-3 mb-4 bg-light border-top border-2 border-dark">
+              <div className="col">
+                {orderHistory ? orderHistory.count : "0"} orders total
+              </div>
+              <div className="col text-right" />
+            </div>
+          </div>
+        </Loader>
+      </DocumentTitle>
+    )
+  }
+}
+
+const mapStateToProps = createStructuredSelector({
+  orderHistory: orderHistorySelector,
+  isLoading:    pathOr(true, ["queries", orderHistoryQueryKey, "isPending"])
+})
+
+const mapDispatchToProps = {}
+
+const mapPropsToConfig = () => [orderHistoryQuery()]
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  connectRequest(mapPropsToConfig)
+)(OrderHistory)

--- a/static/js/flow/cartTypes.js
+++ b/static/js/flow/cartTypes.js
@@ -22,3 +22,10 @@ export type CartItem = {
   user: number,
   basket_items: Array<BasketItem>
 }
+
+export type PaginatedOrderHistory = {
+  count: number,
+  next: ?string,
+  previous: ?string,
+  results: Array<Object>
+}

--- a/static/js/lib/queries/cart.js
+++ b/static/js/lib/queries/cart.js
@@ -4,7 +4,10 @@ import { getCsrfOptions, nextState } from "./util"
 
 export const cartSelector = pathOr(null, ["entities", "cartItems"])
 export const totalPriceSelector = pathOr(null, ["entities", "totalPrice"])
+export const orderHistorySelector = pathOr(null, ["entities", "orderHistory"])
+
 export const cartQueryKey = "cartItems"
+export const orderHistoryQueryKey = "orderHistory"
 
 export const checkoutPayloadSelector = pathOr(null, [
   "entities",
@@ -41,5 +44,16 @@ export const checkoutFormDataMutation = () => ({
   }),
   update: {
     checkoutPayload: nextState
+  }
+})
+
+export const orderHistoryQuery = () => ({
+  url:       `/api/orders/history`,
+  queryKey:  orderHistoryQueryKey,
+  transform: json => ({
+    orderHistory: json
+  }),
+  update: {
+    orderHistory: nextState
   }
 })

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -38,6 +38,10 @@ export const routes = {
     begin: ""
   }),
 
+  orderHistory: include("/orders/history", {
+    begin: ""
+  }),
+
   informationLinks: include("", {
     termsOfService: "terms-of-service",
     privacyPolicy:  "privacy-policy"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [ ] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#433 

#### What's this PR do?
Adds the order history screen per the specs in InVision. 

#### How should this be manually tested?
Navigate to /orders/history once you've put at least one order through the system (successful or not).

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/945611/156244224-eaf8bbfc-58a9-4032-a998-3c2d4adc310e.png)

#### Other notes
- This lacks pagination controls
- The total cost field doesn't use the formatter utility function (so too many decimals, no currency type indicator, no thousands separator, etc.)
- Will need some styling for mobile; there didn't seem to be any in InVision. Should be sorta reasonable but it's not been tested. 