### PR TITLE
Adding OrderReceiptPage

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -137,6 +137,7 @@ class BasketDiscountSerializer(serializers.ModelSerializer):
         fields = ["redeemed_discount", "redeemed_basket"]
         depth = 1
 
+
 class RedeemedDiscountSerializer(serializers.ModelSerializer):
     """DiscountRedemption model serializer"""
 
@@ -238,14 +239,7 @@ class OrderSerializer(serializers.ModelSerializer):
         return discounts
 
     class Meta:
-        fields = [
-            "id",
-            "state",
-            "purchaser",
-            "total_price_paid",
-            "lines",
-            "discounts"
-        ]
+        fields = ["id", "state", "purchaser", "total_price_paid", "lines", "discounts"]
         model = models.Order
 
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -137,6 +137,14 @@ class BasketDiscountSerializer(serializers.ModelSerializer):
         fields = ["redeemed_discount", "redeemed_basket"]
         depth = 1
 
+class RedeemedDiscountSerializer(serializers.ModelSerializer):
+    """DiscountRedemption model serializer"""
+
+    class Meta:
+        model = models.DiscountRedemption
+        fields = ["redeemed_discount"]
+        depth = 1
+
 
 class BasketItemWithProductSerializer(serializers.ModelSerializer):
     product = serializers.SerializerMethodField()
@@ -221,6 +229,13 @@ class LineSerializer(serializers.ModelSerializer):
 
 class OrderSerializer(serializers.ModelSerializer):
     lines = LineSerializer(many=True)
+    discounts = serializers.SerializerMethodField()
+
+    def get_discounts(self, instance):
+        discounts = []
+        for discount in instance.discounts.all():
+            discounts.append(RedeemedDiscountSerializer(discount).data)
+        return discounts
 
     class Meta:
         fields = [
@@ -229,6 +244,7 @@ class OrderSerializer(serializers.ModelSerializer):
             "purchaser",
             "total_price_paid",
             "lines",
+            "discounts"
         ]
         model = models.Order
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -196,18 +196,6 @@ class BasketWithProductSerializer(serializers.ModelSerializer):
         model = models.Basket
 
 
-class OrderSerializer(serializers.ModelSerializer):
-    class Meta:
-        fields = [
-            "id",
-            "state",
-            "purchaser",
-            "total_price_paid",
-            "lines",
-        ]
-        model = models.Order
-
-
 class LineSerializer(serializers.ModelSerializer):
     product = serializers.SerializerMethodField()
 
@@ -229,6 +217,20 @@ class LineSerializer(serializers.ModelSerializer):
             "product",
         ]
         model = models.Line
+
+
+class OrderSerializer(serializers.ModelSerializer):
+    lines = LineSerializer(many=True)
+
+    class Meta:
+        fields = [
+            "id",
+            "state",
+            "purchaser",
+            "total_price_paid",
+            "lines",
+        ]
+        model = models.Order
 
 
 class OrderHistorySerializer(serializers.ModelSerializer):

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -239,7 +239,15 @@ class OrderSerializer(serializers.ModelSerializer):
         return discounts
 
     class Meta:
-        fields = ["id", "state", "purchaser", "total_price_paid", "lines", "discounts", "reference_number"]
+        fields = [
+            "id",
+            "state",
+            "purchaser",
+            "total_price_paid",
+            "lines",
+            "discounts",
+            "reference_number",
+        ]
         model = models.Order
 
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -239,7 +239,7 @@ class OrderSerializer(serializers.ModelSerializer):
         return discounts
 
     class Meta:
-        fields = ["id", "state", "purchaser", "total_price_paid", "lines", "discounts"]
+        fields = ["id", "state", "purchaser", "total_price_paid", "lines", "discounts", "reference_number"]
         model = models.Order
 
 

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -14,7 +14,7 @@ from ecommerce.views.v0 import (
     CheckoutInterstitialView,
     CheckoutProductView,
     OrderHistoryViewSet,
-    OrderReceiptViewSet,
+    OrderReceiptView,
 )
 
 
@@ -26,7 +26,6 @@ router = SimpleRouterWithNesting()
 router.register(r"products", ProductViewSet, basename="products_api")
 router.register(r"checkout", CheckoutApiViewSet, basename="checkout_api")
 router.register(r"orders/history", OrderHistoryViewSet, basename="orderhistory_api")
-router.register(r"orders/receipt", OrderReceiptViewSet, basename="orderreceipt_api")
 
 basketRouter = router.register(r"baskets", BasketViewSet, basename="basket")
 basketRouter.register(
@@ -49,6 +48,11 @@ urlpatterns = [
         "checkout/to_payment",
         CheckoutInterstitialView.as_view(),
         name="checkout_interstitial_page",
+    ),
+    re_path(
+        r"^api/orders/receipt/(?P<reference_number>[0-9A-Za-z_\-]+)/$",
+        OrderReceiptView.as_view(),
+        name="order_receipt_api",
     ),
     re_path(
         r"^checkout/result/",

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -50,7 +50,7 @@ urlpatterns = [
         name="checkout_interstitial_page",
     ),
     re_path(
-        r"^api/orders/receipt/(?P<pk>[0-9A-Za-z_\-]+)/$",
+        r"^api/orders/receipt/(?P<pk>\d+)/$",
         OrderReceiptView.as_view(),
         name="order_receipt_api",
     ),

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -14,6 +14,7 @@ from ecommerce.views.v0 import (
     CheckoutInterstitialView,
     CheckoutProductView,
     OrderHistoryViewSet,
+    OrderReceiptViewSet,
 )
 
 
@@ -25,6 +26,7 @@ router = SimpleRouterWithNesting()
 router.register(r"products", ProductViewSet, basename="products_api")
 router.register(r"checkout", CheckoutApiViewSet, basename="checkout_api")
 router.register(r"orders/history", OrderHistoryViewSet, basename="orderhistory_api")
+router.register(r"orders/receipt", OrderReceiptViewSet, basename="orderreceipt_api")
 
 basketRouter = router.register(r"baskets", BasketViewSet, basename="basket")
 basketRouter.register(

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -50,7 +50,7 @@ urlpatterns = [
         name="checkout_interstitial_page",
     ),
     re_path(
-        r"^api/orders/receipt/(?P<reference_number>[0-9A-Za-z_\-]+)/$",
+        r"^api/orders/receipt/(?P<pk>[0-9A-Za-z_\-]+)/$",
         OrderReceiptView.as_view(),
         name="order_receipt_api",
     ),

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -13,7 +13,7 @@ from main.constants import (
 from main.utils import redirect_with_user_message
 from rest_framework import mixins, status
 from rest_framework.response import Response
-from rest_framework.generics import ListCreateAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveAPIView
 from rest_framework.viewsets import ReadOnlyModelViewSet, GenericViewSet, ViewSet
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
@@ -491,9 +491,13 @@ class OrderHistoryViewSet(ReadOnlyModelViewSet):
         return Order.objects.filter(purchaser=self.request.user).all()
 
 
-class OrderReceiptViewSet(ReadOnlyModelViewSet):
+class OrderReceiptView(RetrieveAPIView):
     serializer_class = OrderSerializer
     permission_classes = [IsAuthenticated]
+    lookup_field = "reference_number"
+
+    def get_object(self, reference_number=None):
+        return Order.objects.get(reference_number=reference_number)
 
     def get_queryset(self):
-        return Order.objects.filter(purchaser=self.request.user).all()
+        return Order.objects.filter(purchaser=self.request.user, status=Order.FULFILLED).all()

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -67,6 +67,8 @@ from ecommerce.models import (
     UserDiscount,
     PendingOrder,
     Order,
+    Line,
+    FulfilledOrder,
 )
 
 log = logging.getLogger(__name__)
@@ -485,6 +487,14 @@ class CheckoutInterstitialView(LoginRequiredMixin, TemplateView):
 class OrderHistoryViewSet(ReadOnlyModelViewSet):
     serializer_class = OrderHistorySerializer
     pagination_class = OrderHistoryPagination
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return Order.objects.filter(purchaser=self.request.user).all()
+
+
+class OrderReceiptViewSet(ReadOnlyModelViewSet):
+    serializer_class = OrderSerializer
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -15,7 +15,6 @@ from rest_framework import mixins, status
 from rest_framework.response import Response
 from rest_framework.generics import ListCreateAPIView
 from rest_framework.viewsets import ReadOnlyModelViewSet, GenericViewSet, ViewSet
-from rest_framework.views import APIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -57,6 +56,7 @@ from ecommerce.serializers import (
     BasketItemSerializer,
     BasketDiscountSerializer,
     BasketWithProductSerializer,
+    OrderSerializer,
 )
 from ecommerce.models import (
     Product,
@@ -67,8 +67,6 @@ from ecommerce.models import (
     UserDiscount,
     PendingOrder,
     Order,
-    Line,
-    FulfilledOrder,
 )
 
 log = logging.getLogger(__name__)

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -494,10 +494,6 @@ class OrderHistoryViewSet(ReadOnlyModelViewSet):
 class OrderReceiptView(RetrieveAPIView):
     serializer_class = OrderSerializer
     permission_classes = [IsAuthenticated]
-    lookup_field = "reference_number"
-
-    def get_object(self, reference_number=None):
-        return Order.objects.get(reference_number=reference_number)
 
     def get_queryset(self):
-        return Order.objects.filter(purchaser=self.request.user, status=Order.FULFILLED).all()
+        return Order.objects.filter(purchaser=self.request.user).all()

--- a/main/urls.py
+++ b/main/urls.py
@@ -67,6 +67,7 @@ urlpatterns = [
     re_path(r"^account-settings/", index, name="account-settings"),
     re_path(r"^cart/.*", index, name="cart"),
     re_path(r"^orders/history/.*", index, name="order-history"),
+    re_path(r"^orders/receipt/.*", index, name="order-receipt"),
     # Wagtail
     re_path(
         r"^cms/login", cms_signin_redirect_to_site_signin, name="wagtailadmin_login"

--- a/static/js/components/CartItemCard.js
+++ b/static/js/components/CartItemCard.js
@@ -1,0 +1,79 @@
+// @flow
+import React from "react"
+import type { BasketItem, Product } from "../flow/cartTypes"
+import moment from "moment"
+import { formatPrettyDateTimeAmPmTz, parseDateString } from "../lib/util"
+
+type Props = {
+  product: Product
+}
+
+export class CartItemCard extends React.Component<Props> {
+  render() {
+    const { product } = this.props
+    if (product.purchasable_object === null) {
+      return null
+    }
+
+    const purchasableObject = product.purchasable_object
+    const course = purchasableObject.course
+
+    const title =
+      course !== undefined ? (
+        <a href="#" target="_blank" rel="noopener noreferrer">
+          {course.title}
+        </a>
+      ) : (
+        <a href="#" target="_blank" rel="noopener noreferrer">
+          {product.description}
+        </a>
+      )
+
+    const readableId =
+      course !== undefined
+        ? purchasableObject.readable_id
+        : purchasableObject.run_tag
+
+    let startDate = ""
+    let startDateDescription = ""
+
+    if (purchasableObject.start_date) {
+      const now = moment()
+      startDate = parseDateString(purchasableObject.start_date)
+      const formattedStartDate = formatPrettyDateTimeAmPmTz(startDate)
+      startDateDescription = now.isBefore(startDate) ? (
+        <span>Starts - {formattedStartDate}</span>
+      ) : (
+        <span>
+          <strong>Active</strong> from {formattedStartDate}
+        </span>
+      )
+    }
+
+    const courseImage =
+      course !== undefined && course.page !== null ? (
+        <img src={course.page.feature_image_src} alt={course.title} />
+      ) : null
+    const cardKey = `cartsummarycard_${product.id}`
+
+    return (
+      <div
+        className="enrolled-item container card mb-4 rounded-0 flex-grow-1"
+        key={cardKey}
+      >
+        <div className="row d-flex flex-sm-columm p-md-3">
+          <div className="img-container">{courseImage}</div>
+
+          <div className="flex-grow-1 d-sm-flex flex-column w-50 mx-3">
+            <h5 className="">{title}</h5>
+            <div className="detail">
+              {readableId}
+              <br />
+              {startDateDescription !== undefined ? startDateDescription : ""}
+            </div>
+          </div>
+        </div>{" "}
+      </div>
+    )
+  }
+}

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -88,7 +88,7 @@ export class OrderSummaryCard extends React.Component<Props> {
       >
         <div className="row order-summary-total mt-3 mt-md-0 mb-3">
           <div className="col-12 col-md-auto px-3 px-md-3">
-            <h5>${title}</h5>
+            <h5>{title}</h5>
           </div>
         </div>
 

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -119,14 +119,16 @@ export class OrderSummaryCard extends React.Component<Props> {
           </div>
         </div>
 
-        {!SETTINGS.features.disable_discount_ui && !orderFulfilled && discountCode ? (
-          <ApplyCouponForm
-            onSubmit={addDiscount}
-            discountCodeIsBad={discountCodeIsBad}
-            couponCode={discountCode}
-            discounts={discounts}
-          />
-        ) : null}
+        {!SETTINGS.features.disable_discount_ui &&
+        !orderFulfilled &&
+        discountCode ? (
+            <ApplyCouponForm
+              onSubmit={addDiscount}
+              discountCodeIsBad={discountCodeIsBad}
+              couponCode={discountCode}
+              discounts={discounts}
+            />
+          ) : null}
 
         {totalPrice > 0 && !orderFulfilled ? (
           <div className="row">

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -14,7 +14,8 @@ type Props = {
   addDiscount?: Function,
   clearDiscount?: Function,
   discountCode?: string,
-  discountCodeIsBad: boolean
+  discountCodeIsBad: boolean,
+  cardTitle?: string
 }
 
 export class OrderSummaryCard extends React.Component<Props> {
@@ -74,10 +75,12 @@ export class OrderSummaryCard extends React.Component<Props> {
       discounts,
       addDiscount,
       discountCodeIsBad,
-      discountCode
+      discountCode,
+      cardTitle
     } = this.props
     const fmtPrice = formatLocalePrice(totalPrice)
     const fmtDiscountPrice = formatLocalePrice(discountedPrice)
+    const title = cardTitle ? cardTitle : "Order Summary"
     return (
       <div
         className="order-summary container card p-md-3 mb-4 rounded-0"
@@ -85,7 +88,7 @@ export class OrderSummaryCard extends React.Component<Props> {
       >
         <div className="row order-summary-total mt-3 mt-md-0 mb-3">
           <div className="col-12 col-md-auto px-3 px-md-3">
-            <h5>Order summary</h5>
+            <h5>${title}</h5>
           </div>
         </div>
 

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -61,7 +61,9 @@ export class OrderSummaryCard extends React.Component<Props> {
               <br />
               {orderFulfilled ? null : clearDiscountLink}
             </div>
-            <div className="ml-auto text-primary">{discountAmountText}</div>
+            <div className="ml-auto text-primary text-right">
+              {discountAmountText}
+            </div>
           </div>
         </div>
       </div>

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -122,15 +122,14 @@ export class OrderSummaryCard extends React.Component<Props> {
           </div>
         </div>
 
-        {!SETTINGS.features.disable_discount_ui &&
-        !orderFulfilled ? (
-            <ApplyCouponForm
-              onSubmit={addDiscount}
-              discountCodeIsBad={discountCodeIsBad}
-              couponCode={discountCode}
-              discounts={discounts}
-            />
-          ) : null}
+        {!SETTINGS.features.disable_discount_ui && !orderFulfilled ? (
+          <ApplyCouponForm
+            onSubmit={addDiscount}
+            discountCodeIsBad={discountCodeIsBad}
+            couponCode={discountCode}
+            discounts={discounts}
+          />
+        ) : null}
 
         {totalPrice > 0 && !orderFulfilled ? (
           <div className="row">

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -2,7 +2,7 @@
 /* global SETTINGS: false */
 import React from "react"
 import { Button } from "reactstrap"
-import {formatLocalePrice, isSuccessResponse} from "../lib/util"
+import { formatLocalePrice, isSuccessResponse } from "../lib/util"
 import ApplyCouponForm from "./forms/ApplyCouponForm"
 import type { Discount } from "../flow/cartTypes"
 
@@ -11,16 +11,15 @@ type Props = {
   orderFulfilled: boolean,
   discountedPrice: number,
   discounts: Array<Discount>,
-  addDiscount: Function,
-  clearDiscount: Function,
-  discountCode: string,
-  discountCodeIsBad: boolean,
+  addDiscount?: Function,
+  clearDiscount?: Function,
+  discountCode?: string,
+  discountCodeIsBad: boolean
 }
 
 export class OrderSummaryCard extends React.Component<Props> {
-
   renderAppliedCoupons() {
-    const { discounts, clearDiscount } = this.props
+    const { discounts, clearDiscount, orderFulfilled } = this.props
 
     if (discounts === null || discounts.length === 0) {
       return null
@@ -42,6 +41,11 @@ export class OrderSummaryCard extends React.Component<Props> {
       discountAmountText = `Fixed Price: ${formatLocalePrice(discountAmount)}`
       break
     }
+    const clearDiscountLink = (
+      <a href="#" className="text-primary" onClick={clearDiscount}>
+        Clear Discount
+      </a>
+    )
 
     return (
       <div className="row order-summary-total">
@@ -54,13 +58,7 @@ export class OrderSummaryCard extends React.Component<Props> {
               </em>{" "}
               )
               <br />
-              <a
-                href="#"
-                className="text-primary"
-                onClick={clearDiscount}
-              >
-                Clear Discount
-              </a>
+              {orderFulfilled ? null : clearDiscountLink}
             </div>
             <div className="ml-auto text-primary">{discountAmountText}</div>
           </div>
@@ -69,7 +67,15 @@ export class OrderSummaryCard extends React.Component<Props> {
     )
   }
   render() {
-    const {orderFulfilled, discountedPrice, totalPrice, discounts, addDiscount, discountCodeIsBad, discountCode} = this.props
+    const {
+      orderFulfilled,
+      discountedPrice,
+      totalPrice,
+      discounts,
+      addDiscount,
+      discountCodeIsBad,
+      discountCode
+    } = this.props
     const fmtPrice = formatLocalePrice(totalPrice)
     const fmtDiscountPrice = formatLocalePrice(discountedPrice)
     return (
@@ -107,13 +113,13 @@ export class OrderSummaryCard extends React.Component<Props> {
                 <h5>Total</h5>
               </div>
               <div className="ml-auto">
-                <h5>{fmtDiscountPrice}</h5>
+                <h5>{fmtDiscountPrice || fmtPrice}</h5>
               </div>
             </div>
           </div>
         </div>
 
-        {!SETTINGS.features.disable_discount_ui ? (
+        {!SETTINGS.features.disable_discount_ui && !orderFulfilled && discountCode ? (
           <ApplyCouponForm
             onSubmit={addDiscount}
             discountCodeIsBad={discountCodeIsBad}
@@ -122,7 +128,7 @@ export class OrderSummaryCard extends React.Component<Props> {
           />
         ) : null}
 
-        {totalPrice > 0 ? (
+        {totalPrice > 0 && !orderFulfilled ? (
           <div className="row">
             <div className="col-12 text-center mt-4 mb-4">
               <Button
@@ -136,7 +142,7 @@ export class OrderSummaryCard extends React.Component<Props> {
           </div>
         ) : null}
 
-        {totalPrice > 0 ? (
+        {totalPrice > 0 && !orderFulfilled ? (
           <div className="row">
             <div className="col-12 px-3 py-3 py-md-0 cart-text-smaller">
               By placing my order I agree to the{" "}

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -1,0 +1,125 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import { Button } from "reactstrap"
+import {formatLocalePrice, roundPrice} from "../lib/util"
+
+type Props = {
+  totalPrice: number,
+  orderFulfilled: boolean
+}
+
+export class OrderSummaryCard extends React.Component<Props> {
+  renderDiscountUI(totalPrice: string) {
+    return SETTINGS.features.enable_discount_ui ? (
+      <div className="row order-summary-total">
+        <div className="col-12 px-3 py-3 py-md-0">
+          <div className="d-flex justify-content-between">
+            <div className="flex-grow-1">
+              Coupon applied (
+              <em className="font-weight-bold text-primary">coupon1</em> )
+            </div>
+            <div className="ml-auto text-primary">-${totalPrice}</div>
+          </div>
+        </div>
+      </div>
+    ) : null
+  }
+  renderPayButton() {
+    const { orderFulfilled, totalPrice } = this.props
+    return totalPrice > 0 && !orderFulfilled ? (
+      <>
+        <div className="row">
+          <div className="col-12 text-center mt-4 mb-4">
+            <Button
+              type="link"
+              className="btn btn-primary btn-gradient-red highlight font-weight-bold text-white"
+              onClick={() => (window.location = "/checkout/to_payment")}
+            >
+              Place your order
+            </Button>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-12 px-3 py-3 py-md-0 cart-text-smaller">
+            By placing my order I agree to the{" "}
+            <a href="/terms-of-service/" target="_blank" rel="noreferrer">
+              Terms of Service
+            </a>
+            , and{" "}
+            <a href="/privacy-policy/" target="_blank" rel="noreferrer">
+              Privacy Policy.
+            </a>
+          </div>
+        </div>
+      </>
+    ) : null
+  }
+  renderAddCoupon() {
+    return SETTINGS.features.enable_discount_ui ? (
+      <div className="row">
+        <div className="col-12 mt-4 px-3 py-3 py-md-0">
+          Have a coupon?
+          <div className="d-flex justify-content-between flex-sm-column flex-md-row">
+            <input
+              type="text"
+              name="coupon-code"
+              className="form-input flex-sm-grow-1"
+            />
+            <button className="btn btn-primary btn-red btn-halfsize mx-2 highlight font-weight-normal">
+              Apply
+            </button>
+          </div>
+          <div className="text-primary mt-2 font-weight-bold cart-text-smaller">
+            Adding another coupon will replace the currently applied coupon.
+          </div>
+        </div>
+      </div>
+    ) : null
+  }
+  render() {
+    let { totalPrice } = this.props
+    const { orderFulfilled } = this.props
+    totalPrice = formatLocalePrice(totalPrice)
+    return (
+      <div
+        className="order-summary container card p-md-3 mb-4 rounded-0"
+        key="ordersummarycard"
+      >
+        <div className="row order-summary-total mt-3 mt-md-0 mb-3">
+          <div className="col-12 col-md-auto px-3 px-md-3">
+            <h5>Order summary</h5>
+          </div>
+        </div>
+
+        <div className="row">
+          <div className="col-12 px-3 py-3 py-md-0">
+            <div className="d-flex justify-content-between">
+              <div className="flex-grow-1">Price</div>
+              <div className="ml-auto">${totalPrice}</div>
+            </div>
+          </div>
+        </div>
+        {orderFulfilled ? null : this.renderDiscountUI(totalPrice)}
+        <div className="row my-3 mx-1">
+          <div className="col-12 px-3 border-top border-dark" />
+        </div>
+
+        <div className="row order-summary-total">
+          <div className="col-12 px-3 py-3 py-md-0">
+            <div className="d-flex justify-content-between">
+              <div className="flex-grow-1">
+                <h5>Total</h5>
+              </div>
+              <div className="ml-auto">
+                <h5>${totalPrice}</h5>
+              </div>
+            </div>
+          </div>
+        </div>
+        {orderFulfilled ? null : this.renderAddCoupon()}
+        {orderFulfilled ? null : this.renderPayButton()}
+      </div>
+    )
+  }
+}

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -88,7 +88,7 @@ export class OrderSummaryCard extends React.Component<Props> {
       >
         <div className="row order-summary-total mt-3 mt-md-0 mb-3">
           <div className="col-12 col-md-auto px-3 px-md-3">
-            <h5>{title}</h5>
+            <h5 id="summary-card-title">{title}</h5>
           </div>
         </div>
 

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -13,7 +13,7 @@ type Props = {
   discounts: Array<Discount>,
   addDiscount?: Function,
   clearDiscount?: Function,
-  discountCode?: string,
+  discountCode: string,
   discountCodeIsBad: boolean,
   cardTitle?: string
 }
@@ -123,8 +123,7 @@ export class OrderSummaryCard extends React.Component<Props> {
         </div>
 
         {!SETTINGS.features.disable_discount_ui &&
-        !orderFulfilled &&
-        discountCode ? (
+        !orderFulfilled ? (
             <ApplyCouponForm
               onSubmit={addDiscount}
               discountCodeIsBad={discountCodeIsBad}

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -151,3 +151,13 @@ export const EMAIL_CONFIRM_PAGE_TITLE = "Confirm Email Change"
 export const CART_DISPLAY_PAGE_TITLE = "Checkout"
 
 export const ORDER_HISTORY_DISPLAY_PAGE_TITLE = "Order History"
+
+export const ORDER_RECEIPT_DISPLAY_PAGE_TITLE = "Order Receipt"
+
+export const ORDER_HISTORY_COLUMN_TITLES = [
+  "Items",
+  "Date placed",
+  "Total cost",
+  "Order number",
+  "Order details"
+]

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -27,6 +27,7 @@ import DashboardPage from "./pages/DashboardPage"
 
 import CartPage from "./pages/checkout/CartPage"
 import OrderHistory from "./pages/checkout/OrderHistory"
+import OrderReceiptPage from "./pages/checkout/OrderReceiptPage"
 
 import type { Match, Location } from "react-router"
 import type { CurrentUser } from "../flow/authTypes"
@@ -101,6 +102,10 @@ export class App extends React.Component<Props, void> {
             <Route
               path={urljoin(match.url, String(routes.orderHistory))}
               component={OrderHistory}
+            />
+            <Route
+              path={urljoin(match.url, String(routes.orderReceipt))}
+              component={OrderReceiptPage}
             />
           </Switch>
         </div>

--- a/static/js/containers/pages/checkout/CartPage.js
+++ b/static/js/containers/pages/checkout/CartPage.js
@@ -171,11 +171,7 @@ export class CartPage extends React.Component<Props, CartState> {
   }
 
   renderOrderSummaryCard() {
-    const {
-      totalPrice,
-      discountedPrice,
-      discounts,
-    } = this.props
+    const { totalPrice, discountedPrice, discounts } = this.props
 
     return (
       <OrderSummaryCard

--- a/static/js/containers/pages/checkout/CartPage.js
+++ b/static/js/containers/pages/checkout/CartPage.js
@@ -29,16 +29,8 @@ import {
 } from "../../../lib/queries/cart"
 
 import type { RouterHistory } from "react-router"
-import {
-  formatPrettyDateTimeAmPmTz,
-  parseDateString,
-  isSuccessResponse,
-  formatLocalePrice
-} from "../../../lib/util"
-import { Button } from "reactstrap"
+import { isSuccessResponse } from "../../../lib/util"
 import { addUserNotification } from "../../../actions"
-
-import ApplyCouponForm from "../../../components/forms/ApplyCouponForm"
 
 type Props = {
   history: RouterHistory,
@@ -62,32 +54,6 @@ export class CartPage extends React.Component<Props, CartState> {
   state = {
     discountCode:      "",
     discountCodeIsBad: false
-  }
-
-  async addDiscount(ev: Object) {
-    const subbedCode = ev.couponCode
-    const { applyDiscountCode, forceRequest, addUserNotification } = this.props
-
-    this.setState({ discountCode: subbedCode, discountCodeIsBad: false })
-
-    if (String(subbedCode).trim().length === 0) {
-      return
-    }
-
-    let userMessage, messageType
-
-    const resp = await applyDiscountCode(this.state.discountCode)
-    if (isSuccessResponse(resp)) {
-      messageType = ALERT_TYPE_SUCCESS
-      userMessage = "Discount code added."
-
-      forceRequest()
-    } else {
-      messageType = ALERT_TYPE_DANGER
-      userMessage = `Discount code ${this.state.discountCode} is invalid.`
-
-      this.setState({ discountCodeIsBad: true })
-    }
   }
 
   async clearDiscount() {

--- a/static/js/containers/pages/checkout/CartPage.js
+++ b/static/js/containers/pages/checkout/CartPage.js
@@ -15,6 +15,8 @@ import { createStructuredSelector } from "reselect"
 import type { BasketItem, Discount } from "../../../flow/cartTypes"
 
 import Loader from "../../../components/Loader"
+import { CartItemCard } from "../../../components/CartItemCard"
+import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
 
 import {
   cartQuery,
@@ -27,7 +29,6 @@ import {
 } from "../../../lib/queries/cart"
 
 import type { RouterHistory } from "react-router"
-import moment from "moment"
 import {
   formatPrettyDateTimeAmPmTz,
   parseDateString,
@@ -128,69 +129,11 @@ export class CartPage extends React.Component<Props, CartState> {
   }
 
   renderCartItemCard(cartItem: BasketItem) {
-    if (cartItem.product.purchasable_object === null) {
-      return null
-    }
-
-    const purchasableObject = cartItem.product.purchasable_object
-    const course = purchasableObject.course
-
-    const title =
-      course !== undefined ? (
-        <a href="#" target="_blank" rel="noopener noreferrer">
-          {course.title}
-        </a>
-      ) : (
-        <a href="#" target="_blank" rel="noopener noreferrer">
-          {cartItem.product.description}
-        </a>
-      )
-
-    const readableId =
-      course !== undefined
-        ? purchasableObject.readable_id
-        : purchasableObject.run_tag
-
-    let startDate = ""
-    let startDateDescription = ""
-
-    if (purchasableObject.start_date) {
-      const now = moment()
-      startDate = parseDateString(purchasableObject.start_date)
-      const formattedStartDate = formatPrettyDateTimeAmPmTz(startDate)
-      startDateDescription = now.isBefore(startDate) ? (
-        <span>Starts - {formattedStartDate}</span>
-      ) : (
-        <span>
-          <strong>Active</strong> from {formattedStartDate}
-        </span>
-      )
-    }
-
-    const courseImage =
-      course !== undefined && course.page !== null ? (
-        <img src={course.page.feature_image_src} alt={course.title} />
-      ) : null
-    const cardKey = `cartsummarycard_${cartItem.id}`
-
     return (
-      <div
-        className="enrolled-item container card mb-4 rounded-0 flex-grow-1"
-        key={cardKey}
-      >
-        <div className="row d-flex flex-sm-columm p-md-3">
-          <div className="img-container">{courseImage}</div>
-
-          <div className="flex-grow-1 d-sm-flex flex-column w-50 mx-3">
-            <h5 className="">{title}</h5>
-            <div className="detail">
-              {readableId}
-              <br />
-              {startDateDescription !== undefined ? startDateDescription : ""}
-            </div>
-          </div>
-        </div>{" "}
-      </div>
+      <CartItemCard
+        key={`cartsummarycard_${cartItem.product.id}`}
+        product={cartItem.product}
+      />
     )
   }
 
@@ -260,6 +203,7 @@ export class CartPage extends React.Component<Props, CartState> {
   }
 
   renderOrderSummaryCard() {
+<<<<<<< HEAD
     const {
       totalPrice,
       discountedPrice,
@@ -349,6 +293,13 @@ export class CartPage extends React.Component<Props, CartState> {
           </div>
         ) : null}
       </div>
+=======
+    return (
+      <OrderSummaryCard
+        totalPrice={this.props.totalPrice}
+        orderFulfilled={false}
+      />
+>>>>>>> Adding OrderReceiptPage
     )
   }
 

--- a/static/js/containers/pages/checkout/CartPage.js
+++ b/static/js/containers/pages/checkout/CartPage.js
@@ -64,13 +64,6 @@ export class CartPage extends React.Component<Props, CartState> {
     discountCodeIsBad: false
   }
 
-  updateCode(event: Object) {
-    this.setState({
-      discountCode:      event.target.value,
-      discountCodeIsBad: false
-    })
-  }
-
   async addDiscount(ev: Object) {
     const subbedCode = ev.couponCode
     const { applyDiscountCode, forceRequest, addUserNotification } = this.props
@@ -128,6 +121,31 @@ export class CartPage extends React.Component<Props, CartState> {
     })
   }
 
+  async addDiscount(ev: Object) {
+    const subbedCode = ev.couponCode
+    const { applyDiscountCode, forceRequest, addUserNotification } = this.props
+
+    this.setState({ discountCode: subbedCode, discountCodeIsBad: false })
+
+    if (String(subbedCode).trim().length === 0) {
+      return
+    }
+
+    let userMessage, messageType
+
+    const resp = await applyDiscountCode(this.state.discountCode)
+    if (isSuccessResponse(resp)) {
+      messageType = ALERT_TYPE_SUCCESS
+      userMessage = "Discount code added."
+
+      forceRequest()
+    } else {
+      messageType = ALERT_TYPE_DANGER
+      userMessage = `Discount code ${this.state.discountCode} is invalid.`
+
+      this.setState({ discountCodeIsBad: true })
+    }
+  }
   renderCartItemCard(cartItem: BasketItem) {
     return (
       <CartItemCard
@@ -152,154 +170,24 @@ export class CartPage extends React.Component<Props, CartState> {
     )
   }
 
-  renderAppliedCoupons() {
-    const discounts = this.props.discounts
-
-    if (discounts === null || discounts.length === 0) {
-      return null
-    }
-
-    let discountAmountText = null
-    const discountAmount = Number(discounts[0].amount)
-
-    switch (discounts[0].discount_type) {
-    case "percent-off":
-      discountAmountText = `${discountAmount}% off`
-      break
-
-    case "dollars-off":
-      discountAmountText = `-${formatLocalePrice(discountAmount)}`
-      break
-
-    default:
-      discountAmountText = `Fixed Price: ${formatLocalePrice(discountAmount)}`
-      break
-    }
-
-    return (
-      <div className="row order-summary-total">
-        <div className="col-12 px-3 py-3 py-md-0">
-          <div className="d-flex justify-content-between">
-            <div className="flex-grow-1">
-              Coupon applied (
-              <em className="font-weight-bold text-primary">
-                {discounts[0].discount_code}
-              </em>{" "}
-              )
-              <br />
-              <a
-                href="#"
-                className="text-primary"
-                onClick={this.clearDiscount.bind(this)}
-              >
-                Clear Discount
-              </a>
-            </div>
-            <div className="ml-auto text-primary">{discountAmountText}</div>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
   renderOrderSummaryCard() {
-<<<<<<< HEAD
     const {
       totalPrice,
       discountedPrice,
       discounts,
-      applyDiscountCode
     } = this.props
 
-    const fmtPrice = formatLocalePrice(totalPrice)
-    const fmtDiscountPrice = formatLocalePrice(discountedPrice)
-
-    return (
-      <div
-        className="order-summary container card p-md-3 mb-4 rounded-0"
-        key="ordersummarycard"
-      >
-        <div className="row order-summary-total mt-3 mt-md-0 mb-3">
-          <div className="col-12 col-md-auto px-3 px-md-3">
-            <h5>Order summary</h5>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="col-12 px-3 py-3 py-md-0">
-            <div className="d-flex justify-content-between">
-              <div className="flex-grow-1">Price</div>
-              <div className="ml-auto">{fmtPrice}</div>
-            </div>
-          </div>
-        </div>
-
-        {!SETTINGS.features.disable_discount_ui
-          ? this.renderAppliedCoupons()
-          : null}
-
-        <div className="row my-3 mx-1">
-          <div className="col-12 px-3 border-top border-dark" />
-        </div>
-
-        <div className="row order-summary-total">
-          <div className="col-12 px-3 py-3 py-md-0">
-            <div className="d-flex justify-content-between">
-              <div className="flex-grow-1">
-                <h5>Total</h5>
-              </div>
-              <div className="ml-auto">
-                <h5>{fmtDiscountPrice}</h5>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {!SETTINGS.features.disable_discount_ui ? (
-          <ApplyCouponForm
-            onSubmit={this.addDiscount.bind(this)}
-            discountCodeIsBad={this.state.discountCodeIsBad}
-            couponCode={this.state.discountCode}
-            discounts={discounts}
-          />
-        ) : null}
-
-        {totalPrice > 0 ? (
-          <div className="row">
-            <div className="col-12 text-center mt-4 mb-4">
-              <Button
-                type="link"
-                className="btn btn-primary btn-gradient-red highlight font-weight-bold text-white"
-                onClick={() => (window.location = "/checkout/to_payment")}
-              >
-                Place your order
-              </Button>
-            </div>
-          </div>
-        ) : null}
-
-        {totalPrice > 0 ? (
-          <div className="row">
-            <div className="col-12 px-3 py-3 py-md-0 cart-text-smaller">
-              By placing my order I agree to the{" "}
-              <a href="/terms-of-service/" target="_blank" rel="noreferrer">
-                Terms of Service
-              </a>
-              , and{" "}
-              <a href="/privacy-policy/" target="_blank" rel="noreferrer">
-                Privacy Policy.
-              </a>
-            </div>
-          </div>
-        ) : null}
-      </div>
-=======
     return (
       <OrderSummaryCard
-        totalPrice={this.props.totalPrice}
+        totalPrice={totalPrice}
         orderFulfilled={false}
+        discountedPrice={discountedPrice}
+        discounts={discounts}
+        clearDiscount={this.clearDiscount.bind(this)}
+        addDiscount={this.addDiscount.bind(this)}
+        discountCodeIsBad={this.state.discountCodeIsBad}
+        discountCode={this.state.discountCode}
       />
->>>>>>> Adding OrderReceiptPage
     )
   }
 

--- a/static/js/containers/pages/checkout/OrderHistory.js
+++ b/static/js/containers/pages/checkout/OrderHistory.js
@@ -37,12 +37,8 @@ type Props = {
 }
 
 export class OrderHistory extends React.Component<Props> {
-  renderOrderReceipt(orderId: number) {
-    window.localStorage.setItem(
-      "selectedOrderReceiptId",
-      JSON.stringify(orderId)
-    )
-    window.location = "/orders/receipt"
+  renderOrderReceipt(orderReference: string) {
+    window.location = `/orders/receipt/${orderReference}/`
   }
 
   renderOrderCard(order: Object) {
@@ -66,7 +62,7 @@ export class OrderHistory extends React.Component<Props> {
         <div className="col">
           <div
             className="link-text"
-            onClick={() => this.renderOrderReceipt(order.id)}
+            onClick={() => this.renderOrderReceipt(order.reference_number)}
           >
             View
           </div>

--- a/static/js/containers/pages/checkout/OrderHistory.js
+++ b/static/js/containers/pages/checkout/OrderHistory.js
@@ -22,7 +22,11 @@ import {
 
 import type { RouterHistory } from "react-router"
 import moment from "moment"
-import { formatPrettyDateTimeAmPmTz, parseDateString } from "../../../lib/util"
+import {
+  formatLocalePrice,
+  formatPrettyDateTimeAmPmTz,
+  parseDateString
+} from "../../../lib/util"
 import { Button } from "reactstrap"
 import type { PaginatedOrderHistory } from "../../../flow/cartTypes"
 
@@ -55,7 +59,9 @@ export class OrderHistory extends React.Component<Props> {
       >
         <div className="col">{orderTitle}</div>
         <div className="col">{orderDate}</div>
-        <div className="col">{order.total_price_paid}</div>
+        <div className="col">
+          {formatLocalePrice(parseFloat(order.total_price_paid))}
+        </div>
         <div className="col">{order.reference_number}</div>
         <div className="col">
           <div

--- a/static/js/containers/pages/checkout/OrderHistory.js
+++ b/static/js/containers/pages/checkout/OrderHistory.js
@@ -2,7 +2,10 @@
 /* global SETTINGS: false */
 import React from "react"
 import DocumentTitle from "react-document-title"
-import { ORDER_HISTORY_DISPLAY_PAGE_TITLE } from "../../../constants"
+import {
+  ORDER_HISTORY_COLUMN_TITLES,
+  ORDER_HISTORY_DISPLAY_PAGE_TITLE
+} from "../../../constants"
 import { compose } from "redux"
 import { connect } from "react-redux"
 import { connectRequest } from "redux-query"
@@ -30,6 +33,14 @@ type Props = {
 }
 
 export class OrderHistory extends React.Component<Props> {
+  renderOrderReceipt(orderId: number) {
+    window.localStorage.setItem(
+      "selectedOrderReceiptId",
+      JSON.stringify(orderId)
+    )
+    window.location = "/orders/receipt"
+  }
+
   renderOrderCard(order: Object) {
     const orderTitle =
       order.titles.length > 0 ? order.titles.join("<br />") : <em>No Items</em>
@@ -38,18 +49,32 @@ export class OrderHistory extends React.Component<Props> {
     )
 
     return (
-      <div className="row d-flex p-3 my-0 bg-light">
+      <div
+        className="row d-flex p-3 my-0 bg-light"
+        key={`ordercard_${order.id}`}
+      >
         <div className="col">{orderTitle}</div>
         <div className="col">{orderDate}</div>
         <div className="col">{order.total_price_paid}</div>
         <div className="col">{order.reference_number}</div>
-        <div className="col">View</div>
+        <div className="col">
+          <div
+            className="link-text"
+            onClick={() => this.renderOrderReceipt(order.id)}
+          >
+            View
+          </div>
+        </div>
       </div>
     )
   }
   render() {
     const { orderHistory, isLoading } = this.props
-
+    const columns = ORDER_HISTORY_COLUMN_TITLES.map((value: string) => (
+      <div key={value} className="col">
+        <strong>{value}</strong>
+      </div>
+    ))
     return (
       <DocumentTitle
         title={`${SETTINGS.site_name} | ${ORDER_HISTORY_DISPLAY_PAGE_TITLE}`}
@@ -63,21 +88,7 @@ export class OrderHistory extends React.Component<Props> {
             </div>
 
             <div className="row d-flex p-3 mt-4 bg-light border-bottom border-2 border-dark">
-              <div className="col">
-                <strong>Items</strong>
-              </div>
-              <div className="col">
-                <strong>Date placed</strong>
-              </div>
-              <div className="col">
-                <strong>Total cost</strong>
-              </div>
-              <div className="col">
-                <strong>Order number</strong>
-              </div>
-              <div className="col">
-                <strong>Order details</strong>
-              </div>
+              {columns}
             </div>
             {orderHistory && orderHistory.results.length > 0
               ? orderHistory.results.map(this.renderOrderCard.bind(this))

--- a/static/js/containers/pages/checkout/OrderHistory.js
+++ b/static/js/containers/pages/checkout/OrderHistory.js
@@ -62,7 +62,7 @@ export class OrderHistory extends React.Component<Props> {
         <div className="col">
           <div
             className="link-text"
-            onClick={() => this.renderOrderReceipt(order.reference_number)}
+            onClick={() => this.renderOrderReceipt(order.id)}
           >
             View
           </div>

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -13,17 +13,20 @@ import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
 
 import { createStructuredSelector } from "reselect"
 import {
+  discountedPriceSelector,
+  discountSelector,
   orderReceiptQuery,
   orderReceiptSelector
 } from "../../../lib/queries/cart"
 
 import type { RouterHistory } from "react-router"
 import { routes } from "../../../lib/urls"
-import type { Line, OrderReceipt } from "../../../flow/cartTypes"
+import type { Discount, Line, OrderReceipt } from "../../../flow/cartTypes"
 
 type Props = {
   history: RouterHistory,
   orderReceipt: OrderReceipt,
+  discounts: Array<Discount>,
   isLoading: boolean
 }
 
@@ -38,11 +41,15 @@ export class OrderReceiptPage extends React.Component<Props> {
   }
 
   renderOrderSummaryCard() {
-    const { orderReceipt } = this.props
+    const { orderReceipt, discounts } = this.props
+    const totalPaid = parseFloat(orderReceipt.total_price_paid)
     return orderReceipt ? (
       <OrderSummaryCard
-        totalPrice={orderReceipt.total_price_paid}
+        totalPrice={totalPaid}
+        discountedPrice={totalPaid}
         orderFulfilled={true}
+        discounts={discounts}
+        discountCodeIsBad={false}
       />
     ) : null
   }
@@ -106,6 +113,7 @@ export class OrderReceiptPage extends React.Component<Props> {
 
 const mapStateToProps = createStructuredSelector({
   orderReceipt: orderReceiptSelector,
+  discounts:    discountSelector,
   isLoading:    () => false
 })
 

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -14,7 +14,6 @@ import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
 import { createStructuredSelector } from "reselect"
 import {
   orderReceiptQuery,
-  orderReceiptSelector
 } from "../../../lib/queries/cart"
 
 import type { RouterHistory } from "react-router"
@@ -26,7 +25,6 @@ import { pathOr } from "ramda"
 type Props = {
   history: RouterHistory,
   orderReceipt: OrderReceipt,
-  discounts: Array<Discount>,
   match: Match,
   isLoading: boolean,
   forceRequest: () => Promise<*>

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -57,7 +57,7 @@ export class OrderReceiptPage extends React.Component<Props> {
 
   renderOrderSummaryCard() {
     const { orderReceipt } = this.props
-    if (!orderReceipt) {
+    if (!orderReceipt || !orderReceipt.total_price_paid) {
       return null
     }
     const totalPaid = parseFloat(orderReceipt.total_price_paid)

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -12,9 +12,7 @@ import { CartItemCard } from "../../../components/CartItemCard"
 import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
 
 import { createStructuredSelector } from "reselect"
-import {
-  orderReceiptQuery,
-} from "../../../lib/queries/cart"
+import { orderReceiptQuery } from "../../../lib/queries/cart"
 
 import type { RouterHistory } from "react-router"
 import type { Match } from "react-router"

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -1,0 +1,124 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import DocumentTitle from "react-document-title"
+import { ORDER_RECEIPT_DISPLAY_PAGE_TITLE } from "../../../constants"
+import { compose } from "redux"
+import { connect } from "react-redux"
+import { connectRequest } from "redux-query"
+
+import Loader from "../../../components/Loader"
+import { CartItemCard } from "../../../components/CartItemCard"
+import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
+
+import { createStructuredSelector } from "reselect"
+import {
+  orderReceiptQuery,
+  orderReceiptSelector
+} from "../../../lib/queries/cart"
+
+import type { RouterHistory } from "react-router"
+import { routes } from "../../../lib/urls"
+import type { Line, OrderReceipt } from "../../../flow/cartTypes"
+
+type Props = {
+  history: RouterHistory,
+  orderReceipt: OrderReceipt,
+  isLoading: boolean
+}
+
+export class OrderReceiptPage extends React.Component<Props> {
+  renderCartItemCard(orderItem: Line) {
+    return (
+      <CartItemCard
+        key={`itemcard_${orderItem.product.id}`}
+        product={orderItem.product}
+      />
+    )
+  }
+
+  renderOrderSummaryCard() {
+    const { orderReceipt } = this.props
+    return orderReceipt ? (
+      <OrderSummaryCard
+        totalPrice={orderReceipt.total_price_paid}
+        orderFulfilled={true}
+      />
+    ) : null
+  }
+  renderEmptyCartCard() {
+    return (
+      <div
+        className="enrolled-item container card mb-4 rounded-0 flex-grow-1"
+        key="emptycard"
+      >
+        <div className="row d-flex flex-sm-columm p-md-3">
+          <div className="flex-grow-1 mx-3 d-sm-flex flex-column">
+            <div className="detail">
+              There was an error retrieving your order.
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  render() {
+    const { orderReceipt, isLoading } = this.props
+    return (
+      <DocumentTitle
+        title={`${SETTINGS.site_name} | ${ORDER_RECEIPT_DISPLAY_PAGE_TITLE}`}
+      >
+        <Loader isLoading={isLoading}>
+          <div className="std-page-body cart container">
+            <div className="row">
+              <div className="col-8 d-flex justify-content-between">
+                <h1 className="flex-grow-1">Order Receipt</h1>
+              </div>
+              <div className="col-md-4 text-right align-middle">
+                <p className="font-weight-normal mt-3">
+                  <a
+                    href={routes.orderHistory}
+                    className="link-text align-middle"
+                  >
+                    Back to Order History
+                  </a>
+                </p>
+              </div>
+            </div>
+
+            <div className="row d-flex flex-column-reverse flex-md-row">
+              <div className="col-md-8 enrolled-items">
+                {orderReceipt &&
+                orderReceipt.lines &&
+                orderReceipt.lines.length > 0
+                  ? orderReceipt.lines.map(this.renderCartItemCard.bind(this))
+                  : this.renderEmptyCartCard()}
+              </div>
+              <div className="col-md-4">{this.renderOrderSummaryCard()}</div>
+            </div>
+          </div>
+        </Loader>
+      </DocumentTitle>
+    )
+  }
+}
+
+const mapStateToProps = createStructuredSelector({
+  orderReceipt: orderReceiptSelector,
+  isLoading:    () => false
+})
+
+const mapDispatchToProps = {}
+
+const mapPropsToConfig = () => [
+  orderReceiptQuery(window.localStorage.getItem("selectedOrderReceiptId"))
+]
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  connectRequest(mapPropsToConfig)
+)(OrderReceiptPage)

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -71,6 +71,7 @@ export class OrderReceiptPage extends React.Component<Props> {
         discounts={discounts}
         cardTitle={`Order Number: ${orderReceipt.reference_number} `}
         discountCodeIsBad={false}
+        discountCode=""
       />
     ) : null
   }

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -37,8 +37,7 @@ export class OrderReceiptPage extends React.Component<Props> {
     // If we have a preloaded order but it's not the one we should display, force a fetch
     if (
       this.props.orderReceipt &&
-      this.props.orderReceipt.id !==
-        parseInt(this.props.match.params.orderId)
+      this.props.orderReceipt.id !== parseInt(this.props.match.params.orderId)
     ) {
       await this.props.forceRequest()
     }

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -12,7 +12,7 @@ import { CartItemCard } from "../../../components/CartItemCard"
 import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
 
 import { createStructuredSelector } from "reselect"
-import { orderReceiptQuery } from "../../../lib/queries/cart"
+import { orderReceiptQuery, receiptQueryKey } from "../../../lib/queries/cart"
 
 import type { RouterHistory } from "react-router"
 import type { Match } from "react-router"
@@ -24,6 +24,7 @@ type Props = {
   history: RouterHistory,
   orderReceipt: OrderReceipt,
   match: Match,
+  discounts: Array<Discount>,
   isLoading: boolean,
   forceRequest: () => Promise<*>
 }
@@ -54,7 +55,7 @@ export class OrderReceiptPage extends React.Component<Props> {
   }
 
   renderOrderSummaryCard() {
-    const { orderReceipt } = this.props
+    const { orderReceipt, discounts } = this.props
     if (!orderReceipt || !orderReceipt.total_price_paid) {
       return null
     }
@@ -64,7 +65,7 @@ export class OrderReceiptPage extends React.Component<Props> {
         totalPrice={totalPaid}
         discountedPrice={totalPaid}
         orderFulfilled={true}
-        discounts={orderReceipt.discounts}
+        discounts={discounts}
         cardTitle={`Order Number: ${orderReceipt.reference_number} `}
         discountCodeIsBad={false}
         discountCode=""
@@ -132,7 +133,8 @@ export class OrderReceiptPage extends React.Component<Props> {
 const mapStateToProps = state => ({
   currentUser:  state.entities.currentUser,
   orderReceipt: state.entities.orderReceipt,
-  isLoading:    pathOr(true, ["queries", "orderReceipt", "isPending"], state)
+  discounts:    state.entities.discounts,
+  isLoading:    pathOr(true, ["queries", receiptQueryKey, "isPending"], state)
 })
 
 const mapDispatchToProps = {}

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -13,7 +13,6 @@ import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
 
 import { createStructuredSelector } from "reselect"
 import {
-  discountSelector,
   orderReceiptQuery,
   orderReceiptSelector
 } from "../../../lib/queries/cart"
@@ -22,6 +21,7 @@ import type { RouterHistory } from "react-router"
 import type { Match } from "react-router"
 import { routes } from "../../../lib/urls"
 import type { Discount, Line, OrderReceipt } from "../../../flow/cartTypes"
+import { pathOr } from "ramda"
 
 type Props = {
   history: RouterHistory,
@@ -58,7 +58,7 @@ export class OrderReceiptPage extends React.Component<Props> {
   }
 
   renderOrderSummaryCard() {
-    const { orderReceipt, discounts } = this.props
+    const { orderReceipt } = this.props
     if (!orderReceipt) {
       return null
     }
@@ -68,7 +68,7 @@ export class OrderReceiptPage extends React.Component<Props> {
         totalPrice={totalPaid}
         discountedPrice={totalPaid}
         orderFulfilled={true}
-        discounts={discounts}
+        discounts={orderReceipt.discounts}
         cardTitle={`Order Number: ${orderReceipt.reference_number} `}
         discountCodeIsBad={false}
         discountCode=""
@@ -78,7 +78,7 @@ export class OrderReceiptPage extends React.Component<Props> {
   renderEmptyCartCard() {
     return (
       <div
-        className="enrolled-item container card mb-4 rounded-0 flex-grow-1"
+        className="empty-card container card mb-4 rounded-0 flex-grow-1"
         key="emptycard"
       >
         <div className="row d-flex flex-sm-columm p-md-3">
@@ -99,7 +99,7 @@ export class OrderReceiptPage extends React.Component<Props> {
         title={`${SETTINGS.site_name} | ${ORDER_RECEIPT_DISPLAY_PAGE_TITLE}`}
       >
         <Loader isLoading={isLoading}>
-          <div className="std-page-body cart container">
+          <div className="std-page-body order-receipt container">
             <div className="row">
               <div className="col-8 d-flex justify-content-between">
                 <h1 className="flex-grow-1">Order Receipt</h1>
@@ -108,7 +108,7 @@ export class OrderReceiptPage extends React.Component<Props> {
                 <p className="font-weight-normal mt-3">
                   <a
                     href={routes.orderHistory}
-                    className="link-text align-middle"
+                    className="link-text align-middle back-link"
                   >
                     Back to Order History
                   </a>
@@ -133,10 +133,10 @@ export class OrderReceiptPage extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = createStructuredSelector({
-  orderReceipt: orderReceiptSelector,
-  discounts:    discountSelector,
-  isLoading:    () => false
+const mapStateToProps = state => ({
+  currentUser:  state.entities.currentUser,
+  orderReceipt: state.entities.orderReceipt,
+  isLoading:    pathOr(true, ["queries", "orderReceipt", "isPending"], state)
 })
 
 const mapDispatchToProps = {}

--- a/static/js/containers/pages/checkout/OrderReceiptPage_test.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage_test.js
@@ -1,11 +1,13 @@
 // @flow
 import { assert } from "chai"
 
-import OrderReceiptPage, { OrderReceiptPage as InnerOrderReceiptPage } from "./OrderReceiptPage"
+import OrderReceiptPage, {
+  OrderReceiptPage as InnerOrderReceiptPage
+} from "./OrderReceiptPage"
 import { makeUser } from "../../../factories/user"
 import IntegrationTestHelper from "../../../util/integration_test_helper"
 import * as courseApi from "../../../lib/courseApi"
-import {ORDER_RECEIPT_OBJECT} from "../../../lib/test_constants"
+import { ORDER_RECEIPT_OBJECT } from "../../../lib/test_constants"
 
 describe("OrderReceiptPage", () => {
   let helper, renderPage, currentUser, isLinkableStub
@@ -44,9 +46,6 @@ describe("OrderReceiptPage", () => {
   it("renders the page with a receipt for a logged in user", async () => {
     const { inner } = await renderPage()
     assert.isTrue(inner.find(".order-receipt").exists())
-    assert.equal(
-      inner.find(".back-link").text(),
-      "Back to Order History"
-    )
+    assert.equal(inner.find(".back-link").text(), "Back to Order History")
   })
 })

--- a/static/js/containers/pages/checkout/OrderReceiptPage_test.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage_test.js
@@ -1,0 +1,52 @@
+// @flow
+import { assert } from "chai"
+
+import OrderReceiptPage, { OrderReceiptPage as InnerOrderReceiptPage } from "./OrderReceiptPage"
+import { makeUser } from "../../../factories/user"
+import IntegrationTestHelper from "../../../util/integration_test_helper"
+import * as courseApi from "../../../lib/courseApi"
+import {ORDER_RECEIPT_OBJECT} from "../../../lib/test_constants"
+
+describe("OrderReceiptPage", () => {
+  let helper, renderPage, currentUser, isLinkableStub
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    isLinkableStub = helper.sandbox.stub(courseApi, "isLinkableCourseRun")
+
+    renderPage = helper.configureHOCRenderer(
+      OrderReceiptPage,
+      InnerOrderReceiptPage,
+      {
+        entities: {
+          orderReceipt: ORDER_RECEIPT_OBJECT,
+          currentUser:  currentUser
+        },
+        queries: {
+          orderReceipt: {
+            isPending: false
+          }
+        }
+      },
+      {
+        match: {
+          params: {
+            orderId: 1
+          }
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+  it("renders the page with a receipt for a logged in user", async () => {
+    const { inner } = await renderPage()
+    assert.isTrue(inner.find(".order-receipt").exists())
+    assert.equal(
+      inner.find(".back-link").text(),
+      "Back to Order History"
+    )
+  })
+})

--- a/static/js/flow/cartTypes.js
+++ b/static/js/flow/cartTypes.js
@@ -49,5 +49,6 @@ export type OrderReceipt = {
   lines: Array<Line>,
   id: number,
   total_price_paid: number,
-  state: string
+  state: string,
+  reference_number: string
 }

--- a/static/js/flow/cartTypes.js
+++ b/static/js/flow/cartTypes.js
@@ -36,3 +36,18 @@ export type Discount = {
   discount_code: string,
   discount_type: string
 }
+
+export type Line = {
+  id: number,
+  product: Product,
+  quantity: number,
+  item_description: string
+}
+
+export type OrderReceipt = {
+  order: number,
+  lines: Array<Line>,
+  id: number,
+  total_price_paid: number,
+  state: string
+}

--- a/static/js/flow/cartTypes.js
+++ b/static/js/flow/cartTypes.js
@@ -50,5 +50,6 @@ export type OrderReceipt = {
   id: number,
   total_price_paid: number,
   state: string,
-  reference_number: string
+  reference_number: string,
+  discounts: Array<Discount>
 }

--- a/static/js/lib/queries/cart.js
+++ b/static/js/lib/queries/cart.js
@@ -13,7 +13,7 @@ export const discountedPriceSelector = pathOr(null, [
 export const discountSelector = pathOr(null, ["entities", "discounts"])
 export const cartQueryKey = "cartItems"
 export const orderHistoryQueryKey = "orderHistory"
-export const receiptQueryKey = "orderItems"
+export const receiptQueryKey = "orderReceipt"
 
 export const checkoutPayloadSelector = pathOr(null, [
   "entities",

--- a/static/js/lib/queries/cart.js
+++ b/static/js/lib/queries/cart.js
@@ -13,11 +13,14 @@ export const discountedPriceSelector = pathOr(null, [
 export const discountSelector = pathOr(null, ["entities", "discounts"])
 export const cartQueryKey = "cartItems"
 export const orderHistoryQueryKey = "orderHistory"
+export const receiptQueryKey = "orderItems"
 
 export const checkoutPayloadSelector = pathOr(null, [
   "entities",
   "checkoutPayload"
 ])
+
+export const orderReceiptSelector = pathOr(null, ["entities", "orderReceipt"])
 
 export const cartQuery = () => ({
   queryKey:  cartQueryKey,
@@ -89,4 +92,15 @@ export const clearDiscountCodeMutation = () => ({
     method: "POST"
   },
   update: {}
+})
+
+export const orderReceiptQuery = (orderId: number) => ({
+  url:       `/api/orders/receipt/${orderId}/`,
+  queryKey:  receiptQueryKey,
+  transform: json => ({
+    orderReceipt: json
+  }),
+  update: {
+    orderReceipt: nextState
+  }
 })

--- a/static/js/lib/queries/cart.js
+++ b/static/js/lib/queries/cart.js
@@ -97,10 +97,15 @@ export const clearDiscountCodeMutation = () => ({
 export const orderReceiptQuery = (orderId: number) => ({
   url:       `/api/orders/receipt/${orderId}/`,
   queryKey:  receiptQueryKey,
-  transform: json => ({
-    orderReceipt: json
-  }),
+  transform: json => {
+    const discounts = json.discounts.map(item => item.redeemed_discount)
+    return {
+      orderReceipt: json,
+      discounts:    discounts
+    }
+  },
   update: {
-    orderReceipt: nextState
+    orderReceipt: nextState,
+    discounts:    nextState
   }
 })

--- a/static/js/lib/test_constants.js
+++ b/static/js/lib/test_constants.js
@@ -22,3 +22,40 @@ export const CYBERSOURCE_CHECKOUT_RESPONSE = {
   url:    "https://testsecureacceptance.cybersource.com/pay",
   method: "POST"
 }
+
+export const ORDER_RECEIPT_OBJECT = {
+    id:               1,
+    created_on:       "2019-10-09T09:47:09.219354Z",
+    reference_number: "mitxonline-dev-1",
+    purchaser:         1,
+    total_price_paid: "200",
+    state:            "fulfilled",
+    lines:            [
+      {
+        id: 2,
+        item_description: "sdfgsdgfs",
+        product: {
+          id: 2, price: '35.00', description: 'sdfgsdgfs', is_active: true,
+          purchasable_object: {}
+        },
+        quantity: 1,
+        total_price: 35,
+        unit_price: 35,
+      },
+    ],
+    discounts: [
+      {
+        redeemed_discount: {
+          amount: "0.00000",
+          automatic: false,
+          created_on: "2022-03-09T19:49:39.409600Z",
+          discount_code: "NOMA",
+          discount_type: "fixed-price",
+          id: 2,
+          max_redemptions: 5,
+          redemption_type: "one-time",
+          updated_on: "2022-03-10T16:42:45.883756Z",
+        }
+      }
+    ]
+  }

--- a/static/js/lib/test_constants.js
+++ b/static/js/lib/test_constants.js
@@ -24,38 +24,41 @@ export const CYBERSOURCE_CHECKOUT_RESPONSE = {
 }
 
 export const ORDER_RECEIPT_OBJECT = {
-    id:               1,
-    created_on:       "2019-10-09T09:47:09.219354Z",
-    reference_number: "mitxonline-dev-1",
-    purchaser:         1,
-    total_price_paid: "200",
-    state:            "fulfilled",
-    lines:            [
-      {
-        id: 2,
-        item_description: "sdfgsdgfs",
-        product: {
-          id: 2, price: '35.00', description: 'sdfgsdgfs', is_active: true,
-          purchasable_object: {}
-        },
-        quantity: 1,
-        total_price: 35,
-        unit_price: 35,
+  id:               1,
+  created_on:       "2019-10-09T09:47:09.219354Z",
+  reference_number: "mitxonline-dev-1",
+  purchaser:        1,
+  total_price_paid: "200",
+  state:            "fulfilled",
+  lines:            [
+    {
+      id:               2,
+      item_description: "sdfgsdgfs",
+      product:          {
+        id:                 2,
+        price:              "35.00",
+        description:        "sdfgsdgfs",
+        is_active:          true,
+        purchasable_object: {}
       },
-    ],
-    discounts: [
-      {
-        redeemed_discount: {
-          amount: "0.00000",
-          automatic: false,
-          created_on: "2022-03-09T19:49:39.409600Z",
-          discount_code: "NOMA",
-          discount_type: "fixed-price",
-          id: 2,
-          max_redemptions: 5,
-          redemption_type: "one-time",
-          updated_on: "2022-03-10T16:42:45.883756Z",
-        }
+      quantity:    1,
+      total_price: 35,
+      unit_price:  35
+    }
+  ],
+  discounts: [
+    {
+      redeemed_discount: {
+        amount:          "0.00000",
+        automatic:       false,
+        created_on:      "2022-03-09T19:49:39.409600Z",
+        discount_code:   "NOMA",
+        discount_type:   "fixed-price",
+        id:              2,
+        max_redemptions: 5,
+        redemption_type: "one-time",
+        updated_on:      "2022-03-10T16:42:45.883756Z"
       }
-    ]
-  }
+    }
+  ]
+}

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -42,6 +42,10 @@ export const routes = {
     begin: ""
   }),
 
+  orderReceipt: include("/orders/receipt/", {
+    begin: ""
+  }),
+
   informationLinks: include("", {
     termsOfService: "terms-of-service",
     privacyPolicy:  "privacy-policy"

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -42,9 +42,7 @@ export const routes = {
     begin: ""
   }),
 
-  orderReceipt: include("/orders/receipt/", {
-    begin: ""
-  }),
+  orderReceipt: "/orders/receipt/:orderId",
 
   informationLinks: include("", {
     termsOfService: "terms-of-service",

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -268,3 +268,10 @@ button.btn-secondary.unstyled {
     }
   }
 }
+
+.link-text {
+  color: $black;
+  text-decoration: underline;
+  box-shadow: none;
+  cursor: pointer;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Fix #424

#### What's this PR do?
Add an order receipts page

#### How should this be manually tested?
Make sure to set up a purchasable product, create a fullfilled oder for it, got to the order summary page `/orders/history/` and click to view one of the orders.

<img width="301" alt="Screen Shot 2022-03-07 at 9 31 44 AM" src="https://user-images.githubusercontent.com/7574259/157053730-d603e20c-e00d-486d-ac2b-8fe8bbef9869.png">
<img width="1521" alt="Screen Shot 2022-03-07 at 9 31 10 AM" src="https://user-images.githubusercontent.com/7574259/157053733-93e52878-5c49-46cd-aa72-30d41b92e07f.png">
