### PR TITLE
Only show the upgrade sidebar if upgrade ui enabled

### DIFF
--- a/static/js/containers/UpsellCardApp.js
+++ b/static/js/containers/UpsellCardApp.js
@@ -109,12 +109,12 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
     const csrfToken = getCookie("csrftoken")
     const run = courseRuns ? courseRuns[0] : null
 
-    return (
+    return SETTINGS.features.upgrade_dialog ? (
       // $FlowFixMe: isLoading null or undefined
       <Loader isLoading={isLoading}>
         {run ? this.renderUpgradeEnrollmentDialog(run) : null}
       </Loader>
-    )
+    ) : null
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Updates the `UpsellCardApp` to only render if the upgrade dialog feature flag is set.

#### How should this be manually tested?

- Enroll in a course
- Set `FEATURE_ENABLE_UPGRADE_DIALOG=True` and verify you see the upgrade card
- Set `FEATURE_ENABLE_UPGRADE_DIALOG=False` and verify you don't see the upgrade card