### PR TITLE
Accessibility: Bypass Blocks: bypass the header on site pages for screen readers

### DIFF
--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="hero-container" style="background-image: url('{% wagtail_img_src page.hero%}')">
+<div id="main" class="hero-container" style="background-image: url('{% wagtail_img_src page.hero%}')">
   <div class="container hero-content">
     <div class="hero-title">
       {% if page.hero_title %}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="product-page" id="wrapper">
+    <div id="main" class="product-page">
       <section class="hero-block">
         <div class="container">
           <div class="content-row">

--- a/cms/templates/resource_page.html
+++ b/cms/templates/resource_page.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 
-  <div class="resource-banner">
+  <div id="main" class="resource-banner">
     <div class="container">
       <h1 class="text-uppercase">{{ page.title }}</h1>
       {% if page.sub_heading %}

--- a/ecommerce/templates/checkout_interstitial.html
+++ b/ecommerce/templates/checkout_interstitial.html
@@ -9,7 +9,7 @@
 {% block title %}{% trans "mitxonline" %}{% endblock %}
 
 {% block content %}    
-    <section class="info-block">
+    <section id="main" class="info-block">
         <div class="container">
             <div class="content-row">
                 <div class="content-col">

--- a/main/templates/404.html
+++ b/main/templates/404.html
@@ -11,7 +11,7 @@
 
 
 {% block content %}
-<div class="error-block">
+<div id="main" class="error-block">
   <div class="container text-center">
     <h2><strong>Oops!</strong> it looks like you have encountered an error. We are unable to find the page you are looking for.</h2>
     <img class="not-found-img" src="{% static 'images/404.png' %}" alt="Page not found">

--- a/main/templates/500.html
+++ b/main/templates/500.html
@@ -11,7 +11,7 @@
 
 
 {% block content %}
-<div class="error-block d-flex flex-column justify-content-center">
+<div id="main" class="error-block d-flex flex-column justify-content-center">
   <div class="container text-center">
     <img class="server-error-img img-fluid" src="{% static 'images/500.png' %}" alt="">
   </div>

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -28,6 +28,7 @@
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
   <div class="main-panel">
+    <a href="#main" class="sr-only sr-only-focusable">Skip to main content</a>
     {% include "partials/gtm_body.html" %}
     {% hijack_notification %}
     {% block headercontent %}

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -68,7 +68,7 @@ export class App extends React.Component<Props, void> {
     return (
       <div className="app">
         <Header currentUser={currentUser} location={location} />
-        <div className="main-page-content">
+        <div id="main" className="main-page-content">
           <Switch>
             <Route
               path={urljoin(match.url, String(routes.login))}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #419 

#### What's this PR do?
Accessibility: Bypass Blocks: bypass the header on site pages for screen readers

#### How should this be manually tested?
just use the screen reader tool to see if it loads Skip to main content link and on clicking that link screen reader should start from the main content

#### Screenshots (if appropriate)

**With Screenreader**

<img width="1440" alt="Screenshot 2022-03-09 at 18 31 32" src="https://user-images.githubusercontent.com/4043989/157456402-f54ae39f-4102-4567-b617-3978b9d20245.png">

**Without Screenreader**

<img width="1440" alt="Screenshot 2022-03-09 at 18 31 54" src="https://user-images.githubusercontent.com/4043989/157456473-21a18ceb-616b-427e-a636-1380897dd770.png">
