### PR TITLE
Fix cart total display when no discounts are applied

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -97,6 +97,11 @@ class BasketItem(TimestampedModel):
             * self.quantity
         )
 
+    @cached_property
+    def base_price(self):
+        """Returns the total price of the basket item without discounts."""
+        return self.product.price * self.quantity
+
 
 class Discount(TimestampedModel):
     """Discount model"""

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -164,15 +164,14 @@ class BasketWithProductSerializer(serializers.ModelSerializer):
 
     def get_total_price(self, instance):
         return sum(
-            product.price
-            for product in [item.product for item in instance.basket_items.all()]
+            basket_item.base_price for basket_item in instance.basket_items.all()
         )
 
     def get_discounted_price(self, instance):
         discounts = instance.discounts.all()
 
         if discounts.count() == 0:
-            return None
+            return self.get_total_price(instance)
 
         return sum(
             basket_item.discounted_price for basket_item in instance.basket_items.all()


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#471 

#### What's this PR do?
Fixes #471 

#### How should this be manually tested?
Add an item to the cart - the total display should be correct. Alternatively, add an item to the cart and hit the cart API (`api/v0/checkout/cart/`) - the discounted_price should match the total_price. 
