### PR TITLE
fix email unsubscription inconsistency after unenrollment

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -37,6 +37,7 @@ from openedx.api import (
     enroll_in_edx_course_runs,
     get_edx_api_course_detail_client,
     unenroll_edx_course_run,
+    subscribe_to_edx_course_emails,
 )
 from openedx.exceptions import (
     EdxApiEnrollErrorException,
@@ -218,7 +219,8 @@ def create_run_enrollments(
             )
             if not created and not enrollment.active:
                 enrollment.edx_enrolled = edx_request_success
-                enrollment.edx_emails_subscription = True
+                subscribed = subscribe_to_edx_course_emails(user, run)
+                enrollment.edx_emails_subscription = True if subscribed else False
                 enrollment.reactivate_and_save()
         except:  # pylint: disable=bare-except
             mail_api.send_enrollment_failure_message(user, run, details=format_exc())

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -244,6 +244,9 @@ def test_create_run_enrollments(mocker, user):
     patched_send_enrollment_email = mocker.patch(
         "courses.api.mail_api.send_course_run_enrollment_email"
     )
+    patched_edx_email_subscribe = mocker.patch(
+        "courses.api.subscribe_to_edx_course_emails"
+    )
 
     successful_enrollments, edx_request_success = create_run_enrollments(
         user,
@@ -252,6 +255,7 @@ def test_create_run_enrollments(mocker, user):
     patched_edx_enroll.assert_called_once_with(
         user, runs, mode=EDX_DEFAULT_ENROLLMENT_MODE
     )
+
     assert patched_send_enrollment_email.call_count == num_runs
     assert edx_request_success is True
     assert len(successful_enrollments) == num_runs

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -217,12 +217,12 @@ class UserEnrollmentsApiViewSet(
                         response = subscribe_to_edx_course_emails(
                             request.user, enrollment.run
                         )
-                        enrollment.edx_emails_subscription = True
+                        enrollment.edx_emails_subscription = True if response else False
                     else:
                         response = unsubscribe_from_edx_course_emails(
                             request.user, enrollment.run
                         )
-                        enrollment.edx_emails_subscription = False
+                        enrollment.edx_emails_subscription = False if response else True
                     enrollment.save()
                     return Response(data=response, status=status.HTTP_200_OK)
                 except (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #445 

#### What's this PR do?
fix email unsubscription inconsistency after un-erollment

#### How should this be manually tested?
- Just unsubscribe to emails before unsubscribe
- enroll back in should be subscribed back 
- that should have deleted the popout entry in edX against email subscription