### PR TITLE
Handle refunded orders

### DIFF
--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -97,6 +97,7 @@ class BasketItemFactory(DjangoModelFactory):
     """Factory for BasketItem"""
 
     product = SubFactory(ProductFactory)
+
     basket = SubFactory(BasketFactory)
 
     class Meta:

--- a/ecommerce/forms.py
+++ b/ecommerce/forms.py
@@ -1,0 +1,17 @@
+from django import forms
+
+
+class AdminRefundOrderForm(forms.Form):
+    _selected_action = forms.CharField(widget=forms.HiddenInput)
+    refund_reason = forms.CharField(
+        label="Refund reason",
+        help_text="The reason for this refund.",
+        widget=forms.Textarea(),
+        required=True,
+    )
+    refund_amount = forms.FloatField(
+        label="Refund amount", help_text="The amount to be refunded", required=True
+    )
+    perform_unenrolls = forms.BooleanField(
+        label="Unenroll from the purchased course", required=False
+    )

--- a/ecommerce/templates/admin/ecommerce/change_form.html
+++ b/ecommerce/templates/admin/ecommerce/change_form.html
@@ -1,0 +1,14 @@
+{% extends 'admin/change_form.html' %}
+{% load i18n admin_urls static admin_modify refund_controls %}
+ 
+{% block content %}
+    {{ block.super }}
+{% endblock %}
+
+{% if save_on_top %}{% block submit_buttons_top %}{{block.super}}{% endblock %}{% endif %}
+
+{% block submit_buttons_bottom %}{% refund_order_buttons %}{% endblock %}
+
+{% block after_field_sets %}
+    {{ block.super }}
+{% endblock %}

--- a/ecommerce/templates/admin/ecommerce/refund_control_row.html
+++ b/ecommerce/templates/admin/ecommerce/refund_control_row.html
@@ -1,0 +1,18 @@
+{% load i18n admin_urls %}
+<div class="submit-row">
+{% block submit-row %}
+{% if show_save %}<input type="submit" value="{% translate 'Save' %}" class="default" name="_save">{% endif %}
+{% if show_delete_link and original %}
+    {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+    <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% translate "Delete" %}</a></p>
+{% endif %}
+{% if original.state == 'fulfilled' %}
+    <a href="{% url 'refund-order' %}/?order={{ original.id }}" class="closelink">Refund Order</a>
+{% endif %}
+
+{% if show_save_as_new %}<input type="submit" value="{% translate 'Save as new' %}" name="_saveasnew">{% endif %}
+{% if show_save_and_add_another %}<input type="submit" value="{% translate 'Save and add another' %}" name="_addanother">{% endif %}
+{% if show_save_and_continue %}<input type="submit" value="{% if can_change %}{% translate 'Save and continue editing' %}{% else %}{% translate 'Save and view' %}{% endif %}" name="_continue">{% endif %}
+{% if show_close %}<a href="{% url opts|admin_urlname:'changelist' %}" class="closelink">{% translate 'Close' %}</a>{% endif %}
+{% endblock %}
+</div>

--- a/ecommerce/templates/refund_order_confirm.html
+++ b/ecommerce/templates/refund_order_confirm.html
@@ -1,0 +1,84 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    <h1>Refund Order</h1>
+
+    <p>Refunding order #{{ order.id }}.</p>
+
+    <ul>
+        <li> Placed {{ order.created_on }}</li>
+        <li> Total: ${{ order.total_price_paid }}</li>
+        <li> Reference: {{ order.reference_number }}</li>
+    </ul>
+
+    <form method="POST" id="refund_order_form" novalidate>
+    {% csrf_token %}
+    <input type="hidden" name="action" value="process_refund" />
+    <input type="hidden" name="order" value="{{ order.id }}" />
+        <div>
+            {% if not form_valid %}
+            <p class="errornote">Please correct the errors below.</p>
+            {% endif %}
+            <fieldset class="module aligned">
+                {% for field in refund_form %}
+                    {% if field.name == '_selected_action' %}
+                    {{ field }}
+                    {% elif field.name == 'perform_unenrolls' %}
+                    <div class="form-row checkbox-row field-{{ field.name }}{% if field.name in refund_form.errors %} errors{% endif %}">
+                        <div>
+                            {% if field.name in refund_form.errors %}
+                                <ul class="errorlist">
+                                    {% for fname, error_list in refund_form.errors.items %}
+                                        {% if fname == field.name %}
+                                            {% for error_string in error_list %}
+                                                <li>{{ error_string }}
+                                            {% endfor %}
+                                        {% endif %}
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+
+                            {{ field }} <label class="vCheckboxLabel" for="{{ field.name }}">{{ field.label }}</label>
+                        </div>
+                    </div>
+                    {% else %}
+                        <div class="form-row field-{{ field.name }}{% if field.name in refund_form.errors %} errors{% endif %}">
+                            {% if field.name in refund_form.errors %}
+                                <ul class="errorlist">
+                                    {% for fname, error_list in refund_form.errors.items %}
+                                        {% if fname == field.name %}
+                                            {% for error_string in error_list %}
+                                                <li>{{ error_string }}
+                                            {% endfor %}
+                                        {% endif %}
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                            <div>
+                                <label for="{{ field.name }}">{{ field.label }}</label>
+                                {{ field }}
+                            </div>
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </fieldset>
+        </div>
+
+        <div>
+            <input type="submit" value="Refund Order" name="refund" />
+            <a href="#" class="cancel-link" style="margin-left: 2rem;">No, take me back</a>
+        </div>
+
+    </form>
+</div>
+{% endblock %}

--- a/ecommerce/templatetags/refund_controls.py
+++ b/ecommerce/templatetags/refund_controls.py
@@ -1,0 +1,12 @@
+from django.contrib.admin.templatetags.admin_modify import submit_row
+from django import template
+from django.template.context import Context
+
+register = template.Library()
+
+
+@register.inclusion_tag("admin/ecommerce/refund_control_row.html", takes_context=True)
+def refund_order_buttons(context):
+    context["show_close"] = True
+
+    return submit_row(context)

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -15,6 +15,7 @@ from ecommerce.views.v0 import (
     CheckoutProductView,
     OrderHistoryViewSet,
     OrderReceiptView,
+    AdminRefundOrderView,
 )
 
 
@@ -60,4 +61,5 @@ urlpatterns = [
         name="checkout-result-callback",
     ),
     re_path(r"^cart/add", CheckoutProductView.as_view(), name="checkout-product"),
+    re_path(r"^int_admin/refund", AdminRefundOrderView.as_view(), name="refund-order"),
 ]

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -21,12 +21,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.decorators import action
 
 from django.views.generic import TemplateView, RedirectView, View
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from django.contrib.auth.mixins import LoginRequiredMixin
-
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib import messages
 from django.db import transaction
 from django.db.models import Q, Count
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
@@ -66,8 +66,10 @@ from ecommerce.models import (
     BasketDiscount,
     UserDiscount,
     PendingOrder,
+    FulfilledOrder,
     Order,
 )
+from ecommerce.forms import AdminRefundOrderForm
 
 log = logging.getLogger(__name__)
 
@@ -488,3 +490,103 @@ class OrderReceiptView(RetrieveAPIView):
 
     def get_queryset(self):
         return Order.objects.filter(purchaser=self.request.user).all()
+
+
+class AdminRefundOrderView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
+    template_name = "refund_order_confirm.html"
+    permission_required = "is_superuser"
+
+    def post(self, request):
+        try:
+            refund_form = AdminRefundOrderForm(request.POST)
+            order = FulfilledOrder.objects.get(pk=request.POST["order"])
+
+            if refund_form.is_valid():
+                unenrolled = order.refund(
+                    request.POST["refund_amount"],
+                    request.POST["refund_reason"],
+                    True
+                    if "perform_unenrolls" in request.POST
+                    and request.POST["perform_unenrolls"]
+                    else False,
+                )
+                order.save()
+
+                if unenrolled:
+                    messages.success(
+                        request, f"Order {order.reference_number} refunded."
+                    )
+                else:
+                    messages.warning(
+                        request,
+                        f"Order {order.reference_number} refunded, but could not unenroll the learner. Unenrollments will be reattempted later.",
+                    )
+
+                return HttpResponseRedirect(
+                    reverse("admin:ecommerce_refundedorder_change", args=(order.id,))
+                )
+
+            errors = []
+            error_messages = {}
+
+            for whatever in refund_form.errors:
+                errors.append(whatever)
+                error_messages[whatever] = refund_form.errors[whatever]
+
+            return render(
+                request,
+                self.template_name,
+                {
+                    "refund_form": refund_form,
+                    "order": order,
+                    "form_valid": refund_form.is_valid(),
+                    "errors": errors,
+                    "error_messages": error_messages,
+                },
+            )
+        except NotImplementedError:
+            messages.error(request, f"Order {request.POST['order']} can't be refunded.")
+            return HttpResponseRedirect(
+                reverse("admin:ecommerce_refundedorder_changelist")
+            )
+        except ObjectDoesNotExist:
+            messages.error(
+                request,
+                f"Order {request.POST['order']} could not be found - is it Fulfilled?",
+            )
+            return HttpResponseRedirect(
+                reverse("admin:ecommerce_fulfilledorder_changelist")
+            )
+
+    def get(self, request):
+        try:
+            order = FulfilledOrder.objects.get(pk=request.GET["order"])
+
+            if order.state != Order.STATE.FULFILLED:
+                raise ObjectDoesNotExist()
+        except ObjectDoesNotExist:
+            messages.error(
+                request,
+                f"Order {request.GET['order']} could not be found - is it Fulfilled?",
+            )
+            return HttpResponseRedirect(
+                reverse("admin:ecommerce_fulfilledorder_changelist")
+            )
+
+        refund_form = AdminRefundOrderForm(
+            initial={
+                "_selected_action": order.id,
+                "refund_amount": order.total_price_paid,
+            }
+        )
+
+        return render(
+            request,
+            self.template_name,
+            {
+                "refund_form": refund_form,
+                "order": order,
+                "form_valid": True,
+                "errors": {},
+            },
+        )


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#465 
#456 

#### What's this PR do?
Adds ability to refund orders in Django Admin. Also updates the fulfill code to keep local enrollments when enrollments in edX fail. 

#### How should this be manually tested?
In Django Admin:
1. Find a Fulfilled Order
2. There should be a Refund Order button on the submit line
3. Clicking the button should bring up a simple form with options for reason, amount, and unenroll. Amount should be pre-filled with the purchase price of the order.
4. Leaving either reason or amount unfilled should re-render the form with an error message (in the same manner as it would in djadmin)
5. Successfully refunding the order should redirect you to the Refunded Orders list page with a success notification. A Transaction record should be created with the data being a dict of reason and amount, with their values being what was supplied in the form. 
6. If the refund succeeds but the unenrollments in edX fails, you should instead get a warning message indicating that. (For testing, I adjusted the refund method in FulfilledOrder to always return False.) 

The URL can be adjusted to attempt to refund an order that does not exist at all. In this case, you should be redirected to the Fulfilled Order list page in djadmin with a "not found" error.

The URL can be adjusted to attempt to refund an order that's already refunded (or otherwise isn't Fulfilled). In this case, you should be redirected to the Fulfilled ORder list page in djadmin with a "not found, might be fulfilled" error. 

If you attempt to refund an order whose state changes from Fulfilled to something else (and thus won't have a refund method anymore), you should be redirected to the Refunded Orders list page with a "can't be refunded" message. 

#### Notes

- The refund order screen may need more data
- The landing pages after you perform an action may need to change - they work like this now:
	- Refund successful: RefundedOrder change (for selected order)
	- Hit NotImplemented: RefundedOrder changelist
	- Hit ObjectDoesNotExist in POST: FulfilledOrder changelist
	- Hit ObjectDoesNotExist in GET: FulfilledOrder changelist

#### Screenshots (if appropriate)
Button on order screen:
![fulfilled-order-with-refund-button](https://user-images.githubusercontent.com/945611/158878920-58ac56da-f157-4c29-817b-52aab9ed8ef9.png)

Refund screen:
![refund-order-screen](https://user-images.githubusercontent.com/945611/158878942-49e0871b-d2f3-4436-9024-b67c04dbd620.png)

Success message:
![unenroll-succeeded](https://user-images.githubusercontent.com/945611/158878979-00a0b043-aa33-4bee-9291-83440dcf0b06.png)

Error messages:
![unenroll-failed](https://user-images.githubusercontent.com/945611/158879016-bd4e8571-67a9-4254-97d6-e9bbd7998a82.png)
![refund-failed-not-found](https://user-images.githubusercontent.com/945611/158879019-cc5585ea-e1b4-4111-9bcc-599dfe128985.png)
![refund-failed-not-FulfilledOrder](https://user-images.githubusercontent.com/945611/158879020-80c9c088-32ed-41ba-844e-c2c3c35d4c02.png)

