### PR TITLE
Handle error states better, fix for cart page loading status

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -337,6 +337,11 @@ class PendingOrder(Order):
 class FulfilledOrder(Order):
     """An order that has a fulfilled payment"""
 
+    @transition(field="state", source=Order.STATE.FULFILLED, target=Order.STATE.ERRORED)
+    def error(self):
+        """Error this order"""
+        pass
+
     @transition(
         field="state",
         source=Order.STATE.FULFILLED,
@@ -397,6 +402,11 @@ class CanceledOrder(Order):
     The state of this can't be altered further.
     """
 
+    @transition(field="state", source=Order.STATE.CANCELED, target=Order.STATE.ERRORED)
+    def error(self):
+        """Error this order"""
+        pass
+
     class Meta:
         proxy = True
 
@@ -418,6 +428,11 @@ class DeclinedOrder(Order):
 
     The state of this can't be altered further.
     """
+
+    @transition(field="state", source=Order.STATE.DECLINED, target=Order.STATE.ERRORED)
+    def error(self):
+        """Error this order"""
+        pass
 
     class Meta:
         proxy = True

--- a/static/js/containers/pages/checkout/CartPage.js
+++ b/static/js/containers/pages/checkout/CartPage.js
@@ -11,6 +11,7 @@ import { compose } from "redux"
 import { connect } from "react-redux"
 import { connectRequest, mutateAsync } from "redux-query"
 import { createStructuredSelector } from "reselect"
+import { pathOr } from "ramda"
 
 import type { BasketItem, Discount } from "../../../flow/cartTypes"
 
@@ -20,6 +21,7 @@ import { OrderSummaryCard } from "../../../components/OrderSummaryCard"
 
 import {
   cartQuery,
+  cartQueryKey,
   cartSelector,
   totalPriceSelector,
   discountedPriceSelector,
@@ -222,7 +224,7 @@ const mapStateToProps = createStructuredSelector({
   totalPrice:      totalPriceSelector,
   discountedPrice: discountedPriceSelector,
   discounts:       discountSelector,
-  isLoading:       () => false
+  isLoading:       pathOr(true, ["queries", cartQueryKey, "isPending"])
 })
 
 const mapDispatchToProps = {


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#481 

#### What's this PR do?
Fixes #481 

#### How should this be manually tested?
Refer to 481 - the 500 error is due to the order object not having an "error" method, which is now resolved, so the 500 error should not be reachable anymore. In addition, the cart page now properly implements the loading screen on page load, so weirdness from half-loaded pages (noted as "sometimes the Place Order button doesn't work") should now no longer appear. 

If working locally, throttling should be applied to properly test the loading screen - otherwise the relevant API requests will likely load too fast to be testable. (I tested by setting Throttling to Slow 3G in Chrome devtools.) 

