### PR TITLE
refactor: use youtube controls for youtube videos

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -309,7 +309,11 @@ class ProductPage(Page):
                 # The solution in #2 is used below.
                 if provider_name == "youtube":
                     config["controls"] = False
-                    config["youtube"] = {"ytControls": 2, "cc_load_policy": 1, "cc_lang_pref": 1}
+                    config["youtube"] = {
+                        "ytControls": 2,
+                        "cc_load_policy": 1,
+                        "cc_lang_pref": 1,
+                    }
 
             except EmbedException:
                 log.info(

--- a/cms/models.py
+++ b/cms/models.py
@@ -300,6 +300,17 @@ class ProductPage(Page):
                 provider_name = embed.provider_name.lower()
                 config["techOrder"] = [provider_name, *config["techOrder"]]
                 config["sources"][0]["type"] = f"video/{provider_name}"
+
+                # As per https://github.com/mitodl/mitxonline/issues/490 we want to use the same controls of youtube in
+                # case of youtube videos for supporting closed captions. We can do it in two possible ways:
+                # 1) We add "Track" key of type `Captions` to the config with a hosted or static transcript file URL
+                # 2) Or we can just disable `video.js` self controls and enable all the youtube controls for the youtube
+                # based videos with embedded support for the closed captioning.
+                # The solution in #2 is used below.
+                if provider_name == "youtube":
+                    config["controls"] = False
+                    config["youtube"] = {"ytControls": 2, "cc_load_policy": 1, "cc_lang_pref": 1}
+
             except EmbedException:
                 log.info(
                     f"The embed for the current url {self.video_url} is unavailable."


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#490 

#### What's this PR do?
- Uses the youtube controls for the youtube based videos for the closed captioning support

#### How should this be manually tested?
- Setup MitxOnline
- Add a product page
- Add a youtube URL in the video URL
- Play the video and make sure the closed captioning support is available
- Make sure that the design remains intact
#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
We used [video.js](https://github.com/videojs/videojs-youtube) package in a recent PR(https://github.com/mitodl/mitxonline/pull/95) to support videos, but the closed captioning support was not added/enabled. So, we have now enabled youtube controls for that to make it similar to how it works in xPRO.


## Reviewer Note:
      # As per https://github.com/mitodl/mitxonline/issues/490 we want to use the same controls of youtube in
      # case of youtube videos for supporting closed captions. We can do it in two possible ways:
      # 1) We add "Track" key of type `Captions` to the config with a hosted or static transcript file URL
      # 2) Or we can just disable `video.js` self controls and enable all the youtube controls for the youtube
      # based videos with embedded support for the closed captioning.
      # The solution in #2 is used below.

#### Screenshots (if appropriate)
**After (Desktop)**
<img width="726" alt="Screenshot 2022-03-28 at 5 52 09 PM" src="https://user-images.githubusercontent.com/34372316/160401897-c4c2a720-05c6-4db4-91c2-673b10ec4997.png">

**After (Mobile)**
<img width="539" alt="Screenshot 2022-03-28 at 5 52 17 PM" src="https://user-images.githubusercontent.com/34372316/160401980-44ce45b1-90d3-4238-b6c6-90beb12906c8.png">

**Before (Desktop)**
<img width="734" alt="Screenshot 2022-03-28 at 5 51 50 PM" src="https://user-images.githubusercontent.com/34372316/160402109-1364071a-cb93-4d7e-b2af-2776529b55e8.png">

**Before (Mobile)**
<img width="499" alt="Screenshot 2022-03-28 at 5 51 58 PM" src="https://user-images.githubusercontent.com/34372316/160402182-3c44aa71-a740-496f-b084-df97ce060780.png">
