### PR TITLE
Add midpoint state between sm and lg to fix styling issues on cart page

### DIFF
--- a/static/js/components/CartItemCard.js
+++ b/static/js/components/CartItemCard.js
@@ -61,10 +61,10 @@ export class CartItemCard extends React.Component<Props> {
         className="enrolled-item container card mb-4 rounded-0 flex-grow-1"
         key={cardKey}
       >
-        <div className="row d-flex flex-sm-columm p-md-3">
+        <div className="row d-flex flex-md-columm p-md-3">
           <div className="img-container">{courseImage}</div>
 
-          <div className="flex-grow-1 d-sm-flex flex-column w-50 mx-3">
+          <div className="flex-grow-1 d-md-flex flex-column w-50 mx-3">
             <h5 className="">{title}</h5>
             <div className="detail">
               {readableId}

--- a/static/js/components/OrderSummaryCard.js
+++ b/static/js/components/OrderSummaryCard.js
@@ -50,7 +50,7 @@ export class OrderSummaryCard extends React.Component<Props> {
 
     return (
       <div className="row order-summary-total">
-        <div className="col-12 px-3 py-3 py-md-0">
+        <div className="col-12 px-3 py-3 py-lg-0">
           <div className="d-flex justify-content-between">
             <div className="flex-grow-1">
               Coupon applied (
@@ -85,17 +85,17 @@ export class OrderSummaryCard extends React.Component<Props> {
     const title = cardTitle ? cardTitle : "Order Summary"
     return (
       <div
-        className="order-summary container card p-md-3 mb-4 rounded-0"
+        className="order-summary container card p-lg-3 mb-4 rounded-0"
         key="ordersummarycard"
       >
-        <div className="row order-summary-total mt-3 mt-md-0 mb-3">
-          <div className="col-12 col-md-auto px-3 px-md-3">
+        <div className="row order-summary-total mt-3 mt-lg-0 mb-3">
+          <div className="col-12 col-lg-auto px-3 px-lg-3">
             <h5 id="summary-card-title">{title}</h5>
           </div>
         </div>
 
         <div className="row">
-          <div className="col-12 px-3 py-3 py-md-0">
+          <div className="col-12 px-3 py-3 py-lg-0">
             <div className="d-flex justify-content-between">
               <div className="flex-grow-1">Price</div>
               <div className="ml-auto">{fmtPrice}</div>
@@ -112,7 +112,7 @@ export class OrderSummaryCard extends React.Component<Props> {
         </div>
 
         <div className="row order-summary-total">
-          <div className="col-12 px-3 py-3 py-md-0">
+          <div className="col-12 px-3 py-3 py-lg-0">
             <div className="d-flex justify-content-between">
               <div className="flex-grow-1">
                 <h5>Total</h5>
@@ -149,7 +149,7 @@ export class OrderSummaryCard extends React.Component<Props> {
 
         {totalPrice > 0 && !orderFulfilled ? (
           <div className="row">
-            <div className="col-12 px-3 py-3 py-md-0 cart-text-smaller">
+            <div className="col-12 px-3 py-3 py-lg-0 cart-text-smaller">
               By placing my order I agree to the{" "}
               <a href="/terms-of-service/" target="_blank" rel="noreferrer">
                 Terms of Service

--- a/static/js/containers/pages/checkout/CartPage.js
+++ b/static/js/containers/pages/checkout/CartPage.js
@@ -197,13 +197,13 @@ export class CartPage extends React.Component<Props, CartState> {
               </div>
             </div>
 
-            <div className="row d-flex flex-column-reverse flex-md-row">
-              <div className="col-md-8 enrolled-items">
+            <div className="row d-flex flex-column-reverse flex-md-column flex-lg-row">
+              <div className="col-lg-8 enrolled-items">
                 {cartItems && cartItems.length > 0
                   ? cartItems.map(this.renderCartItemCard.bind(this))
                   : this.renderEmptyCartCard()}
               </div>
-              <div className="col-md-4">{this.renderOrderSummaryCard()}</div>
+              <div className="col-lg-4">{this.renderOrderSummaryCard()}</div>
             </div>
           </div>
         </Loader>


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#493 

#### What's this PR do?
Adds a midpoint for the checkout page to make the transition between mobile view and full-width view better.
- Mobile view should not change at all, nor should full-width/desktop view.
- In between, the view changes to stack the cart items on top of the cart summary, and adds back in the "You are about to purchase" header. The card items display using the desktop-style view (small image on left, text on right) rather than the mobile view (image on top, text below). 

#### How should this be manually tested?
Add an item to the cart, then use the dev tools to turn on responsive view and switch between devices. You will need to cycle through between the [small, medium, and large breakpoints](https://getbootstrap.com/docs/4.6/layout/overview/) to see all three states - good choices for this in Chrome devtools are a phone (iPhone SE/Pixel 5), a tablet (iPad Mini/Surface Pro 7, both in portrait) and responsive mode off or tablet in landscape mode. 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/945611/160670490-b3eb4ec5-147d-4b37-b0ec-08de0deb9079.png)
