### PR TITLE
Fixing some issues with order history/receipt views

### DIFF
--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -491,7 +491,12 @@ class OrderHistoryViewSet(ReadOnlyModelViewSet):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        return Order.objects.filter(purchaser=self.request.user).all()
+        return (
+            Order.objects.filter(purchaser=self.request.user)
+            .filter(state__in=[Order.STATE.FULFILLED, Order.STATE.REFUNDED])
+            .order_by("-created_on")
+            .all()
+        )
 
 
 class OrderReceiptView(RetrieveAPIView):

--- a/static/js/containers/pages/checkout/OrderReceiptPage.js
+++ b/static/js/containers/pages/checkout/OrderReceiptPage.js
@@ -119,15 +119,15 @@ export class OrderReceiptPage extends React.Component<Props> {
               </div>
             </div>
 
-            <div className="row d-flex flex-column-reverse flex-md-row">
-              <div className="col-md-8 enrolled-items">
+            <div className="row d-flex flex-column-reverse flex-md-column flex-lg-row">
+              <div className="col-lg-8 enrolled-items">
                 {orderReceipt &&
                 orderReceipt.lines &&
                 orderReceipt.lines.length > 0
                   ? orderReceipt.lines.map(this.renderCartItemCard.bind(this))
                   : this.renderEmptyCartCard()}
               </div>
-              <div className="col-md-4">{this.renderOrderSummaryCard()}</div>
+              <div className="col-lg-4">{this.renderOrderSummaryCard()}</div>
             </div>
           </div>
         </Loader>


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#495  #496

#### What's this PR do?

* Adjusts Order History page to only show Fulfilled and Refunded orders
* Migrates styling changes (md breakpoint stuff) from the Checkout page to the Order Receipt page
* Adds sorting to the Order History page (created date, descending)

#### How should this be manually tested?

* Navigate to Order History page as a user with some orders - it should only display Fulfilled or Refunded orders, and they should be listed most recent first.
* Open the receipt page for an order and set view to something in the md breakpoint (768px <= width <= 991px). It should mirror the Checkout page. See https://github.com/mitodl/mitxonline/pull/494 for more details.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/945611/161066615-bd13a22b-393c-4aff-8d42-4178e580ed80.png)
![image](https://user-images.githubusercontent.com/945611/161066679-55ce9927-b8a7-46db-9732-e992d1387825.png)
