### PR TITLE
Adds administrative discount APIs

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -299,3 +299,58 @@ class OrderHistorySerializer(serializers.ModelSerializer):
         ]
         model = models.Order
         depth = 1
+
+
+class DiscountSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Discount
+        fields = [
+            "id",
+            "amount",
+            "automatic",
+            "discount_type",
+            "redemption_type",
+            "max_redemptions",
+            "discount_code",
+        ]
+        depth = 2
+
+
+class DiscountRedemptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.DiscountRedemption
+        fields = [
+            "id",
+            "redemption_date",
+            "redeemed_by",
+            "redeemed_discount",
+            "redeemed_order",
+        ]
+        read_only_fields = [
+            "redemption_date",
+            "redeemed_by",
+            "redeemed_discount",
+            "redeemed_order",
+        ]
+        depth = 1
+
+
+class UserDiscountSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.UserDiscount
+        fields = [
+            "id",
+            "discount",
+            "user",
+        ]
+
+
+class UserDiscountMetaSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.UserDiscount
+        fields = [
+            "id",
+            "discount",
+            "user",
+        ]
+        depth = 1

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -16,6 +16,10 @@ from ecommerce.views.v0 import (
     OrderHistoryViewSet,
     OrderReceiptView,
     AdminRefundOrderView,
+    DiscountViewSet,
+    NestedDiscountRedemptionViewSet,
+    NestedUserDiscountViewSet,
+    UserDiscountViewSet,
 )
 
 
@@ -27,6 +31,24 @@ router = SimpleRouterWithNesting()
 router.register(r"products", ProductViewSet, basename="products_api")
 router.register(r"checkout", CheckoutApiViewSet, basename="checkout_api")
 router.register(r"orders/history", OrderHistoryViewSet, basename="orderhistory_api")
+router.register(r"discounts/user", UserDiscountViewSet, basename="userdiscounts_api")
+
+discountsRouter = router.register(
+    r"discounts", DiscountViewSet, basename="discounts_api"
+)
+discountsRouter.register(
+    r"redemptions",
+    NestedDiscountRedemptionViewSet,
+    basename="discounts_api-redemptions",
+    parents_query_lookups=["redeemed_discount"],
+)
+discountsRouter.register(
+    r"assignees",
+    NestedUserDiscountViewSet,
+    basename="discounts_api-assignees",
+    parents_query_lookups=["discount"],
+)
+
 
 basketRouter = router.register(r"baskets", BasketViewSet, basename="basket")
 basketRouter.register(


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#436 (to an extent)

#### What's this PR do?
Adds some simple APIs for working with discount codes via REST API. These are meant to be used for upcoming Refine development.

#### How should this be manually tested?
Navigate to /api/v0/discounts - you should be able to work through the API via the standard DRF interface.
The discount detail should also include redemptions (with detail) for the discount. 

#### Any background context you want to provide?
* This is a backport of stuff I set up while testing out Refine - it made some intuitive sense to have a Refine console to manage discount codes (since they'll be used in flexible pricing). 
* These are limited to admin-level users but can be bumped down to staff or something else (depending on how we want to limit access to the Refine bits that haven't been done yet). Admin made the most sense now. 
 