### PR TITLE
fix ecommerce accessibility coupon code field has no label

### DIFF
--- a/frontend/public/src/components/forms/ApplyCouponForm.js
+++ b/frontend/public/src/components/forms/ApplyCouponForm.js
@@ -28,7 +28,9 @@ const ApplyCouponForm = ({
       <Form>
         <div className="row">
           <div className="col-12 mt-4 px-3 py-3 py-md-0">
-            Have a coupon?
+            <label htmlFor="couponCode">
+              <span id="couponCodeDesc">Have a coupon?</span>
+            </label>
             {discountCodeIsBad ? (
               <div
                 id="invalidCode"
@@ -41,10 +43,10 @@ const ApplyCouponForm = ({
               <Field
                 type="text"
                 name="couponCode"
-                id="coupon_code"
+                id="couponCode"
                 className="form-control"
                 autoComplete="given-name"
-                aria-describedby="coupon_code_error"
+                aria-describedby="couponCodeDesc"
               />
 
               <button


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #516 

#### What's this PR do?
fix ecommerce accessibility coupon code field has no label

#### Screenshots (if appropriate)
**BEFORE**
<img width="1440" alt="Screenshot 2022-04-19 at 13 31 48" src="https://user-images.githubusercontent.com/4043989/163975973-46a9cfb0-6d95-43dd-889c-dca222aa339c.png">
**NOW**
<img width="1438" alt="Screenshot 2022-04-19 at 14 39 51" src="https://user-images.githubusercontent.com/4043989/163975990-cc93284f-39b0-4867-a6af-845660563986.png">

