### PR TITLE
Adds discounts to Refine admin

### DIFF
--- a/app.json
+++ b/app.json
@@ -67,6 +67,10 @@
       "description": "Comma separated string of trusted domains that should be allowed for CORS",
       "required": false
     },
+    "CORS_ALLOW_CREDENTIALS": {
+      "description": "Allow cookies to be sent in cross-site HTTP requests",
+      "required": false
+    },
     "CRON_COURSERUN_SYNC_DAYS": {
       "description": "day_of_week' value for scheduled task to sync course run data (by default, it will run each day of the week).",
       "required": false

--- a/frontend/staff-dashboard/src/App.tsx
+++ b/frontend/staff-dashboard/src/App.tsx
@@ -2,7 +2,6 @@ import { Refine } from "@pankod/refine-core";
 import { Icons, notificationProvider } from "@pankod/refine-antd";
 import routerProvider from "@pankod/refine-react-router-v6";
 import "@pankod/refine-antd/dist/styles.min.css";
-import dataProvider from "@pankod/refine-simple-rest";
 import { useAuthProvider } from "hooks/useAuthProvider";
 import {
   Title,
@@ -14,20 +13,50 @@ import {
 } from "components/layout";
 import LoginPage from "pages/login";
 import { DashboardPage } from "pages/dashboard";
+import { DiscountList, DiscountEdit, DiscountShow, DiscountCreate } from "pages/discounts";
+import axios from "axios";
+import useDrfDataProvider from "hooks/useDrfDataProvider";
 
-const {UserOutlined} = Icons;
+const {UserOutlined, BarcodeOutlined} = Icons;
+const axiosInterface = axios.create();
+
+axiosInterface.interceptors.request.use((config: any) => {
+  let token = sessionStorage.getItem(`oidc.user:${OIDC_CONFIG.authority}:${OIDC_CONFIG.client_id}`);
+
+  if (token !== null) {
+    token = JSON.parse(token).access_token;
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  return config;
+}, (error: any) => Promise.reject(error));
 
 export default function App() {
   const authProvider = useAuthProvider();
+  const xonlineProvider = useDrfDataProvider("http://mitxonline.odl.local:8013/api/v0");
+
   return (
     <Refine
       routerProvider={routerProvider}
       notificationProvider={notificationProvider}
-      dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+      dataProvider={xonlineProvider}
       authProvider={authProvider}
       LoginPage={LoginPage}
       DashboardPage={DashboardPage}
-      resources={[{name: "learners", icon: <UserOutlined/>}]}
+      resources={[
+        {
+          name: "learners", 
+          icon: <UserOutlined/>
+        },
+        {
+          name: "discounts",
+          icon: <BarcodeOutlined/>,
+          show: DiscountShow,
+          list: DiscountList,
+          edit: DiscountEdit,
+          create: DiscountCreate,
+        },
+      ]}
       Title={Title}
       Header={Header}
       Sider={Sider}

--- a/frontend/staff-dashboard/src/components/discounts/index.ts
+++ b/frontend/staff-dashboard/src/components/discounts/index.ts
@@ -1,0 +1,2 @@
+export { RedemptionList } from "./redemption-list";
+export { UserAssignments } from "./user-assignments";

--- a/frontend/staff-dashboard/src/components/discounts/redemption-list.tsx
+++ b/frontend/staff-dashboard/src/components/discounts/redemption-list.tsx
@@ -1,0 +1,34 @@
+import { 
+    Table,
+    useTable,
+    List,
+    DateField,
+} from "@pankod/refine-antd";
+import moment from "moment";
+
+export const RedemptionList = (props: any) => {
+    const { record } = props
+    const { tableProps } = useTable({
+        resource: `discounts/${record?.id}/redemptions`
+    });
+
+    return (
+        <List title="Redemptions" canCreate={false}>
+            <Table {...tableProps} rowKey="id">
+                <Table.Column dataIndex="id" title="ID"></Table.Column>
+                <Table.Column 
+                    dataIndex="redeemed_by" 
+                    title="Redeemed By"
+                    render={(value) => {
+                        return value.username;
+                    }}
+                ></Table.Column>
+                <Table.Column 
+                    dataIndex="redeemed_on" 
+                    title="Redeemed On"
+                    render={(value) => <DateField format="LLL" value={value} />}
+                ></Table.Column>
+            </Table>
+        </List>
+    );
+}

--- a/frontend/staff-dashboard/src/components/discounts/user-assignments.tsx
+++ b/frontend/staff-dashboard/src/components/discounts/user-assignments.tsx
@@ -1,0 +1,27 @@
+import { 
+    Table,
+    useTable,
+    List,
+} from "@pankod/refine-antd";
+import moment from "moment";
+
+export const UserAssignments = (props: any) => {
+    const { record } = props
+
+    if (record === undefined) {
+        return null;
+    }
+
+    const { tableProps } = useTable({
+        resource: `discounts/${record?.id}/assignees`
+    });
+
+    return (
+        <List title="Assigned Users" resource="discounts/user" canCreate={false}>
+            <Table {...tableProps} rowKey="id">
+                <Table.Column dataIndex="id" title="ID"></Table.Column>
+                <Table.Column dataIndex="user" title="User" render={(value: any) => value.name}></Table.Column>
+            </Table>
+        </List>
+    );
+}

--- a/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
@@ -5,7 +5,7 @@ export function useAuthProvider(): AuthProvider {
   const auth = useAuth()
   return {
     login: async () => {
-      await auth.signinPopup();
+      let result = await auth.signinPopup();
       return Promise.resolve();
     },
     logout: async () => {

--- a/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
@@ -1,0 +1,130 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import {
+    Pagination, 
+    CrudSorting,
+    CrudFilters,
+    CrudOperators,
+    DataProvider,
+} from "@pankod/refine-core"
+import dataProvider from "@pankod/refine-simple-rest";
+import { stringify } from "query-string";
+
+axios.defaults.withCredentials = true;
+axios.defaults.xsrfCookieName = 'csrftoken';
+axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+
+const axiosInterface = axios.create();
+
+axiosInterface.interceptors.request.use((config: AxiosRequestConfig) => {
+    let token = sessionStorage.getItem(`oidc.user:${OIDC_CONFIG.authority}:${OIDC_CONFIG.client_id}`);
+
+    if (token !== null) {
+        token = JSON.parse(token).access_token;
+        config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    if (config.url) {
+        const desturl = new URL(config.url);
+
+        if (! desturl.pathname.endsWith('/')) {
+            desturl.pathname += '/';
+            config.url = desturl.href;
+        }
+    }
+
+    return config;
+}, (error: any) => Promise.reject(error));
+
+const generateSort = (sort?: CrudSorting) => {
+    if (sort && sort.length > 0) {
+        const _sort: string[] = [];
+        const _order: string[] = [];
+
+        sort.map((item) => {
+            _sort.push(item.field);
+            _order.push(item.order);
+        });
+
+        return {
+            _sort: _sort.join(','),
+            _order: _order.join(','),
+        };
+    }
+
+    return {};
+};
+
+const mapOperator = (operator: CrudOperators): string => {
+    switch (operator) {
+        case "ne":
+        case "gte":
+        case "lte":
+            return `_${operator}`;
+        case "contains":
+            return "_like";
+        case "eq":
+        default:
+            return "";
+    }
+};
+
+const generateFilter = (filters?: CrudFilters) => {
+    const queryFilters: { [key: string]: string } = {};
+    if (filters) {
+        filters.map((filter) => {
+            if (filter.operator !== "or") {
+                const { field, operator, value } = filter;
+
+                if (field === "q") {
+                    queryFilters[field] = value;
+                    return;
+                }
+
+                const mappedOperator = mapOperator(operator);
+                queryFilters[`${field}${mappedOperator}`] = value;
+            }
+        });
+    }
+
+    return queryFilters;
+};
+
+const generatePagination = (pagination?: Pagination) => {
+    const current = pagination?.current || 1;
+    const pageSize = pagination?.pageSize || 3;
+
+    return { 
+        o: (current - 1) * pageSize,
+        l: pageSize
+    };
+};
+
+const useDrfDataProvider = (
+    apiUrl: string,
+    httpClient: AxiosInstance = axiosInterface
+): DataProvider => {
+    const simpleDataProvider = dataProvider(apiUrl, httpClient);
+
+    simpleDataProvider.getList = async ({ resource, pagination, filters, sort }) => {
+        const url = `${apiUrl}/${resource}/`;
+        
+        const query = {
+            ...generateFilter(filters),
+            ...generateSort(sort),
+            ...generatePagination(pagination),
+        }
+
+        const uri = `${url}?${stringify(query)}`;
+
+        const { data: { results: data, count: total }, headers } = await httpClient.get(uri);
+
+        return {
+            data, 
+            total,
+        };
+    };
+
+    return simpleDataProvider;
+}
+
+export default useDrfDataProvider;

--- a/frontend/staff-dashboard/src/interfaces/index.d.ts
+++ b/frontend/staff-dashboard/src/interfaces/index.d.ts
@@ -1,0 +1,21 @@
+export interface IDiscount {
+    id: int;
+    discount_code: string;
+    amount: float;
+    discount_type: string;
+    redemption_type: string;
+    max_redemptions: int;
+}
+
+export interface IDiscountRedemption {
+    redemption_date: string;
+    redeemed_by: Object;
+    redeemed_discount: Object<IDiscount>;
+    redeemed_order: Object;
+}
+
+export interface IUserDiscount {
+    id: int;
+    discount: IDiscount;
+    user: any;
+}

--- a/frontend/staff-dashboard/src/pages/discounts/create.tsx
+++ b/frontend/staff-dashboard/src/pages/discounts/create.tsx
@@ -1,0 +1,41 @@
+import { 
+    useForm,
+    Form,
+    Input,
+    InputNumber,
+    Select,
+    Create,
+ } from "@pankod/refine-antd";
+
+import { IDiscount } from "interfaces";
+
+export const DiscountCreate = () => {
+    const { formProps, saveButtonProps } = useForm<IDiscount>();
+
+    return (
+        <Create saveButtonProps={saveButtonProps}>
+            <Form {...formProps} layout="vertical">
+                <Form.Item label="Discount Code" name="discount_code">
+                    <Input />
+                </Form.Item>
+                <Form.Item label="Redemption Type" name="redemption_type">
+                    <Select options={[
+                        { label: 'Unlimited', value: 'unlimited' },
+                        { label: 'One-Time', value: 'one-time' },
+                        { label: 'One Time Per User', value: 'one-time-per-user' }, 
+                    ]}></Select>
+                </Form.Item>
+                <Form.Item label="Discount Type" name="discount_type">
+                    <Select options={[
+                        { label: 'Percent Off', value: 'percent-off' },
+                        { label: 'Dollars Off', value: 'dollars-off' },
+                        { label: 'Fixed Price', value: 'fixed-price' }, 
+                    ]}></Select>
+                </Form.Item>
+                <Form.Item label="Amount" name="amount">
+                    <InputNumber precision={2} />
+                </Form.Item>
+            </Form>
+        </Create>
+    );
+};

--- a/frontend/staff-dashboard/src/pages/discounts/edit.tsx
+++ b/frontend/staff-dashboard/src/pages/discounts/edit.tsx
@@ -1,0 +1,45 @@
+import { 
+    useForm,
+    Form,
+    Input,
+    InputNumber,
+    Select,
+    Edit,
+ } from "@pankod/refine-antd";
+
+import { IDiscount } from "interfaces";
+
+
+export const DiscountEdit = () => {
+    const { formProps, saveButtonProps, queryResult } = useForm<IDiscount>();
+    const discount_type = queryResult?.data?.data.discount_type
+
+    return (
+        <div>
+            <Edit saveButtonProps={saveButtonProps}>
+                <Form {...formProps} layout="vertical">
+                    <Form.Item label="Discount Code" name="discount_code">
+                        <Input />
+                    </Form.Item>
+                    <Form.Item label="Redemption Type" name="redemption_type">
+                        <Select options={[
+                            { label: 'Unlimited', value: 'unlimited' },
+                            { label: 'One-Time', value: 'one-time' },
+                            { label: 'One Time Per User', value: 'one-time-per-user' }, 
+                        ]}></Select>
+                    </Form.Item>
+                    <Form.Item label="Discount Type" name="discount_type">
+                        <Select options={[
+                            { label: 'Percent Off', value: 'percent-off' },
+                            { label: 'Dollars Off', value: 'dollars-off' },
+                            { label: 'Fixed Price', value: 'fixed-price' }, 
+                        ]}></Select>
+                    </Form.Item>
+                    <Form.Item label="Amount" name="amount">
+                        <InputNumber precision={2} />
+                    </Form.Item>
+                </Form>
+            </Edit>
+        </div>
+    );
+};

--- a/frontend/staff-dashboard/src/pages/discounts/index.tsx
+++ b/frontend/staff-dashboard/src/pages/discounts/index.tsx
@@ -1,0 +1,4 @@
+export * from "./list";
+export * from "./show";
+export * from "./edit";
+export * from "./create";

--- a/frontend/staff-dashboard/src/pages/discounts/list.tsx
+++ b/frontend/staff-dashboard/src/pages/discounts/list.tsx
@@ -1,0 +1,61 @@
+import {
+    List,
+    DateField,
+    ShowButton,
+    Table,
+    useTable,
+    Space, 
+    EditButton,
+} from "@pankod/refine-antd";
+
+import { IDiscount } from "interfaces";
+
+export const DiscountList: React.FC = () => {
+    const {tableProps} = useTable<IDiscount>({
+        resource: 'discounts',
+        initialCurrent: 1,
+        initialPageSize: 3,
+    });
+    
+    return (
+        <List>
+            <Table {...tableProps} rowKey="id">
+                <Table.Column dataIndex="discount_code" title="Discount Code" />
+                <Table.Column
+                    dataIndex="amount"
+                    title="Amount"
+                    render={(value, record: any) => parseFloat(value).toLocaleString('en-US') + ' ' + record?.discount_type }
+                />
+                <Table.Column
+                    dataIndex="discount_type"
+                    title="Discount Type"
+                />
+                <Table.Column
+                    dataIndex="createdAt"
+                    title="Created At"
+                    render={(value) => <DateField format="LLL" value={value} />}
+                />
+                <Table.Column<IDiscount>
+                    title="Actions"
+                    dataIndex="actions"
+                    render={(_text, record): React.ReactNode => {
+                        return (
+                            <Space>
+                                <ShowButton
+                                    size="small"
+                                    recordItemId={record.id}
+                                    hideText
+                                />
+                                <EditButton
+                                    size="small"
+                                    recordItemId={record.id}
+                                    hideText
+                                />
+                            </Space>
+                        );
+                    }}
+                />
+            </Table>
+        </List>
+    );
+};

--- a/frontend/staff-dashboard/src/pages/discounts/show.tsx
+++ b/frontend/staff-dashboard/src/pages/discounts/show.tsx
@@ -1,0 +1,35 @@
+import { useShow, useOne } from "@pankod/refine-core";
+import { Show, Typography, Tag,
+    Table,
+    useTable,
+ } from "@pankod/refine-antd";
+import { IDiscountRedemption } from "interfaces";
+import { RedemptionList, UserAssignments } from "components/discounts";
+const { Title, Text } = Typography;
+
+export const DiscountShow = () => {
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
+    const record = data?.data;
+
+    return (
+        <Show isLoading={isLoading}>
+            <h2>Discount Detail</h2>
+            
+            <Title level={5}>Code</Title>
+            <Text>{record?.discount_code}</Text>
+
+            <Title level={5}>Redemption Type</Title>
+            <Text>
+                <Tag>{record?.redemption_type}</Tag>
+            </Text>
+
+            <Title level={5}>Amount</Title>
+            <Text>{record?.amount} {record?.discount_type}</Text>
+
+            {record ? <UserAssignments record={record} key={record?.user} /> : null}
+
+            {record ? <RedemptionList record={record} key={record?.id} /> : null}
+        </Show>
+    );
+};

--- a/main/settings.py
+++ b/main/settings.py
@@ -81,7 +81,6 @@ DEBUG = get_bool(
     description="Set to True to enable DEBUG mode. Don't turn on in production.",
 )
 
-
 ALLOWED_HOSTS = ["*"]
 
 CSRF_TRUSTED_ORIGINS = get_delimited_list(
@@ -94,6 +93,12 @@ CORS_ALLOWED_ORIGINS = get_delimited_list(
     name="CORS_ALLOWED_ORIGINS",
     default=[],
     description="Comma separated string of trusted domains that should be allowed for CORS",
+)
+
+CORS_ALLOW_CREDENTIALS = get_bool(
+    name="CORS_ALLOW_CREDENTIALS",
+    default=True,
+    description="Allow cookies to be sent in cross-site HTTP requests",
 )
 
 SECURE_SSL_REDIRECT = get_bool(


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
n/a

#### What's this PR do?
Adds CRUD operations for discounts to the Refine admin UI. Also adds in some infrastructure stuff:
- AuthProvider in the API that doesn't check for the CSRF token (which Refine doesn't know about)
- A DRF-aware DataProvider for Refine; this is mostly the simple data provider with a couple of methods reworked a bit to make them usable with a DRF-based API

#### How should this be manually tested?
Once the code is checked out and the refine app rebuilds, you should have a Discounts menu item on the left. Clicking that should show you the list of discounts in the system. Create button should work, as should edit and view. The view button in particular should additionally show you redemptions and assigned users (UserDiscounts) for that discount. (You can't add new UserDiscounts yet.) 

#### Any background context you want to provide?
The things that needed adjustment in the data provider are the pathnames that it constructs and the handling of metadata that comes back from a paginated DRF request. 
- Pathnames: these needed a trailing slash. Django usually takes care of this with a redirect, but it can't do that for POST-like requests. 
- Paginated DRF requests: The simple data provider expects a simple array of results back (and then to do the pagination itself). DRF sends back a bunch of metadata with it (item counts, prev/next, etc.) so rather than try to adjust the API to work with Refine, I opted to make Refine work with it so that it'd be easier to use with other DRF-based APIs. There was also a discrepancy in limit and offset parameters, so this takes care of that too. 

This code also implements the Bearer token for OIDC auth; it doesn't do that by default (that I saw) so it's implemented here using an axios-http interceptor. 

#### Screenshots (if appropriate)
![Screen Shot 2022-04-27 at 3 48 08 PM](https://user-images.githubusercontent.com/945611/165629388-547d3571-afa2-402f-a2d9-e3bb2c6032b8.png)
![Screen Shot 2022-04-27 at 3 48 16 PM](https://user-images.githubusercontent.com/945611/165629387-39bc79d2-3383-4438-91b9-feab0119c48e.png)
![Screen Shot 2022-04-27 at 3 48 21 PM](https://user-images.githubusercontent.com/945611/165629382-47d2ebeb-a318-4691-9f81-c76f73ed9142.png)

