### PR TITLE
Refactor out start date display code

### DIFF
--- a/frontend/public/src/components/CartItemCard.js
+++ b/frontend/public/src/components/CartItemCard.js
@@ -3,6 +3,7 @@ import React from "react"
 import type { BasketItem, Product } from "../flow/cartTypes"
 import moment from "moment"
 import { formatPrettyDateTimeAmPmTz, parseDateString } from "../lib/util"
+import { generateStartDateText } from "../lib/courseApi"
 
 type Props = {
   product: Product
@@ -34,22 +35,7 @@ export class CartItemCard extends React.Component<Props> {
         ? purchasableObject.readable_id
         : purchasableObject.run_tag
 
-    let startDate = ""
-    let startDateDescription = ""
-
-    if (purchasableObject.start_date) {
-      const now = moment()
-      startDate = parseDateString(purchasableObject.start_date)
-      const formattedStartDate = formatPrettyDateTimeAmPmTz(startDate)
-      startDateDescription = now.isBefore(startDate) ? (
-        <span>Starts - {formattedStartDate}</span>
-      ) : (
-        <span>
-          <strong>Active</strong> from {formattedStartDate}
-        </span>
-      )
-    }
-
+    const startDateDescription = generateStartDateText(purchasableObject)
     const courseImage =
       course !== undefined && course.page !== null ? (
         <img src={course.page.feature_image_src} alt={course.title} />

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -28,7 +28,7 @@ import {
   courseEmailsSubscriptionMutation
 } from "../lib/queries/enrollment"
 import { currentUserSelector } from "../lib/queries/users"
-import { isLinkableCourseRun } from "../lib/courseApi"
+import { isLinkableCourseRun, generateStartDateText } from "../lib/courseApi"
 import {
   formatPrettyDateTimeAmPmTz,
   isSuccessResponse,
@@ -232,7 +232,6 @@ export class EnrolledItemCard extends React.Component<
       addUserNotification
     } = this.props
 
-    let startDateDescription = null
     const title = isLinkableCourseRun(enrollment.run, currentUser) ? (
       <a
         href={enrollment.run.courseware_url}
@@ -244,18 +243,7 @@ export class EnrolledItemCard extends React.Component<
     ) : (
       enrollment.run.course.title
     )
-    if (enrollment.run.start_date) {
-      const now = moment()
-      const startDate = parseDateString(enrollment.run.start_date)
-      const formattedStartDate = formatPrettyDateTimeAmPmTz(startDate)
-      startDateDescription = now.isBefore(startDate) ? (
-        <span>Starts - {formattedStartDate}</span>
-      ) : (
-        <span>
-          <strong>Active</strong> from {formattedStartDate}
-        </span>
-      )
-    }
+    const startDateDescription = generateStartDateText(enrollment.run)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
 
     return (

--- a/frontend/public/src/components/forms/ApplyCouponForm.js
+++ b/frontend/public/src/components/forms/ApplyCouponForm.js
@@ -6,19 +6,15 @@ import FormError from "./elements/FormError"
 type Props = {
   onSubmit: Function,
   couponCode: string,
-  discounts: Array<Object>,
+  discounts: Array<Object>
 }
 
 const getInitialValues = (couponCode, discounts) => ({
-  couponCode:        couponCode,
-  discounts:         discounts,
+  couponCode: couponCode,
+  discounts:  discounts
 })
 
-const ApplyCouponForm = ({
-  onSubmit,
-  couponCode,
-  discounts,
-}: Props) => (
+const ApplyCouponForm = ({ onSubmit, couponCode, discounts }: Props) => (
   <Formik
     onSubmit={onSubmit}
     initialValues={getInitialValues(couponCode, discounts)}
@@ -39,7 +35,12 @@ const ApplyCouponForm = ({
                   autoComplete="given-name"
                   aria-describedby="couponCodeError"
                 />
-                <ErrorMessage name="couponCode" className="form-control" id="couponCodeError" component={FormError} />
+                <ErrorMessage
+                  name="couponCode"
+                  className="form-control"
+                  id="couponCodeError"
+                  component={FormError}
+                />
               </div>
 
               <div>

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -250,8 +250,8 @@ export class DashboardPage extends React.Component<
           <Loader isLoading={isLoading}>
             <h1>My Courses</h1>
             <div className="enrolled-items">
-              {enrollments && enrollments.length > 0
-                ? enrollments.map(enrollment => (
+              {enrollments && enrollments.length > 0 ? (
+                enrollments.map(enrollment => (
                   <EnrolledItemCard
                     key={enrollment.id}
                     enrollment={enrollment}
@@ -261,15 +261,15 @@ export class DashboardPage extends React.Component<
                     addUserNotification={addUserNotification}
                   ></EnrolledItemCard>
                 ))
-                : (
-                  <div className="card no-enrollments p-3 p-md-5 rounded-0">
-                    <h2>Enroll Now</h2>
-                    <p>
-                      You are not enrolled in any courses yet. Please{" "}
-                      <a href={routes.root}>browse our courses</a>.
-                    </p>
-                  </div>
-                )}
+              ) : (
+                <div className="card no-enrollments p-3 p-md-5 rounded-0">
+                  <h2>Enroll Now</h2>
+                  <p>
+                    You are not enrolled in any courses yet. Please{" "}
+                    <a href={routes.root}>browse our courses</a>.
+                  </p>
+                </div>
+              )}
             </div>
           </Loader>
         </div>

--- a/frontend/public/src/containers/pages/checkout/CartPage.js
+++ b/frontend/public/src/containers/pages/checkout/CartPage.js
@@ -48,12 +48,12 @@ type Props = {
 }
 
 type CartState = {
-  discountCode: string,
+  discountCode: string
 }
 
 export class CartPage extends React.Component<Props, CartState> {
   state = {
-    discountCode: "",
+    discountCode: ""
   }
 
   async clearDiscount() {

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -1,9 +1,10 @@
 // @flow
 /* global SETTINGS:false */
+import React from "react"
 import moment from "moment"
 import { isNil } from "ramda"
 
-import { notNil } from "./util"
+import { notNil, parseDateString, formatPrettyDateTimeAmPmTz } from "./util"
 
 import type Moment from "moment"
 import type { CourseRunDetail } from "../flow/courseTypes"
@@ -33,4 +34,21 @@ export const isWithinEnrollmentPeriod = (run: CourseRunDetail): boolean => {
     now.isAfter(enrollStart) &&
     (isNil(enrollEnd) || now.isBefore(enrollEnd))
   )
+}
+
+export const generateStartDateText = (run: CourseRunDetail) => {
+  if (run.start_date) {
+    const now = moment()
+    const startDate = parseDateString(run.start_date)
+    const formattedStartDate = formatPrettyDateTimeAmPmTz(startDate)
+    return now.isBefore(startDate) ? (
+      <span>Starts - {formattedStartDate}</span>
+    ) : (
+      <span>
+        <strong>Active</strong> from {formattedStartDate}
+      </span>
+    )
+  }
+
+  return null
 }

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -1,6 +1,10 @@
 /* global SETTINGS: false */
 // @flow
-import { isLinkableCourseRun, isWithinEnrollmentPeriod } from "./courseApi"
+import {
+  isLinkableCourseRun,
+  isWithinEnrollmentPeriod,
+  generateStartDateText
+} from "./courseApi"
 import { assert } from "chai"
 import moment from "moment"
 
@@ -77,6 +81,25 @@ describe("Course API", () => {
         courseRun.enrollment_start = enrollStart
         courseRun.enrollment_end = enrollEnd
         assert.equal(isWithinEnrollmentPeriod(courseRun), expResult)
+      })
+    })
+  })
+
+  describe("generateStartDateText", () => {
+    [
+      [exampleUrl, past, future, "run is in progress", {}],
+      [exampleUrl, past, null, "run is in progress with no end date", {}],
+      [exampleUrl, future, null, "run is not in progress", {}],
+      [exampleUrl, null, null, "run has no start date", null]
+    ].forEach(([coursewareUrl, startDate, endDate, desc, expLinkable]) => {
+      it(`returns ${String(expLinkable)} when ${desc}`, () => {
+        courseRun.courseware_url = coursewareUrl
+        courseRun.start_date = startDate
+        courseRun.end_date = endDate
+        assert.equal(
+          typeof generateStartDateText(courseRun),
+          typeof expLinkable
+        )
       })
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#523 

#### What's this PR do?
Moves the code that generates the course start date out into a library function, and updates EnrolledItemCard and CartItemCard to use the library function. There appeared to be a scope issue (I think) with the code as it was in the EnrolledItemCard component, and this code is duplicated anyway in CartItemCard.

#### How should this be manually tested?
As a user with enrollments, log in and navigate to the dashboard. The enrollments should display with the proper start date. 

As a user with items in the cart, navigate to the cart. The cart items should display the course start date properly. Additional items (added manually through the Django admin) should also display properly.

#### Any background context you want to provide?
The underlying issue also appears on the cart page, but had gone unnoticed there because there's no "official" way to have more than one thing in your cart. (All of the pathways to add items to the cart on the frontend also clear the cart before adding the new item.)