### PR TITLE
Reworked generateStartDateText to avoid short circuiting

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,4 +33,3 @@ services:
 volumes:
   django_media: {}
   yarn-cache: {}
-

--- a/frontend/public/src/components/CartItemCard.js
+++ b/frontend/public/src/components/CartItemCard.js
@@ -55,7 +55,18 @@ export class CartItemCard extends React.Component<Props> {
             <div className="detail">
               {readableId}
               <br />
-              {startDateDescription !== undefined ? startDateDescription : ""}
+              {startDateDescription !== null && startDateDescription.active ? (
+                <span>Starts - {startDateDescription.datestr}</span>
+              ) : (
+                <span>
+                  {startDateDescription === null ? null : (
+                    <span>
+                      <strong>Active</strong> from{" "}
+                      {startDateDescription.datestr}
+                    </span>
+                  )}
+                </span>
+              )}
             </div>
           </div>
         </div>{" "}

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -296,7 +296,20 @@ export class EnrolledItemCard extends React.Component<
                 </DropdownMenu>
               </Dropdown>
             </div>
-            <div className="detail">{startDateDescription}</div>
+            <div className="detail">
+              {startDateDescription !== null && startDateDescription.active ? (
+                <span>Starts - {startDateDescription.datestr}</span>
+              ) : (
+                <span>
+                  {startDateDescription === null ? null : (
+                    <span>
+                      <strong>Active</strong> from{" "}
+                      {startDateDescription.datestr}
+                    </span>
+                  )}
+                </span>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -41,13 +41,9 @@ export const generateStartDateText = (run: CourseRunDetail) => {
     const now = moment()
     const startDate = parseDateString(run.start_date)
     const formattedStartDate = formatPrettyDateTimeAmPmTz(startDate)
-    return now.isBefore(startDate) ? (
-      <span>Starts - {formattedStartDate}</span>
-    ) : (
-      <span>
-        <strong>Active</strong> from {formattedStartDate}
-      </span>
-    )
+    return now.isBefore(startDate)
+      ? { active: false, datestr: formattedStartDate }
+      : { active: true, datestr: formattedStartDate }
   }
 
   return null

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -87,9 +87,9 @@ describe("Course API", () => {
 
   describe("generateStartDateText", () => {
     [
-      [exampleUrl, past, future, "run is in progress", {}],
-      [exampleUrl, past, null, "run is in progress with no end date", {}],
-      [exampleUrl, future, null, "run is not in progress", {}],
+      [exampleUrl, past, future, "run is in progress", {active: true, datestr: ''}],
+      [exampleUrl, past, null, "run is in progress with no end date", {active: true, datestr: ''}],
+      [exampleUrl, future, null, "run is not in progress", {active: true, datestr: ''}],
       [exampleUrl, null, null, "run has no start date", null]
     ].forEach(([coursewareUrl, startDate, endDate, desc, expLinkable]) => {
       it(`returns ${String(expLinkable)} when ${desc}`, () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#523 

#### What's this PR do?
Hopefully the final fix for dashboard dates. 

#### How should this be manually tested?

As a user with enrollments, log in and navigate to the dashboard. The enrollments should display with the proper start date.

As a user with items in the cart, navigate to the cart. The cart items should display the course start date properly. Additional items (added manually through the Django admin) should also display properly.

#### Any background context you want to provide?

A production build of the app may be useful for testing - the code works (and has worked) successfully on dev builds but failed once it was minimized. 