### PR TITLE
Adds email receipts

### DIFF
--- a/ecommerce/constants.py
+++ b/ecommerce/constants.py
@@ -31,3 +31,29 @@ TRANSACTION_TYPE_PAYMENT = "payment"
 ALL_TRANSACTION_TYPES = [TRANSACTION_TYPE_PAYMENT, TRANSACTION_TYPE_REFUND]
 
 TRANSACTION_TYPES = list(zip(ALL_TRANSACTION_TYPES, ALL_TRANSACTION_TYPES))
+
+CYBERSOURCE_CARD_TYPES = {
+    "001": "Visa",
+    "002": "Mastercard",
+    "003": "American Express",
+    "004": "Discover",
+    "005": "Diners Club",
+    "006": "Carte Blanche",
+    "007": "JCB",
+    "014": "Enroute",
+    "021": "JAL",
+    "024": "Maestro (UK)",
+    "031": "Delta",
+    "033": "Visa Electron",
+    "034": "Dankort",
+    "036": "Carte Bancaires",
+    "037": "Carta Si",
+    "039": "EAN",
+    "040": "UATP",
+    "042": "Maestro (Intl)",
+    "050": "Hipercard",
+    "051": "Aura",
+    "054": "Elo",
+    "061": "RuPay",
+    "062": "China UnionPay",
+}

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -1,0 +1,64 @@
+"""Ecommerce mail functions"""
+import pycountry
+import logging
+
+from ecommerce.messages import OrderReceiptMessage
+from mitol.mail.api import get_message_sender
+
+log = logging.getLogger()
+
+
+def send_ecommerce_order_receipt(order):
+    """
+    Send emails receipt summarizing the user purchase detail.
+
+    Args:
+        order: An order.
+    """
+    from ecommerce.serializers import OrderReceiptSerializer
+
+    data = OrderReceiptSerializer(instance=order).data
+    purchaser = data.get("purchaser")
+    coupon = data.get("coupon")
+    lines = data.get("lines")
+    order = data.get("order")
+    receipt = data.get("receipt")
+    country = pycountry.countries.get(alpha_2=purchaser.get("country"))
+    recipient = purchaser.get("email")
+
+    try:
+        with get_message_sender(OrderReceiptMessage) as sender:
+            sender.build_and_send_message(
+                recipient,
+                {
+                    "coupon": coupon,
+                    "content_title": lines[0].get("content_title") if lines else None,
+                    "lines": lines,
+                    "order_total": format(
+                        sum(float(line["total_paid"]) for line in lines),
+                        ".2f",
+                    ),
+                    "order": order,
+                    "receipt": receipt,
+                    "purchaser": {
+                        "name": " ".join(
+                            [
+                                purchaser.get("first_name"),
+                                purchaser.get("last_name"),
+                            ]
+                        ),
+                        "email": purchaser.get("email"),
+                        "street_address": purchaser.get("street_address"),
+                        "state_code": purchaser.get("state_or_territory").split("-")[
+                            -1
+                        ],
+                        "postal_code": purchaser.get("postal_code"),
+                        "city": purchaser.get("city"),
+                        "country": country.name if country else None,
+                        "company": purchaser.get("company"),
+                    },
+                },
+            )
+
+    except:  # pylint: disable=bare-except
+        log.exception("Error sending order receipt email.")

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -1,0 +1,59 @@
+import pytest
+import reversion
+
+from ecommerce.serializers_test import create_order_receipt
+from ecommerce.factories import ProductFactory
+from ecommerce.tasks import send_ecommerce_order_receipt
+from ecommerce.views_test import payment_gateway_settings
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture()
+def products():
+    with reversion.create_revision():
+        return ProductFactory.create_batch(5)
+
+
+def test_mail_api_task_called(mocker, user, products, user_client):
+    """
+    Tests that the Order model is properly calling the send email receipt task
+    rather than calling the mail_api version directly. The create_order_receipt
+    function should create a basket and process the order through to the point
+    where the Order model itself will send the receipt email.
+    """
+    mock_delayed_send_ecommerce_order_receipt = mocker.patch(
+        "ecommerce.tasks.send_ecommerce_order_receipt.delay"
+    )
+
+    order = create_order_receipt(mocker, user, products, user_client)
+
+    mock_delayed_send_ecommerce_order_receipt.assert_called()
+    assert mock_delayed_send_ecommerce_order_receipt.call_args[0][0] == order.id
+
+
+def test_mail_api_receipt_generation(mocker, user, products, user_client):
+    """
+    Tests email generation. Mocks actual message sending and then looks for some
+    key data in the rendered template body (name from legal address, order ID,
+    and line item unit price).
+    """
+    mock_send_message = mocker.patch("mitol.mail.api.send_message")
+
+    order = create_order_receipt(mocker, user, products, user_client)
+
+    mock_send_message.assert_called()
+
+    rendered_template = mock_send_message.call_args[0][0]
+
+    assert (
+        "{} {}".format(
+            order.purchaser.legal_address.first_name,
+            order.purchaser.legal_address.last_name,
+        )
+        in rendered_template.body
+    )
+    assert order.reference_number in rendered_template.body
+
+    lines = order.lines.all()
+    assert str(lines[0].unit_price) in rendered_template.body

--- a/ecommerce/messages.py
+++ b/ecommerce/messages.py
@@ -1,0 +1,7 @@
+""" Ecommerce email messages """
+from mitol.mail.messages import TemplatedMessage
+
+
+class OrderReceiptMessage(TemplatedMessage):
+    template_name = "mail/product_order_receipt"
+    name = "Order Receipt"

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,11 +1,17 @@
 import pytest
+import json
 from main.test_utils import assert_drf_json_equal
+from django.urls import reverse
+import reversion
+from decimal import Decimal
+from dateutil.parser import parse
 
 from courses.factories import (
     CourseRunFactory,
     ProgramFactory,
     ProgramRunFactory,
 )
+from courses.models import ProgramRun, CourseRun
 
 from ecommerce.serializers import (
     BasketWithProductSerializer,
@@ -15,20 +21,33 @@ from ecommerce.serializers import (
     BasketSerializer,
     BasketItemSerializer,
     BaseProductSerializer,
+    OrderReceiptSerializer,
+    TransactionPurchaseSerializer,
+    TransactionPurchaserSerializer,
+    TransactionOrderSerializer,
+    TransactionLineSerializer,
 )
 from ecommerce.factories import (
     ProductFactory,
     BasketItemFactory,
     UnlimitedUseDiscountFactory,
 )
-from ecommerce.models import BasketDiscount
+from ecommerce.models import BasketDiscount, Order
 from ecommerce.discounts import DiscountType
+from ecommerce.constants import CYBERSOURCE_CARD_TYPES
+from ecommerce.views_test import create_basket, payment_gateway_settings
 
 from users.factories import UserFactory
 
 from mitol.common.utils import now_in_utc
 
 pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture()
+def products():
+    with reversion.create_revision():
+        return ProductFactory.create_batch(5)
 
 
 def test_product_course_serializer(mock_context):
@@ -147,3 +166,159 @@ def test_basket_with_product_serializer():
     assert serialized_basket["total_price"] == basket_item.product.price
     assert serialized_basket["discounted_price"] == discount_price
     assert len(serialized_basket["discounts"]) == 1
+
+
+def create_order_receipt(mocker, user, products, user_client):
+    """
+    Sets up an order for use with the receipt serializer tests.
+    """
+    mocker.patch(
+        "mitol.payment_gateway.api.PaymentGateway.validate_processor_response",
+        return_value=True,
+    )
+    basket = create_basket(user, products)
+
+    resp = user_client.post(reverse("checkout_api-start_checkout"))
+
+    payload = resp.json()["payload"]
+    payload = {
+        **{f"req_{key}": value for key, value in payload.items()},
+        "decision": "ACCEPT",
+        "message": "payment processor message",
+    }
+
+    order = Order.objects.get(state=Order.STATE.PENDING, purchaser=user)
+
+    resp = user_client.post(reverse("checkout-result-callback"), payload)
+
+    order.refresh_from_db()
+    return order
+
+
+def get_test_order_data(order, receipt_data):
+    return {
+        "coupon": None,
+        "lines": [],
+        "order": {
+            "id": order.id,
+            "created_on": order.created_on,
+            "reference_number": order.reference_number,
+        },
+        "purchaser": {
+            "first_name": order.purchaser.legal_address.first_name,
+            "last_name": order.purchaser.legal_address.last_name,
+            "email": order.purchaser.email,
+            "country": order.purchaser.legal_address.country,
+            "state_or_territory": "",
+            "city": "",
+            "postal_code": "",
+            "company": "",
+            "street_address_1": None,
+            "street_address_2": None,
+            "street_address_3": None,
+            "street_address_4": None,
+            "street_address_5": None,
+            "street_address": [],
+        },
+        "receipt": {
+            "card_number": receipt_data["req_card_number"]
+            if "req_card_number" in receipt_data
+            else None,
+            "card_type": CYBERSOURCE_CARD_TYPES[receipt_data["req_card_type"]]
+            if "req_card_type" in receipt_data
+            else None,
+            "payment_method": receipt_data["req_payment_method"]
+            if "req_payment_method" in receipt_data
+            else None,
+            "bill_to_email": receipt_data["req_bill_to_email"]
+            if "req_bill_to_email" in receipt_data
+            else None,
+            "name": f"{receipt_data['req_bill_to_forename']} {receipt_data['req_bill_to_surname']}"
+            if "req_bill_to_forename" in receipt_data
+            or "req_bill_to_surname" in receipt_data
+            else None,
+        },
+    }
+
+
+def get_receipt_serializer_test_data(mocker, user, products, user_client):
+    order = create_order_receipt(mocker, user, products, user_client)
+    receipt_data = order.transactions.order_by("-created_on").first().data
+    test_data = get_test_order_data(order, receipt_data)
+
+    return (order, test_data)
+
+
+def test_order_receipt_purchase_serializer(mocker, user, products, user_client):
+    (order, test_data) = get_receipt_serializer_test_data(
+        mocker, user, products, user_client
+    )
+
+    serialized_data = TransactionPurchaseSerializer(instance=order).data
+
+    assert serialized_data == test_data["receipt"]
+
+
+def test_order_receipt_purchaser_serializer(mocker, user, products, user_client):
+    (order, test_data) = get_receipt_serializer_test_data(
+        mocker, user, products, user_client
+    )
+
+    serialized_data = TransactionPurchaserSerializer(instance=order).data
+
+    assert serialized_data == test_data["purchaser"]
+
+
+def test_order_receipt_order_serializer(mocker, user, products, user_client):
+    (order, test_data) = get_receipt_serializer_test_data(
+        mocker, user, products, user_client
+    )
+
+    serialized_data = TransactionOrderSerializer(instance=order).data
+    serialized_data["created_on"] = parse(serialized_data["created_on"])
+
+    assert serialized_data == test_data["order"]
+
+
+def test_order_receipt_lines_serializer(mocker, user, products, user_client):
+    (order, test_data) = get_receipt_serializer_test_data(
+        mocker, user, products, user_client
+    )
+
+    for instance in order.lines.all():
+        coupon_redemption = instance.order.discounts.first()
+        discount = 0.0
+
+        if coupon_redemption:
+            discount = instance.product.price - instance.discounted_price
+
+        total_paid = (instance.product.price - Decimal(discount)) * instance.quantity
+
+        content_object = instance.product.purchasable_object
+        (content_title, readable_id) = (None, None)
+
+        if isinstance(content_object, ProgramRun):
+            content_title = content_object.program.title
+            readable_id = content_object.program.readable_id
+        elif isinstance(content_object, CourseRun):
+            readable_id = content_object.course.readable_id
+            content_title = "{} {}".format(
+                content_object.course_number, content_object.title
+            )
+
+        line = dict(
+            quantity=instance.quantity,
+            total_paid=str(total_paid),
+            discount=str(discount),
+            CEUs=None,
+            content_title=content_title,
+            readable_id=readable_id,
+            price=str(instance.product.price),
+            start_date=content_object.start_date,
+            end_date=content_object.end_date,
+        )
+        test_data["lines"].append(line)
+
+    serialized_data = TransactionLineSerializer(instance=order.lines, many=True).data
+
+    assert serialized_data == test_data["lines"]

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -1,0 +1,11 @@
+from main.celery import app
+
+
+@app.task
+def send_ecommerce_order_receipt(order_id):
+    from ecommerce.mail_api import send_ecommerce_order_receipt
+    from ecommerce.models import Order
+
+    order = Order.objects.get(pk=order_id)
+
+    send_ecommerce_order_receipt(order)

--- a/ecommerce/tasks_test.py
+++ b/ecommerce/tasks_test.py
@@ -1,0 +1,29 @@
+import pytest
+import reversion
+
+from ecommerce.serializers_test import create_order_receipt
+from ecommerce.factories import ProductFactory
+from ecommerce.views_test import payment_gateway_settings
+
+
+@pytest.fixture()
+def products():
+    with reversion.create_revision():
+        return ProductFactory.create_batch(5)
+
+
+def test_delayed_order_receipt_sends_email(mocker, user, products, user_client):
+    """
+    Tests that the Order model is properly calling the send email receipt task
+    rather than calling the mail_api version directly. The create_order_receipt
+    function should create a basket and process the order through to the point
+    where the Order model itself will send the receipt email.
+    """
+
+    mock_send_ecommerce_order_receipt = mocker.patch(
+        "ecommerce.mail_api.send_ecommerce_order_receipt"
+    )
+
+    create_order_receipt(mocker, user, products, user_client)
+
+    mock_send_ecommerce_order_receipt.assert_called()

--- a/ecommerce/templates/mail/product_order_receipt/body.html
+++ b/ecommerce/templates/mail/product_order_receipt/body.html
@@ -1,0 +1,89 @@
+{% extends "email_base.html" %}
+
+{% block content %}
+<tr class="receipt-new-wrapper" style="font: 14px/22px 'Arial', sans-serif; margin: 0 auto; padding: 0 20px">
+    <table style="margin: 0 20px !important;">
+    <td class="rec-head" style="color: rgba(0,0,0,0.85); font: 14px/20px 'Arial', sans-serif; max-width: 696px; ">
+        <p style="font-weight: normal; margin: 0 0 20px;">Dear {{ purchaser.name }},</p>
+        <p style="font-weight: normal; margin: 0 0 20px;">You have been enrolled {% if content_title %} in {{ content_title }}{% endif %}.
+            The course should now appear on your MITxOnline <a href="{{ base_url }}{% url 'user-dashboard' %}" style="color: #0070DA">dashboard</a>. You can also access your receipt by <a style="color: #0070DA" href="{{ base_url }}/orders/receipt/{{order.id }}">clicking here</a>.
+        </p>
+        <p style="font-weight: normal; margin: 0 0 20px;">Below you will find a copy of you receipt:</p>
+    </td>
+    <tr>
+        <td>
+            <h1 style="color: #000000; font-size: 24px; font-weight: 700; line-height: 26px; margin: 0 0 24px;">MITxOnline</h1>
+            <h2 style="color: #000000; font-size: 22px; font-weight: 700; line-height: 24px; margin: 0 0 22px;">Receipt</h2>
+            <h3 style="color: #000000; font-size: 16px; font-weight: 700; line-height: 18px; margin: 0 0 20px;">Order Information</h3>
+            <p>
+                {% if order.reference_number  %}<strong style="font-weight: 700;">Order Number:</strong> {{ order.reference_number }}<br> {% endif %}
+                <strong style="font-weight: 700;">Order Date:</strong><span> {{ order.created_on|date:"F j, Y"}} </span><br>
+                <strong style="font-weight: 700;">Order Total:</strong> ${{ order_total }}<br>
+            </p>
+            {% for line in lines %}
+            <p>
+                <strong style="font-weight: 700;">Order Item:</strong> {{ line.content_title }}<br>
+                <strong style="font-weight: 700;">Product Number:</strong> {{ line.readable_id }}<br>
+                <strong style="font-weight: 700;">Dates:</strong>   {{ line.start_date|date:"F j, Y" }} - {{ line.end_date|date:"F j, Y" }}
+            </p>
+            <p>
+                <strong style="font-weight: 700;">Quantity:</strong>  {{ line.quantity }}<br>
+                <strong style="font-weight: 700;">Unit Price:</strong> ${{ line.price }}<br>
+                <strong style="font-weight: 700;">Discount:</strong> ${{ line.discount }}<br>
+                <strong style="font-weight: 700;">Total Paid:</strong> ${{ line.total_paid }}
+            </p>
+            {% endfor %}
+
+            <h3 style="color: #000000; font-size: 16px; font-weight: 700; line-height: 18px; margin: 0 0 20px;">Customer Information</h3>
+            <p style="margin: 0;">
+                <strong style="font-weight: 700;">Name:</strong> {{ purchaser.name }}<br>
+                <strong style="font-weight: 700;">Company Name:</strong> {{ purchaser.company }}<br>
+                {% if purchaser.street_address %}
+                    <table width="100%">
+                        <tr>
+                            <td style="width: 60px; vertical-align: top">
+                                <strong style="font-weight: 700;">Address:</strong>
+                            </td>
+                            <td>
+                                {% for address in purchaser.street_address %}
+                                    <div>{{ address }} </div>
+                                {% endfor %}
+                            <div>
+                                {{ purchaser.city}}, {{ purchaser.state_code}} {{ purchaser.postal_code}} {{ purchaser.country }}
+                            </div>
+                            </td>
+                        </tr>
+                    </table>
+                {% endif %}
+                <strong style="font-weight: 700;">Email Address:</strong> {{ purchaser.email }}<br>
+            </p>
+            {% if receipt or coupon %}
+                <h3 style="color: #000000; font-size: 16px; font-weight: 700; line-height: 18px; margin: 0 0 20px;">Payment Information</h3>
+                <p>
+                    {%  if receipt %}
+                        <strong style="font-weight: 700;">Name:</strong> {{ receipt.name }}<br>
+                        {% if receipt.payment_method == 'card' %}
+                            <strong style="font-weight: 700;">Email:</strong> {{ receipt.bill_to_email }}<br>
+                            <strong style="font-weight: 700;">Payment Method:</strong> {{ receipt.card_type }} | {{ receipt.card_number }}<br>
+                        {% elif receipt.payment_method == 'paypal' %}
+                            <strong style="font-weight: 700;">Email:</strong> {{ receipt.bill_to_email }} (Paypal account email)<br>
+                            <strong style="font-weight: 700;">Payment Method:</strong> Paypal<br>
+                        {% endif %}
+                    {% endif %}
+                    {% if coupon %}
+                        <strong style="font-weight: 700;">Discount Code:</strong> {{ coupon.redeemed_discount.discount_code }}
+                    {% endif %}
+                </p>
+            {% endif %}
+        </td>
+    </tr>
+</table>
+</tr>
+{%  endblock %}
+{% block footer-address %}
+    <div style="text-align: center">
+        MIT Open Learning, 600 Technology Square, NE49-2000, Cambridge, MA 02139
+        <br>
+        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ base_url }}/terms-of-service" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="{{ base_url }}/privacy-policy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
+    </div>
+{% endblock %}

--- a/ecommerce/templates/mail/product_order_receipt/subject.txt
+++ b/ecommerce/templates/mail/product_order_receipt/subject.txt
@@ -1,0 +1,1 @@
+Purchase Order Receipt

--- a/mail/constants.py
+++ b/mail/constants.py
@@ -3,6 +3,7 @@
 EMAIL_VERIFICATION = "verification"
 EMAIL_PW_RESET = "password_reset"
 EMAIL_CHANGE_EMAIL = "change_email"
+EMAIL_PRODUCT_ORDER_RECEIPT = "product_order_receipt"
 
 EMAIL_TYPE_DESCRIPTIONS = {
     EMAIL_VERIFICATION: "Verify Email",


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#532 

#### What's this PR do?
This is mostly a cross-port of the xPro receipt email code into MITxOnline. Upon successful payment, this will send the learner an emailed copy of their receipt. 

#### How should this be manually tested?
1. Ensure you have Mailgun credentials in your local environment, or you won't be able to send email. The credentials from RC can be used for testing.
2. Complete the payment process. 
3. You should receive an email from the system with the receipt for your purchase. It should look mostly like the email that is sent by xPro (see #532 for a screenshot of that).

Additionally, there's a pytest test for the serializer itself. You can manually send emails for other (completed) orders by loading the order and calling mail_api.send_ecommerce_order_receipt. 

Depending on the CyberSource settings, you still may get a CyberSource receipt email. That functionality is set in the CS account so CyberSource receipts should be turned off when this is ready for production.

#### Screenshots (if appropriate)
(My local dev doesn't have the logo - that is part of the base email template so should work elsewhere; I just don't have it locally. Color changes below are from Gmail colorization, not the email template.) 

![Screen Shot 2022-05-12 at 2 20 51 PM](https://user-images.githubusercontent.com/945611/168152256-403f239c-3799-4e86-bddb-2b3c50c4a380.png)

