### PR TITLE
Added check to see if there's a product for Enroll button

### DIFF
--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -132,6 +132,7 @@ export class ProductDetailEnrollApp extends React.Component<
     const { courseRuns, isLoading, status } = this.props
     const csrfToken = getCookie("csrftoken")
     const run = courseRuns ? courseRuns[0] : null
+    const product = run && run.products ? run.products[0] : null
 
     return (
       // $FlowFixMe: isLoading null or undefined
@@ -163,7 +164,7 @@ export class ProductDetailEnrollApp extends React.Component<
                 Enroll now
               </a>
             ) : run && isWithinEnrollmentPeriod(run) ? (
-              SETTINGS.features.upgrade_dialog ? (
+              SETTINGS.features.upgrade_dialog && product ? (
                 <button
                   className="btn btn-primary btn-gradient-red highlight enroll-now"
                   onClick={() => this.toggleUpgradeDialogVisibility()}

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -1,6 +1,6 @@
 /* global SETTINGS: false */
 // @flow
-import { assert } from "chai"
+import { assert, expect } from "chai"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import ProductDetailEnrollApp, {
@@ -10,7 +10,8 @@ import ProductDetailEnrollApp, {
 import { courseRunsSelector } from "../lib/queries/courseRuns"
 import {
   makeCourseRunDetail,
-  makeCourseRunEnrollment
+  makeCourseRunEnrollment,
+  makeCourseRunDetailWithProduct
 } from "../factories/course"
 
 import * as courseApi from "../lib/courseApi"
@@ -137,6 +138,33 @@ describe("ProductDetailEnrollApp", () => {
     assert.equal(
       inner
         .find(".enroll-now")
+        .at(0)
+        .text(),
+      "Enroll now"
+    )
+  })
+
+  it("checks for form-based enrollment form if there is no product", async () => {
+    const courseRun = makeCourseRunDetail()
+    isWithinEnrollmentPeriodStub.returns(true)
+    const { inner } = await renderPage(
+      {
+        entities: {
+          courseRuns: [courseRun]
+        },
+        queries: {
+          courseRuns: {
+            isPending: false,
+            status:    200
+          }
+        }
+      },
+      {}
+    )
+
+    assert.equal(
+      inner
+        .find("form > button.enroll-now")
         .at(0)
         .text(),
       "Enroll now"

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -17,12 +17,14 @@ import type {
   ProgramCertificate,
   CourseDetail
 } from "../flow/courseTypes"
+import type { Product } from "../flow/ecommerceTypes"
 
 const genCourseRunId = incrementer()
 const genEnrollmentId = incrementer()
 const genCoursewareId = incrementer()
 const genRunTagNumber = incrementer()
 const genReadableId = incrementer()
+const genProductId = incrementer()
 
 export const makeCourseRun = (): CourseRun => ({
   title:            casual.text,
@@ -39,6 +41,28 @@ export const makeCourseRun = (): CourseRun => ({
   products:         []
 })
 
+export const makeCourseRunWithProduct = (): CourseRun => ({
+  title:            casual.text,
+  start_date:       casual.moment.add(2, "M").format(),
+  end_date:         casual.moment.add(4, "M").format(),
+  enrollment_start: casual.moment.add(-1, "M").format(),
+  enrollment_end:   casual.moment.add(3, "M").format(),
+  courseware_url:   casual.url,
+  courseware_id:    casual.word.concat(genCoursewareId.next().value),
+  run_tag:          casual.word.concat(genRunTagNumber.next().value),
+  // $FlowFixMe
+  id:               genCourseRunId.next().value,
+  course_number:    casual.word,
+  products:         [
+    {
+      description: casual.text,
+      id:          genProductId.next().value,
+      is_active:   true,
+      price:       casual.integer(1, 200)
+    }
+  ]
+})
+
 const genCourseId = incrementer()
 const makeCourseDetail = (): CourseDetail => ({
   // $FlowFixMe
@@ -52,6 +76,13 @@ const makeCourseDetail = (): CourseDetail => ({
 export const makeCourseRunDetail = (): CourseRunDetail => {
   return {
     ...makeCourseRun(),
+    course: makeCourseDetail()
+  }
+}
+
+export const makeCourseRunDetailWithProduct = (): CourseRunDetail => {
+  return {
+    ...makeCourseRunWithProduct(),
     course: makeCourseDetail()
   }
 }

--- a/frontend/public/src/flow/ecommerceTypes.js
+++ b/frontend/public/src/flow/ecommerceTypes.js
@@ -11,4 +11,9 @@ export type Basket = {
   items: Array<BasketItem>
 }
 
-export type Product = {}
+export type Product = {
+  description: string,
+  id: number,
+  is_active: boolean,
+  price: number
+}

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -87,9 +87,27 @@ describe("Course API", () => {
 
   describe("generateStartDateText", () => {
     [
-      [exampleUrl, past, future, "run is in progress", {active: true, datestr: ''}],
-      [exampleUrl, past, null, "run is in progress with no end date", {active: true, datestr: ''}],
-      [exampleUrl, future, null, "run is not in progress", {active: true, datestr: ''}],
+      [
+        exampleUrl,
+        past,
+        future,
+        "run is in progress",
+        { active: true, datestr: "" }
+      ],
+      [
+        exampleUrl,
+        past,
+        null,
+        "run is in progress with no end date",
+        { active: true, datestr: "" }
+      ],
+      [
+        exampleUrl,
+        future,
+        null,
+        "run is not in progress",
+        { active: true, datestr: "" }
+      ],
       [exampleUrl, null, null, "run has no start date", null]
     ].forEach(([coursewareUrl, startDate, endDate, desc, expLinkable]) => {
       it(`returns ${String(expLinkable)} when ${desc}`, () => {


### PR DESCRIPTION
This will present the old form submit button if there's no product.

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#561 

#### What's this PR do?
Fixes the Enroll Now button to enroll users if there's no product associated with the course. 

#### How should this be manually tested?
As a learner, attempt to enroll in a course that has no product. The Enroll Now button should be displayed and activating it should simply enroll you in the course (or, at least, attempt to).
