### PR TITLE
Adds enrollment status and upsell button to dashboard enrollment cards

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -11,6 +11,7 @@ class CoursePageSerializer(serializers.ModelSerializer):
     """Course page model serializer"""
 
     feature_image_src = serializers.SerializerMethodField()
+    page_url = serializers.SerializerMethodField()
 
     def get_feature_image_src(self, instance):
         """Serializes the source of the feature_image"""
@@ -20,8 +21,12 @@ class CoursePageSerializer(serializers.ModelSerializer):
 
         return feature_img_src or static(DEFAULT_COURSE_IMG_PATH)
 
+    def get_page_url(self, instance):
+        return instance.get_url()
+
     class Meta:
         model = models.CoursePage
         fields = [
             "feature_image_src",
+            "page_url",
         ]

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -10,6 +10,8 @@ import pytz
 from django.contrib.auth.models import AnonymousUser
 
 from cms.factories import CoursePageFactory
+from cms.serializers import CoursePageSerializer
+from cms.models import CoursePage
 from courses.factories import (
     CourseFactory,
     CourseRunEnrollmentFactory,
@@ -28,6 +30,7 @@ from courses.serializers import (
     ProgramEnrollmentSerializer,
     ProgramSerializer,
 )
+from ecommerce.serializers import BaseProductSerializer
 from main.test_utils import assert_drf_json_equal, drf_datetime
 
 pytestmark = [pytest.mark.django_db]
@@ -165,6 +168,7 @@ def test_serialize_course_with_page_fields(mocker, mock_context):
             "readable_id": course.readable_id,
             "id": course.id,
             "feature_image_src": fake_image_src,
+            "page_url": None,
         },
     )
     patched_get_wagtail_src.assert_called_once_with(course_page.feature_image)
@@ -199,6 +203,7 @@ def test_serialize_course_run_detail():
     """Test CourseRunDetailSerializer serialization"""
     course_run = CourseRunFactory.create()
     data = CourseRunDetailSerializer(course_run).data
+
     assert data == {
         "course": BaseCourseSerializer(course_run.course).data,
         "course_number": course_run.course_number,
@@ -211,6 +216,8 @@ def test_serialize_course_run_detail():
         "enrollment_end": drf_datetime(course_run.enrollment_end),
         "expiration_date": drf_datetime(course_run.expiration_date),
         "id": course_run.id,
+        "products": BaseProductSerializer(course_run.products, many=True).data,
+        "page": None,
     }
 
 
@@ -224,6 +231,7 @@ def test_serialize_course_run_enrollments(settings, receipts_enabled):
         "run": CourseRunDetailSerializer(course_run_enrollment.run).data,
         "id": course_run_enrollment.id,
         "edx_emails_subscription": True,
+        "enrollment_mode": "audit",
     }
 
 

--- a/frontend/public/scss/dashboard.scss
+++ b/frontend/public/scss/dashboard.scss
@@ -72,6 +72,39 @@ $featureImgMobileHeight: 223px;
   .unenroll-denied-msg .tooltip {
     width: 250px;
   }
+
+  .enrollment-mode-container {
+    span.badge {
+      font-weight: normal;
+      padding: .20rem;
+      margin-bottom: .5rem;
+    }
+    span.badge.badge-red {
+        color: $red;
+        background-color: #FAE8E8;
+      }
+
+    span.badge.badge-green {
+        color: $green;
+        background-color: #DBF3E9;
+      }
+  }
+
+  .enrollment-extra-links {
+    margin-top: .5rem;
+    font-size: smaller;
+
+    a {
+      text-decoration: underline;
+      color: $light-gray;
+      margin-right: 2rem;
+    }
+
+    form button.btn-primary {
+      font-size: 14px;
+      padding: 9px 18px;
+    }
+  }
 }
 
 .dashboard h1 {

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -35,6 +35,7 @@ import {
   parseDateString
 } from "../lib/util"
 import { addUserNotification } from "../actions"
+import { EnrollmentRoleTag } from "./EnrollmentRoleTag"
 
 import type { RunEnrollment } from "../flow/courseTypes"
 import type { CurrentUser } from "../flow/authTypes"
@@ -245,6 +246,11 @@ export class EnrolledItemCard extends React.Component<
     )
     const startDateDescription = generateStartDateText(enrollment.run)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
+    const courseId = enrollment.run.course_number
+    const enrollmentMode = enrollment.enrollment_mode
+    const pageLocation = enrollment.run.page
+    // certLocation is not used yet, just here to test layout
+    const certLocation = false
 
     return (
       <div
@@ -263,8 +269,10 @@ export class EnrolledItemCard extends React.Component<
             </div>
           )}
           <div className="col-12 col-md px-3 py-3 py-md-0">
-            <div className="d-flex justify-content-between align-content-start flex-nowrap mb-3">
-              <h2 className="my-0 mr-3">{title}</h2>
+            <div className="d-flex justify-content-between align-content-start flex-nowrap w-100 enrollment-mode-container">
+              <EnrollmentRoleTag
+                enrollmentMode={enrollmentMode}
+              ></EnrollmentRoleTag>
               <Dropdown
                 isOpen={this.isActiveMenuId(enrollment.id)}
                 toggle={this.toggleActiveMenuId(enrollment.id).bind(this)}
@@ -296,7 +304,12 @@ export class EnrolledItemCard extends React.Component<
                 </DropdownMenu>
               </Dropdown>
             </div>
+
+            <div className="d-flex justify-content-between align-content-start flex-nowrap mb-3">
+              <h2 className="my-0 mr-3">{title}</h2>
+            </div>
             <div className="detail">
+              {courseId} |{" "}
               {startDateDescription !== null && startDateDescription.active ? (
                 <span>Starts - {startDateDescription.datestr}</span>
               ) : (
@@ -309,6 +322,34 @@ export class EnrolledItemCard extends React.Component<
                   )}
                 </span>
               )}
+              <div className="enrollment-extra-links d-flex">
+                {pageLocation ? (
+                  <a href={pageLocation.page_url}>Course details</a>
+                ) : null}
+                {certLocation ? (
+                  <a href={certLocation}>View certificate</a>
+                ) : null}
+                {enrollment.run.products.length > 0 &&
+                enrollmentMode === "audit" ? (
+                    <form
+                      action="/cart/add/"
+                      method="get"
+                      className="text-center ml-auto"
+                    >
+                      <input
+                        type="hidden"
+                        name="product_id"
+                        value={enrollment.run.products[0].id}
+                      />
+                      <button
+                        type="submit"
+                        className="btn btn-primary btn-gradient-red"
+                      >
+                      Get Certificate
+                      </button>
+                    </form>
+                  ) : null}
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/public/src/components/EnrollmentRoleTag.js
+++ b/frontend/public/src/components/EnrollmentRoleTag.js
@@ -1,0 +1,20 @@
+import React from "react"
+import { Badge } from "reactstrap"
+
+type Props = {
+  enrollmentMode: string
+}
+
+export class EnrollmentRoleTag extends React.Component<Props> {
+  render() {
+    const { enrollmentMode } = this.props
+
+    let label = <Badge color="red">Enrolled in free course</Badge>
+
+    if (enrollmentMode === "verified") {
+      label = <Badge color="green">Enrolled in certificate course</Badge>
+    }
+
+    return label
+  }
+}

--- a/frontend/public/src/flow/cmsTypes.js
+++ b/frontend/public/src/flow/cmsTypes.js
@@ -1,0 +1,4 @@
+export type CoursePage = {
+  featured_image_src: string,
+  page_url: string
+}

--- a/frontend/public/src/flow/courseTypes.js
+++ b/frontend/public/src/flow/courseTypes.js
@@ -1,4 +1,5 @@
 import type { Product } from "./ecommerceTypes"
+import type { Page } from "./cmsTypes"
 
 export type CourseDetail = {
   id: number,
@@ -17,7 +18,8 @@ export type BaseCourseRun = {
   courseware_id: string,
   run_tag: ?string,
   products: Array<Product>,
-  id: number
+  id: number,
+  page: ?Page
 }
 
 export type EnrollmentFlaggedCourseRun = BaseCourseRun & {
@@ -32,5 +34,6 @@ export type CourseRunDetail = BaseCourseRun & {
 export type RunEnrollment = {
   run: CourseRunDetail,
   id: number,
-  edx_emails_subscription: ?string
+  edx_emails_subscription: ?string,
+  enrollment_mode: string
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [x] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#533 

#### What's this PR do?
Adds a tag to the enrolled item card on the dashboard to inform the learner of their enrollment status in the course. Adds an upgrade button if the learner is auditing the course (and there's an upgrade path). 

#### How should this be manually tested?
View the dashboard. Your audit enrollments should have a red "Enrolled in free course" and the verified enrollments should have a green "Enrolled in certificate course" badge. 

Any audit enrollments you have that have an upgrade path (i.e., there's a Product associated with them) should also show a Get Certificate button on the right side of the card. 

Enrollments with a related course page should have a link to the page at the bottom of the card. 

#### Screenshots (if appropriate)

390w on mobile is copied from iPhone 12 Pro preset.

![image](https://user-images.githubusercontent.com/945611/168654503-cd42f152-83cf-4197-94ed-1780951bfa51.png)
![image](https://user-images.githubusercontent.com/945611/168654633-058ec9c2-66ac-43d8-abaf-45129c5e90ec.png)