### PR TITLE
Removes call to "save_and_log" in FlexiblePrice admin

### DIFF
--- a/flexiblepricing/admin.py
+++ b/flexiblepricing/admin.py
@@ -38,12 +38,6 @@ class FlexiblePriceAdmin(VersionAdmin):
     ):  # pylint: disable=unused-argument, signature-differs
         return False
 
-    def save_model(self, request, obj, form, change):
-        """
-        Saves object and logs change to object
-        """
-        obj.save_and_log(request.user)
-
 
 @admin.register(FlexiblePricingRequestSubmission)
 class FlexiblePricingRequestSubmissionAdmin(admin.ModelAdmin):


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#582 

#### What's this PR do?
Fixes #582 by removing the call to `save_and_log()` in the FlexiblePriceAdmin class.

#### How should this be manually tested?
Open a Flexible Price record in Django Admin and attempt to save it. It should work (provided you've filled out the form properly). 
