### PR TITLE
Adds flexible pricing list view to Refine admin

### DIFF
--- a/flexiblepricing/serializers.py
+++ b/flexiblepricing/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from flexiblepricing import models
+from users.serializers import UserSerializer
 
 
 class CurrencyExchangeRateSerializer(serializers.ModelSerializer):
@@ -20,6 +21,8 @@ class CountryIncomeThresholdSerializer(serializers.ModelSerializer):
 
 
 class FlexiblePriceSerializer(serializers.ModelSerializer):
+    user = UserSerializer(read_only=True)
+
     class Meta:
         model = models.FlexiblePrice
         fields = [

--- a/flexiblepricing/views/v0/__init__.py
+++ b/flexiblepricing/views/v0/__init__.py
@@ -3,9 +3,10 @@ MITxOnline Flexible Pricing/Financial Aid views
 """
 from rest_framework import mixins, status
 from rest_framework.viewsets import ModelViewSet
-from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from django_filters.rest_framework import DjangoFilterBackend
+from main.views import RefinePagination
 
 from flexiblepricing import models, serializers
 
@@ -28,6 +29,7 @@ class FlexiblePriceViewSet(ModelViewSet):
     serializer_class = serializers.FlexiblePriceSerializer
     authentication_classes = (SessionAuthentication, TokenAuthentication)
     permission_classes = (IsAuthenticated,)
+    pagination_class = RefinePagination
 
     def get_queryset(self):
         return models.FlexiblePrice.objects.filter(user=self.request.user).all()
@@ -38,3 +40,6 @@ class FlexiblePriceAdminViewSet(ModelViewSet):
     authentication_classes = (SessionAuthentication, TokenAuthentication)
     permission_classes = (IsAdminUser,)
     queryset = models.FlexiblePrice.objects.all()
+    pagination_class = RefinePagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["status", "user", "country_of_income"]

--- a/flexiblepricing/views_test.py
+++ b/flexiblepricing/views_test.py
@@ -101,10 +101,13 @@ def test_basic_flex_payments(
 
     resp = user_drf_client.get(reverse("fp_flexiblepricing_api-list"))
     assert resp.status_code == 200
-    assert len(resp.json()) == 1
-    data = resp.json()
-    assert data[0]["user"] == user.id
+    json_response = resp.json()
+    assert len(json_response["results"]) == 1
+    assert json_response["results"][0]["user"]["id"] == user.id
+
+    allapps = models.FlexiblePrice.objects.all()
 
     resp = admin_drf_client.get(reverse("fp_admin_flexiblepricing_api-list"))
+    json_response = resp.json()
     assert resp.status_code == 200
-    assert len(resp.json()) > 1
+    assert json_response["count"] == allapps.count()

--- a/frontend/staff-dashboard/src/App.tsx
+++ b/frontend/staff-dashboard/src/App.tsx
@@ -14,10 +14,11 @@ import {
 import LoginPage from "pages/login";
 import { DashboardPage } from "pages/dashboard";
 import { DiscountList, DiscountEdit, DiscountShow, DiscountCreate } from "pages/discounts";
+import { FlexiblePricingList } from "./pages/flexible_pricing";
 import axios from "axios";
 import useDrfDataProvider from "hooks/useDrfDataProvider";
 
-const {UserOutlined, BarcodeOutlined} = Icons;
+const {UserOutlined, BarcodeOutlined, FormOutlined} = Icons;
 const axiosInterface = axios.create();
 
 axiosInterface.interceptors.request.use((config: any) => {
@@ -56,6 +57,14 @@ export default function App() {
           edit: DiscountEdit,
           create: DiscountCreate,
         },
+        {
+          name: 'flexible_pricing',
+          icon: <FormOutlined/>,
+          options: {
+            label: 'Flexible Pricing'
+          },
+          list: FlexiblePricingList,
+        }
       ]}
       Title={Title}
       Header={Header}

--- a/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
@@ -116,12 +116,20 @@ const useDrfDataProvider = (
 
         const uri = `${url}?${stringify(query)}`;
 
-        const { data: { results: data, count: total }, headers } = await httpClient.get(uri);
+        const { data, headers } = await httpClient.get(uri);
 
-        return {
-            data, 
-            total,
-        };
+        if (data.hasOwnProperty('results')) {
+            return {
+                data: data['results'],
+                total: data['total']
+            };
+        } else {
+            return {
+                data: data,
+                total: data.length
+            };
+        }
+
     };
 
     return simpleDataProvider;

--- a/frontend/staff-dashboard/src/interfaces/index.d.ts
+++ b/frontend/staff-dashboard/src/interfaces/index.d.ts
@@ -19,3 +19,22 @@ export interface IUserDiscount {
     discount: IDiscount;
     user: any;
 }
+
+export interface IFlexiblePriceRequest {
+    id: number;
+    user: number;
+    status: string;
+    income_usd: number;
+    original_income: number;
+    original_currency: string;
+    country_of_income: null;
+    date_exchange_rate: Date;
+    date_documents_sent: Date;
+    justification: string;
+    country_of_residence: string;
+}
+
+export interface IFlexiblePriceStatus {
+    id: string,
+    title: string
+}

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/index.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/index.tsx
@@ -1,0 +1,1 @@
+export * from "./list";

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -1,0 +1,93 @@
+import { useMany } from "@pankod/refine-core";
+import {
+    List,
+    DateField,
+    ShowButton,
+    Table,
+    useTable,
+    Space, 
+    EditButton,
+    FilterDropdown,
+    Select,
+    useSelect,
+} from "@pankod/refine-antd";
+
+import { IFlexiblePriceRequest, IFlexiblePriceStatus } from "interfaces";
+
+export const FlexiblePricingList: React.FC = () => {
+    const {tableProps} = useTable<IFlexiblePriceRequest>({ resource: 'flexible_pricing/applications_admin' });
+
+    return (
+        <List title="Flexible Pricing Requests">
+            <Table {...tableProps} rowKey="id">
+                <Table.Column 
+                    dataIndex="user" 
+                    title="Name/Location"
+                    render={(value) => <div><strong>{value.name}</strong> <br /> {value.legal_address.country}</div>}
+                />
+                <Table.Column
+                    dataIndex="status"
+                    title="Status"
+                    filterDropdown={(props) => (
+                        <FilterDropdown {...props}>
+                            <Select mode="multiple" 
+                                style={{ minWidth: 300 }}
+                                placeholder="Select Status" 
+                                options={[
+                                {
+                                    label: 'Created',
+                                    value: 'created'
+                                },
+                                {
+                                    label: 'Approved',
+                                    value: 'approved'
+                                },
+                                {
+                                    label: 'Auto-Approved',
+                                    value: 'auto-approved'
+                                },
+                                {
+                                    label: 'Pending Manual Approval',
+                                    value: 'pending-manual-approval'
+                                },
+                                { 
+                                    label: 'Skipped',
+                                    value: 'skipped'
+                                },
+                                { 
+                                    label: 'Reset',
+                                    value: 'reset'
+                                }
+                            ]} />
+                        </FilterDropdown>
+                    )}
+                />
+                <Table.Column
+                    dataIndex="income_usd"
+                    title="Income (USD)"
+                    render={(value) => parseFloat(value).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                />
+                <Table.Column
+                    dataIndex="date_exchange_rate"
+                    title="Date Calculated"
+                    render={(value) => <DateField format="LLL" value={value} />}
+                />
+                <Table.Column
+                    dataIndex="original_currency"
+                    title="Original Currency"
+                />
+                <Table.Column
+                    dataIndex="date_documents_sent"
+                    title="Documents Sent"
+                    render={(value) => value ? <DateField format="LLL" value={value} /> : 'No Documents Sent'}
+                />
+
+                <Table.Column
+                    dataIndex="createdAt"
+                    title="Created At"
+                    render={(value) => <DateField format="LLL" value={value} />}
+                />
+            </Table>
+        </List>
+    );
+};

--- a/main/views.py
+++ b/main/views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseNotFound, HttpResponseServerError
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from rest_framework.pagination import LimitOffsetPagination
 
 
 def index(request, **kwargs):
@@ -31,3 +32,14 @@ def handler500(request):
 def cms_signin_redirect_to_site_signin(request):
     """Redirect wagtail admin signin to site signin page"""
     return redirect_to_login(reverse("wagtailadmin_home"), login_url="/signin")
+
+
+class RefinePagination(LimitOffsetPagination):
+    """
+    A pagination class that uses the default Refine limit and offset parameters.
+    """
+
+    default_limit = 10
+    limit_query_param = "l"
+    offset_query_param = "o"
+    max_limit = 50


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Migrations
  - [X] Migration is backwards-compatible with current production code
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#574 

#### What's this PR do?
Implements #574 - adds Flexible Pricing to the Refine admin and implements a page with status filtering. Also adds a few refinements to the DrfDataProvider (in Refine) and in the app's underlying DRF infrastructure.

#### How should this be manually tested?

Prepare a few Flexible Pricing requests. (See the documentation for this process.)
Check out and build the Refine admin, and navigate to it. Selecting the Flexible Pricing item on the left nav should pull up the flexible pricing records in the system, and the Status column should be filterable.

#### Any background context you want to provide?
[Overall story](https://github.com/mitodl/mitxonline/issues/543)

[Financial Aid dashboard on MicroMasters](https://github.com/mitodl/micromasters/pull/5135) - design should basically match this.

#### Screenshots (if appropriate)
![Screen Shot 2022-05-24 at 8 41 32 AM](https://user-images.githubusercontent.com/945611/170050789-1e50a80b-5999-4de6-a9ce-8f2b65b54efb.png)

