### PR TITLE
Adds a check for exchange rate description when constructing the currency list

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -80,7 +80,7 @@ class FlexiblePricingFormBuilder(FormBuilder):
 
         for record in CurrencyExchangeRate.objects.all():
             desc = record.currency_code
-            if len(record.description) > 0:
+            if record.description is not None and len(record.description) > 0:
                 desc = "{code} - {code_description}".format(
                     code=record.currency_code, code_description=record.description
                 )


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #594 

#### What's this PR do?

Adds a check for None in the currency field options generation code. (It checked for length > 0 but not `None` specifically.) 

#### How should this be manually tested?

Steps to reproduce are in #594 - you should see the form render successfully, and exchange rates without descriptions should render as just the currency code.
