### PR TITLE
Adds free-form search on name fields to Flexible Pricing admin

### DIFF
--- a/frontend/staff-dashboard/src/interfaces/index.d.ts
+++ b/frontend/staff-dashboard/src/interfaces/index.d.ts
@@ -35,6 +35,11 @@ export interface IFlexiblePriceRequest {
 }
 
 export interface IFlexiblePriceStatus {
-    id: string,
-    title: string
+    id: string;
+    title: string;
+}
+
+export interface IFlexiblePriceRequestFilters {
+    q: string;
+    status: string;
 }

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -1,4 +1,4 @@
-import { useMany } from "@pankod/refine-core";
+import { IResourceComponentsProps, useMany, CrudFilters, HttpError } from "@pankod/refine-core";
 import {
     List,
     DateField,
@@ -10,84 +10,151 @@ import {
     FilterDropdown,
     Select,
     useSelect,
+    FormProps,
+    Form,
+    Input, 
+    Button,
+    Icons,
+    Row,
+    Col,
+    Card,
 } from "@pankod/refine-antd";
 
-import { IFlexiblePriceRequest, IFlexiblePriceStatus } from "interfaces";
+import { IFlexiblePriceRequest, IFlexiblePriceStatus, IFlexiblePriceRequestFilters } from "interfaces";
+
+const FlexiblePricingStatuses = [
+    {
+        label: 'Created',
+        value: 'created'
+    },
+    {
+        label: 'Approved',
+        value: 'approved'
+    },
+    {
+        label: 'Auto-Approved',
+        value: 'auto-approved'
+    },
+    {
+        label: 'Pending Manual Approval',
+        value: 'pending-manual-approval'
+    },
+    { 
+        label: 'Skipped',
+        value: 'skipped'
+    },
+    { 
+        label: 'Reset',
+        value: 'reset'
+    }
+];
+const FlexiblePricingStatusText = "Select Status";
+
+const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formProps }) => {
+    return (
+        <Form layout="vertical" {...formProps}>
+            <Form.Item label="Search by Name" name="q">
+                <Input placeholder="Name, username, email address" prefix={<Icons.SearchOutlined />}></Input>
+            </Form.Item>
+            <Form.Item label="Search by Status" name="status">
+                <Select
+                    style={{ minWidth: 200 }}
+                    placeholder={FlexiblePricingStatusText}
+                    options={FlexiblePricingStatuses} />
+            </Form.Item>
+            <Form.Item>
+                <Button htmlType="submit" type="primary">
+                    Find Records
+                </Button>
+            </Form.Item>
+        </Form>
+    )
+}
 
 export const FlexiblePricingList: React.FC = () => {
-    const {tableProps} = useTable<IFlexiblePriceRequest>({ resource: 'flexible_pricing/applications_admin' });
+    const {tableProps, searchFormProps} = useTable<
+        IFlexiblePriceRequest,
+        HttpError, 
+        IFlexiblePriceRequestFilters
+    >({ 
+        resource: 'flexible_pricing/applications_admin',
+        onSearch: (params) => {
+            const filters: CrudFilters = [];
+            const { q, status } = params;
+
+            filters.push({
+                field: 'q',
+                operator: 'eq',
+                value: q
+            });
+
+            filters.push({
+                field: 'status',
+                operator: 'eq',
+                value: status
+            });
+
+            return filters;
+        }
+    });
 
     return (
-        <List title="Flexible Pricing Requests">
-            <Table {...tableProps} rowKey="id">
-                <Table.Column 
-                    dataIndex="user" 
-                    title="Name/Location"
-                    render={(value) => <div><strong>{value.name}</strong> <br /> {value.legal_address.country}</div>}
-                />
-                <Table.Column
-                    dataIndex="status"
-                    title="Status"
-                    filterDropdown={(props) => (
-                        <FilterDropdown {...props}>
-                            <Select mode="multiple" 
-                                style={{ minWidth: 300 }}
-                                placeholder="Select Status" 
-                                options={[
-                                {
-                                    label: 'Created',
-                                    value: 'created'
-                                },
-                                {
-                                    label: 'Approved',
-                                    value: 'approved'
-                                },
-                                {
-                                    label: 'Auto-Approved',
-                                    value: 'auto-approved'
-                                },
-                                {
-                                    label: 'Pending Manual Approval',
-                                    value: 'pending-manual-approval'
-                                },
-                                { 
-                                    label: 'Skipped',
-                                    value: 'skipped'
-                                },
-                                { 
-                                    label: 'Reset',
-                                    value: 'reset'
-                                }
-                            ]} />
-                        </FilterDropdown>
-                    )}
-                />
-                <Table.Column
-                    dataIndex="income_usd"
-                    title="Income (USD)"
-                    render={(value) => parseFloat(value).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
-                />
-                <Table.Column
-                    dataIndex="date_exchange_rate"
-                    title="Date Calculated"
-                    render={(value) => <DateField format="LLL" value={value} />}
-                />
-                <Table.Column
-                    dataIndex="original_currency"
-                    title="Original Currency"
-                />
-                <Table.Column
-                    dataIndex="date_documents_sent"
-                    title="Documents Sent"
-                    render={(value) => value ? <DateField format="LLL" value={value} /> : 'No Documents Sent'}
-                />
+        <div>
+            <Row gutter={[10, 10]}>
+                <Col sm={6}>
+                    <Card title="Find Records">
+                        <FlexiblePricingFilterForm formProps={searchFormProps} />
+                    </Card>
+                </Col>
+                <Col sm={18}>
+                    <List title="Flexible Pricing Requests">
+                        <Table {...tableProps} rowKey="id">
+                            <Table.Column 
+                                dataIndex="user" 
+                                title="Name/Location"
+                                render={(value) => <div><strong>{value.name}</strong> <br /> {value.legal_address.country}</div>}
+                            />
+                            <Table.Column
+                                dataIndex="status"
+                                title="Status"
+                                filterDropdown={(props) => (
+                                    <FilterDropdown {...props}>
+                                        <Select mode="multiple" 
+                                            style={{ minWidth: 300 }}
+                                            placeholder={FlexiblePricingStatusText}
+                                            options={FlexiblePricingStatuses} />
+                                    </FilterDropdown>
+                                )}
+                            />
+                            <Table.Column
+                                dataIndex="income_usd"
+                                title="Income (USD)"
+                                render={(value) => parseFloat(value).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                            />
+                            <Table.Column
+                                dataIndex="date_exchange_rate"
+                                title="Date Calculated"
+                                render={(value) => <DateField format="LLL" value={value} />}
+                            />
+                            <Table.Column
+                                dataIndex="original_currency"
+                                title="Original Currency"
+                            />
+                            <Table.Column
+                                dataIndex="date_documents_sent"
+                                title="Documents Sent"
+                                render={(value) => value ? <DateField format="LLL" value={value} /> : 'No Documents Sent'}
+                            />
 
-                <Table.Column
-                    dataIndex="createdAt"
-                    title="Created At"
-                    render={(value) => <DateField format="LLL" value={value} />}
-                />
-            </Table>
-        </List>
+                            <Table.Column
+                                dataIndex="createdAt"
+                                title="Created At"
+                                render={(value) => <DateField format="LLL" value={value} />}
+                            />
+                        </Table>
+                    </List>
+                </Col>
+            </Row>
+        </div>        
     );
 };


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#575 

#### What's this PR do?

Adds a search pane to the Flexible Pricing admin page (in the Refine admin) to allow people to filter the request list by name. (Name, in this case, can be either full name, email address, or username.) 

#### How should this be manually tested?

Put in at least one Flexible Price request. Then, navigate to the admin and click Flexible Pricing on the left nav. You should see a Find Records card to the left of the table. Supplying a search term in the Search by Name field will limit the result list to records for the person you've filtered for (or will return no data, depending). Similarly, supplying a status in the Search by Status will limit the table to just records in that particular status. Supplying both will be performed with an AND operator. 

#### Screenshots (if appropriate)
With results:
![image](https://user-images.githubusercontent.com/945611/171276361-d79d4725-e4ec-4454-8b9d-91e3441705fc.png)

With no results: 
![Screen Shot 2022-05-31 at 3 12 37 PM](https://user-images.githubusercontent.com/945611/171276649-3ae48f85-6aa1-4e14-bd94-3e98d2fdbd00.png)

#### Other

The filtering on the Status field has been retained. It's a bit redundant now that there's a search card. 

The Find Records card could be positioned above the results table rather than alongside. (I think it looks better as it is, especially if you collapse the left nav.) 