### PR TITLE
Adds message when paid learners attempt to unenroll

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -116,7 +116,6 @@ export class EnrolledItemCard extends React.Component<
     const { deactivateEnrollment, addUserNotification } = this.props
 
     if (enrollment.enrollment_mode === "verified") {
-      console.log("enrollment is paid, can't unenroll")
       this.toggleVerifiedUnenrollmentModalVisibility(enrollment.id)
       return
     }

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -273,7 +273,7 @@ export class EnrolledItemCard extends React.Component<
         </ModalHeader>
         <ModalBody>
           <p>
-            You are enrolled in the certificate course for{" "}
+            You are enrolled in the certificate track for{" "}
             {enrollment.run.course_number} {enrollment.run.title}. You can't
             unenroll from this course from My Courses.
           </p>

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -1,0 +1,104 @@
+/* global SETTINGS: false */
+// @flow
+import React from "react"
+
+import { assert } from "chai"
+import moment from "moment"
+import sinon from "sinon"
+import { Formik } from "formik"
+import { shallow } from "enzyme"
+
+import EnrolledItemCard, {
+  EnrolledItemCard as InnerEnrolledItemCard
+} from "./EnrolledItemCard"
+import { ALERT_TYPE_DANGER, ALERT_TYPE_SUCCESS } from "../constants"
+import { formatPrettyDateTimeAmPmTz } from "../lib/util"
+import { shouldIf, isIf } from "../lib/test_utils"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeCourseRunEnrollment } from "../factories/course"
+import { makeUser } from "../factories/user"
+import * as courseApi from "../lib/courseApi"
+
+describe("EnrolledItemCard", () => {
+  let helper,
+    renderedCard,
+    userEnrollment,
+    currentUser,
+    isLinkableStub,
+    enrollmentCardProps
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    userEnrollment = makeCourseRunEnrollment()
+    currentUser = makeUser()
+    isLinkableStub = helper.sandbox.stub(courseApi, "isLinkableCourseRun")
+    enrollmentCardProps = {
+      enrollment:           userEnrollment,
+      currentUser:          currentUser,
+      deactivateEnrollment: helper.sandbox
+        .stub()
+        .withArgs(userEnrollment.id)
+        .returns(Promise),
+      courseEmailsSubscription: helper.sandbox
+        .stub()
+        .withArgs(userEnrollment.id, "test")
+        .returns(Promise),
+      addUserNotification: helper.sandbox.stub().returns(Function)
+    }
+
+    renderedCard = () =>
+      shallow(
+        <EnrolledItemCard
+          key={enrollmentCardProps.enrollment.id}
+          enrollment={enrollmentCardProps.enrollment}
+          currentUser={currentUser}
+          deactivateEnrollment={enrollmentCardProps.deactivateEnrollment}
+          courseEmailsSubscription={
+            enrollmentCardProps.courseEmailsSubscription
+          }
+          addUserNotification={enrollmentCardProps.addUserNotification}
+        />
+      )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("renders the card", async () => {
+    const inner = await renderedCard()
+    const enrolledItems = inner.find(".enrolled-item")
+    assert.lengthOf(enrolledItems, 1)
+    const enrolledItem = enrolledItems.at(0)
+    assert.equal(
+      enrolledItem.find("h2").text(),
+      userEnrollment.run.course.title
+    )
+  })
+
+  it("renders the unenrollment verification modal", async () => {
+    const inner = await renderedCard()
+    const modalId = `verified-unenrollment-${userEnrollment.id}-modal`
+    const modals = inner.find(`#${modalId}`)
+    assert.lengthOf(modals, 1)
+  })
+  ;[
+    [true, "verified"],
+    [false, "audit"]
+  ].forEach(([activationStatus, enrollmentType]) => {
+    it(`${shouldIf(
+      activationStatus
+    )} activate the unenrollment verification modal if the enrollment type is ${enrollmentType}`, async () => {
+      enrollmentCardProps.enrollment.enrollment_mode = enrollmentType
+      const inner = await renderedCard()
+      const unenrollButton = inner.find("Dropdown DropdownItem").at(0)
+
+      assert.isTrue(unenrollButton.exists())
+      await unenrollButton.prop("onClick")()
+
+      const modal = inner.find("Modal").at(0)
+      assert.isTrue(modal.exists())
+      assert.isTrue(modal.prop("isOpen") === activationStatus)
+    })
+  })
+})

--- a/frontend/public/src/components/ReceiptPageDetailCard.js
+++ b/frontend/public/src/components/ReceiptPageDetailCard.js
@@ -1,12 +1,16 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import { parseDateString, formatLocalePrice, formatPrettyDate } from "../lib/util"
+import {
+  parseDateString,
+  formatLocalePrice,
+  formatPrettyDate
+} from "../lib/util"
 import type { OrderReceipt, Discount } from "../flow/cartTypes"
 
 type Props = {
   orderReceipt: OrderReceipt,
-  discounts: Array<Discount>,
+  discounts: Array<Discount>
 }
 
 export class ReceiptPageDetailCard extends React.Component<Props> {
@@ -34,9 +38,7 @@ export class ReceiptPageDetailCard extends React.Component<Props> {
       discountAmountText = `-${formatLocalePrice(discountAmount)}`
       break
     default:
-      discountAmountText = `Fixed Price: ${formatLocalePrice(
-        discountAmount
-      )}`
+      discountAmountText = `Fixed Price: ${formatLocalePrice(discountAmount)}`
       break
     }
 
@@ -185,12 +187,8 @@ export class ReceiptPageDetailCard extends React.Component<Props> {
             </thead>
             <tbody>
               {orderReceipt.lines.map(line => {
-                const startDate = parseDateString(
-                  line.start_date
-                )
-                const endDate = parseDateString(
-                  line.end_date
-                )
+                const startDate = parseDateString(line.start_date)
+                const endDate = parseDateString(line.end_date)
                 return (
                   <tr key={line.readable_id}>
                     <td>

--- a/frontend/public/src/containers/pages/checkout/OrderReceiptPage.js
+++ b/frontend/public/src/containers/pages/checkout/OrderReceiptPage.js
@@ -16,11 +16,7 @@ import { orderReceiptQuery, receiptQueryKey } from "../../../lib/queries/cart"
 
 import type { RouterHistory } from "react-router"
 import type { Match } from "react-router"
-import type {
-  Discount,
-  Line,
-  OrderReceipt,
-} from "../../../flow/cartTypes"
+import type { Discount, Line, OrderReceipt } from "../../../flow/cartTypes"
 import { pathOr } from "ramda"
 
 type Props = {

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -87,9 +87,16 @@ export const makeCourseRunDetailWithProduct = (): CourseRunDetail => {
   }
 }
 
+const genEnrollmentMode = () => {
+  const modes = ["audit", "verified"]
+
+  return modes[Math.random() * modes.length]
+}
+
 export const makeCourseRunEnrollment = (): CourseRunEnrollment => ({
   // $FlowFixMe
   id:                      genEnrollmentId.next().value,
   run:                     makeCourseRunDetail(),
-  edx_emails_subscription: true
+  edx_emails_subscription: true,
+  enrollment_mode:         genEnrollmentMode()
 })

--- a/frontend/public/src/flow/cartTypes.js
+++ b/frontend/public/src/flow/cartTypes.js
@@ -93,5 +93,5 @@ export type OrderReceipt = {
   created_on: string,
   transactions: Transactions,
   street_address: StreetAddress,
-  purchaser: Purchaser,
+  purchaser: Purchaser
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#534 

#### What's this PR do?
Adds a modal that is displayed when a learner attempts to unenroll from a certificate (paid) course instructing them to contact customer support, and then blocks the unenrollment.

#### How should this be manually tested?
Enroll in a certificate course. Then, attempt to unenroll from it using the dropdown menu on the Dashboard. You should be presented with a modal instructing you to contact customer support. 

Enroll in a free course. Then, attempt to unenroll from it using the dropdown menu on the Dashboard. The unenrollment should take place. 

#### Any background context you want to provide?
There's no UX for this defined in InVision so just winged the copy - will be expecting changes.

#### Screenshots (if appropriate)
![Screen Shot 2022-06-01 at 2 45 39 PM](https://user-images.githubusercontent.com/945611/171490080-404a53df-e97f-4707-8960-96e187cf23a5.png)

![Screen Shot 2022-06-01 at 2 46 24 PM](https://user-images.githubusercontent.com/945611/171490091-773d3e6f-1176-4123-b47f-26f70509b564.png)

