### PR TITLE
Allows for setting some Refine admin settings via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ SECRET_KEY=
 STATUS_TOKEN=
 UWSGI_THREADS=5
 SENTRY_DSN=
+MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8013
+MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
+MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,8 +109,9 @@ services:
     environment:
       PORT: 8016
       REACT_APP_OIDC_CONFIG_AUTHORITY: ${MITX_ONLINE_BASE_URL:-http://mitxonline.odl.local:8013}/oauth2/
-      REACT_APP_OIDC_CONFIG_CLIENT_ID: refine-local-client-id
-      REACT_APP_OIDC_CONFIG_REDIRECT_URI: http://mitxonline.odl.local:8016/oauth2/login/
+      REACT_APP_OIDC_CONFIG_CLIENT_ID: ${MITX_ONLINE_ADMIN_CLIENT_ID:-refine-local-client-id}
+      REACT_APP_OIDC_CONFIG_REDIRECT_URI: ${MITX_ONLINE_ADMIN_BASE_URL:-http://mitxonline.odl.local:8016}/oauth2/login/
+      REACT_APP_MITX_ONLINE_DATASOURCE: ${MITX_ONLINE_BASE_URL:-http://mitxonline.odl.local:8013}/api
     volumes:
       - .:/src
       - npm-cache:/root/.npm

--- a/frontend/staff-dashboard/src/App.tsx
+++ b/frontend/staff-dashboard/src/App.tsx
@@ -33,8 +33,9 @@ axiosInterface.interceptors.request.use((config: any) => {
 }, (error: any) => Promise.reject(error));
 
 export default function App() {
+  const dataURI = process.env["REACT_APP_MITX_ONLINE_DATASOURCE"] ? process.env["REACT_APP_MITX_ONLINE_DATASOURCE"] : "";
   const authProvider = useAuthProvider();
-  const xonlineProvider = useDrfDataProvider("http://mitxonline.odl.local:8013/api/v0");
+  const xonlineProvider = useDrfDataProvider(dataURI);
 
   return (
     <Refine


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested
- [X] Settings
  - [X] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

#550 

#### What's this PR do?

Updates the Docker compose environment to pull in settings for the Refine admin from the .env file, and updates the data provider to use a variable for the data source URI rather than a hard-coded value.

The following settings can be set via `.env`:

* `MITX_ONLINE_ADMIN_CLIENT_ID`: the client ID used for OAuth2 authentication
* `MITX_ONLINE_BASE_URL`: the base URL for the MITxOnline application. (This already existed, but noting it since it's being used here now too.) 
* `MITX_ONLINE_ADMIN_BASE_URL`: the base URL for the Refine admin app

These are used in the Docker environment (and, thus, in the app) like this:

| Environment Variable | `.env` Setting Formula | Default |
| --- | --- | --- |
| `REACT_APP_OIDC_CONFIG_CLIENT_ID` | `MITX_ONLINE_ADMIN_CLIENT_ID` | `refine-local-client-id` |
| `REACT_APP_OIDC_CONFIG_AUTHORITY` | `MITX_ONLINE_BASE_URL` + `/oauth2` | `http://mitxonline.odl.local:8013` |
| `REACT_APP_OIDC_CONFIG_REDIRECT_URI` | `MITX_ONLINE_ADMIN_BASE_URL` + `/oauth2/login` | `http://mitxonline.odl.local:8016` |
| `REACT_APP_MITX_ONLINE_DATASOURCE` | `MITX_ONLINE_BASE_URL` + `/api` | `http://mitxonline.odl.local:8013` |

The `.env.example` was updated to include these variables and has been set up with reasonable defaults. 

#### How should this be manually tested?

Update your `.env` file appropriately and recycle your Docker containers (`docker compose stop && docker compose up`). The changes should be reflected in the app - changing `MITX_ONLINE_BASE_URL` should cause it to pull data from another URL, etc. 

If you change the client ID or admin base URL settings, you will also need to update your OAuth2 application record in MITxOnline using Django Admin. 
