### PR TITLE
flexible pricing should be applied automatically when a course is add…

### DIFF
--- a/flexiblepricing/factories.py
+++ b/flexiblepricing/factories.py
@@ -34,6 +34,7 @@ class FlexiblePriceTierFactory(DjangoModelFactory):
     income_threshold_usd = random.randrange(0, 150000, 1000)
     courseware_object = SubFactory(CourseFactory)
     discount = SubFactory(DiscountFactory)
+    current = True
 
     class Meta:
         model = models.FlexiblePriceTier


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #541 

#### What's this PR do?
flexible pricing should be applied automatically when a course is added to the cart

#### How should this be manually tested?
Just make sure you have flexible price income threshold tiers against a course, apply for the flexible price and try to enroll in the course run and see the discount applied on 

#### Screenshots (if appropriate)
(Optional)
