### PR TITLE
Changes coupon code label to "Coupon code" from "Have a coupon?"

### DIFF
--- a/frontend/public/src/components/forms/ApplyCouponForm.js
+++ b/frontend/public/src/components/forms/ApplyCouponForm.js
@@ -23,7 +23,7 @@ const ApplyCouponForm = ({ onSubmit, couponCode, discounts }: Props) => (
         <div className="row">
           <div className="col-12 mt-4 px-3 py-3 py-md-0">
             <label htmlFor="couponCode">
-              <span>Have a coupon?</span>
+              <span>Coupon code</span>
             </label>
             <div className="d-flex justify-content-between flex-sm-column flex-md-row">
               <div className="pt-2">


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots

#### What are the relevant tickets?

#547 

#### What's this PR do?

Fixes #547 - just a content change.

#### How should this be manually tested?

Attempt to check out, then note the text above the coupon code field has changed to "Coupon code". 

#### Screenshots (if appropriate)
![Screen Shot 2022-06-13 at 10 19 05 AM](https://user-images.githubusercontent.com/945611/173387766-cc706f5a-21db-466b-be20-a50200740558.png)

![image](https://user-images.githubusercontent.com/945611/173388167-53b1d171-327c-4db5-a8c8-4e7fcb2dc117.png)
