### PR TITLE
Show justification once status changed

### DIFF
--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -155,7 +155,7 @@ export const FlexiblePricingList: React.FC = () => {
     };
 
     const handleChange = (e: any) => {
-        setJustification(e.target.options[e.target.selectedIndex].text)
+        setJustification(e.target.options[e.target.selectedIndex].value)
       }
 
 
@@ -268,7 +268,7 @@ export const FlexiblePricingList: React.FC = () => {
                                                         </span>
                                                         <select onChange={(e) => handleChange(e)} style={{ marginLeft: "20px" }}>
                                                             {All_Justifications.map((option) => (
-                                                            <option value={option.value} selected={justification == option.value}>{option.label}</option>
+                                                            <option value={option.value} selected={justification == option.value}>{option.value}</option>
                                                             ))}
                                                         </select>
                                                     </p>

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -22,6 +22,7 @@ import {
 } from "@pankod/refine-antd";
 
 import { IFlexiblePriceRequest, IFlexiblePriceRequestFilters } from "interfaces";
+import { Type } from "typescript";
 
 const FlexiblePricingStatuses = [
     {
@@ -49,6 +50,31 @@ const FlexiblePricingStatuses = [
         value: 'reset'
     }
 ];
+
+const All_Justifications = [
+    {
+        label: 'OK',
+        value: 'Documents in order'
+    },
+    {
+        label: 'NOT_NOTARIZED',
+        value: 'Docs not notarized'
+    },
+    {
+        label: 'INSUFFICIENT',
+        value: 'Insufficient docs'
+    },
+    {
+        label: 'INCOME_INACCURATE',
+        value: 'Inaccurate income reported'
+    },
+    { 
+        label: 'COUNTRY_INACCURATE',
+        value: 'Inaccurate country reported'
+    },
+];
+
+
 const FlexiblePricingStatusText = "Select Status";
 
 const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formProps }) => {
@@ -101,6 +127,7 @@ export const FlexiblePricingList: React.FC = () => {
     const [modaldata, setmodaldata] = useState({} as IFlexiblePriceRequest);
     const [isModalVisible, setIsModalVisible] = useState(false);
     const mutationResult = useUpdate<IFlexiblePriceRequest>();
+    const [justification, setJustification] = useState("OK");
     const { mutate, isLoading: mutateIsLoading } = mutationResult;
     const handleUpdate = (item: IFlexiblePriceRequest, status: string) => {
         mutate({ 
@@ -118,6 +145,7 @@ export const FlexiblePricingList: React.FC = () => {
     };
 
     const handleOk = () => {
+        modaldata['justification'] = justification
         handleUpdate(modaldata, modaldata.action)
         setIsModalVisible(false);
     };
@@ -125,6 +153,10 @@ export const FlexiblePricingList: React.FC = () => {
     const handleCancel = () => {
         setIsModalVisible(false);
     };
+
+    const handleChange = (e: any) => {
+        setJustification(e.target.options[e.target.selectedIndex].text)
+      }
 
 
     return (
@@ -174,11 +206,10 @@ export const FlexiblePricingList: React.FC = () => {
                                 title="Documents Sent"
                                 render={(value) => value ? <DateField format="LLL" value={value} /> : 'No Documents Sent'}
                             />
-
                             <Table.Column
-                                dataIndex="createdAt"
-                                title="Created At"
-                                render={(value) => <DateField format="LLL" value={value} />}
+                                dataIndex="justification"
+                                title="Justification"
+                                render={(value) => value}
                             />
                             <Table.Column<IFlexiblePriceRequest>
                                 title="Actions"
@@ -230,6 +261,16 @@ export const FlexiblePricingList: React.FC = () => {
                                                     <p>
                                                         <strong>Country of Income:</strong>
                                                         <div>{modaldata.country_of_income}</div>
+                                                    </p>
+                                                    <p>
+                                                        <span>
+                                                            <strong>Justification:</strong>
+                                                        </span>
+                                                        <select onChange={(e) => handleChange(e)} style={{ marginLeft: "20px" }}>
+                                                            {All_Justifications.map((option) => (
+                                                            <option value={option.value} selected={justification == option.value}>{option.label}</option>
+                                                            ))}
+                                                        </select>
                                                     </p>
                                                 </Modal>
                                         </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes: #608 

#### What's this PR do?
As a staff member, when I change the status of a Flexible Pricing request, I'd like to provide a justification of why I am changing the status of the request. The justification should be one from a set of pre-defined justifications available in the app.

#### How should this be manually tested?
Visit the admin portal in Refine UI to test it.

#### Screenshots (if appropriate)

![screencapture-mitxonline-odl-local-8016-flexible-pricing-2022-06-14-16_40_29](https://user-images.githubusercontent.com/7334669/173569398-5fb8d038-9bce-47a2-9382-ff90d6d74b37.png)

![screencapture-mitxonline-odl-local-8016-flexible-pricing-2022-06-14-16_39_59](https://user-images.githubusercontent.com/7334669/173569403-190f2f36-c270-4c7d-80fe-82d06b8932d5.png)
![screencapture-mitxonline-odl-local-8016-flexible-pricing-2022-06-14-16_39_40](https://user-images.githubusercontent.com/7334669/173569410-308e4d9e-c63f-4a3f-9427-237bcb5f9a4e.png)

<img width="1676" alt="Screenshot 2022-06-14 at 4 40 19 PM" src="https://user-images.githubusercontent.com/7334669/173569484-bda0d9ba-4bcf-412d-9697-b415362da966.png">

![screencapture-mitxonline-odl-local-8013-admin-flexiblepricing-flexibleprice-1-change-2022-06-14-16_40_57](https://user-images.githubusercontent.com/7334669/173569385-677e0cce-3937-4ce8-9b86-a7c43b9f94af.png)

