### PR TITLE
chore: update mitol dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,11 +26,11 @@ django-storages==1.11.1
 djoser==2.1.0
 edx-api-client==1.1.0
 ipython
-mitol-django-common~=2.1.0
-mitol-django-mail~=3.0.1
-mitol-django-authentication~=1.3.1
+mitol-django-common~=2.2.4
+mitol-django-mail~=3.1.0
+mitol-django-authentication~=1.4.1
 mitol-django-openedx~=1.0.0
-mitol-django-payment-gateway~=1.2.2
+mitol-django-payment-gateway~=1.4.0
 newrelic
 pyOpenSSL
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -222,21 +222,21 @@ markupsafe==2.0.1
     # via jinja2
 matplotlib-inline==0.1.2
     # via ipython
-mitol-django-authentication==1.3.1
+mitol-django-authentication==1.4.1
     # via -r requirements.in
-mitol-django-common==2.1.0
+mitol-django-common==2.2.4
     # via
     #   -r requirements.in
     #   mitol-django-authentication
     #   mitol-django-mail
     #   mitol-django-payment-gateway
-mitol-django-mail==3.0.1
+mitol-django-mail==3.1.0
     # via
     #   -r requirements.in
     #   mitol-django-authentication
 mitol-django-openedx==1.0.0
     # via -r requirements.in
-mitol-django-payment-gateway==1.2.2
+mitol-django-payment-gateway==1.4.0
     # via -r requirements.in
 newrelic==6.4.1.158
     # via -r requirements.in


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
None, Just noticed that there were dependency resolver issues while working on payment_gateway.

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
mitol-django-mail 3.0.1 requires mitol-django-common~=2.1.0, but you have mitol-django-common 2.2.4 which is incompatible.
mitol-django-authentication 1.3.1 requires mitol-django-common~=2.1.0, but you have mitol-django-common 2.2.4 which is incompatible.
```

#### What's this PR do?
- Updates the dependencies for MITOL packages

#### How should this be manually tested?
I tested payment_gateway, **Should i test it end to end or i can rely on tests?**

