### PR TITLE
Adds Order History to top menu

### DIFF
--- a/frontend/public/src/components/UserMenu.js
+++ b/frontend/public/src/components/UserMenu.js
@@ -82,6 +82,11 @@ const UserMenu = ({ currentUser, useScreenOverlay }: Props) => {
           </MixedLink>
         </li>
         <li {...(menuChildProps.li || {})}>
+          <MixedLink dest={routes.orderHistory} aria-label="Order History">
+            Order History
+          </MixedLink>
+        </li>
+        <li {...(menuChildProps.li || {})}>
           <a href={routes.logout} aria-label="Sign Out">
             Sign Out
           </a>

--- a/frontend/public/src/components/UserMenu_test.js
+++ b/frontend/public/src/components/UserMenu_test.js
@@ -13,7 +13,7 @@ describe("UserMenu component", () => {
     const userMenu = shallow(
       <UserMenu currentUser={user} useScreenOverlay={false} />
     )
-    assert.lengthOf(userMenu.find("MixedLink"), 3)
+    assert.lengthOf(userMenu.find("MixedLink"), 4)
     assert.lengthOf(userMenu.find("a"), 1)
   })
 
@@ -22,7 +22,7 @@ describe("UserMenu component", () => {
       shallow(<UserMenu currentUser={user} useScreenOverlay={true} />).find(
         "ul li"
       ),
-      4
+      5
     )
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#620 

#### What's this PR do?

Adds an Order History link to the top nav menu.

#### How should this be manually tested?

Log into the application, then load a page (any page). The top nav menu should display an Order History link, and it should take you to `/orders/history/` when activated.

#### Screenshots (if appropriate)
![Screen Shot 2022-06-14 at 10 35 56 AM](https://user-images.githubusercontent.com/945611/173618185-67049bcd-832a-4e02-ad41-4b5741232963.png)
![Screen Shot 2022-06-14 at 10 36 06 AM](https://user-images.githubusercontent.com/945611/173618203-4341ad77-ea3b-4188-ade0-f3d39fc60fd0.png)

