### PR TITLE
Adds management command to find possible username conflicts

### DIFF
--- a/users/management/commands/find_username_conflicts.py
+++ b/users/management/commands/find_username_conflicts.py
@@ -1,0 +1,52 @@
+import sys
+import unicodedata
+from argparse import RawTextHelpFormatter
+
+from django.core.management import BaseCommand
+
+from users.models import User
+
+
+class Command(BaseCommand):
+    """Finds usernames that would cause conflicts after normalization"""
+
+    help = """
+  Finds usernames that would cause conflicts after normalization. 
+  """
+
+    def make_normalized_username(self, username):
+        """Strips non-ASCII characters from the username."""
+        normalized_username = unicodedata.normalize("NFD", username)
+        normalized_username = normalized_username.encode("ascii", "ignore").decode(
+            "utf-8"
+        )
+        return str(normalized_username)
+
+    def create_parser(self, prog_name, subcommand):  # pylint: disable=arguments-differ
+        """
+        create parser to add new line in help text.
+        """
+        parser = super().create_parser(prog_name, subcommand)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
+
+    def handle(self, *args, **kwargs):
+        all_users = User.objects.only("id", "username").all()
+        username_lookup = {}
+
+        for user in all_users:
+            normalized_username = self.make_normalized_username(user.username)
+            if normalized_username not in username_lookup:
+                username_lookup[normalized_username] = [user.id]
+            else:
+                username_lookup[normalized_username].append(user.id)
+
+        conflicts = [x for x in username_lookup if len(x) > 0]
+
+        for conflict in conflicts:
+            if len(username_lookup[conflict]) > 1:
+                self.stdout.write(
+                    "Username {} has conflicts: {}".format(
+                        conflict, " ".join(map(str, username_lookup[conflict]))
+                    )
+                )

--- a/users/management/tests/find_username_conflicts_test.py
+++ b/users/management/tests/find_username_conflicts_test.py
@@ -1,0 +1,27 @@
+"""Tests the username conflict finder."""
+import pytest
+from io import StringIO
+
+from django.core.management import call_command
+from users.factories import UserFactory
+
+
+@pytest.mark.parametrize("with_accents", [True, False])
+@pytest.mark.django_db
+def test_find_username_conflicts(with_accents):
+    users = UserFactory.create_batch(2)
+
+    if with_accents:
+        users[0].username = "aeiou"
+        users[0].save()
+
+        users[1].username = "aéîöü"
+        users[1].save()
+
+    output = StringIO()
+    call_command("find_username_conflicts", stdout=output)
+
+    if with_accents:
+        assert "has conflicts" in output.getvalue()
+    else:
+        assert "has conflicts" not in output.getvalue()


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#259 

#### What's this PR do?

Adds a management command to identify usernames that would conflict after normalization. This is step one of the process for resolving #259. 

The management command is `find_username_conflicts` and running it will load all user IDs and usernames from the database and run through them to see if a normalized username would be generated more than once. If the normalized username would be generated more than once, it outputs that normalized username with the IDs of the users that would cause a conflict. These can then be manually edited (in Django Admin or in the database directly). 

The command does not change usernames at all and the standard caveats apply to modifying usernames manually - they will need to be modified on the Open edX side as well. 

This command will need to be run and the affected accounts adjusted before https://github.com/mitodl/mitxonline/pull/627 can be merged, as it adds a uniqued `normalized_username` field and automatically normalizes existing usernames. 

#### How should this be manually tested?

Create two users: their usernames should share spelling but one should contain accented characters where the other doesn't. (For example, `taylor` and `tâylör`.) Then, run the `find_username_conflicts` command. It should identify those two accounts specifically as accounts that may conflict after normalization. 
