### PR TITLE
Fixes spacing and order date on emailed receipts

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -2,22 +2,23 @@
 import pycountry
 import logging
 
+from dateutil import parser
 from ecommerce.messages import OrderReceiptMessage
 from mitol.mail.api import get_message_sender
 
 log = logging.getLogger()
 
 
-def send_ecommerce_order_receipt(order):
+def send_ecommerce_order_receipt(order_record):
     """
     Send emails receipt summarizing the user purchase detail.
 
     Args:
-        order: An order.
+        order_record: An order.
     """
     from ecommerce.serializers import OrderReceiptSerializer
 
-    data = OrderReceiptSerializer(instance=order).data
+    data = OrderReceiptSerializer(instance=order_record).data
     purchaser = data.get("purchaser")
     coupon = data.get("coupon")
     lines = data.get("lines")
@@ -38,7 +39,10 @@ def send_ecommerce_order_receipt(order):
                         sum(float(line["total_paid"]) for line in lines),
                         ".2f",
                     ),
-                    "order": order,
+                    "order": {
+                        "reference_number": order.get("reference_number"),
+                        "created_on": parser.parse(order.get("created_on")),
+                    },
                     "receipt": receipt,
                     "purchaser": {
                         "name": " ".join(

--- a/ecommerce/templates/mail/product_order_receipt/body.html
+++ b/ecommerce/templates/mail/product_order_receipt/body.html
@@ -17,7 +17,7 @@
             <h3 style="color: #000000; font-size: 16px; font-weight: 700; line-height: 18px; margin: 0 0 20px;">Order Information</h3>
             <p>
                 {% if order.reference_number  %}<strong style="font-weight: 700;">Order Number:</strong> {{ order.reference_number }}<br> {% endif %}
-                <strong style="font-weight: 700;">Order Date:</strong><span> {{ order.created_on|date:"F j, Y"}} </span><br>
+                <strong style="font-weight: 700;">Order Date:</strong><span> {{ order.created_on|date:"F j, Y" }} </span><br>
                 <strong style="font-weight: 700;">Order Total:</strong> ${{ order_total }}<br>
             </p>
             {% for line in lines %}
@@ -35,7 +35,7 @@
             {% endfor %}
 
             <h3 style="color: #000000; font-size: 16px; font-weight: 700; line-height: 18px; margin: 0 0 20px;">Customer Information</h3>
-            <p style="margin: 0;">
+            <p>
                 <strong style="font-weight: 700;">Name:</strong> {{ purchaser.name }}<br>
                 <strong style="font-weight: 700;">Company Name:</strong> {{ purchaser.company }}<br>
                 {% if purchaser.street_address %}
@@ -57,23 +57,24 @@
                 {% endif %}
                 <strong style="font-weight: 700;">Email Address:</strong> {{ purchaser.email }}<br>
             </p>
+
             {% if receipt or coupon %}
-                <h3 style="color: #000000; font-size: 16px; font-weight: 700; line-height: 18px; margin: 0 0 20px;">Payment Information</h3>
-                <p>
-                    {%  if receipt %}
-                        <strong style="font-weight: 700;">Name:</strong> {{ receipt.name }}<br>
-                        {% if receipt.payment_method == 'card' %}
-                            <strong style="font-weight: 700;">Email:</strong> {{ receipt.bill_to_email }}<br>
-                            <strong style="font-weight: 700;">Payment Method:</strong> {{ receipt.card_type }} | {{ receipt.card_number }}<br>
-                        {% elif receipt.payment_method == 'paypal' %}
-                            <strong style="font-weight: 700;">Email:</strong> {{ receipt.bill_to_email }} (Paypal account email)<br>
-                            <strong style="font-weight: 700;">Payment Method:</strong> Paypal<br>
-                        {% endif %}
+            <h3 style="color: #000000; font-size: 16px; font-weight: 700; line-height: 18px; margin: 0 0 20px;">Payment Information</h3>
+            <p>
+                {%  if receipt %}
+                    <strong style="font-weight: 700;">Name:</strong> {{ receipt.name }}<br>
+                    {% if receipt.payment_method == 'card' %}
+                        <strong style="font-weight: 700;">Email:</strong> {{ receipt.bill_to_email }}<br>
+                        <strong style="font-weight: 700;">Payment Method:</strong> {{ receipt.card_type }} | {{ receipt.card_number }}<br>
+                    {% elif receipt.payment_method == 'paypal' %}
+                        <strong style="font-weight: 700;">Email:</strong> {{ receipt.bill_to_email }} (Paypal account email)<br>
+                        <strong style="font-weight: 700;">Payment Method:</strong> Paypal<br>
                     {% endif %}
-                    {% if coupon %}
-                        <strong style="font-weight: 700;">Discount Code:</strong> {{ coupon.redeemed_discount.discount_code }}
-                    {% endif %}
-                </p>
+                {% endif %}
+                {% if coupon %}
+                    <strong style="font-weight: 700;">Discount Code:</strong> {{ coupon.redeemed_discount.discount_code }}
+                {% endif %}
+            </p>
             {% endif %}
         </td>
     </tr>


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#638 

#### What's this PR do?

Fixes #638: removes some extraneous inline CSS from the email template and adjusts the send_ecommerce_order_receipt code to parse the Order's created_on (since that ends up becoming a string at some point).

#### How should this be manually tested?

Place an order. The receipt email should display the order date and should have proper spacing above the Payment Information block.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/945611/175326235-859dacfc-94e3-448f-9a43-56b38b832747.png)