### PR TITLE
Adjusts Flexible Pricing dashboard to make the filters horizontal

### DIFF
--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -79,7 +79,7 @@ const FlexiblePricingStatusText = "Select Status";
 
 const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formProps }) => {
     return (
-        <Form layout="vertical" {...formProps}>
+        <Form layout="inline" {...formProps}>
             <Form.Item label="Search by Name" name="q">
                 <Input placeholder="Name, username, email address" prefix={<Icons.SearchOutlined />}></Input>
             </Form.Item>
@@ -162,12 +162,15 @@ export const FlexiblePricingList: React.FC = () => {
     return (
         <div>
             <Row gutter={[10, 10]}>
-                <Col sm={6}>
+                <Col sm={24}>
                     <Card title="Find Records">
                         <FlexiblePricingFilterForm formProps={searchFormProps} />
                     </Card>
                 </Col>
-                <Col sm={18}>
+            </Row>
+
+            <Row gutter={[10, 10]}>
+                <Col sm={24}>
                     <List title="Flexible Pricing Requests">
                         <Table {...tableProps} rowKey="id">
                             <Table.Column 
@@ -178,14 +181,6 @@ export const FlexiblePricingList: React.FC = () => {
                             <Table.Column
                                 dataIndex="status"
                                 title="Status"
-                                filterDropdown={(props) => (
-                                    <FilterDropdown {...props}>
-                                        <Select mode="multiple" 
-                                            style={{ minWidth: 300 }}
-                                            placeholder={FlexiblePricingStatusText}
-                                            options={FlexiblePricingStatuses} />
-                                    </FilterDropdown>
-                                )}
                             />
                             <Table.Column
                                 dataIndex="income_usd"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
n/a

#### What's this PR do?

Eliminates the filter dropdown on the Status header item and realigns the filter card to be horizontal.

#### How should this be manually tested?

Load the staff dashboard and navigate to the Flexible Pricing screen. The filter card should now run across the top of the page rather than down the left side. The Status dropdown filter in the table header should now also be removed (it was redundant). 

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/945611/175646882-4a688707-9f54-4f2a-a098-0cf99e3e37ba.png)
