### PR TITLE
Capture learner's country when saving flexible pricing request

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -706,6 +706,7 @@ class FlexiblePricingRequestForm(AbstractForm):
             user=form.user,
             original_income=form.cleaned_data["your_income"],
             original_currency=form.cleaned_data["income_currency"],
+            country_of_income=form.user.legal_address.country,
             income_usd=income_usd,
             date_exchange_rate=datetime.datetime.now(),
             cms_submission=form_submission,

--- a/flexiblepricing/api.py
+++ b/flexiblepricing/api.py
@@ -121,26 +121,26 @@ def determine_tier_courseware(courseware, income):
     return tier
 
 
-def determine_auto_approval(flexibe_price, tier):
+def determine_auto_approval(flexible_price, tier):
     """
     Takes income and country code and returns a boolean if auto-approved. Logs an error if the country of
-    flexibe_price does not exist in CountryIncomeThreshold.
+    flexible_price does not exist in CountryIncomeThreshold.
     Args:
-        flexibe_price (FlexiblePrice): the flexibe price object to determine auto-approval
+        flexible_price (FlexiblePrice): the flexibe price object to determine auto-approval
         tier (FlexiblePriceTier): the FlexiblePrice for the user's income level
     Returns:
         boolean: True if auto-approved, False if not
     """
     try:
         country_income_threshold = CountryIncomeThreshold.objects.get(
-            country_code=flexibe_price.country_of_income
+            country_code=flexible_price.country_of_income
         )
         income_threshold = country_income_threshold.income_threshold
     except CountryIncomeThreshold.DoesNotExist:
         log.error(
             "Country code %s does not exist in CountryIncomeThreshold for flexible price id %s",
-            flexibe_price.country_of_income,
-            flexibe_price.id,
+            flexible_price.country_of_income,
+            flexible_price.id,
         )
         income_threshold = DEFAULT_INCOME_THRESHOLD
     if tier.discount.amount == 0:
@@ -150,7 +150,7 @@ def determine_auto_approval(flexibe_price, tier):
         # There is no income which we need to check the financial aid application
         return True
     else:
-        return flexibe_price.income_usd > income_threshold
+        return flexible_price.income_usd > income_threshold
 
 
 def determine_income_usd(original_income, original_currency):


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#650

#### What's this PR do?

Fixes #650 - pulls the learner's country from their profile when submitting their flexible pricing request so the auto-approve code has something to consider (outside of the default)

#### How should this be manually tested?

Submit a flexible pricing request for a course as a user in a country that has a threshold of < $75,000. The request should be for an income level above the threshold. It should auto-approve the request.
