### PR TITLE
Move NotificationContainer into the Header component to assist with screen reading

### DIFF
--- a/frontend/public/src/components/Header.js
+++ b/frontend/public/src/components/Header.js
@@ -3,7 +3,6 @@ import React from "react"
 import * as Sentry from "@sentry/browser"
 
 import TopAppBar from "./TopAppBar"
-import NotificationContainer from "./NotificationContainer"
 
 import type { CurrentUser } from "../flow/authTypes"
 import type { Location } from "react-router"
@@ -31,7 +30,6 @@ const Header = ({ currentUser, location }: Props) => {
   return (
     <React.Fragment>
       <TopAppBar currentUser={currentUser} location={location} />
-      <NotificationContainer />
     </React.Fragment>
   )
 }

--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -58,7 +58,7 @@ export class NotificationContainer extends React.Component<Props, State> {
     const { hiddenNotifications } = this.state
 
     return (
-      <div className="notifications">
+      <div className="notifications order-2" id="notifications-container">
         {Object.keys(userNotifications).map((notificationKey, i) => {
           const dismiss = partial(this.onDismiss, [notificationKey])
           const notification = userNotifications[notificationKey]
@@ -80,7 +80,7 @@ export class NotificationContainer extends React.Component<Props, State> {
               toggle={dismiss}
               fade={true}
             >
-              <AlertBodyComponent dismiss={dismiss} {...notification.props} />
+              <AlertBodyComponent aria-live="assertive" dismiss={dismiss} {...notification.props} />
             </Alert>
           )
         })}

--- a/frontend/public/src/components/ReceiptPageDetailCard.js
+++ b/frontend/public/src/components/ReceiptPageDetailCard.js
@@ -183,7 +183,7 @@ export class ReceiptPageDetailCard extends React.Component<Props> {
                 <th>Product Description</th>
                 <th>Quantity</th>
                 <th>Unit Price</th>
-                {discountAmountText !== null ? (<th>Discount</th>) : null }
+                {discountAmountText !== null ? <th>Discount</th> : null}
                 <th>Total Paid</th>
               </tr>
             </thead>
@@ -211,7 +211,7 @@ export class ReceiptPageDetailCard extends React.Component<Props> {
                       <td>
                         <div>{discountAmountText}</div>
                       </td>
-                    ) : null }
+                    ) : null}
                     <td>
                       <div>${line.total_paid}</div>
                     </td>

--- a/frontend/public/src/components/TopAppBar.js
+++ b/frontend/public/src/components/TopAppBar.js
@@ -6,6 +6,7 @@ import { routes } from "../lib/urls"
 import UserMenu from "./UserMenu"
 import AnonymousMenu from "./AnonymousMenu"
 import InstituteLogo from "./InstituteLogo"
+import NotificationContainer from "./NotificationContainer"
 import type { Location } from "react-router"
 
 import type { CurrentUser } from "../flow/authTypes"
@@ -16,9 +17,10 @@ type Props = {
 }
 
 const TopAppBar = ({ currentUser, location }: Props) => (
-  <header className="site-header py-2 px-3 py-sm-3 px-sm-4">
+  <header className="site-header d-flex d-flex flex-column">
+    <NotificationContainer />
     <nav
-      className={`sub-nav navbar navbar-expand-md link-section ${
+      className={`order-1 sub-nav navbar navbar-expand-md link-section py-2 px-3 py-sm-3 px-sm-4 ${
         currentUser.is_authenticated ? "nowrap login" : ""
       }`}
     >

--- a/frontend/public/src/containers/App.js
+++ b/frontend/public/src/containers/App.js
@@ -66,7 +66,7 @@ export class App extends React.Component<Props, void> {
     }
 
     return (
-      <div className="app">
+      <div className="app" aria-flowto="notifications-container">
         <Header currentUser={currentUser} location={location} />
         <div id="main" className="main-page-content">
           <Switch>


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
#537 

#### What's this PR do?

Moves the NotificationContainer component into the Header component, so screen readers will read notifications first when the page reloads (as in when a learner has completed purchasing a course). 

#### How should this be manually tested?

Verifying normal operation:
1. Log in.
2. Perform some action that generates a notification. (Going to the Dashboard and attempting to adjust Email Settings from the menu is a good choice here.) The notification should appear in the same spot it did - under the header - and should be closable. 
3. Attempt to purchase a course. The checkout process should complete successfully, and the notification should appear below the header and be closable. 

Verifying screen reader operation:
1. Log in. 
2. Enable screen reader - this was tested specifically with VoiceOver on macOS 12 and Narrator on Windows 11. 
3. Complete the same steps 3 and 4 as above. In each case, the screen reader should read the notification before continuing on to the page content.
   * For checkout messages (ones that require a reload), the screen recorder will read the "Skip to main content." text first. 

All operations should work as expected on either mobile or on desktop style views. Changes were tested in Chrome with responsive mode turned on but this hasn't yet been tested on an actual mobile device.
