### PR TITLE
fix(warning): use StreamFieldPanel instead of FieldPanel

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -389,7 +389,7 @@ class ProductPage(Page):
         FieldPanel("description"),
         FieldPanel("length"),
         FieldPanel("effort"),
-        FieldPanel("price"),
+        StreamFieldPanel("price"),
         FieldPanel("prerequisites"),
         FieldPanel("about"),
         FieldPanel("what_you_learn"),


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
#410 

#### What's this PR do?
Fixes wagtail warning regarding usage of `FieldPanel` instead of `StreamFieldPanel` for price field(Which is a `StremField`)

#### How should this be manually tested?
- In a course make sure you have added a price field, No move to this branch rebuild and check if the Price field on the course page still works fine.
- In a new course you can also try creating a Price field in the course through CMS and check that users can see that on the course details page.
- Check the logs and there should be no warning mentioned in the associated ticket
- Tests pass

#### Screenshots
<img width="807" alt="Screenshot 2022-07-06 at 3 24 13 PM" src="https://user-images.githubusercontent.com/34372316/177529590-e86a4786-7ebc-478b-af2c-10a96678bad4.png">
<img width="1261" alt="Screenshot 2022-07-06 at 3 24 26 PM" src="https://user-images.githubusercontent.com/34372316/177529605-3d7cd320-3658-438e-8ced-473f9bc51f0b.png">
