### PR TITLE
Fixes error on justification field when changing a flex pricing request status 

### DIFF
--- a/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
+++ b/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
@@ -1,0 +1,120 @@
+import { useUpdate, useNotification } from "@pankod/refine-core";
+import React from "react"
+const { useState } = React;
+import {
+    Select,
+    Modal
+} from "@pankod/refine-antd";
+
+import { IFlexiblePriceRequest, IFlexiblePriceStatusModalProps } from "interfaces";
+
+const All_Justifications = [
+    {
+        label: '',
+        value: '',
+    },
+    {
+        label: 'Documents in order',
+        value: 'Documents in order'
+    },
+    {
+        label: 'Docs not notarized',
+        value: 'Docs not notarized'
+    },
+    {
+        label: 'Insufficient docs',
+        value: 'Insufficient docs'
+    },
+    {
+        label: 'Inaccurate income reported',
+        value: 'Inaccurate income reported'
+    },
+    { 
+        label: 'Inaccurate country reported',
+        value: 'Inaccurate country reported'
+    },
+];
+
+
+export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps> = (props) => {
+    const { record: modaldata, status, onClose } = props;
+    const { open: displayToast } = useNotification();
+    const mutationResult = useUpdate<IFlexiblePriceRequest>();
+    const { mutate } = mutationResult;
+
+    const [ justification, setJustification ] = useState(modaldata.justification);
+
+    const handleCancel = () => {
+        onClose();
+    }
+
+    const handleChangeJustification = (e: string) => {
+        setJustification(e);
+    }
+
+    const handleOk = () => {
+        if (justification.length === 0) {
+            displayToast({
+                message: "Please choose a justification.",
+                description: "Error",
+                key: "bad-justification-error",
+                type: "error",
+                undoableTimeout: 3000,
+            });
+
+            return;
+        }
+
+        const sendableData = { ...modaldata, status: status, justification: justification };
+
+        mutate({ 
+            resource: "flexible_pricing/applications_admin",
+            id: sendableData.id,
+            mutationMode: "undoable",
+            values: sendableData
+        });
+        handleCancel();
+    }
+
+    return (
+        <Modal title="Flexible Pricing | Management" visible={true} onOk={() => handleOk()} onCancel={handleCancel}>
+            <div>
+                <strong>Are you sure you want to <u>{status == "skipped" ? "deny": String(status).replace(/d|ped$/, '') }</u> the request?</strong>
+                {status == "skipped" ? <div>User will be notified by email of the denial </div> : null}
+            </div>
+            <br></br>
+            <p>
+                <strong>Current Status:</strong>
+                <div>{modaldata.status}</div>
+            </p>
+            <p>
+                <strong>Income USD:</strong>
+                <div>{modaldata.income_usd}</div>
+            </p>
+            <p>
+                <strong>Original Income:</strong>
+                <div>{modaldata.original_income}</div>
+            </p>
+            <p>
+                <strong>Original Currency:</strong>
+                <div>{modaldata.original_currency}</div>
+            </p>
+            <p>
+                <strong>Country of Income:</strong>
+                <div>{modaldata.country_of_income}</div>
+            </p>
+            <p>
+                <span>
+                    <strong>Justification:</strong>
+                </span>
+                <Select 
+                    onChange={(e) => handleChangeJustification(e)} 
+                    style={{ marginLeft: "20px", 'width': '20rem' }}
+                    options={All_Justifications}
+                    defaultValue={justification}
+                >
+                </Select>
+            </p>
+        </Modal>
+    );
+}

--- a/frontend/staff-dashboard/src/interfaces/index.d.ts
+++ b/frontend/staff-dashboard/src/interfaces/index.d.ts
@@ -45,3 +45,9 @@ export interface IFlexiblePriceRequestFilters {
     q: string;
     status: string;
 }
+
+export interface IFlexiblePriceStatusModalProps {
+    record: IFlexiblePriceRequest;
+    status: string;
+    onClose: Function;
+}

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -156,13 +156,16 @@ export const FlexiblePricingList: React.FC = () => {
                 description: "Error",
                 key: "bad-justification-error",
                 type: "error",
+                undoableTimeout: 3000,
             });
 
             return;
         }
-        console.log(justification);
-        setmodaldata({...modaldata, justification: justification})
-        console.log(modaldata);
+
+        let settable_modaldata = modaldata;
+        settable_modaldata.justification = justification;
+        setmodaldata(settable_modaldata)
+        
         handleUpdate(modaldata, modaldata.action)
         setIsModalVisible(false);
     };

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -1,4 +1,4 @@
-import { useUpdate, useNotification, CrudFilters, HttpError } from "@pankod/refine-core";
+import { CrudFilters, HttpError } from "@pankod/refine-core";
 import React from "react"
 const { useState } = React;
 import {
@@ -73,8 +73,6 @@ const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formPro
 }
 
 export const FlexiblePricingList: React.FC = () => {
-    const { open: displayToast } = useNotification();
-
     const {tableProps, searchFormProps} = useTable<
         IFlexiblePriceRequest,
         HttpError, 

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -16,12 +16,11 @@ import {
     Icons,
     Row,
     Col,
-    Card,
-    Modal
+    Card
 } from "@pankod/refine-antd";
 
 import { IFlexiblePriceRequest, IFlexiblePriceRequestFilters } from "interfaces";
-import { Type } from "typescript";
+import { FlexiblePricingStatusModal } from "components/flexiblepricing/statusmodal";
 
 const FlexiblePricingStatuses = [
     {
@@ -49,34 +48,6 @@ const FlexiblePricingStatuses = [
         value: 'reset'
     }
 ];
-
-const All_Justifications = [
-    {
-        label: '',
-        value: '',
-    },
-    {
-        label: 'OK',
-        value: 'Documents in order'
-    },
-    {
-        label: 'NOT_NOTARIZED',
-        value: 'Docs not notarized'
-    },
-    {
-        label: 'INSUFFICIENT',
-        value: 'Insufficient docs'
-    },
-    {
-        label: 'INCOME_INACCURATE',
-        value: 'Inaccurate income reported'
-    },
-    { 
-        label: 'COUNTRY_INACCURATE',
-        value: 'Inaccurate country reported'
-    },
-];
-
 
 const FlexiblePricingStatusText = "Select Status";
 
@@ -129,55 +100,18 @@ export const FlexiblePricingList: React.FC = () => {
             return filters;
         }
     });
-    const [modaldata, setmodaldata] = useState({} as IFlexiblePriceRequest);
+
+    const [modaldata, setModalData] = useState({} as IFlexiblePriceRequest);
+    const [approveStatus, setApproveStatus] = useState('');
+
     const [isModalVisible, setIsModalVisible] = useState(false);
-    const mutationResult = useUpdate<IFlexiblePriceRequest>();
-    const [justification, setJustification] = useState('');
-    const { mutate, isLoading: mutateIsLoading } = mutationResult;
-    const handleUpdate = (item: IFlexiblePriceRequest, status: string) => {
-        mutate({ 
-            resource: "flexible_pricing/applications_admin",
-            id: item.id,
-            mutationMode: "undoable",
-            values: { ...item, status }
-        });
-    };
-
+    
     const showModal = (record: IFlexiblePriceRequest, action: string) => {
-        const newRecord = {...record, 'action': action}
-        setmodaldata(newRecord);
+        setModalData(record);
+        setApproveStatus(action);
         setIsModalVisible(true);
+
     };
-
-    const handleOk = () => {
-        if (justification.length === 0) {
-            displayToast({
-                message: "Please choose a justification.",
-                description: "Error",
-                key: "bad-justification-error",
-                type: "error",
-                undoableTimeout: 3000,
-            });
-
-            return;
-        }
-
-        let settable_modaldata = modaldata;
-        settable_modaldata.justification = justification;
-        setmodaldata(settable_modaldata)
-        
-        handleUpdate(modaldata, modaldata.action)
-        setIsModalVisible(false);
-    };
-
-    const handleCancel = () => {
-        setIsModalVisible(false);
-    };
-
-    const handleChange = (e: string) => {
-        console.log(e);
-        setJustification(e)
-    }
 
     return (
         <div>
@@ -251,43 +185,6 @@ export const FlexiblePricingList: React.FC = () => {
                                                     Deny
                                                 </Button>
                                             </Space>
-                                            <Modal title="Flexible Pricing | Management" visible={isModalVisible} onOk={() => handleOk()} onCancel={handleCancel}>
-                                                    <div>
-                                                        <strong>Are you sure you want to <u>{modaldata.action == "skipped" ? "deny": String(modaldata.action).replace(/d|ped$/, '') }</u> the request?</strong>
-                                                        {modaldata.action == "skipped" ? <div>User will be notified by email of the denial </div> : null}
-                                                    </div>
-                                                    <br></br>
-                                                    <p>
-                                                        <strong>Current Status:</strong>
-                                                        <div>{modaldata.status}</div>
-                                                    </p>
-                                                    <p>
-                                                        <strong>Income USD:</strong>
-                                                        <div>{modaldata.income_usd}</div>
-                                                    </p>
-                                                    <p>
-                                                        <strong>Original Income:</strong>
-                                                        <div>{modaldata.original_income}</div>
-                                                    </p>
-                                                    <p>
-                                                        <strong>Original Currency:</strong>
-                                                        <div>{modaldata.original_currency}</div>
-                                                    </p>
-                                                    <p>
-                                                        <strong>Country of Income:</strong>
-                                                        <div>{modaldata.country_of_income}</div>
-                                                    </p>
-                                                    <p>
-                                                        <span>
-                                                            <strong>Justification:</strong>
-                                                        </span>
-                                                        <Select onChange={(e) => handleChange(e)} style={{ marginLeft: "20px", 'width': '20rem' }} defaultValue={modaldata['justification']}>
-                                                            {All_Justifications.map((option) => (
-                                                            <option value={option.value} selected={option.value === modaldata.justification}>{option.value}</option>
-                                                            ))}
-                                                        </Select>
-                                                    </p>
-                                                </Modal>
                                         </div>
                                     );
                                 }}
@@ -296,6 +193,7 @@ export const FlexiblePricingList: React.FC = () => {
                     </List>
                 </Col>
             </Row>
+            {isModalVisible ? <FlexiblePricingStatusModal record={modaldata} status={approveStatus} onClose={() => {setIsModalVisible(false);}}></FlexiblePricingStatusModal> : null}
         </div>
     );
 };

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -1,4 +1,4 @@
-import { useUpdate, CrudFilters, HttpError } from "@pankod/refine-core";
+import { useUpdate, useNotification, CrudFilters, HttpError } from "@pankod/refine-core";
 import React from "react"
 const { useState } = React;
 import {
@@ -52,6 +52,10 @@ const FlexiblePricingStatuses = [
 
 const All_Justifications = [
     {
+        label: '',
+        value: '',
+    },
+    {
         label: 'OK',
         value: 'Documents in order'
     },
@@ -98,6 +102,8 @@ const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formPro
 }
 
 export const FlexiblePricingList: React.FC = () => {
+    const { open: displayToast } = useNotification();
+
     const {tableProps, searchFormProps} = useTable<
         IFlexiblePriceRequest,
         HttpError, 
@@ -144,7 +150,19 @@ export const FlexiblePricingList: React.FC = () => {
     };
 
     const handleOk = () => {
-        modaldata['justification'] = justification
+        if (justification.length === 0) {
+            displayToast({
+                message: "Please choose a justification.",
+                description: "Error",
+                key: "bad-justification-error",
+                type: "error",
+            });
+
+            return;
+        }
+        console.log(justification);
+        setmodaldata({...modaldata, justification: justification})
+        console.log(modaldata);
         handleUpdate(modaldata, modaldata.action)
         setIsModalVisible(false);
     };
@@ -153,9 +171,10 @@ export const FlexiblePricingList: React.FC = () => {
         setIsModalVisible(false);
     };
 
-    const handleChange = (e: any) => {
-        setJustification(e.target.options[e.target.selectedIndex].text)
-      }
+    const handleChange = (e: string) => {
+        console.log(e);
+        setJustification(e)
+    }
 
     return (
         <div>
@@ -259,11 +278,11 @@ export const FlexiblePricingList: React.FC = () => {
                                                         <span>
                                                             <strong>Justification:</strong>
                                                         </span>
-                                                        <select onChange={(e) => handleChange(e)} style={{ marginLeft: "20px" }}>
+                                                        <Select onChange={(e) => handleChange(e)} style={{ marginLeft: "20px", 'width': '20rem' }} defaultValue={modaldata['justification']}>
                                                             {All_Justifications.map((option) => (
-                                                            <option value={option.value} selected={modaldata['justification'] == option.value}>{option.value}</option>
+                                                            <option value={option.value} selected={option.value === modaldata.justification}>{option.value}</option>
                                                             ))}
-                                                        </select>
+                                                        </Select>
                                                     </p>
                                                 </Modal>
                                         </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#665

#### What's this PR do?

Fixes #665 - refactors the approval modal out into its own component so that the state of the approval doesn't become weird. This also refactors the dialog to use the Ant Design `<Select>` component rather than a bare HTML `select` and adds a no-choice option for requests that haven't had a justification set yet.

#### How should this be manually tested?

1. Log into the staff dashboard and navigate to the Flexible Pricing screen.
2. Attempt to change the status of a request that has a justification set. Do not change the justification. The change should succeed. 
3. Attempt to change the status of a request that has not had a justification set. Leave the justification field blank. You should receive a toast informing you to choose a justification. 
4. Change the justification of a request and save the change. The justification should change. 
5. Open the status dialog on several requests. The Justification field should report the current justification that's set for each of them. 