### PR TITLE
Added order ID to the data that gets sent to the receipt email template

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -42,6 +42,7 @@ def send_ecommerce_order_receipt(order_record):
                     "order": {
                         "reference_number": order.get("reference_number"),
                         "created_on": parser.parse(order.get("created_on")),
+                        "id": order.get("id"),
                     },
                     "receipt": receipt,
                     "purchaser": {

--- a/ecommerce/templates/mail/product_order_receipt/body.html
+++ b/ecommerce/templates/mail/product_order_receipt/body.html
@@ -6,7 +6,7 @@
     <td class="rec-head" style="color: rgba(0,0,0,0.85); font: 14px/20px 'Arial', sans-serif; max-width: 696px; ">
         <p style="font-weight: normal; margin: 0 0 20px;">Dear {{ purchaser.name }},</p>
         <p style="font-weight: normal; margin: 0 0 20px;">You have been enrolled {% if content_title %} in {{ content_title }}{% endif %}.
-            The course should now appear on your MITxOnline <a href="{{ base_url }}{% url 'user-dashboard' %}" style="color: #0070DA">dashboard</a>. You can also access your receipt by <a style="color: #0070DA" href="{{ base_url }}/orders/receipt/{{order.id }}">clicking here</a>.
+            The course should now appear on your MITxOnline <a href="{{ base_url }}{% url 'user-dashboard' %}" style="color: #0070DA">dashboard</a>. You can also access your receipt by <a style="color: #0070DA" href="{{ base_url }}orders/receipt/{{order.id }}/">clicking here</a>.
         </p>
         <p style="font-weight: normal; margin: 0 0 20px;">Below you will find a copy of you receipt:</p>
     </td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#619 

#### What's this PR do?

Adds the order ID to the email receipt template so that the link to the online receipt works, and adjusts the generated URL so that the page loads properly. 

#### How should this be manually tested?

Complete a purchase. The link in the sentence "You can also access your receipt by clicking here" should include an ID and should take you to the correct order history page. 
