### PR TITLE
Changed to add in path to the file you need to edit for lms settings

### DIFF
--- a/docs/source/configuration/open_edx.rst
+++ b/docs/source/configuration/open_edx.rst
@@ -134,7 +134,7 @@ In MITx Online:
 
 In Open edX (derived from instructions `here <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_oauth.html#additional-oauth2-providers-advanced>`_):
 
-* ``make lms-shell`` into the LMS container and ensure the following settings:
+* ``make lms-shell`` into the LMS container and ensure the following settings are set in ``/edx/etc/lms.yml`` if you are using Juniper or a more recent Open edX release, otherwise they should be in ``/edx/app/edxapp/cms.env.json``:
     .. code-block:: yaml
 
       FEATURES:


### PR DESCRIPTION
#### Pre-Flight checklist

- nothing, this is a documentation change

#### What are the relevant tickets?
n/a

#### What's this PR do?

Adds in the path to the file you need to edit to configure LMS settings in the Open edX config instructions.

#### How should this be manually tested?

Should be a path under "Configure MITx Online as a OAuth provider for Open edX" in the "In Open edX" section, and it should be to the right file. 