### PR TITLE
Adds healthcheck to watch and refine containers; makes refine "depend" on watch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,12 @@ services:
     volumes:
       - .:/app
       - yarn-cache:/home/mitodl/.cache/yarn
+    healthcheck:
+      test: curl -f http://watch:8012/health || exit 1
+      interval: 5s
+      timeout: 1s
+      retries: 3
+      start_period: 30s
 
   celery:
     build:
@@ -128,6 +134,16 @@ services:
     volumes:
       - .:/app
       - npm-cache:/root/.npm
+    depends_on:
+      # this doesn't really depend on watch but they step on each other if they start at the same time
+      watch:
+        condition: service_healthy
+    healthcheck:
+      test: curl -f http://refine:8016/health || exit 1
+      interval: 5s
+      timeout: 1s
+      retries: 3
+      start_period: 30s
 
   notebook:
     build:


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

n/a

#### What's this PR do?

This makes a couple small changes to the `docker-compose.yml` file to make the services start up a bit more reliably locally:
1. Adds a healthcheck for the `watch` and `refine` containers that just pings the existing watchdog script. (This is required for the next bit for the watch container; added it to refine just for consistency.)
2. Adds a dependency on `refine` to `watch` so that they don't start up at the same time. 

After doing some troubleshooting with @annagav regarding her local instance not starting properly, I noticed that the `watch` container and the `refine` container seem to conflict with each other when they're starting up. (There's some package resolution that happens in each, and since they share the same `node_modules` folder one has a tendency to remove stuff that the other is expecting.) The end result of this is that either the `watch` container or the `refine` container fails to start. Restarting it fixes the problem but you have to figure out and restart whichever one failed, and if you don't catch it in time, the health check in the `web` container will also timeout and cause it to stop. So, this makes docker-compose check to see if the watch container has started up before starting the refine one. 

As an added benefit, the Docker healthcheck will restart the containers if they stop (but only a few times). 

#### How should this be manually tested?

You shouldn't have to completely tear down your environment (`docker compose down`) but it won't hurt to do it for testing. In addition, the problem here seems to manifest itself more on macOS than anywhere else; I can definitely reproduce this on macOS Monterey but not so much on my WSL/Ubuntu 20 environment. 

1. In a terminal, run this:
   ```
   while [ 1 ] ; do docker compose ps ; sleep 5 ; done
   ```
   This will loop the `ps` command so it's easier to see which containers are starting when. 
1. Start the environment using `docker compose up`.
3. Monitor the `ps` output. The `watch` container should come up first, and the `refine` container shouldn't move from "created" status until `watch` is "running (healthy)". 
4. When the app has come up, check to make sure everything's working as per usual. 

#### Other

The timings on the healthchecks might need some adjustment.