### PR TITLE
Fixes link to order receipt in the email

### DIFF
--- a/ecommerce/templates/mail/product_order_receipt/body.html
+++ b/ecommerce/templates/mail/product_order_receipt/body.html
@@ -6,9 +6,9 @@
     <td class="rec-head" style="color: rgba(0,0,0,0.85); font: 14px/20px 'Arial', sans-serif; max-width: 696px; ">
         <p style="font-weight: normal; margin: 0 0 20px;">Dear {{ purchaser.name }},</p>
         <p style="font-weight: normal; margin: 0 0 20px;">You have been enrolled {% if content_title %} in {{ content_title }}{% endif %}.
-            The course should now appear on your MITxOnline <a href="{{ base_url }}{% url 'user-dashboard' %}" style="color: #0070DA">dashboard</a>. You can also access your receipt by <a style="color: #0070DA" href="{{ base_url }}orders/receipt/{{order.id }}/">clicking here</a>.
+            The course should now appear on your MITxOnline <a href="{{ base_url }}{% url 'user-dashboard' %}" style="color: #0070DA">dashboard</a>. You can also access your receipt by <a style="color: #0070DA" href="{{ base_url }}/orders/receipt/{{order.id }}/">clicking here</a>.
         </p>
-        <p style="font-weight: normal; margin: 0 0 20px;">Below you will find a copy of you receipt:</p>
+        <p style="font-weight: normal; margin: 0 0 20px;">Below you will find a copy of your receipt:</p>
     </td>
     <tr>
         <td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#619

#### What's this PR do?

The URL for the order receipt was bad; this tested OK locally but that was due to also having some local config set wrong. This also fixes a typo in the text ("Below you will find a copy of your receipt" vs. "Below you will find a copy of you receipt"). 

#### How should this be manually tested?

Generate a receipt email. you can do this either by creating a new order, or through the shell. (In the shell, I just import the Order model and the `send_ecommerce_order_receipt` function from mail_api and then run `send_ecommerce_order_receipt` on the last Order object to test.) The receipt link should be valid and the text immediately following it should be correct. 
