### PR TITLE
Use master branch and don't clone mitodl edx

### DIFF
--- a/docs/source/configuration/open_edx.rst
+++ b/docs/source/configuration/open_edx.rst
@@ -23,18 +23,8 @@ Clone edx/devstack
 
   git clone https://github.com/edx/devstack
   cd devstack
-  git checkout open-release/ironwood.master
   make requirements
-  export OPENEDX_RELEASE=ironwood.master
   make dev.clone
-
-Clone and checkout edx-platform (if not already)
-------------------------------------------------
-
-.. code-block:: shell
-
-  git clone https://github.com/mitodl/edx-platform
-  git checkout master
 
 Pull latest images and run provision
 ------------------------------------


### PR DESCRIPTION
Removal of out-of-date instructions.

#### What's this PR do?
Removes instructions in order to ensure that the reader will use the master branch for `devstack` instead of a specific version.  Removes instructions for the reader to clone the mitodl edx repo which is no longer required.