### PR TITLE
Flexible pricing display personalized price

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -60,7 +60,9 @@ class ProductRelatedField(serializers.RelatedField):
     """serializer for the Product generic field"""
 
     def to_representation(self, instance):
-        serializer = ProductFlexibilePriceSerializer(instance=instance, context=self.context)
+        serializer = ProductFlexibilePriceSerializer(
+            instance=instance, context=self.context
+        )
         return serializer.data
 
 

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -15,7 +15,7 @@ from courses import models
 from courses.api import create_run_enrollments
 from courses.models import ProgramRun, CourseRun
 from ecommerce.models import Product
-from ecommerce.serializers import ProductSerializer, BaseProductSerializer
+from ecommerce.serializers import ProductFlexibilePriceSerializer, BaseProductSerializer
 from main import features
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
@@ -59,8 +59,8 @@ class BaseCourseSerializer(serializers.ModelSerializer):
 class ProductRelatedField(serializers.RelatedField):
     """serializer for the Product generic field"""
 
-    def to_representation(self, value):
-        serializer = BaseProductSerializer(value)
+    def to_representation(self, instance):
+        serializer = ProductFlexibilePriceSerializer(instance=instance, context=self.context)
         return serializer.data
 
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -14,6 +14,7 @@ from ecommerce.constants import TRANSACTION_TYPE_REFUND, CYBERSOURCE_CARD_TYPES
 
 from cms.serializers import CoursePageSerializer
 
+from flexiblepricing.api import determine_courseware_flexible_price_discount
 
 class ProgramRunProductPurchasableObjectSerializer(serializers.ModelSerializer):
     class Meta:
@@ -89,6 +90,19 @@ class ProductSerializer(BaseProductSerializer):
     class Meta:
         fields = BaseProductSerializer.Meta.fields + [
             "purchasable_object",
+        ]
+        model = models.Product
+        
+class ProductFlexibilePriceSerializer(BaseProductSerializer):
+    product_flexible_price = serializers.SerializerMethodField()
+    
+    def get_product_flexible_price(self, instance):
+        discount_record = determine_courseware_flexible_price_discount(instance, self.context["request"].user)
+        return DiscountSerializer(discount_record, context=self.context).data
+
+    class Meta:
+        fields = BaseProductSerializer.Meta.fields + [
+            "product_flexible_price",
         ]
         model = models.Product
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -16,6 +16,7 @@ from cms.serializers import CoursePageSerializer
 
 from flexiblepricing.api import determine_courseware_flexible_price_discount
 
+
 class ProgramRunProductPurchasableObjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProgramRun
@@ -92,12 +93,15 @@ class ProductSerializer(BaseProductSerializer):
             "purchasable_object",
         ]
         model = models.Product
-        
+
+
 class ProductFlexibilePriceSerializer(BaseProductSerializer):
     product_flexible_price = serializers.SerializerMethodField()
-    
+
     def get_product_flexible_price(self, instance):
-        discount_record = determine_courseware_flexible_price_discount(instance, self.context["request"].user)
+        discount_record = determine_courseware_flexible_price_discount(
+            instance, self.context["request"].user
+        )
         return DiscountSerializer(discount_record, context=self.context).data
 
     class Meta:

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -103,7 +103,8 @@ def test_product_program_serializer(mock_context):
             "purchasable_object": run_serialized,
         },
     )
-    
+
+
 def test_product_flexible_price_serializer(mock_context):
     """
     Tests serialization of a product that has an associated flexible price for the user.
@@ -129,7 +130,8 @@ def test_product_flexible_price_serializer(mock_context):
                 "redemption_type": flexible_price.tier.discount.redemption_type,
                 "max_redemptions": None,
                 "discount_code": flexible_price.tier.discount.discount_code,
-                "for_flexible_pricing": flexible_price.tier.discount.for_flexible_pricing}
+                "for_flexible_pricing": flexible_price.tier.discount.for_flexible_pricing,
+            },
         },
     )
 

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -128,7 +128,7 @@ def test_product_flexible_price_serializer(mock_context):
                 "automatic": None,
                 "discount_code": flexible_price.tier.discount.discount_code,
                 "discount_type": flexible_price.tier.discount.discount_type,
-                "for_flexible_pricing": None
+                "for_flexible_pricing": None,
                 "id": flexible_price.tier.discount.id,
                 "max_redemptions": None,
                 "redemption_type": flexible_price.tier.discount.redemption_type,

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,46 +1,46 @@
-from flexiblepricing.factories import FlexiblePriceFactory
-import pytest
 import json
-from main.test_utils import assert_drf_json_equal
-from django.urls import reverse
-import reversion
 from decimal import Decimal
+
+from django.test import RequestFactory
+from flexiblepricing.constants import FlexiblePriceStatus
+from flexiblepricing.models import FlexiblePrice
+
+import pytest
+import reversion
 from dateutil.parser import parse
+from django.contrib.auth.models import AnonymousUser
+from django.urls import reverse
+from mitol.common.utils import now_in_utc
 
-from courses.factories import (
-    CourseRunFactory,
-    ProgramFactory,
-    ProgramRunFactory,
-)
-from courses.models import ProgramRun, CourseRun
-
-from ecommerce.serializers import (
-    BasketWithProductSerializer,
-    ProductSerializer,
-    CourseRunProductPurchasableObjectSerializer,
-    ProgramRunProductPurchasableObjectSerializer,
-    BasketSerializer,
-    BasketItemSerializer,
-    BaseProductSerializer,
-    OrderReceiptSerializer,
-    TransactionPurchaseSerializer,
-    TransactionPurchaserSerializer,
-    TransactionOrderSerializer,
-    TransactionLineSerializer,
-)
+from courses.factories import CourseRunFactory, ProgramFactory, ProgramRunFactory
+from courses.models import CourseRun, ProgramRun
+from ecommerce.constants import CYBERSOURCE_CARD_TYPES
+from ecommerce.discounts import DiscountType
 from ecommerce.factories import (
-    ProductFactory,
     BasketItemFactory,
+    ProductFactory,
     UnlimitedUseDiscountFactory,
 )
 from ecommerce.models import BasketDiscount, Order
-from ecommerce.discounts import DiscountType
-from ecommerce.constants import CYBERSOURCE_CARD_TYPES
+from ecommerce.serializers import (
+    BaseProductSerializer,
+    BasketItemSerializer,
+    BasketSerializer,
+    BasketWithProductSerializer,
+    CourseRunProductPurchasableObjectSerializer,
+    OrderReceiptSerializer,
+    ProductFlexibilePriceSerializer,
+    ProductSerializer,
+    ProgramRunProductPurchasableObjectSerializer,
+    TransactionLineSerializer,
+    TransactionOrderSerializer,
+    TransactionPurchaserSerializer,
+    TransactionPurchaseSerializer,
+)
 from ecommerce.views_test import create_basket, payment_gateway_settings
-
+from flexiblepricing.factories import FlexiblePriceFactory
+from main.test_utils import assert_drf_json_equal
 from users.factories import UserFactory
-
-from mitol.common.utils import now_in_utc
 
 pytestmark = [pytest.mark.django_db]
 
@@ -109,12 +109,20 @@ def test_product_flexible_price_serializer(mock_context):
     """
     Tests serialization of a product that has an associated flexible price for the user.
     """
-    run = ProgramRunFactory.create()
+    program = ProgramFactory.create()
+    run = CourseRunFactory.create(course__program=program)
     product = ProductFactory.create(purchasable_object=run)
-    product_serialized = ProductSerializer(instance=product).data
-    run_serialized = ProgramRunProductPurchasableObjectSerializer(instance=run).data
-    flexible_price = FlexiblePriceFactory.create()
-
+    flexible_price = FlexiblePriceFactory.create(
+        courseware_object=run.course,
+        user=mock_context["request"].user,
+        status=FlexiblePriceStatus.APPROVED,
+    )
+    product_serialized = ProductFlexibilePriceSerializer(
+        context={**mock_context}, instance=product
+    ).data
+    product_serialized["product_flexible_price"]["amount"] = float(
+        product_serialized["product_flexible_price"]["amount"]
+    )
     assert_drf_json_equal(
         product_serialized,
         {
@@ -122,15 +130,14 @@ def test_product_flexible_price_serializer(mock_context):
             "id": product.id,
             "is_active": product.is_active,
             "price": str(product.price),
-            "purchasable_object": run_serialized,
             "product_flexible_price": {
-                "amount": flexible_price.tier.discount.amount,
-                "automatic": None,
+                "amount": float(flexible_price.tier.discount.amount),
+                "automatic": flexible_price.tier.discount.automatic,
                 "discount_code": flexible_price.tier.discount.discount_code,
                 "discount_type": flexible_price.tier.discount.discount_type,
-                "for_flexible_pricing": None,
+                "for_flexible_pricing": flexible_price.tier.discount.for_flexible_pricing,
                 "id": flexible_price.tier.discount.id,
-                "max_redemptions": None,
+                "max_redemptions": flexible_price.tier.discount.max_redemptions,
                 "redemption_type": flexible_price.tier.discount.redemption_type,
             },
         },

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -130,7 +130,7 @@ def test_product_flexible_price_serializer(mock_context):
                 "discount_type": flexible_price.tier.discount.discount_type,
                 "redemption_type": flexible_price.tier.discount.redemption_type,
                 "max_redemptions": None,
-                "discount_code": flexible_price.tier.discount.discount_code
+                "discount_code": flexible_price.tier.discount.discount_code,
             },
         },
     )

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -124,13 +124,14 @@ def test_product_flexible_price_serializer(mock_context):
             "price": str(product.price),
             "purchasable_object": run_serialized,
             "product_flexible_price": {
-                "id": flexible_price.tier.discount.id,
                 "amount": flexible_price.tier.discount.amount,
                 "automatic": None,
-                "discount_type": flexible_price.tier.discount.discount_type,
-                "redemption_type": flexible_price.tier.discount.redemption_type,
-                "max_redemptions": None,
                 "discount_code": flexible_price.tier.discount.discount_code,
+                "discount_type": flexible_price.tier.discount.discount_type,
+                "for_flexible_pricing": None
+                "id": flexible_price.tier.discount.id,
+                "max_redemptions": None,
+                "redemption_type": flexible_price.tier.discount.redemption_type,
             },
         },
     )

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,3 +1,4 @@
+from flexiblepricing.factories import FlexiblePriceFactory
 import pytest
 import json
 from main.test_utils import assert_drf_json_equal
@@ -100,6 +101,35 @@ def test_product_program_serializer(mock_context):
             "is_active": product.is_active,
             "price": str(product.price),
             "purchasable_object": run_serialized,
+        },
+    )
+    
+def test_product_flexible_price_serializer(mock_context):
+    """
+    Tests serialization of a product that has an associated flexible price for the user.
+    """
+    run = ProgramRunFactory.create()
+    product = ProductFactory.create(purchasable_object=run)
+    product_serialized = ProductSerializer(instance=product).data
+    run_serialized = ProgramRunProductPurchasableObjectSerializer(instance=run).data
+    flexible_price = FlexiblePriceFactory.create()
+
+    assert_drf_json_equal(
+        product_serialized,
+        {
+            "description": product.description,
+            "id": product.id,
+            "is_active": product.is_active,
+            "price": str(product.price),
+            "purchasable_object": run_serialized,
+            "product_flexible_price": {
+                "amount": flexible_price.tier.discount.amount,
+                "automatic": None,
+                "discount_type": flexible_price.tier.discount.discount_type,
+                "redemption_type": flexible_price.tier.discount.redemption_type,
+                "max_redemptions": None,
+                "discount_code": flexible_price.tier.discount.discount_code,
+                "for_flexible_pricing": flexible_price.tier.discount.for_flexible_pricing}
         },
     )
 

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -130,8 +130,7 @@ def test_product_flexible_price_serializer(mock_context):
                 "discount_type": flexible_price.tier.discount.discount_type,
                 "redemption_type": flexible_price.tier.discount.redemption_type,
                 "max_redemptions": None,
-                "discount_code": flexible_price.tier.discount.discount_code,
-                "for_flexible_pricing": flexible_price.tier.discount.for_flexible_pricing,
+                "discount_code": flexible_price.tier.discount.discount_code
             },
         },
     )

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -124,6 +124,7 @@ def test_product_flexible_price_serializer(mock_context):
             "price": str(product.price),
             "purchasable_object": run_serialized,
             "product_flexible_price": {
+                "id": flexible_price.tier.discount.id,
                 "amount": flexible_price.tier.discount.amount,
                 "automatic": None,
                 "discount_type": flexible_price.tier.discount.discount_type,

--- a/frontend/public/src/constants.js
+++ b/frontend/public/src/constants.js
@@ -163,3 +163,7 @@ export const ORDER_HISTORY_COLUMN_TITLES = [
   "Order number",
   "Order details"
 ]
+
+export const DISCOUNT_TYPE_FIXED_PRICE = "fixed-price"
+export const DISCOUNT_TYPE_DOLLARS_OFF = "dollars-off"
+export const DISCOUNT_TYPE_PERCENT_OFF = "percent-off"

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -50,6 +50,8 @@ function calculateCoursePriceWithFlex(coursePrice, flexDiscountAmount, flexDisco
     return coursePrice - ((flexDiscountAmount / 100) * coursePrice)
   case DISCOUNT_TYPE_FIXED_PRICE:
     return flexDiscountAmount
+  default:
+    return coursePrice
   }
 }
 

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -55,7 +55,6 @@ export class ProductDetailEnrollApp extends React.Component<
     const { courseRuns } = this.props
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
-    const flexPriceDiscountAmount = product.product_flexible_price ?? 0
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
@@ -71,7 +70,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${product.price - flexPriceDiscountAmount}</div>
+            <div className="text-right align-self-end">${product.price - product.product_flexible_price.amount}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -8,6 +8,12 @@ import { connect } from "react-redux"
 import { connectRequest } from "redux-query"
 import { Modal, ModalBody, ModalHeader } from "reactstrap"
 
+import {
+  DISCOUNT_TYPE_DOLLARS_OFF,
+  DISCOUNT_TYPE_PERCENT_OFF,
+  DISCOUNT_TYPE_FIXED_PRICE
+} from "../constants"
+
 import Loader from "../components/Loader"
 import { routes } from "../lib/urls"
 import { EnrollmentFlaggedCourseRun } from "../flow/courseTypes"
@@ -36,6 +42,17 @@ type ProductDetailState = {
   upgradeEnrollmentDialogVisibility: boolean
 }
 
+function calculateCoursePriceWithFlex(coursePrice, flexDiscountAmount, flexDiscountType) {
+  switch (flexDiscountType) {
+  case DISCOUNT_TYPE_DOLLARS_OFF:
+    return coursePrice - flexDiscountAmount
+  case DISCOUNT_TYPE_PERCENT_OFF:
+    return coursePrice - ((flexDiscountAmount / 100) * coursePrice)
+  case DISCOUNT_TYPE_FIXED_PRICE:
+    return flexDiscountAmount
+  }
+}
+
 export class ProductDetailEnrollApp extends React.Component<
   Props,
   ProductDetailState
@@ -55,7 +72,9 @@ export class ProductDetailEnrollApp extends React.Component<
     const { courseRuns } = this.props
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
-    const flexPriceDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
+    const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
+    const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
+    const flexAdjustedCoursePrice = Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2)
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
@@ -71,7 +90,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${product.price - flexPriceDiscountAmount}</div>
+            <div className="text-right align-self-end">${flexAdjustedCoursePrice}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -70,7 +70,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${product.price - product.product_flexible_price.amount}</div>
+            <div className="text-right align-self-end">${product.price - product.product_flexible_price?.amount}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -55,6 +55,7 @@ export class ProductDetailEnrollApp extends React.Component<
     const { courseRuns } = this.props
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
+    const flexPriceDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
@@ -70,7 +71,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${product.price - product.product_flexible_price.amount}</div>
+            <div className="text-right align-self-end">${product.price - flexPriceDiscountAmount}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -55,6 +55,7 @@ export class ProductDetailEnrollApp extends React.Component<
     const { courseRuns } = this.props
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
+    const flexPriceDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
@@ -70,7 +71,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${product.price - product.product_flexible_price?.amount}</div>
+            <div className="text-right align-self-end">${product.price - flexPriceDiscountAmount}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -8,14 +8,9 @@ import { connect } from "react-redux"
 import { connectRequest } from "redux-query"
 import { Modal, ModalBody, ModalHeader } from "reactstrap"
 
-import {
-  DISCOUNT_TYPE_DOLLARS_OFF,
-  DISCOUNT_TYPE_PERCENT_OFF,
-  DISCOUNT_TYPE_FIXED_PRICE
-} from "../constants"
-
 import Loader from "../components/Loader"
 import { routes } from "../lib/urls"
+import { getFlexiblePriceForProduct } from "../lib/util"
 import { EnrollmentFlaggedCourseRun } from "../flow/courseTypes"
 import {
   courseRunsSelector,
@@ -42,19 +37,6 @@ type ProductDetailState = {
   upgradeEnrollmentDialogVisibility: boolean
 }
 
-function calculateCoursePriceWithFlex(coursePrice, flexDiscountAmount, flexDiscountType) {
-  switch (flexDiscountType) {
-  case DISCOUNT_TYPE_DOLLARS_OFF:
-    return coursePrice - flexDiscountAmount
-  case DISCOUNT_TYPE_PERCENT_OFF:
-    return coursePrice - ((flexDiscountAmount / 100) * coursePrice)
-  case DISCOUNT_TYPE_FIXED_PRICE:
-    return flexDiscountAmount
-  default:
-    return coursePrice
-  }
-}
-
 export class ProductDetailEnrollApp extends React.Component<
   Props,
   ProductDetailState
@@ -74,9 +56,6 @@ export class ProductDetailEnrollApp extends React.Component<
     const { courseRuns } = this.props
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
-    const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
-    const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
-    const flexAdjustedCoursePrice = product ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
@@ -92,7 +71,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${flexAdjustedCoursePrice}</div>
+            <div className="text-right align-self-end">${getFlexiblePriceForProduct(product)}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -55,7 +55,7 @@ export class ProductDetailEnrollApp extends React.Component<
     const { courseRuns } = this.props
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
-    const flexPriceDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
+    const flexPriceDiscountAmount = product.product_flexible_price ?? 0
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -76,7 +76,7 @@ export class ProductDetailEnrollApp extends React.Component<
     const product = run.products ? run.products[0] : null
     const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
     const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
-    const flexAdjustedCoursePrice = product.price ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
+    const flexAdjustedCoursePrice = product ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -70,7 +70,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${product.price}</div>
+            <div className="text-right align-self-end">${product.price - product.product_flexible_price.amount}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -76,7 +76,7 @@ export class ProductDetailEnrollApp extends React.Component<
     const product = run.products ? run.products[0] : null
     const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
     const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
-    const flexAdjustedCoursePrice = Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2)
+    const flexAdjustedCoursePrice = product.price ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
     return product ? (
       <Modal
         id={`upgrade-enrollment-dialog`}

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -207,6 +207,7 @@ describe("ProductDetailEnrollApp", () => {
     [false, 400]
   ].forEach(([success, returnedStatusCode]) => {
     it(`shows dialog to upgrade user enrollment and handles ${returnedStatusCode} response`, async () => {
+      courseRun["products"] = [{ id: 1, price: 10, product_flexible_price: { amount: 1 }}]
       isWithinEnrollmentPeriodStub.returns(true)
       SETTINGS.features.upgrade_dialog = true
       const { inner } = await renderPage()
@@ -227,6 +228,15 @@ describe("ProductDetailEnrollApp", () => {
       assert.isTrue(upgradeForm.exists())
 
       assert.equal(upgradeForm.find("input[type='hidden']").prop("value"), "1")
+
+      assert.equal(
+        inner
+          .find(".text-right")
+          .at(0)
+          .text()
+          .at(1),
+        "9"
+      )
     })
   })
 })

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -24,7 +24,7 @@ describe("ProductDetailEnrollApp", () => {
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
-    courseRun = makeCourseRunDetail()
+    courseRun = makeCourseRunDetailWithProduct()
     currentUser = makeUser()
     courseRun["products"] = [{ id: 1 }]
     renderPage = helper.configureHOCRenderer(

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -14,6 +14,12 @@ import {
   makeCourseRunDetailWithProduct
 } from "../factories/course"
 
+import {
+  DISCOUNT_TYPE_DOLLARS_OFF,
+  DISCOUNT_TYPE_PERCENT_OFF,
+  DISCOUNT_TYPE_FIXED_PRICE
+} from "../constants"
+
 import * as courseApi from "../lib/courseApi"
 
 import sinon from "sinon"
@@ -206,8 +212,74 @@ describe("ProductDetailEnrollApp", () => {
     [true, 201],
     [false, 400]
   ].forEach(([success, returnedStatusCode]) => {
-    it(`shows dialog to upgrade user enrollment and handles ${returnedStatusCode} response`, async () => {
-      courseRun["products"] = [{ id: 1, price: 10, product_flexible_price: { amount: 1 }}]
+    it(`shows dialog to upgrade user enrollment with flexible dollars-off discount and handles ${returnedStatusCode} response`, async () => {
+      courseRun["products"] = [{ id: 1, price: 10, product_flexible_price: { amount: 1, discount_type: DISCOUNT_TYPE_DOLLARS_OFF}}]
+      isWithinEnrollmentPeriodStub.returns(true)
+      SETTINGS.features.upgrade_dialog = true
+      const { inner } = await renderPage()
+
+      sinon.assert.calledWith(
+        helper.handleRequestStub,
+        "/api/course_runs/?relevant_to=",
+        "GET"
+      )
+      sinon.assert.calledWith(helper.handleRequestStub, "/api/users/me", "GET")
+
+      const enrollBtn = inner.find(".enroll-now").at(0)
+      assert.isTrue(enrollBtn.exists())
+      await enrollBtn.prop("onClick")()
+
+      const modal = inner.find(".upgrade-enrollment-modal")
+      const upgradeForm = modal.find("form").at(0)
+      assert.isTrue(upgradeForm.exists())
+
+      assert.equal(upgradeForm.find("input[type='hidden']").prop("value"), "1")
+
+      assert.equal(
+        inner
+          .find(".text-right")
+          .at(0)
+          .text()
+          .at(1),
+        "9"
+      )
+    })
+
+    it(`shows dialog to upgrade user enrollment with flexible percent-off discount and handles ${returnedStatusCode} response`, async () => {
+      courseRun["products"] = [{ id: 1, price: 10, product_flexible_price: { amount: 10, discount_type: DISCOUNT_TYPE_PERCENT_OFF}}]
+      isWithinEnrollmentPeriodStub.returns(true)
+      SETTINGS.features.upgrade_dialog = true
+      const { inner } = await renderPage()
+
+      sinon.assert.calledWith(
+        helper.handleRequestStub,
+        "/api/course_runs/?relevant_to=",
+        "GET"
+      )
+      sinon.assert.calledWith(helper.handleRequestStub, "/api/users/me", "GET")
+
+      const enrollBtn = inner.find(".enroll-now").at(0)
+      assert.isTrue(enrollBtn.exists())
+      await enrollBtn.prop("onClick")()
+
+      const modal = inner.find(".upgrade-enrollment-modal")
+      const upgradeForm = modal.find("form").at(0)
+      assert.isTrue(upgradeForm.exists())
+
+      assert.equal(upgradeForm.find("input[type='hidden']").prop("value"), "1")
+
+      assert.equal(
+        inner
+          .find(".text-right")
+          .at(0)
+          .text()
+          .at(1),
+        "9"
+      )
+    })
+
+    it(`shows dialog to upgrade user enrollment with flexible fixed-price discount and handles ${returnedStatusCode} response`, async () => {
+      courseRun["products"] = [{ id: 1, price: 10, product_flexible_price: { amount: 9, discount_type: DISCOUNT_TYPE_FIXED_PRICE}}]
       isWithinEnrollmentPeriodStub.returns(true)
       SETTINGS.features.upgrade_dialog = true
       const { inner } = await renderPage()

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -50,6 +50,8 @@ function calculateCoursePriceWithFlex(coursePrice, flexDiscountAmount, flexDisco
     return coursePrice - ((flexDiscountAmount / 100) * coursePrice)
   case DISCOUNT_TYPE_FIXED_PRICE:
     return flexDiscountAmount
+  default:
+    return coursePrice
   }
 }
 

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -64,7 +64,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
             <h2>Get a certificate</h2>
           </div>
           <div className="text-right align-self-end">
-            <h2>${product.price - flexPriceDiscountAmount ?? null}</h2>
+            <h2>${product.price - flexPriceDiscountAmount}</h2>
           </div>
         </div>
         <div className="row">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -64,7 +64,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
             <h2>Get a certificate</h2>
           </div>
           <div className="text-right align-self-end">
-            <h2>${product.price - flexPriceDiscountAmount}</h2>
+            <h2>${product.price - flexPriceDiscountAmount ?? null}</h2>
           </div>
         </div>
         <div className="row">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -54,6 +54,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
       run.products && !run.is_verified && run.is_enrolled
         ? run.products[0]
         : null
+    const flexPriceDiscountAmount = product.product_flexible_price ? product.product_flexible_price.amount : 0
 
     return product ? (
       <div className="card">
@@ -63,7 +64,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
             <h2>Get a certificate</h2>
           </div>
           <div className="text-right align-self-end">
-            <h2>${product.price - product.product_flexible_price.amount}</h2>
+            <h2>${product.price - flexPriceDiscountAmount}</h2>
           </div>
         </div>
         <div className="row">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -75,7 +75,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
         : null
     const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
     const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
-    const flexAdjustedCoursePrice = product.price ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
+    const flexAdjustedCoursePrice = product ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
     return product ? (
       <div className="card">
         <div className="row d-flex upsell-header">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -126,7 +126,6 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
   }
 
 
-
   render() {
     const { courseRuns, isLoading, status } = this.props
     const csrfToken = getCookie("csrftoken")

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -54,7 +54,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
       run.products && !run.is_verified && run.is_enrolled
         ? run.products[0]
         : null
-    const flexPriceDiscountAmount = product?.product_flexible_price ? product.product_flexible_price.amount : 0
+    const flexPriceDiscountAmount = product ? product.product_flexible_price.amount : 0
 
     return product ? (
       <div className="card">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -75,7 +75,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
         : null
     const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
     const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
-    const flexAdjustedCoursePrice = Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2)
+    const flexAdjustedCoursePrice = product.price ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
     return product ? (
       <div className="card">
         <div className="row d-flex upsell-header">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -54,7 +54,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
       run.products && !run.is_verified && run.is_enrolled
         ? run.products[0]
         : null
-    const flexPriceDiscountAmount = product ? product.product_flexible_price.amount : 0
+    const flexPriceDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
 
     return product ? (
       <div className="card">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -8,12 +8,6 @@ import { connect } from "react-redux"
 import { connectRequest } from "redux-query"
 import { Badge } from "reactstrap"
 
-import {
-  DISCOUNT_TYPE_DOLLARS_OFF,
-  DISCOUNT_TYPE_PERCENT_OFF,
-  DISCOUNT_TYPE_FIXED_PRICE
-} from "../constants"
-
 import Loader from "../components/Loader"
 import { routes } from "../lib/urls"
 import { EnrollmentFlaggedCourseRun } from "../flow/courseTypes"
@@ -22,6 +16,7 @@ import {
   courseRunsQuery,
   courseRunsQueryKey
 } from "../lib/queries/courseRuns"
+import { getFlexiblePriceForProduct } from "../lib/util"
 
 import { isWithinEnrollmentPeriod } from "../lib/courseApi"
 
@@ -42,19 +37,6 @@ type ProductDetailState = {
   upgradeEnrollmentDialogVisibility: boolean
 }
 
-function calculateCoursePriceWithFlex(coursePrice, flexDiscountAmount, flexDiscountType) {
-  switch (flexDiscountType) {
-  case DISCOUNT_TYPE_DOLLARS_OFF:
-    return coursePrice - flexDiscountAmount
-  case DISCOUNT_TYPE_PERCENT_OFF:
-    return coursePrice - ((flexDiscountAmount / 100) * coursePrice)
-  case DISCOUNT_TYPE_FIXED_PRICE:
-    return flexDiscountAmount
-  default:
-    return coursePrice
-  }
-}
-
 export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
   state = {
     upgradeEnrollmentDialogVisibility: false
@@ -73,9 +55,6 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
       run.products && !run.is_verified && run.is_enrolled
         ? run.products[0]
         : null
-    const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
-    const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
-    const flexAdjustedCoursePrice = product ? Number(calculateCoursePriceWithFlex(product.price, flexDiscountAmount, flexDiscountType)).toFixed(2) : null
     return product ? (
       <div className="card">
         <div className="row d-flex upsell-header">
@@ -84,7 +63,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
             <h2>Get a certificate</h2>
           </div>
           <div className="text-right align-self-end">
-            <h2>${flexAdjustedCoursePrice}</h2>
+            <h2>${getFlexiblePriceForProduct(product)}</h2>
           </div>
         </div>
         <div className="row">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -54,7 +54,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
       run.products && !run.is_verified && run.is_enrolled
         ? run.products[0]
         : null
-    const flexPriceDiscountAmount = product.product_flexible_price ? product.product_flexible_price.amount : 0
+    const flexPriceDiscountAmount = product?.product_flexible_price ? product.product_flexible_price.amount : 0
 
     return product ? (
       <div className="card">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -63,7 +63,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
             <h2>Get a certificate</h2>
           </div>
           <div className="text-right align-self-end">
-            <h2>${product.price}</h2>
+            <h2>${product.price - product.product_flexible_price.amount}</h2>
           </div>
         </div>
         <div className="row">

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -59,6 +59,15 @@ export const makeCourseRunWithProduct = (): CourseRun => ({
       id:          genProductId.next().value,
       is_active:   true,
       price:       casual.integer(1, 200)
+      product_flexible_price: {
+        amount:              null,
+        automatic:           false,
+        discount_type:       null,
+        redemption_type:     null,
+        max_redemptions:     null,
+        discount_code:       "",
+        for_flexible_pricing:false
+      }
     }
   ]
 })

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -55,18 +55,18 @@ export const makeCourseRunWithProduct = (): CourseRun => ({
   course_number:    casual.word,
   products:         [
     {
-      description: casual.text,
-      id:          genProductId.next().value,
-      is_active:   true,
-      price:       casual.integer(1, 200),
+      description:            casual.text,
+      id:                     genProductId.next().value,
+      is_active:              true,
+      price:                  casual.integer(1, 200),
       product_flexible_price: {
-        amount:              null,
-        automatic:           false,
-        discount_type:       null,
-        redemption_type:     null,
-        max_redemptions:     null,
-        discount_code:       "",
-        for_flexible_pricing:false
+        amount:               null,
+        automatic:            false,
+        discount_type:        null,
+        redemption_type:      null,
+        max_redemptions:      null,
+        discount_code:        "",
+        for_flexible_pricing: false
       }
     }
   ]

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -58,7 +58,7 @@ export const makeCourseRunWithProduct = (): CourseRun => ({
       description: casual.text,
       id:          genProductId.next().value,
       is_active:   true,
-      price:       casual.integer(1, 200)
+      price:       casual.integer(1, 200),
       product_flexible_price: {
         amount:              null,
         automatic:           false,

--- a/frontend/public/src/flow/cartTypes.js
+++ b/frontend/public/src/flow/cartTypes.js
@@ -8,7 +8,8 @@ export type Product = {
   price: number,
   description: string,
   purchasable_object: any,
-  is_active: boolean
+  is_active: boolean,
+  product_flexible_price: Discount
 }
 
 export type BasketItem = {

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -231,10 +231,9 @@ export const formatLocalePrice = (amount: number | null) => {
   return amount.toLocaleString("en-US", { style: "currency", currency: "USD" })
 }
 
-export const getFlexiblePriceForProduct = product => {
+export const getFlexiblePriceForProduct = (product:any) => {
   const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
   const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
-  const flexAdjustedCoursePrice = product ? formatLocalePrice(product.price, flexDiscountAmount, flexDiscountType) : null
 
   switch (flexDiscountType) {
   case DISCOUNT_TYPE_DOLLARS_OFF:

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -23,6 +23,7 @@ import moment from "moment-timezone"
 import type Moment from "moment"
 
 import type { HttpRespErrorMessage, HttpResponse } from "../flow/httpTypes"
+import type { Product } from "../flow/cartTypes"
 
 import {
   DISCOUNT_TYPE_DOLLARS_OFF,
@@ -231,7 +232,7 @@ export const formatLocalePrice = (amount: number | null) => {
   return amount.toLocaleString("en-US", { style: "currency", currency: "USD" })
 }
 
-export const getFlexiblePriceForProduct = (product:any) => {
+export const getFlexiblePriceForProduct = (product: Product) => {
   const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
   const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
 

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -24,6 +24,12 @@ import type Moment from "moment"
 
 import type { HttpRespErrorMessage, HttpResponse } from "../flow/httpTypes"
 
+import {
+  DISCOUNT_TYPE_DOLLARS_OFF,
+  DISCOUNT_TYPE_PERCENT_OFF,
+  DISCOUNT_TYPE_FIXED_PRICE
+} from "../constants"
+
 /**
  * Returns a promise which resolves after a number of milliseconds have elapsed
  */
@@ -223,4 +229,21 @@ export const formatLocalePrice = (amount: number | null) => {
   if (amount === null) amount = 0
 
   return amount.toLocaleString("en-US", { style: "currency", currency: "USD" })
+}
+
+export const getFlexiblePriceForProduct = product => {
+  const flexDiscountAmount = product && product.product_flexible_price ? product.product_flexible_price.amount : 0
+  const flexDiscountType = product && product.product_flexible_price ? product.product_flexible_price.discount_type : null
+  const flexAdjustedCoursePrice = product ? formatLocalePrice(product.price, flexDiscountAmount, flexDiscountType) : null
+
+  switch (flexDiscountType) {
+  case DISCOUNT_TYPE_DOLLARS_OFF:
+    return product.price - flexDiscountAmount
+  case DISCOUNT_TYPE_PERCENT_OFF:
+    return product.price - ((flexDiscountAmount / 100) * product.price)
+  case DISCOUNT_TYPE_FIXED_PRICE:
+    return flexDiscountAmount
+  default:
+    return product.price
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/670

#### What's this PR do?
Displays the course price, with the deducted flex price discount, for a logged in user who has been approved for flexible pricing.

#### How should this be manually tested?

1. Ensure you have the following already created: standard user, course, course run, flexible pricing tier, flexible price that is approved for the course and user.
3. Login to mitxonline
4. From the dashboard, click 'browse our courses'
5. Click on the course card
6. Click 'Enroll now'
7. A modal will display.  You should see the flexible pricing adjusted certificate price in the modal.
8. Click 'No thanks, I'll take the course....'
9. From the dashboard, click 'Course details'
10. You should see the flexible pricing adjusted certificate price in the card.


#### Screenshots (if appropriate)
![Screen Shot 2022-07-20 at 1 25 03 PM](https://user-images.githubusercontent.com/8311573/180044650-d7c0f71a-6f52-49d1-9c23-8168def47131.png)
![Screen Shot 2022-07-20 at 1 24 26 PM](https://user-images.githubusercontent.com/8311573/180044689-1d011d3a-6091-4353-8cc4-770fcf634b3a.png)

