### PR TITLE
Update refine docs to conform to poorly formatted URL

### DIFF
--- a/docs/source/configuration/refine_admin.rst
+++ b/docs/source/configuration/refine_admin.rst
@@ -37,7 +37,7 @@ Step 2: Configuring MITxOnline
 You will need to add a new Application in the Django Oauth Toolkit section in Django Admin (``/admin/oauth2_provider/application/``). Navigate there and create a new Application. Use these values (overwriting the defaults where necessary):
 
 * **Client Id**: ``refine-local-client-id``
-* **Redirect uris**: ``http://mitxonline.odl.local:8013/staff-dashboard/oauth2/login/``
+* **Redirect uris**: ``http://mitxonline.odl.local:8013//staff-dashboard/oauth2/login/``
 * **Client type**: Public
 * **Authorization grants**: Authorization Code
 * **Skip authorization**: checked


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What's this PR do?
Updates the refine admin configuration document to use the poorly formatted `//` in the redirect URL which acts as a workaround for a bug.  The bug should be fixed at some point, and this PR should be reverted after the fix is released.

#### How should this be manually tested?
Negative test - Set the redirect URL without the `//`
Positive test - Set the redirect URL with the `//` shown in this PR.
