### PR TITLE
Adds code to group course run enrollment by program

### DIFF
--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -225,6 +225,24 @@ def test_get_user_enrollments(user):
         key=key_func,
     )
 
+    # Create a separate Course and Program and then just enroll in the course
+    # The program ought to still show up as an enrollment
+    separate_program = ProgramFactory.create()
+    separate_courserun = CourseRunFactory.create(course__program=separate_program)
+    separate_courserun_enrollment = CourseRunEnrollmentFactory.create(
+        run=separate_courserun, user=user
+    )
+
+    user_enrollments = get_user_enrollments(user)
+    assert len(list(user_enrollments.programs)) == 2
+
+    user_enrollments = get_user_enrollments(user)
+    enrollment_programs = [
+        enrollment.program for enrollment in user_enrollments.programs
+    ]
+    assert program_enrollment.program in enrollment_programs
+    assert separate_program in enrollment_programs
+
 
 def test_create_run_enrollments(mocker, user):
     """

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -341,3 +341,8 @@ class ProgramEnrollmentSerializer(serializers.ModelSerializer):
             "program",
             "course_run_enrollments",
         ]
+
+
+class UserProgramEnrollmentDetailSerializer(serializers.Serializer):
+    program = ProgramSerializer()
+    enrollments = CourseRunEnrollmentSerializer(many=True)

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -15,5 +15,11 @@ router.register(
 urlpatterns = [
     re_path(r"^api/v1/", include(router.urls)),
     re_path(r"^api/", include(router.urls)),
+    re_path(
+        r"^api//v1/program_enrollments",
+        v1.get_user_program_enrollments,
+        name="user-program-enrollments-api",
+    ),
+    re_path(r"^api/program_enrollments", v1.get_user_program_enrollments),
     path("enrollments/", v1.create_enrollment_view, name="create-enrollment-via-form"),
 ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#719 

#### What's this PR do?

Adds a new `program_enrollment` REST API that groups course run enrollments by program for the given user. Also updates the `get_user_enrollments` API function to include implicit program enrollments. 

#### How should this be manually tested?

Automated tests should pass.

Add an enrollment for a course run in a program. Then, visit http://mitxonline.odl.local:8013/api/program_enrollments/ - you should see the enrollment listed alongside the program that it belongs to. 
