### PR TITLE
add validation to block payment for the paid courserun

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -17,6 +17,7 @@ from main.constants import (
     USER_MSG_TYPE_PAYMENT_ACCEPTED,
     USER_MSG_TYPE_PAYMENT_ACCEPTED_NOVALUE,
     USER_MSG_TYPE_ENROLL_BLOCKED,
+    USER_MSG_TYPE_ENROLL_DUPLICATED,
 )
 
 from mitol.payment_gateway.api import (
@@ -57,6 +58,16 @@ def generate_checkout_payload(request):
                 {"type": USER_MSG_TYPE_ENROLL_BLOCKED},
             ),
         }
+
+    if basket.has_user_purchased_same_courserun(request.user):
+        return {
+            "purchased_same_courserun": True,
+            "response": redirect_with_user_message(
+                reverse("cart"),
+                {"type": USER_MSG_TYPE_ENROLL_DUPLICATED},
+            ),
+        }
+
     basket = establish_basket(request)
 
     order = PendingOrder.create_from_basket(basket)

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -573,6 +573,8 @@ class CheckoutInterstitialView(LoginRequiredMixin, TemplateView):
             return checkout_payload["response"]
         if "no_checkout" in checkout_payload:
             return checkout_payload["response"]
+        if "purchased_same_courserun" in checkout_payload:
+            return checkout_payload["response"]
 
         return render(
             request,

--- a/frontend/public/src/constants.js
+++ b/frontend/public/src/constants.js
@@ -109,6 +109,7 @@ export const USER_MSG_COOKIE_NAME = "user-message"
 export const USER_MSG_TYPE_ENROLLED = "enrolled"
 export const USER_MSG_TYPE_ENROLL_FAILED = "enroll-failed"
 export const USER_MSG_TYPE_ENROLL_BLOCKED = "enroll-blocked"
+export const USER_MSG_TYPE_ENROLL_DUPLICATED = "enroll-duplicated"
 export const USER_MSG_TYPE_COMPLETED_AUTH = "completed-auth"
 
 export const USER_MSG_TYPE_PAYMENT_DECLINED = "payment-declined"

--- a/frontend/public/src/lib/notificationsApi.js
+++ b/frontend/public/src/lib/notificationsApi.js
@@ -7,6 +7,7 @@ import {
   USER_MSG_COOKIE_NAME,
   USER_MSG_TYPE_COMPLETED_AUTH,
   USER_MSG_TYPE_ENROLL_BLOCKED,
+  USER_MSG_TYPE_ENROLL_DUPLICATED,
   USER_MSG_TYPE_ENROLL_FAILED,
   USER_MSG_TYPE_ENROLLED,
   USER_MSG_TYPE_PAYMENT_DECLINED,
@@ -54,6 +55,10 @@ export function parseStoredUserMessage(
     alertType = ALERT_TYPE_DANGER
     msgText =
         "We're sorry, your country is currently blocked from enrolling in this course."
+    break
+  case USER_MSG_TYPE_ENROLL_DUPLICATED:
+    alertType = ALERT_TYPE_DANGER
+    msgText = `You have already enrolled and paid for this course. If this is unexpected, please contact customer support at ${SETTINGS.support_email}.`
     break
   case USER_MSG_TYPE_COMPLETED_AUTH:
     alertType = ALERT_TYPE_SUCCESS

--- a/main/constants.py
+++ b/main/constants.py
@@ -4,6 +4,7 @@ USER_MSG_COOKIE_MAX_AGE = 20
 USER_MSG_TYPE_ENROLLED = "enrolled"
 USER_MSG_TYPE_ENROLL_FAILED = "enroll-failed"
 USER_MSG_TYPE_ENROLL_BLOCKED = "enroll-blocked"
+USER_MSG_TYPE_ENROLL_DUPLICATED = "enroll-duplicated"
 USER_MSG_TYPE_COMPLETED_AUTH = "completed-auth"
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/676

#### What's this PR do?
Adding validation on checkout to payment view to see if user has already purchased for that course run, displaying a error message if that happens

#### How should this be manually tested?
- enroll a course on the frontend, but leave it in the cart
- go to /admin/ecommerce/order/ and find this order, manually change it to 'Fullfilled'
-  go back to frontend to enroll this course again, when you click on place your order, you should see
![image](https://user-images.githubusercontent.com/3138890/182199719-89ef1b40-bb4d-4862-8967-f52c192a088d.png)


#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)
