### PR TITLE
728: flexible pricing learner cant resubmit income after request has been denied reset

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -662,7 +662,9 @@ class FlexiblePricingRequestForm(AbstractForm):
 
     def serve(self, request, *args, **kwargs):
         previous_submission = self.get_previous_submission(request)
-        if request.method == "POST" and (previous_submission is not None and not previous_submission.is_reset()):
+        if request.method == "POST" and (
+            previous_submission is not None and not previous_submission.is_reset()
+        ):
             form = self.get_form(page=self, user=request.user)
 
             context = self.get_context(request)

--- a/cms/models.py
+++ b/cms/models.py
@@ -655,25 +655,14 @@ class FlexiblePricingRequestForm(AbstractForm):
         context = super().get_context(request, *args, **kwargs)
         context["course"] = self.get_parent_product_page()
 
-        if (
-            self.get_submission_class()
-            .objects.filter(page=self, user__pk=request.user.pk)
-            .exists()
-        ):
-            fp_request = (
-                FlexiblePrice.objects.filter(user__pk=request.user.pk)
-                .order_by("-created_on")
-                .first()
-            )
-
-            context["has_submission"] = True
-            context["prior_request"] = fp_request
+        fp_request = self.get_previous_submission(request)
+        context["prior_request"] = fp_request
 
         return context
 
     def serve(self, request, *args, **kwargs):
         previous_submission = self.get_previous_submission(request)
-        if request.method == "POST" and previous_submission is not None:
+        if request.method == "POST" and (previous_submission is not None and not previous_submission.is_reset()):
             form = self.get_form(page=self, user=request.user)
 
             context = self.get_context(request)

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -247,7 +247,6 @@ def test_flex_pricing_form_state_display(mocker, submission_status):
     )
 
     response = generate_flexible_pricing_response(request_user, flex_form)
-    
 
     if submission_status == FlexiblePriceStatus.CREATED:
         assert "Application Processing" in response.rendered_content
@@ -256,4 +255,6 @@ def test_flex_pricing_form_state_display(mocker, submission_status):
     elif submission_status == FlexiblePriceStatus.SKIPPED:
         assert "Application Denied" in response.rendered_content
     elif submission_status == FlexiblePriceStatus.RESET:
-        assert "csrfmiddlewaretoken" in response.rendered_content, response.rendered_content
+        assert (
+            "csrfmiddlewaretoken" in response.rendered_content
+        ), response.rendered_content

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -220,9 +220,10 @@ def test_flex_pricing_form_display(mocker, is_authed, has_submission):
 @pytest.mark.parametrize(
     "submission_status",
     [
-        [FlexiblePriceStatus.CREATED],
-        [FlexiblePriceStatus.APPROVED],
-        [FlexiblePriceStatus.SKIPPED],
+        FlexiblePriceStatus.CREATED,
+        FlexiblePriceStatus.APPROVED,
+        FlexiblePriceStatus.SKIPPED,
+        FlexiblePriceStatus.RESET,
     ],
 )
 def test_flex_pricing_form_state_display(mocker, submission_status):
@@ -246,6 +247,7 @@ def test_flex_pricing_form_state_display(mocker, submission_status):
     )
 
     response = generate_flexible_pricing_response(request_user, flex_form)
+    
 
     if submission_status == FlexiblePriceStatus.CREATED:
         assert "Application Processing" in response.rendered_content
@@ -253,3 +255,5 @@ def test_flex_pricing_form_state_display(mocker, submission_status):
         assert "Application Approved" in response.rendered_content
     elif submission_status == FlexiblePriceStatus.SKIPPED:
         assert "Application Denied" in response.rendered_content
+    elif submission_status == FlexiblePriceStatus.RESET:
+        assert "csrfmiddlewaretoken" in response.rendered_content, response.rendered_content

--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -18,7 +18,32 @@
           {{ page.intro|richtext }}
           
           {% if user.is_authenticated %}{# is logged in #}
-            {% if has_submission %}{# has submission #}
+            {% if prior_request is None or prior_request.is_reset %}{# has submission #}
+              <form action="{% pageurl page %}" method="POST">
+                {% csrf_token %}
+                <div class="form-group">
+                  <label for="your_income">Your Income</label>
+                  <input type="number" name="your_income" step="any" class="form-control" id="your_income" aria-describedby="your_incomeError">
+                  {% for error in form.your_income.errors %}
+                    <div class="form-error" id="your_incomeError" role="alert">{{error}}</div>
+                  {% endfor %}
+                </div>
+                <div class="form-group">
+                  <label for="income_currency">Income Currency</label>
+                  <select name="income_currency" id="income_currency" class="form-control" >
+                    {% for choice in form.fields.income_currency.choices %}
+                      <option value="{{ choice.0 }}">{{ choice.1 }}</option>  
+                    {%  endfor %}
+                  </select>
+                  {% for error in form.income_currency.errors %}
+                    <div class="form-error" id="income_currencyError" role="alert">{{error}}</div>
+                  {% endfor %}
+                </div>
+                <div class="row submit-row no-gutters justify-content-end">
+                  <button type="submit" class="btn btn-primary btn-gradient-red large">Submit</button>
+                </div>
+              </form>
+            {% else %}
               {% if prior_request.is_approved %}{# request status #}
                 {{ page.application_approved_text|richtext }}
               {% elif prior_request.is_denied %}
@@ -26,31 +51,6 @@
               {% else %}
                 {{ page.application_processing_text|richtext }}
               {% endif %}{# request status #}
-            {% else %}
-              <form action="{% pageurl page %}" method="POST">
-                  {% csrf_token %}
-                  <div class="form-group">
-                    <label for="your_income">Your Income</label>
-                    <input type="number" name="your_income" step="any" class="form-control" id="your_income" aria-describedby="your_incomeError">
-                    {% for error in form.your_income.errors %}
-                      <div class="form-error" id="your_incomeError" role="alert">{{error}}</div>
-                    {% endfor %}
-                  </div>
-                  <div class="form-group">
-                    <label for="income_currency">Income Currency</label>
-                    <select name="income_currency" id="income_currency" class="form-control" >
-                      {% for choice in form.fields.income_currency.choices %}
-                        <option value="{{ choice.0 }}">{{ choice.1 }}</option>  
-                      {%  endfor %}
-                    </select>
-                    {% for error in form.income_currency.errors %}
-                      <div class="form-error" id="income_currencyError" role="alert">{{error}}</div>
-                    {% endfor %}
-                  </div>
-                  <div class="row submit-row no-gutters justify-content-end">
-                    <button type="submit" class="btn btn-primary btn-gradient-red large">Submit</button>
-                  </div>
-              </form>
             {% endif %}{# has submission #}
           {% else %}
             {{ page.guest_text|richtext }}

--- a/flexiblepricing/models.py
+++ b/flexiblepricing/models.py
@@ -146,6 +146,6 @@ class FlexiblePrice(TimestampedModel):
 
     def is_denied(self):
         return self.status == FlexiblePriceStatus.SKIPPED
-    
+
     def is_reset(self):
         return self.status == FlexiblePriceStatus.RESET

--- a/flexiblepricing/models.py
+++ b/flexiblepricing/models.py
@@ -146,3 +146,6 @@ class FlexiblePrice(TimestampedModel):
 
     def is_denied(self):
         return self.status == FlexiblePriceStatus.SKIPPED
+    
+    def is_reset(self):
+        return self.status == FlexiblePriceStatus.RESET

--- a/flexiblepricing/models_test.py
+++ b/flexiblepricing/models_test.py
@@ -33,5 +33,7 @@ def test_submission_status():
             assert submission.is_approved()
         elif status == FlexiblePriceStatus.SKIPPED:
             assert submission.is_denied()
+        elif status == FlexiblePriceStatus.RESET:
+            assert submission.is_reset()
         else:
             assert not submission.is_approved() and not submission.is_denied()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/728

#### What's this PR do?
If a flexible price record has a status of 'reset', when the user visits the `http://mitxonline.odl.local:8013/courses/<COURSE>/flex-price/` they should be able to view the form fields and submit the form.

#### How should this be manually tested?

1. Create a `flexible price` record for a user and course or program.
2. Set the status of the `flex price` record to `reset`
3. Login as the user from step 1.  Navigate to `http://mitxonline.odl.local:8013/courses/<COURSE_FROM_STEP_1>/flex-price/`
4. Ensure that you can see the form and submit the completed form.
5. Ensure that a new `flexible price` record for the user and course or program has been created.

#### Where should the reviewer start?

- Create a flexible price tier following: https://github.com/mitodl/hq/discussions/133

#### Any background context you want to provide?

- The test at https://github.com/mitodl/mitxonline/blob/63f90bb49f35e46ae6bfc4ba9d8f9018593903ae/cms/models_test.py#L229 needed to be refactored as it was originally always passing.  I don't believe any of the assertions were actually being run.
- The changes I made are organized in each of the commits of this PR.
- I've tested the following flex price status transitions:
-- `auto-approved` -> `reset`: should see form.
-- `skipped` -> `reset`: should see form.
-- `pending-manual-approval` -> `reset`: should see form.
-- `reset` -> `pending-manual-approval`: should see pending text.
-- `reset` -> `auto-approved`: should see approved text.
-- `reset` -> `skipped`: should see denied text.
I tested this with a course specific flexible price tier and form.
