### PR TITLE
747 - Fix pagination within Refine by using count API response attribute

### DIFF
--- a/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
@@ -121,7 +121,7 @@ const useDrfDataProvider = (
         if (data.hasOwnProperty('results')) {
             return {
                 data: data['results'],
-                total: data['total']
+                total: data['count']
             };
         } else {
             return {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/747

#### What's this PR do?
Pagination was not working within the staff-dashboard (refine). 

#### How should this be manually tested?
View a list page (such as https://<BASE_URL>/staff-dashboard/flexible_pricing) which is known to retrieve more than 10 results from the associated API.  Ensure that there are multiple pages shown in the bottom right of the list page.  Ensure that you can navigate to the other pages.

#### Any background context you want to provide?
The default behavior _should_ have been that any list associated with more than 10 entries should display 10 entries on the first page and the remaining entries on subsequent pages, each showing only 10 entries.

#### Screenshots (if appropriate)
![Screen Shot 2022-07-28 at 6 54 04 AM](https://user-images.githubusercontent.com/8311573/181488896-5f2ce338-534e-469e-aee4-c1b674c81964.png)

