### PR TITLE
734 - registration validate username against openedx

### DIFF
--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -1,7 +1,7 @@
 """Tests of user pipeline actions"""
 # pylint: disable=redefined-outer-name
 
-from openedx.api import OPENEDX_VALIDATION_REGISTRATION_PATH
+from openedx.api import OPENEDX_REGISTRATION_VALIDATION_PATH
 import pytest
 import responses
 from django.contrib.auth import get_user_model
@@ -260,7 +260,7 @@ def test_create_user_via_email(
     """
     responses.add(
         responses.POST,
-        settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
+        settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
         json={"validation_decisions": {"username": ""}},
         status=status.HTTP_200_OK,
     )

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -1,12 +1,15 @@
 """Tests of user pipeline actions"""
 # pylint: disable=redefined-outer-name
 
+from openedx.api import OPENEDX_VALIDATION_REGISTRATION_PATH
 import pytest
+import responses
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.db import IntegrityError
 from social_core.backends.email import EmailAuth
 from social_django.utils import load_backend, load_strategy
+from rest_framework import status
 
 from authentication.exceptions import (
     EmailBlockedException,
@@ -58,6 +61,12 @@ def mock_create_user_strategy(mocker):
         },
     }
     return strategy
+
+
+@pytest.fixture()
+def application(settings):
+    """Test data and settings needed for create_edx_user tests"""
+    settings.OPENEDX_API_BASE_URL = "http://example.com"
 
 
 def validate_email_auth_request_not_email_backend(mocker):
@@ -240,12 +249,21 @@ def test_create_user_via_email_exit(mocker, backend_name, flow):
     mock_strategy.request_data.assert_not_called()
 
 
+@responses.activate
 @pytest.mark.django_db
-def test_create_user_via_email(mocker, mock_email_backend, mock_create_user_strategy):
+def test_create_user_via_email(
+    mocker, mock_email_backend, mock_create_user_strategy, settings
+):
     """
     Tests that create_user_via_email creates a user via social_core.pipeline.user.create_user_via_email
     and sets a name and password
     """
+    responses.add(
+        responses.POST,
+        settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
+        json={"validation_decisions": {"username": ""}},
+        status=status.HTTP_200_OK,
+    )
     email = "user@example.com"
     response = user_actions.create_user_via_email(
         mock_create_user_strategy,

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -122,7 +122,6 @@ def noop():
     yield
 
 
-@pytest.mark.usefixtures("validate_username")
 class AuthStateMachine(RuleBasedStateMachine):
     """
     State machine for auth flows

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -122,6 +122,7 @@ def noop():
     yield
 
 
+@pytest.mark.usefixtures("validate_username")
 class AuthStateMachine(RuleBasedStateMachine):
     """
     State machine for auth flows
@@ -151,6 +152,10 @@ class AuthStateMachine(RuleBasedStateMachine):
     email_send_patcher = patch(
         "mail.verification_api.send_verification_email", autospec=True
     )
+    mock_api_patcher = patch(
+        "users.serializers.UserSerializer.validate_username",
+        return_value="dummy-username",
+    )
     openedx_api_patcher = patch("authentication.pipeline.user.openedx_api")
     openedx_tasks_patcher = patch("authentication.pipeline.user.openedx_tasks")
 
@@ -163,6 +168,7 @@ class AuthStateMachine(RuleBasedStateMachine):
 
         # wrap the execution in a patch()
         self.mock_email_send = self.email_send_patcher.start()
+        self.mock_api = self.mock_api_patcher.start()
         self.mock_openedx_api = self.openedx_api_patcher.start()
         self.mock_openedx_tasks = self.openedx_tasks_patcher.start()
 
@@ -186,6 +192,7 @@ class AuthStateMachine(RuleBasedStateMachine):
         self.email_send_patcher.stop()
         self.openedx_api_patcher.stop()
         self.openedx_tasks_patcher.stop()
+        self.mock_api_patcher.stop()
 
         # end the transaction with a rollback to cleanup any state
         transaction.set_rollback(True)

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -716,7 +716,7 @@ def unsubscribe_from_edx_course_emails(user, course_run):
     return result
 
 
-def username_exists_in_openedx(username):
+def check_username_exists_in_edx(username):
     """
     Returns true if the username exists within Open edX.
     Returns false if the username does not exists in Open edX.

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -715,6 +715,7 @@ def unsubscribe_from_edx_course_emails(user, course_run):
         raise UnknownEdxApiEmailSettingsException(user, course_run, exc) from exc
     return result
 
+
 def username_exists_in_openedx(username):
     """
     Returns true if the username exists within Open edX.
@@ -722,17 +723,15 @@ def username_exists_in_openedx(username):
 
     Args:
         username (str): the username
-        
+
     Raises:
         EdxApiRegistrationValidationException: Raised if the edX API HTTP request fails
     """
-    
+
     req_session = requests.Session()
     req_session.headers.update(
-                {
-                    ACCESS_TOKEN_HEADER_NAME: settings.MITX_ONLINE_REGISTRATION_ACCESS_TOKEN
-                }
-            )
+        {ACCESS_TOKEN_HEADER_NAME: settings.MITX_ONLINE_REGISTRATION_ACCESS_TOKEN}
+    )
     resp = req_session.post(
         edx_url(OPENEDX_VALIDATION_REGISTRATION_PATH),
         data=dict(
@@ -740,6 +739,10 @@ def username_exists_in_openedx(username):
         ),
     )
     if resp.status_code != status.HTTP_200_OK:
-            raise EdxApiRegistrationValidationException(username, resp)
+        raise EdxApiRegistrationValidationException(username, resp)
     result = resp.json()
-    return result['validation_decisions']['username'] == "It looks like {} belongs to an existing account. Try again with a different username.".format(username) 
+    return result["validation_decisions"][
+        "username"
+    ] == "It looks like {} belongs to an existing account. Try again with a different username.".format(
+        username
+    )

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -51,7 +51,7 @@ log = logging.getLogger(__name__)
 User = get_user_model()
 
 OPENEDX_REGISTER_USER_PATH = "/user_api/v1/account/registration/"
-OPENEDX_VALIDATION_REGISTRATION_PATH = "/api/user/v1/validation/registration"
+OPENEDX_REGISTRATION_VALIDATION_PATH = "/api/user/v1/validation/registration"
 OPENEDX_REQUEST_DEFAULTS = dict(country="US", honor_code=True)
 
 OPENEDX_SOCIAL_LOGIN_XPRO_PATH = "/auth/login/mitxpro-oauth2/?auth_entry=login"
@@ -733,7 +733,7 @@ def username_exists_in_openedx(username):
         {ACCESS_TOKEN_HEADER_NAME: settings.MITX_ONLINE_REGISTRATION_ACCESS_TOKEN}
     )
     resp = req_session.post(
-        edx_url(OPENEDX_VALIDATION_REGISTRATION_PATH),
+        edx_url(OPENEDX_REGISTRATION_VALIDATION_PATH),
         data=dict(
             username=username,
         ),

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -86,6 +86,17 @@ def test_create_user(user, mocker):
     mock_create_edx_auth_token.assert_called_with(user)
 
 
+"""
+    Adds a mocked response from the EdX username validation API. 
+
+    Args:
+       username_exists (boolean): Determines whether the mocked response will indicate a matched EdX username (True), or not (False).
+       settings (pytest.fixture): Application settings.
+       user (str): The username being passed to the EdX username validation API.  This is required if username_exists is True.
+
+    """
+
+
 def edx_username_validation_response_mock(username_exists, settings, username=None):
     if username_exists:
         validation_decisions = {"username": ""}

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -35,7 +35,7 @@ from openedx.api import (
     retry_failed_edx_enrollments,
     subscribe_to_edx_course_emails,
     unsubscribe_from_edx_course_emails,
-    username_exists_in_openedx,
+    check_username_exists_in_edx,
 )
 from openedx.constants import (
     EDX_ENROLLMENT_AUDIT_MODE,
@@ -185,7 +185,7 @@ def test_validate_edx_username_conflict(settings, user):
     """Test that username_exists_in_openedx handles a username validation conflict"""
     edx_username_validation_response_mock(True, settings, user.username)
 
-    assert username_exists_in_openedx(user.username) == True
+    assert check_username_exists_in_edx(user.username) == True
 
 
 @responses.activate
@@ -202,7 +202,7 @@ def test_validate_edx_username_conflict(settings, user):
         status=status.HTTP_400_BAD_REQUEST,
     )
     with pytest.raises(EdxApiRegistrationValidationException):
-        username_exists_in_openedx(user.username)
+        check_username_exists_in_edx(user.username)
 
 
 @responses.activate

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -182,7 +182,7 @@ def test_create_edx_user_conflict(settings, user):
 
 @responses.activate
 def test_validate_edx_username_conflict(settings, user):
-    """Test that username_exists_in_openedx handles a username validation conflict"""
+    """Test that check_username_exists_in_edx handles a username validation conflict"""
     edx_username_validation_response_mock(True, settings, user.username)
 
     assert check_username_exists_in_edx(user.username) == True
@@ -190,7 +190,7 @@ def test_validate_edx_username_conflict(settings, user):
 
 @responses.activate
 def test_validate_edx_username_conflict(settings, user):
-    """Test that username_exists_in_openedx raises an exception for non-200 response"""
+    """Test that check_username_exists_in_edx raises an exception for non-200 response"""
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -99,7 +99,7 @@ def test_create_edx_user(user, settings, application, access_token_count):
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
-        json={"validation_decisions": { "username": ""}},
+        json={"validation_decisions": {"username": ""}},
         status=status.HTTP_200_OK,
     )
 
@@ -149,7 +149,7 @@ def test_create_edx_user_conflict(settings, user):
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
-        json={"validation_decisions": { "username": ""}},
+        json={"validation_decisions": {"username": ""}},
         status=status.HTTP_200_OK,
     )
 
@@ -158,17 +158,23 @@ def test_create_edx_user_conflict(settings, user):
 
     assert OpenEdxUser.objects.count() == 0
 
+
 @responses.activate
 def test_validate_edx_username_conflict(settings, user):
     """Test that username_exists_in_openedx handles a username validation conflict"""
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
-        json={"validation_decisions": { "username": f"It looks like {user.username} belongs to an existing account. Try again with a different username."}},
+        json={
+            "validation_decisions": {
+                "username": f"It looks like {user.username} belongs to an existing account. Try again with a different username."
+            }
+        },
         status=status.HTTP_200_OK,
     )
 
     assert username_exists_in_openedx(user.username) == True
+
 
 @responses.activate
 def test_validate_edx_username_conflict(settings, user):
@@ -176,11 +182,16 @@ def test_validate_edx_username_conflict(settings, user):
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
-        json={"validation_decisions": { "username": f"It looks like {user.username} belongs to an existing account. Try again with a different username."}},
+        json={
+            "validation_decisions": {
+                "username": f"It looks like {user.username} belongs to an existing account. Try again with a different username."
+            }
+        },
         status=status.HTTP_400_BAD_REQUEST,
     )
     with pytest.raises(EdxApiRegistrationValidationException):
         username_exists_in_openedx(user.username)
+
 
 @responses.activate
 @freeze_time("2019-03-24 11:50:36")
@@ -251,10 +262,9 @@ def test_update_edx_user_email(settings, user):
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
-        json={"validation_decisions": { "username": ""}},
+        json={"validation_decisions": {"username": ""}},
         status=status.HTTP_200_OK,
     )
-    
 
     create_edx_user(user)
 

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -123,6 +123,7 @@ class UnknownEdxApiEmailSettingsException(Exception):
             )
         super().__init__(msg)
 
+
 class EdxApiRegistrationValidationException(Exception):
     """An edX Registration Validation API call resulted in an error response"""
 

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -132,7 +132,7 @@ class EdxApiRegistrationValidationException(Exception):
         Sets exception properties and adds a default message
 
         Args:
-            username (str): The user for which the enrollment failed
+            username (str): The username being compared for uniqueness
             http_error (requests.exceptions.HTTPError): The exception from the API call which contains
                 request and response data.
         """

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -122,3 +122,25 @@ class UnknownEdxApiEmailSettingsException(Exception):
                 str(base_exc),
             )
         super().__init__(msg)
+
+class EdxApiRegistrationValidationException(Exception):
+    """An edX Registration Validation API call resulted in an error response"""
+
+    def __init__(self, username, http_error, msg=None):
+        """
+        Sets exception properties and adds a default message
+
+        Args:
+            username (str): The user for which the enrollment failed
+            http_error (requests.exceptions.HTTPError): The exception from the API call which contains
+                request and response data.
+        """
+        self.username = username
+        self.http_error = http_error
+        if msg is None:
+            # Set some default useful error message
+            msg = "EdX API error validating registration username {}.\n{}".format(
+                self.username,
+                get_error_response_summary(self.http_error),
+            )
+        super().__init__(msg)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -118,11 +118,9 @@ class UserSerializer(serializers.ModelSerializer):
     def validate_username(self, value):
         """Validates the username field"""
         trimmed_value = value.strip()
-        username_exist_in_openedx = False
         try:
-            username_exist_in_openedx = username_exists_in_openedx(trimmed_value)
+            username_exists_in_openedx(trimmed_value)
         except (
-            EdxApiRegistrationValidationException,
             HTTPError,
             RequestsConnectionError,
         ):
@@ -130,7 +128,7 @@ class UserSerializer(serializers.ModelSerializer):
                 "edX username verification failure for username: %s",
                 trimmed_value,
             )
-        if username_exist_in_openedx:
+        except EdxApiRegistrationValidationException:
             raise serializers.ValidationError(USERNAME_ALREADY_EXISTS_MSG)
         if not re.fullmatch(USERNAME_RE, trimmed_value):
             raise serializers.ValidationError(USERNAME_ERROR_MSG)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -18,7 +18,7 @@ from mail import verification_api
 from main.serializers import WriteableSerializerMethodField
 from openedx.tasks import change_edx_user_email_async
 from users.models import ChangeEmailRequest, LegalAddress, Profile, User
-from openedx.api import username_exists_in_openedx
+from openedx.api import check_username_exists_in_edx
 
 log = logging.getLogger()
 
@@ -120,7 +120,7 @@ class UserSerializer(serializers.ModelSerializer):
         trimmed_value = value.strip()
         openedx_username_taken = False
         try:
-            openedx_username_taken = username_exists_in_openedx(trimmed_value)
+            openedx_username_taken = check_username_exists_in_edx(trimmed_value)
         except (
             HTTPError,
             RequestsConnectionError,

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -127,9 +127,9 @@ class UserSerializer(serializers.ModelSerializer):
             RequestsConnectionError,
         ):
             log.exception(
-            "edX username verification failure for username: %s",
-            trimmed_value,
-        )
+                "edX username verification failure for username: %s",
+                trimmed_value,
+            )
         if username_exist_in_openedx:
             raise serializers.ValidationError(USERNAME_ALREADY_EXISTS_MSG)
         if not re.fullmatch(USERNAME_RE, trimmed_value):

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -120,7 +120,7 @@ class UserSerializer(serializers.ModelSerializer):
         trimmed_value = value.strip()
         if not re.fullmatch(USERNAME_RE, trimmed_value):
             raise serializers.ValidationError(USERNAME_ERROR_MSG)
-        
+
         openedx_username_taken = False
         try:
             openedx_username_taken = check_username_exists_in_edx(trimmed_value)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -32,7 +32,9 @@ USER_GIVEN_NAME_RE = re.compile(
 USERNAME_RE_PARTIAL = r"[\w ._+-]+"
 USERNAME_RE = re.compile(rf"(?P<username>{USERNAME_RE_PARTIAL})")
 USERNAME_ERROR_MSG = "Username can only contain letters, numbers, spaces, and the following characters: _+-"
-USERNAME_ALREADY_EXISTS_MSG = "A user already exists with this username. Please try a different one."
+USERNAME_ALREADY_EXISTS_MSG = (
+    "A user already exists with this username. Please try a different one."
+)
 
 
 class LegalAddressSerializer(serializers.ModelSerializer):
@@ -112,7 +114,8 @@ class UserSerializer(serializers.ModelSerializer):
     def validate_username(self, value):
         """Validates the username field"""
         trimmed_value = value.strip()
-        if username_exists_in_openedx(trimmed_value): raise serializers.ValidationError(USERNAME_ALREADY_EXISTS_MSG)
+        if username_exists_in_openedx(trimmed_value):
+            raise serializers.ValidationError(USERNAME_ALREADY_EXISTS_MSG)
         if not re.fullmatch(USERNAME_RE, trimmed_value):
             raise serializers.ValidationError(USERNAME_ERROR_MSG)
         return trimmed_value

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -118,17 +118,19 @@ class UserSerializer(serializers.ModelSerializer):
     def validate_username(self, value):
         """Validates the username field"""
         trimmed_value = value.strip()
+        openedx_username_taken = False
         try:
-            username_exists_in_openedx(trimmed_value)
+            openedx_username_taken = username_exists_in_openedx(trimmed_value)
         except (
             HTTPError,
             RequestsConnectionError,
+            EdxApiRegistrationValidationException,
         ):
             log.exception(
                 "edX username verification failure for username: %s",
                 trimmed_value,
             )
-        except EdxApiRegistrationValidationException:
+        if openedx_username_taken:
             raise serializers.ValidationError(USERNAME_ALREADY_EXISTS_MSG)
         if not re.fullmatch(USERNAME_RE, trimmed_value):
             raise serializers.ValidationError(USERNAME_ERROR_MSG)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -118,6 +118,9 @@ class UserSerializer(serializers.ModelSerializer):
     def validate_username(self, value):
         """Validates the username field"""
         trimmed_value = value.strip()
+        if not re.fullmatch(USERNAME_RE, trimmed_value):
+            raise serializers.ValidationError(USERNAME_ERROR_MSG)
+        
         openedx_username_taken = False
         try:
             openedx_username_taken = check_username_exists_in_edx(trimmed_value)
@@ -132,8 +135,6 @@ class UserSerializer(serializers.ModelSerializer):
             )
         if openedx_username_taken:
             raise serializers.ValidationError(USERNAME_ALREADY_EXISTS_MSG)
-        if not re.fullmatch(USERNAME_RE, trimmed_value):
-            raise serializers.ValidationError(USERNAME_ERROR_MSG)
         return trimmed_value
 
     def get_email(self, instance):

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -229,9 +229,12 @@ def test_username_validation_exception(user, settings):
         == "A user already exists with this username. Please try a different one."
     )
 
+
 @pytest.mark.django_db
 @pytest.mark.parametrize("exception_raised", [RequestsConnectionError, HTTPError])
-def test_username_validation_connection_exception(mocker, exception_raised, sample_address):
+def test_username_validation_connection_exception(
+    mocker, exception_raised, sample_address
+):
     """
     UserSerializer should raise a RequestsConnectionError or HTTPError if the connection to OpenEdx
     fails.  The serializer should still be valid.

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -1,6 +1,6 @@
 """Tests for users.serializers"""
 from requests import HTTPError
-from openedx.api import OPENEDX_VALIDATION_REGISTRATION_PATH
+from openedx.api import OPENEDX_REGISTRATION_VALIDATION_PATH
 from openedx.exceptions import EdxApiRegistrationValidationException
 import pytest
 import responses
@@ -82,7 +82,7 @@ def test_create_user_serializer(settings, sample_address):
     """Test that a UserSerializer can be created properly"""
     responses.add(
         responses.POST,
-        settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
+        settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
         json={"validation_decisions": {"username": ""}},
         status=status.HTTP_200_OK,
     )
@@ -177,7 +177,7 @@ def test_username_validation(
     """
     responses.add(
         responses.POST,
-        settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
+        settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
         json={"validation_decisions": {"username": ""}},
         status=status.HTTP_200_OK,
     )
@@ -206,7 +206,7 @@ def test_username_validation_exception(user, settings):
     """
     responses.add(
         responses.POST,
-        settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
+        settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
         json={
             "validation_decisions": {
                 "username": f"It looks like {user.username} belongs to an existing account. Try again with a different username."
@@ -273,7 +273,7 @@ def test_user_create_required_fields_post(sample_address, settings):
     request.user = AnonymousUser()
     responses.add(
         responses.POST,
-        settings.OPENEDX_API_BASE_URL + OPENEDX_VALIDATION_REGISTRATION_PATH,
+        settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
         json={"validation_decisions": {"username": ""}},
         status=status.HTTP_200_OK,
     )

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -1,6 +1,7 @@
 """Tests for users.serializers"""
 from requests import HTTPError
 from openedx.api import OPENEDX_VALIDATION_REGISTRATION_PATH
+from openedx.exceptions import EdxApiRegistrationValidationException
 import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
@@ -231,7 +232,7 @@ def test_username_validation_exception(user, settings):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("exception_raised", [RequestsConnectionError, HTTPError])
+@pytest.mark.parametrize("exception_raised", [EdxApiRegistrationValidationException, RequestsConnectionError, HTTPError])
 def test_username_validation_connection_exception(
     mocker, exception_raised, sample_address
 ):

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -34,17 +34,7 @@ def sample_address():
 @pytest.fixture()
 def application(settings):
     """Test data and settings needed for create_edx_user tests"""
-    settings.OPENEDX_OAUTH_APP_NAME = "test_app_name"
     settings.OPENEDX_API_BASE_URL = "http://example.com"
-    settings.MITX_ONLINE_OAUTH_PROVIDER = "test_provider"
-    settings.MITX_ONLINE_REGISTRATION_ACCESS_TOKEN = "access_token"
-    return Application.objects.create(
-        name=settings.OPENEDX_OAUTH_APP_NAME,
-        user=None,
-        client_type="confidential",
-        authorization_grant_type="authorization-code",
-        skip_authorization=True,
-    )
 
 
 def test_validate_legal_address(sample_address):

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -243,7 +243,9 @@ def test_username_validation_connection_exception(
     UserSerializer should raise a RequestsConnectionError or HTTPError if the connection to OpenEdx
     fails.  The serializer should still be valid.
     """
-    mocker.patch("openedx.api.check_username_exists_in_edx", side_effect=exception_raised)
+    mocker.patch(
+        "openedx.api.check_username_exists_in_edx", side_effect=exception_raised
+    )
 
     serializer = UserSerializer(
         data={

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -243,7 +243,7 @@ def test_username_validation_connection_exception(
     UserSerializer should raise a RequestsConnectionError or HTTPError if the connection to OpenEdx
     fails.  The serializer should still be valid.
     """
-    mocker.patch("openedx.api.username_exists_in_openedx", side_effect=exception_raised)
+    mocker.patch("openedx.api.check_username_exists_in_edx", side_effect=exception_raised)
 
     serializer = UserSerializer(
         data={

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -197,9 +197,8 @@ def test_username_validation(
 @responses.activate
 def test_username_validation_exception(user, settings):
     """
-    UserSerializer should raise a validation error if the given username has invalid characters,
-    or if there is already a user with that username after trimming and ignoring case. The saved
-    username should have whitespace trimmed.
+    UserSerializer should raise a EdxApiRegistrationValidationException if the username already exists
+    in OpenEdx.
     """
     responses.add(
         responses.POST,

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -232,7 +232,10 @@ def test_username_validation_exception(user, settings):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("exception_raised", [EdxApiRegistrationValidationException, RequestsConnectionError, HTTPError])
+@pytest.mark.parametrize(
+    "exception_raised",
+    [EdxApiRegistrationValidationException, RequestsConnectionError, HTTPError],
+)
 def test_username_validation_connection_exception(
     mocker, exception_raised, sample_address
 ):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/734

#### What's this PR do?
Restricts a new `mitxonline` user from registering with a username that is currently taken by an OpenEdx user.  If a new `mitxonline` user attempts to use a username which is already taken by an OpenEdx user, they will be unable to submit the user registration form and presented with an error message.

#### How should this be manually tested?

1. Create an OpenEdx user with a known username.
2. Register a new user through `mitxonline` and attempt to use the same username as in Step 1.
3. Verify that you are unable to create a new user with the username from Step 1, and that you receive an error message.

If you are running `mitxonline` and `openedx` locally, you can also test out the workflow when `mitxonline` cannot connect to `openedx` by only running `mitxonline` locally.  You should perform the same steps listed above, but you will not receive an error message and you should be allowed to successfully submit the registration form.

#### Where should the reviewer start?

- There is a new method added to the `openedx` API service which handles making the request to the `openedx` registration verification service.
- I have added a call to the `openedx` API service method to the User Serializer username validation.
- There is a custom exception that is thrown if the `openedx` API call is unsuccessful.

#### Screenshots (if appropriate)
![Screen Shot 2022-07-29 at 12 10 07 PM](https://user-images.githubusercontent.com/8311573/181800505-90d84df8-207c-4d26-a5c1-30729e00d0da.png)

