### PR TITLE
add migration queries for courserun and enrollment

### DIFF
--- a/micromasters_import/management/commands/queries/002_import_courserun.sql
+++ b/micromasters_import/management/commands/queries/002_import_courserun.sql
@@ -1,0 +1,38 @@
+--courserun migration from MicroMaster to MITxOnline
+INSERT INTO public.courses_courserun(
+    title,
+    courseware_id,
+    run_tag,
+    courseware_url_path,
+    start_date,
+    end_date,
+    enrollment_start,
+    enrollment_end,
+    expiration_date,
+    live,
+    created_on,
+    updated_on,
+    course_id)
+SELECT
+    mm_courserun.title,
+    mm_courserun.edx_course_key,
+    (regexp_match(mm_courserun.edx_course_key, '[^(+|/)]+$'))[1],
+    mm_courserun.enrollment_url,
+    mm_courserun.start_date,
+    mm_courserun.end_date,
+    mm_courserun.enrollment_start,
+    mm_courserun.enrollment_end,
+    mm_courserun.end_date + INTERVAL '1 day', -- expiration date must be later than end_date per validation
+    true, --live
+    coalesce(mm_courserun.enrollment_start, now()),
+    coalesce(mm_courserun.enrollment_end, now()),
+    pk_map.course_id
+FROM micromasters.courses_courserun AS mm_courserun
+JOIN public.micromasters_import_courseid AS pk_map
+  ON mm_courserun.course_id = pk_map.micromasters_id
+LEFT JOIN public.courses_courserun AS mo_courserun
+  ON mo_courserun.courseware_id = mm_courserun.edx_course_key
+WHERE mm_courserun.is_discontinued = false
+  AND mm_courserun.courseware_backend = 'edxorg'
+  AND mo_courserun.courseware_id IS NULL ---course runs that don't exist in MITxOnline
+ON CONFLICT DO NOTHING;

--- a/micromasters_import/management/commands/queries/003_import_enrollment.sql
+++ b/micromasters_import/management/commands/queries/003_import_enrollment.sql
@@ -1,0 +1,32 @@
+--courserun Enrollment migration from MicroMaster to MITxOnline
+INSERT INTO public.courses_courserunenrollment(
+    run_id,
+    user_id,
+    change_status,
+    active,
+    edx_enrolled,
+    edx_emails_subscription,
+    enrollment_mode,
+    created_on,
+    updated_on)
+SELECT
+    mo_courserun.id,
+    mo_user.id,
+    '' AS change_status,
+    (mm_enrollment.data->>'is_active')::boolean,
+    true,
+    false,
+    mm_enrollment.data->>'mode',
+    coalesce(((mm_enrollment.data->'course_details'->>'enrollment_start')::timestamp), now()),
+    coalesce(((mm_enrollment.data->'course_details'->>'enrollment_end')::timestamp), now())
+FROM micromasters.dashboard_cachedenrollment AS mm_enrollment
+JOIN micromasters.courses_courserun AS mm_courserun
+  ON mm_enrollment.course_run_id = mm_courserun.id
+JOIN micromasters.social_auth_usersocialauth AS mm_social
+  ON mm_enrollment.user_id = mm_social.user_id
+JOIN public.users_user AS mo_user
+  ON mm_social.uid = mo_user.username
+JOIN public.courses_courserun AS mo_courserun
+  ON mm_courserun.edx_course_key = mo_courserun.courseware_id
+WHERE mm_social.provider = 'mitxonline'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/701

#### What's this PR do?
This PR contains the queries need to run against MITxOnline to bring over DEDP courserun and enrollment data from MicroMaster

#### How should this be manually tested?

- Go to /admin/micromasters_import/courseid/ to map McroMaster course id to MITxOnline course for DEDP 
- run ```docker-compose run --rm web ./manage.py import_micromasters_data ```

18 courses migrated from MicroMaster RC
![image](https://user-images.githubusercontent.com/3138890/182940501-5b3bed1d-a6d6-458e-af94-5b3a5087ea47.png)
3 enrollments migrated
![image](https://user-images.githubusercontent.com/3138890/182940699-3329a2e7-efe4-4ca1-8c64-406023b51135.png)

