### PR TITLE
fix: enrollment upgrade from free to paid version

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -554,8 +554,13 @@ class EnrollmentModel(TimestampedModel, AuditableModel):
 
     def reactivate_and_save(self, no_user=False):
         """Sets an enrollment to be active again and saves"""
+
         self.active = True
         self.change_status = None
+        return self.save_and_log(None if no_user else self.user)
+
+    def update_mode_and_save(self, mode, no_user=False):
+        self.enrollment_mode = mode
         return self.save_and_log(None if no_user else self.user)
 
 

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -5,8 +5,7 @@ Tasks for the courses app
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
-from courses.api import sync_course_runs
-from courses.models import CourseRun
+from courses.models import CourseRun, CourseRunEnrollment
 from main.celery import app
 
 
@@ -15,6 +14,8 @@ def sync_courseruns_data():
     """
     Task to sync titles and dates for course runs from edX.
     """
+    from courses.api import sync_course_runs
+
     now = now_in_utc()
     runs = CourseRun.objects.live().filter(
         Q(expiration_date__isnull=True) | Q(expiration_date__gt=now)
@@ -22,3 +23,19 @@ def sync_courseruns_data():
 
     # `sync_course_runs` logs internally so no need to capture/output the returned values
     sync_course_runs(runs)
+
+
+@app.task(acks_late=True)
+def subscribe_edx_course_emails(enrollment_id):
+    """Task to subscribe user to edX Emails"""
+    from openedx.api import subscribe_to_edx_course_emails
+
+    enrollment = CourseRunEnrollment.objects.select_related("user", "run").get(
+        id=enrollment_id
+    )
+
+    subscribed = subscribe_to_edx_course_emails(enrollment.user, enrollment.run)
+
+    if subscribed:
+        enrollment.edx_emails_subscription = subscribed
+        enrollment.save()

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -1,0 +1,24 @@
+"""Tests for Course related tasks"""
+
+import pytest
+
+from courses.factories import CourseRunEnrollmentFactory
+from courses.tasks import subscribe_edx_course_emails
+
+pytestmark = pytest.mark.django_db
+
+
+def test_subscribe_edx_course_emails(mocker, user):
+    """Test that subscribe_edx_course_emails task updates the state correctly after subscribing to edX emails"""
+    enrollment = CourseRunEnrollmentFactory.create(
+        user=user, edx_enrolled=True, active=True, edx_emails_subscription=False
+    )
+    subscribe_edx_emails_patch = mocker.patch(
+        "openedx.api.subscribe_to_edx_course_emails", return_value=True
+    )
+
+    subscribe_edx_course_emails.delay(enrollment_id=enrollment.id)
+
+    subscribe_edx_emails_patch.assert_called_once()
+    enrollment.refresh_from_db()
+    assert enrollment.edx_emails_subscription is True


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#762 

#### What's this PR do?
- Refactors the logic in enrollment to add a case when the free enrollment exists and user upgrades to paid

#### How should this be manually tested?
There are a couple of paths you should test it with (The enrollment should properly reflect the state as per the below scenarios):

1. A new user new enrolment _Unpaid_
2. A new user new enrolment _Paid_
3. User enrolled in _Unpaid_, now Pays and enrolles in _Paid Mode_
4. User enrolled unpaid, then _Unenrolls_, now _pays and enrolls again_

