### PR TITLE
online-677 Indicate Financial Assistance links if available for a course

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -1,10 +1,11 @@
 """CMS app serializers"""
+from django.templatetags.static import static
 from rest_framework import serializers
 
 from cms import models
 from cms.api import get_wagtail_img_src
+from cms.models import FlexiblePricingRequestForm
 from courses.constants import DEFAULT_COURSE_IMG_PATH
-from django.templatetags.static import static
 
 
 class CoursePageSerializer(serializers.ModelSerializer):
@@ -12,6 +13,7 @@ class CoursePageSerializer(serializers.ModelSerializer):
 
     feature_image_src = serializers.SerializerMethodField()
     page_url = serializers.SerializerMethodField()
+    financial_assistance_form_url = serializers.SerializerMethodField()
 
     def get_feature_image_src(self, instance):
         """Serializes the source of the feature_image"""
@@ -24,9 +26,23 @@ class CoursePageSerializer(serializers.ModelSerializer):
     def get_page_url(self, instance):
         return instance.get_url()
 
+    def get_financial_assistance_form_url(self, instance):
+        """
+        Returns URL of the Financial Assistance Form.
+        """
+        financial_assistance_page = (
+            instance.get_children().type(FlexiblePricingRequestForm).live().first()
+        )
+        return (
+            f"{instance.get_url()}{financial_assistance_page.slug}/"
+            if financial_assistance_page
+            else ""
+        )
+
     class Meta:
         model = models.CoursePage
         fields = [
             "feature_image_src",
             "page_url",
+            "financial_assistance_form_url",
         ]

--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -1,0 +1,30 @@
+"""
+Tests for cms serializers
+"""
+from cms.factories import FlexiblePricingFormFactory
+from cms.serializers import CoursePageSerializer
+from main.test_utils import assert_drf_json_equal
+
+
+def test_serialize_course_page(mocker, mock_context):
+    """
+    Tests course page serialization with Financial Assistance form.
+    """
+    fake_image_src = "http://example.com/my.img"
+    patched_get_wagtail_src = mocker.patch(
+        "cms.serializers.get_wagtail_img_src", return_value=fake_image_src
+    )
+
+    financial_assistance_form = FlexiblePricingFormFactory()
+    course_page = financial_assistance_form.get_parent()
+
+    data = CoursePageSerializer(instance=course_page).data
+    assert_drf_json_equal(
+        data,
+        {
+            "feature_image_src": fake_image_src,
+            "page_url": None,
+            "financial_assistance_form_url": f"{course_page.get_url()}{financial_assistance_form.slug}/",
+        },
+    )
+    patched_get_wagtail_src.assert_called_once_with(course_page.feature_image)

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -169,6 +169,7 @@ def test_serialize_course_with_page_fields(mocker, mock_context):
             "id": course.id,
             "feature_image_src": fake_image_src,
             "page_url": None,
+            "financial_assistance_form_url": ""
         },
     )
     patched_get_wagtail_src.assert_called_once_with(course_page.feature_image)
@@ -195,6 +196,7 @@ def test_serialize_course_run():
             "expiration_date": drf_datetime(course_run.expiration_date),
             "id": course_run.id,
             "products": [],
+            "page": None,
         },
     )
 

--- a/frontend/public/scss/dashboard.scss
+++ b/frontend/public/scss/dashboard.scss
@@ -29,7 +29,7 @@ $featureImgMobileHeight: 223px;
 
     @include media-breakpoint-up(md) {
       .row {
-        height: $featureImgHeight;
+        height: auto;
 
         > * {
           height: 100%;
@@ -97,12 +97,32 @@ $featureImgMobileHeight: 223px;
     a {
       text-decoration: underline;
       color: $light-gray;
-      margin-right: 2rem;
+      margin: auto 0;
     }
 
     form button.btn-primary {
       font-size: 14px;
       padding: 9px 18px;
+    }
+
+    .pricing-links {
+      display: flex;
+      margin-left: auto;
+
+      form button.btn-primary {
+        font-size: 14px;
+        padding: 0 18px;
+        margin-top: 0;
+        font-weight: 500;
+        height: 36px;
+        @include media-breakpoint-down(sm) {
+          height: auto;
+        }
+      }
+
+      .financial-assist-link {
+        margin: auto 23px auto auto;
+      }
     }
   }
 }

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -344,6 +344,9 @@
           color: #b43e3e;
         }
       }
+      form {
+        margin-bottom: 20px;
+      }
     }
   }
 
@@ -414,5 +417,23 @@
     text-decoration: underline;
     box-shadow: none;
     font-weight: bold;
+  }
+  form {
+    margin-bottom: 20px;
+  }
+}
+
+.financial-assistance-link {
+  height: 22px;
+  font-size: 18px;
+  font-weight: bold;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-align: right;
+  text-decoration: underline;
+  margin-bottom: 0;
+
+  a {
+    color: black;
   }
 }

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -28,7 +28,7 @@ import {
   courseEmailsSubscriptionMutation
 } from "../lib/queries/enrollment"
 import { currentUserSelector } from "../lib/queries/users"
-import { isLinkableCourseRun, generateStartDateText } from "../lib/courseApi"
+import { isFinancialAssistanceAvailable, isLinkableCourseRun, generateStartDateText } from "../lib/courseApi"
 import {
   formatPrettyDateTimeAmPmTz,
   isSuccessResponse,
@@ -272,6 +272,52 @@ export class EnrolledItemCard extends React.Component<
     ) : (
       enrollment.run.course.title
     )
+    const certificateLinks = (
+      enrollment.run.products.length > 0 &&
+      enrollment.enrollment_mode === "audit" &&
+      isFinancialAssistanceAvailable(enrollment.run)
+    ) ? (
+      <div className="pricing-links">
+        <a className="financial-assist-link" href={enrollment.run.page.financial_assistance_form_url}>
+          Financial assistance?
+        </a>
+        <form
+          action="/cart/add/"
+          method="get"
+          className="text-center ml-auto"
+        >
+          <input
+            type="hidden"
+            name="product_id"
+            value={enrollment.run.products[0].id}
+          />
+          <button
+            type="submit"
+            className="btn btn-primary btn-gradient-red"
+          >
+            Get Certificate
+          </button>
+        </form>
+      </div>
+    ) : (
+      <form
+        action="/cart/add/"
+        method="get"
+        className="text-center ml-auto"
+      >
+        <input
+          type="hidden"
+          name="product_id"
+          value={enrollment.run.products[0].id}
+        />
+        <button
+          type="submit"
+          className="btn btn-primary btn-gradient-red"
+        >
+          Get Certificate
+        </button>
+      </form>
+    )
     const startDateDescription = generateStartDateText(enrollment.run)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
@@ -356,26 +402,7 @@ export class EnrolledItemCard extends React.Component<
                 {certLocation ? (
                   <a href={certLocation}>View certificate</a>
                 ) : null}
-                {enrollment.run.products.length > 0 &&
-                enrollmentMode === "audit" ? (
-                    <form
-                      action="/cart/add/"
-                      method="get"
-                      className="text-center ml-auto"
-                    >
-                      <input
-                        type="hidden"
-                        name="product_id"
-                        value={enrollment.run.products[0].id}
-                      />
-                      <button
-                        type="submit"
-                        className="btn btn-primary btn-gradient-red"
-                      >
-                      Get Certificate
-                      </button>
-                    </form>
-                  ) : null}
+                {certificateLinks}
               </div>
             </div>
           </div>

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -272,15 +272,18 @@ export class EnrolledItemCard extends React.Component<
     ) : (
       enrollment.run.course.title
     )
+
+    const financialAssistanceLink = isFinancialAssistanceAvailable(enrollment.run) ? (
+      <a className="financial-assist-link" href={enrollment.run.page.financial_assistance_form_url}>
+        Financial assistance?
+      </a>
+    ) : null
     const certificateLinks = (
       enrollment.run.products.length > 0 &&
-      enrollment.enrollment_mode === "audit" &&
-      isFinancialAssistanceAvailable(enrollment.run)
+      enrollment.enrollment_mode === "audit"
     ) ? (
       <div className="pricing-links">
-        <a className="financial-assist-link" href={enrollment.run.page.financial_assistance_form_url}>
-          Financial assistance?
-        </a>
+        {financialAssistanceLink}
         <form
           action="/cart/add/"
           method="get"
@@ -299,25 +302,8 @@ export class EnrolledItemCard extends React.Component<
           </button>
         </form>
       </div>
-    ) : (
-      <form
-        action="/cart/add/"
-        method="get"
-        className="text-center ml-auto"
-      >
-        <input
-          type="hidden"
-          name="product_id"
-          value={enrollment.run.products[0].id}
-        />
-        <button
-          type="submit"
-          className="btn btn-primary btn-gradient-red"
-        >
-          Get Certificate
-        </button>
-      </form>
-    )
+    ) : null
+
     const startDateDescription = generateStartDateText(enrollment.run)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -282,27 +282,27 @@ export class EnrolledItemCard extends React.Component<
       enrollment.run.products.length > 0 &&
       enrollment.enrollment_mode === "audit"
     ) ? (
-      <div className="pricing-links">
-        {financialAssistanceLink}
-        <form
-          action="/cart/add/"
-          method="get"
-          className="text-center ml-auto"
-        >
-          <input
-            type="hidden"
-            name="product_id"
-            value={enrollment.run.products[0].id}
-          />
-          <button
-            type="submit"
-            className="btn btn-primary btn-gradient-red"
+        <div className="pricing-links">
+          {financialAssistanceLink}
+          <form
+            action="/cart/add/"
+            method="get"
+            className="text-center ml-auto"
           >
+            <input
+              type="hidden"
+              name="product_id"
+              value={enrollment.run.products[0].id}
+            />
+            <button
+              type="submit"
+              className="btn btn-primary btn-gradient-red"
+            >
             Get Certificate
-          </button>
-        </form>
-      </div>
-    ) : null
+            </button>
+          </form>
+        </div>
+      ) : null
 
     const startDateDescription = generateStartDateText(enrollment.run)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -44,7 +44,7 @@ describe("EnrolledItemCard", () => {
         .stub()
         .withArgs(userEnrollment.id, "test")
         .returns(Promise),
-      addUserNotification: helper.sandbox.stub().returns(Function),
+      addUserNotification:                helper.sandbox.stub().returns(Function),
       isFinancialAssistanceAvailableStub: helper.sandbox.stub(
         courseApi,
         "isFinancialAssistanceAvailable"

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -25,7 +25,8 @@ describe("EnrolledItemCard", () => {
     userEnrollment,
     currentUser,
     isLinkableStub,
-    enrollmentCardProps
+    enrollmentCardProps,
+    isFinancialAssistanceAvailableStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -43,7 +44,11 @@ describe("EnrolledItemCard", () => {
         .stub()
         .withArgs(userEnrollment.id, "test")
         .returns(Promise),
-      addUserNotification: helper.sandbox.stub().returns(Function)
+      addUserNotification: helper.sandbox.stub().returns(Function),
+      isFinancialAssistanceAvailableStub: helper.sandbox.stub(
+        courseApi,
+        "isFinancialAssistanceAvailable"
+      )
     }
 
     renderedCard = () =>

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -18,7 +18,7 @@ import {
   courseRunsQueryKey
 } from "../lib/queries/courseRuns"
 
-import { isWithinEnrollmentPeriod } from "../lib/courseApi"
+import {isFinancialAssistanceAvailable, isWithinEnrollmentPeriod} from "../lib/courseApi"
 
 import { getCookie } from "../lib/api"
 import type { User } from "../flow/authTypes"
@@ -54,6 +54,14 @@ export class ProductDetailEnrollApp extends React.Component<
 
   renderUpgradeEnrollmentDialog(run: EnrollmentFlaggedCourseRun) {
     const { courseRuns } = this.props
+    const needFinancialAssistanceLink = isFinancialAssistanceAvailable(run) ?
+      (
+        <p className="text-center financial-assistance-link">
+          <a href={run.page.financial_assistance_form_url}>
+            Need financial assistance??
+          </a>
+        </p>
+      ) : null
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
     return product ? (
@@ -98,6 +106,7 @@ export class ProductDetailEnrollApp extends React.Component<
                   Continue
                 </button>
               </form>
+              {needFinancialAssistanceLink}
             </div>
           </div>
           <div className="cancel-link">{this.getEnrollmentForm()}</div>

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -58,7 +58,7 @@ export class ProductDetailEnrollApp extends React.Component<
       (
         <p className="text-center financial-assistance-link">
           <a href={run.page.financial_assistance_form_url}>
-            Need financial assistance??
+            Need financial assistance?
           </a>
         </p>
       ) : null

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -26,7 +26,7 @@ import sinon from "sinon"
 import { makeUser } from "../factories/user"
 
 describe("ProductDetailEnrollApp", () => {
-  let helper, renderPage, isWithinEnrollmentPeriodStub, courseRun, currentUser
+  let helper, renderPage, isWithinEnrollmentPeriodStub, isFinancialAssistanceAvailableStub, courseRun, currentUser
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -49,6 +49,10 @@ describe("ProductDetailEnrollApp", () => {
     isWithinEnrollmentPeriodStub = helper.sandbox.stub(
       courseApi,
       "isWithinEnrollmentPeriod"
+    )
+    isFinancialAssistanceAvailableStub = helper.sandbox.stub(
+      courseApi,
+      "isFinancialAssistanceAvailable"
     )
   })
 
@@ -281,6 +285,7 @@ describe("ProductDetailEnrollApp", () => {
     it(`shows dialog to upgrade user enrollment with flexible fixed-price discount and handles ${returnedStatusCode} response`, async () => {
       courseRun["products"] = [{ id: 1, price: 10, product_flexible_price: { amount: 9, discount_type: DISCOUNT_TYPE_FIXED_PRICE}}]
       isWithinEnrollmentPeriodStub.returns(true)
+      isFinancialAssistanceAvailableStub.returns(false)
       SETTINGS.features.upgrade_dialog = true
       const { inner } = await renderPage()
 

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -18,7 +18,7 @@ import {
 } from "../lib/queries/courseRuns"
 import { getFlexiblePriceForProduct } from "../lib/util"
 
-import { isWithinEnrollmentPeriod } from "../lib/courseApi"
+import {isFinancialAssistanceAvailable, isWithinEnrollmentPeriod} from "../lib/courseApi"
 
 import { getCookie } from "../lib/api"
 import type { User } from "../flow/authTypes"
@@ -51,6 +51,14 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
 
   renderUpgradeEnrollmentDialog(run: EnrollmentFlaggedCourseRun) {
     const { courseRuns } = this.props
+    const needFinancialAssistanceLink = isFinancialAssistanceAvailable(run) ?
+      (
+        <p className="text-center financial-assistance-link">
+          <a href={run.page.financial_assistance_form_url}>
+            Need financial assistance?
+          </a>
+        </p>
+      ) : null
     const product =
       run.products && !run.is_verified && run.is_enrolled
         ? run.products[0]
@@ -84,6 +92,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
                 Get Certificate
               </button>
             </form>
+            {needFinancialAssistanceLink}
           </div>
         </div>
       </div>

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -48,3 +48,7 @@ export const generateStartDateText = (run: CourseRunDetail) => {
 
   return null
 }
+
+export const isFinancialAssistanceAvailable = (run: CourseRunDetail) => {
+  return !!run.page.financial_assistance_form_url;
+}

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -50,5 +50,5 @@ export const generateStartDateText = (run: CourseRunDetail) => {
 }
 
 export const isFinancialAssistanceAvailable = (run: CourseRunDetail) => {
-  return !!run.page.financial_assistance_form_url;
+  return !!run.page.financial_assistance_form_url
 }

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -3,7 +3,7 @@
 import {
   isLinkableCourseRun,
   isWithinEnrollmentPeriod,
-  generateStartDateText
+  generateStartDateText, isFinancialAssistanceAvailable
 } from "./courseApi"
 import { assert } from "chai"
 import moment from "moment"
@@ -118,6 +118,19 @@ describe("Course API", () => {
           typeof generateStartDateText(courseRun),
           typeof expLinkable
         )
+      })
+    })
+  })
+
+  describe("isFinancialAssistanceAvailable", () => {
+    [
+      ["", false],
+      [null, false],
+      ["/courses/course-v1:MITx+14.310x/financial-assistance-request/", true],
+    ].forEach(([url, expResult]) => {
+      it(`returns ${String(expResult)}`, () => {
+        courseRun["page"] = {financial_assistance_form_url: url}
+        assert.equal(isFinancialAssistanceAvailable(courseRun), expResult)
       })
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/677

#### What's this PR do?
In this PR, we have added an indication for financial assistance for the courses. Financial assistance indication is displayed on the following places:
- User Dashboard
- Course Detail Page
- Course Detail Page Upsell Modal

#### How should this be manually tested?
Follow these steps:
- Add financial assistance form for a course page in CMS by following https://github.com/mitodl/hq/discussions/133.
- Visit the course detail page and click on `Enroll` button. `Need financial assistance?` link is displayed in the popup modal.
- Enroll in the free version(audit mode) of the course.
- Visit Course Detail Page. You can see the `Need financial assistance?` link in the course upsell card.
- Visit the dashboard page from the user profile, you can see the `Financial assistance?` link beside the `Get Certificate` button.

#### Screenshots (if appropriate)
<img width="1026" alt="Screenshot 2022-08-01 at 5 54 20 PM" src="https://user-images.githubusercontent.com/52656433/182152942-acfd7b85-0ee4-4f3c-9615-9925cf804815.png">
<img width="768" alt="Screenshot 2022-08-01 at 5 54 37 PM" src="https://user-images.githubusercontent.com/52656433/182152972-29dde5e3-3745-4721-89d3-e7aa05da945b.png">
<img width="427" alt="Screenshot 2022-08-01 at 5 54 54 PM" src="https://user-images.githubusercontent.com/52656433/182152976-a2a2c674-3543-4c80-8724-1e8d39d480fd.png">
<img width="1396" alt="Screenshot 2022-08-01 at 5 55 26 PM" src="https://user-images.githubusercontent.com/52656433/182152979-8734209e-8d30-496a-b980-790a9c794cbf.png">
<img width="770" alt="Screenshot 2022-08-01 at 5 55 51 PM" src="https://user-images.githubusercontent.com/52656433/182152994-2d503bca-0812-4c0d-a378-d594658eeeb5.png">
<img width="428" alt="Screenshot 2022-08-01 at 5 56 05 PM" src="https://user-images.githubusercontent.com/52656433/182153000-cb55720d-7192-4c27-b05b-1032fbe8b628.png">
<img width="1399" alt="Screenshot 2022-08-01 at 5 56 45 PM" src="https://user-images.githubusercontent.com/52656433/182153009-1f995824-0eb4-4add-aad3-f3a1916fc1ae.png">
<img width="792" alt="Screenshot 2022-08-01 at 5 57 02 PM" src="https://user-images.githubusercontent.com/52656433/182153017-be761f0b-0afe-4259-b2ba-5ee7b6c677d9.png">
<img width="420" alt="Screenshot 2022-08-01 at 5 57 13 PM" src="https://user-images.githubusercontent.com/52656433/182153021-b461c004-7da0-402b-b81c-e35d5d92eefe.png">

