### PR TITLE
770 - flexible pricing: too many decimal places

### DIFF
--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -201,7 +201,7 @@ def test_basket_with_product_serializer():
     serialized_basket = BasketWithProductSerializer(basket_item.basket).data
 
     logic = DiscountType.for_discount(discount)
-    discount_price = logic.get_product_price(basket_item.product)
+    discount_price = logic.get_discounted_price([discount], basket_item.product)
 
     assert serialized_basket["total_price"] == basket_item.product.price
     assert serialized_basket["discounted_price"] == discount_price

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -10,7 +10,7 @@ import { Modal, ModalBody, ModalHeader } from "reactstrap"
 
 import Loader from "../components/Loader"
 import { routes } from "../lib/urls"
-import { getFlexiblePriceForProduct } from "../lib/util"
+import { getFlexiblePriceForProduct, formatLocalePrice } from "../lib/util"
 import { EnrollmentFlaggedCourseRun } from "../flow/courseTypes"
 import {
   courseRunsSelector,
@@ -71,7 +71,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">${getFlexiblePriceForProduct(product)}</div>
+            <div className="text-right align-self-end">{formatLocalePrice(getFlexiblePriceForProduct(product))}</div>
           </div>
           <div className="row">
             <div className="col-12">

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -239,8 +239,7 @@ describe("ProductDetailEnrollApp", () => {
         inner
           .find(".text-right")
           .at(0)
-          .text()
-          .at(1),
+          .text(),
         "$9.00"
       )
     })

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -241,7 +241,7 @@ describe("ProductDetailEnrollApp", () => {
           .at(0)
           .text()
           .at(1),
-        "9"
+        "$9.00"
       )
     })
 

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -16,7 +16,7 @@ import {
   courseRunsQuery,
   courseRunsQueryKey
 } from "../lib/queries/courseRuns"
-import { getFlexiblePriceForProduct } from "../lib/util"
+import { getFlexiblePriceForProduct, formatLocalePrice } from "../lib/util"
 
 import { isWithinEnrollmentPeriod } from "../lib/courseApi"
 
@@ -63,7 +63,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
             <h2>Get a certificate</h2>
           </div>
           <div className="text-right align-self-end">
-            <h2>${getFlexiblePriceForProduct(product)}</h2>
+            <h2>{formatLocalePrice(getFlexiblePriceForProduct(product))}</h2>
           </div>
         </div>
         <div className="row">

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -238,12 +238,12 @@ export const getFlexiblePriceForProduct = (product: Product) => {
 
   switch (flexDiscountType) {
   case DISCOUNT_TYPE_DOLLARS_OFF:
-    return product.price - flexDiscountAmount
+    return Number(product.price - flexDiscountAmount)
   case DISCOUNT_TYPE_PERCENT_OFF:
-    return product.price - ((flexDiscountAmount / 100) * product.price)
+    return Number(product.price - ((flexDiscountAmount / 100) * product.price))
   case DISCOUNT_TYPE_FIXED_PRICE:
-    return flexDiscountAmount
+    return Number(flexDiscountAmount)
   default:
-    return product.price
+    return Number(product.price)
   }
 }


### PR DESCRIPTION
Just like James recommended in my prior PR but I never did...

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/770

#### What's this PR do?
Displays the course price in a format such as `$xxx.xx`.  

#### How should this be manually tested?

1. Login as a learner and navigate to a course that is not free
2. Click the "Enroll" button
3. A modal should appear which will display the certificate price in the top right.  Verify the price is in the correct format.

#### Any background context you want to provide?
James suggested that I use `formatLocalePrice` in a prior PR and I completely forgot to ensure that I did.

#### Screenshots
Desktop:
![Screen Shot 2022-08-02 at 3 35 50 PM](https://user-images.githubusercontent.com/8311573/182459420-71a99ebd-a669-4f92-abb0-cc576c2640e3.png)

Mobile:
![Screen Shot 2022-08-02 at 3 40 41 PM](https://user-images.githubusercontent.com/8311573/182459580-18a2eeed-0eb8-466d-aed5-ca9d30440762.png)

