### PR TITLE
online-779 Display `Documents in order` as default

### DIFF
--- a/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
+++ b/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
@@ -43,7 +43,8 @@ export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps
     const { mutate } = mutationResult;
 
     let [ justification, setJustification ] = useState(modaldata.justification);
-    justification = justification || status !== "approved" ? justification : "Documents in order"
+
+    !justification && status === "approved" ? setJustification("Documents in order") : null
 
     const handleCancel = () => {
         onClose();

--- a/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
+++ b/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
@@ -42,7 +42,8 @@ export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps
     const mutationResult = useUpdate<IFlexiblePriceRequest>();
     const { mutate } = mutationResult;
 
-    const [ justification, setJustification ] = useState(modaldata.justification);
+    let [ justification, setJustification ] = useState(modaldata.justification);
+    justification = justification || status !== "approved" ? justification : "Documents in order"
 
     const handleCancel = () => {
         onClose();


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/779

#### What's this PR do?
Displays `Documents in order` as a default choice in Staff Dashboard while approving a pending financial assistance request.

#### How should this be manually tested?
1. Setup financial assistance for a course using https://github.com/mitodl/hq/discussions/133. 
2. Visit the financial assistance form for a course and request financial assistance.
3. Visit the staff dashboard and go to the flexible prices tab.
4. Click on `approve` for the request that you just submitted.
5. Popup will show `Documents in order` as a default choice.

#### Screenshots (if appropriate)
(Optional)
<img width="1176" alt="Screenshot 2022-08-04 at 4 51 01 PM" src="https://user-images.githubusercontent.com/52656433/182841131-56a05e32-c5e2-4273-b2cb-26d3eb4f8565.png">
<img width="517" alt="Screenshot 2022-08-04 at 4 51 16 PM" src="https://user-images.githubusercontent.com/52656433/182841140-6510d633-c613-4a03-bd79-1079729ea4ba.png">
