### PR TITLE
Fix Issue 767: More dates for course enrollment

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -41,9 +41,47 @@
             {% if start_date %}
             <div class="stat-col">
               <div class="title">start date</div>
-              <div class="text">
+              <div class="date-links-text text" id="start_date">
                 <strong>{{ start_date|date:"F j, Y" }}</strong>
               </div>
+              {% if page.product.unexpired_runs|length > 1 %}
+                {% with course_runs=page.product.unexpired_runs %}
+                  <strong class="more-dates">
+                    <a tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
+                      data-toggle="popover" data-placement="auto" title="More dates available for this course" data-html="true"
+                      data-content="
+                        <div>
+                          <p>Click below to enroll in one of these dates</p>
+                        </div>
+                        {% for course_run in course_runs %}
+                            <div>
+                              <a class='date-link' id='{{ course_run.courseware_id }}' href='#' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                            </div>
+                        {% endfor %}
+                      ">
+                      More Dates
+                    </a>
+                  </strong>
+                {% endwith %}
+              {% elif page.product.first_course_unexpired_runs|length > 1 %}
+                {% with course_runs=page.product.first_course_unexpired_runs product_id=page.product.products.first.id %}
+                  <strong class="more-dates">
+                    <a tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
+                      data-toggle="popover" data-html="true" data-placement="auto" title="More dates available for this program"
+                      data-content="
+                        <div>
+                          <p>Click below to enroll in one of these dates</p>
+                        </div>
+                        {% for course_run in course_runs %}
+                            <div>
+                              <a class='date-link' id='{{ course_run.courseware_id }}' href='#' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                            </div>
+                        {% endfor %}">
+                      More Dates
+                    </a>
+                  </strong>
+                {% endwith %}
+              {% endif %}
             </div>
             {% endif %}
             {% if page.length %}

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -234,6 +234,21 @@
         }
       }
 
+      .more-dates {
+        padding-bottom: 6px;
+        width: 100%;
+        font-size: 12px;
+
+        .dates-tooltip {
+          color: $link-blue !important;
+          text-decoration: underline;
+        }
+      }
+
+      .date-links-text {
+        padding-bottom: 7px !important;
+      }
+
       .title {
         background-color: $sirocco;
         font-weight: 500;

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -43,7 +43,7 @@ export class ProductDetailEnrollApp extends React.Component<
 > {
   state = {
     upgradeEnrollmentDialogVisibility: false,
-    currentCourseRun: null,
+    currentCourseRun:                  null,
   }
 
   toggleUpgradeDialogVisibility = () => {

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -43,7 +43,7 @@ export class ProductDetailEnrollApp extends React.Component<
 > {
   state = {
     upgradeEnrollmentDialogVisibility: false,
-    currentCourseRun: null
+    currentCourseRun: null,
   }
 
   toggleUpgradeDialogVisibility = () => {
@@ -53,7 +53,7 @@ export class ProductDetailEnrollApp extends React.Component<
     })
   }
 
-  setCurrentCourseRun = (courseRun) => {
+  setCurrentCourseRun = courseRun => {
     this.setState({
       currentCourseRun: courseRun
     })
@@ -154,14 +154,14 @@ export class ProductDetailEnrollApp extends React.Component<
     let run = !this.getCurrentCourseRun() && courseRuns ? courseRuns[0] : this.getCurrentCourseRun()
     let product = run && run.products ? run.products[0] : null
     if (courseRuns) {
-      let thisScope = this
+      const thisScope = this
       courseRuns.map(courseRun => {
-        document.addEventListener('click', function(e){
-          if(e.target && e.target.id== courseRun.courseware_id){
+        document.addEventListener('click', function(e) {
+          if (e.target && e.target.id === courseRun.courseware_id) {
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null
-            document.getElementById('start_date').innerHTML = '<strong>'+formatPrettyDate(parseDateString(courseRun.start_date))+'</strong>'
+            document.getElementById('start_date').innerHTML = `<strong>${formatPrettyDate(parseDateString(courseRun.start_date))}</strong>`
           }
         })
       })

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -34,7 +34,8 @@ type Props = {
   currentUser: User
 }
 type ProductDetailState = {
-  upgradeEnrollmentDialogVisibility: boolean
+  upgradeEnrollmentDialogVisibility: boolean,
+  currentCourseRun:                  ?EnrollmentFlaggedCourseRun
 }
 
 export class ProductDetailEnrollApp extends React.Component<
@@ -53,13 +54,13 @@ export class ProductDetailEnrollApp extends React.Component<
     })
   }
 
-  setCurrentCourseRun = courseRun => {
+  setCurrentCourseRun = (courseRun: EnrollmentFlaggedCourseRun) => {
     this.setState({
       currentCourseRun: courseRun
     })
   }
 
-  getCurrentCourseRun = () => {
+  getCurrentCourseRun = (): EnrollmentFlaggedCourseRun => {
     return this.state.currentCourseRun
   }
 
@@ -135,7 +136,7 @@ export class ProductDetailEnrollApp extends React.Component<
       </Modal>
     ) : null
   }
-  getEnrollmentForm(run) {
+  getEnrollmentForm(run: EnrollmentFlaggedCourseRun) {
     const csrfToken = getCookie("csrftoken")
     return (
       <form action="/enrollments/" method="post">
@@ -156,11 +157,13 @@ export class ProductDetailEnrollApp extends React.Component<
     if (courseRuns) {
       const thisScope = this
       courseRuns.map(courseRun => {
+        // $FlowFixMe
         document.addEventListener('click', function(e) {
           if (e.target && e.target.id === courseRun.courseware_id) {
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null
+            // $FlowFixMe
             document.getElementById('start_date').innerHTML = `<strong>${formatPrettyDate(parseDateString(courseRun.start_date))}</strong>`
           }
         })

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -19,7 +19,7 @@ import {
 } from "../lib/queries/courseRuns"
 
 import {isFinancialAssistanceAvailable, isWithinEnrollmentPeriod} from "../lib/courseApi"
-
+import { formatPrettyDate, parseDateString } from "../lib/util"
 import { getCookie } from "../lib/api"
 import type { User } from "../flow/authTypes"
 import users, { currentUserSelector } from "../lib/queries/users"
@@ -42,7 +42,8 @@ export class ProductDetailEnrollApp extends React.Component<
   ProductDetailState
 > {
   state = {
-    upgradeEnrollmentDialogVisibility: false
+    upgradeEnrollmentDialogVisibility: false,
+    currentCourseRun: null
   }
 
   toggleUpgradeDialogVisibility = () => {
@@ -52,8 +53,19 @@ export class ProductDetailEnrollApp extends React.Component<
     })
   }
 
-  renderUpgradeEnrollmentDialog(run: EnrollmentFlaggedCourseRun) {
+  setCurrentCourseRun = (courseRun) => {
+    this.setState({
+      currentCourseRun: courseRun
+    })
+  }
+
+  getCurrentCourseRun = () => {
+    return this.state.currentCourseRun
+  }
+
+  renderUpgradeEnrollmentDialog() {
     const { courseRuns } = this.props
+    const run = !this.getCurrentCourseRun() && courseRuns ? courseRuns[0] : this.getCurrentCourseRun()
     const needFinancialAssistanceLink = isFinancialAssistanceAvailable(run) ?
       (
         <p className="text-center financial-assistance-link">
@@ -109,7 +121,7 @@ export class ProductDetailEnrollApp extends React.Component<
               {needFinancialAssistanceLink}
             </div>
           </div>
-          <div className="cancel-link">{this.getEnrollmentForm()}</div>
+          <div className="cancel-link">{this.getEnrollmentForm(run)}</div>
           <div className="faq-link">
             <a
               href="https://mitxonline.zendesk.com/hc/en-us"
@@ -123,10 +135,8 @@ export class ProductDetailEnrollApp extends React.Component<
       </Modal>
     ) : null
   }
-  getEnrollmentForm() {
+  getEnrollmentForm(run) {
     const csrfToken = getCookie("csrftoken")
-    const { courseRuns } = this.props
-    const run = courseRuns ? courseRuns[0] : null
     return (
       <form action="/enrollments/" method="post">
         <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
@@ -141,8 +151,21 @@ export class ProductDetailEnrollApp extends React.Component<
   render() {
     const { courseRuns, isLoading, status } = this.props
     const csrfToken = getCookie("csrftoken")
-    const run = courseRuns ? courseRuns[0] : null
-    const product = run && run.products ? run.products[0] : null
+    let run = !this.getCurrentCourseRun() && courseRuns ? courseRuns[0] : this.getCurrentCourseRun()
+    let product = run && run.products ? run.products[0] : null
+    if (courseRuns) {
+      let thisScope = this
+      courseRuns.map(courseRun => {
+        document.addEventListener('click', function(e){
+          if(e.target && e.target.id== courseRun.courseware_id){
+            thisScope.setCurrentCourseRun(courseRun)
+            run = thisScope.getCurrentCourseRun()
+            product = run && run.products ? run.products[0] : null
+            document.getElementById('start_date').innerHTML = '<strong>'+formatPrettyDate(parseDateString(courseRun.start_date))+'</strong>'
+          }
+        })
+      })
+    }
 
     return (
       // $FlowFixMe: isLoading null or undefined
@@ -201,7 +224,7 @@ export class ProductDetailEnrollApp extends React.Component<
               )
             ) : null}
             {SETTINGS.features.upgrade_dialog && run
-              ? this.renderUpgradeEnrollmentDialog(run)
+              ? this.renderUpgradeEnrollmentDialog()
               : null}
           </Fragment>
         )}

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -5,10 +5,10 @@ import "video.js"
 import "videojs-youtube/dist/Youtube"
 import $ from 'jquery'
 $(".dates-tooltip").popover({
-    template:
-        '<div class="popover" role="tooltip">' +
-        '<div class="arrow"></div>' +
-        '<div class="popover-header py-2 px-0 mx-5"></div>' +
-        '<div class="popover-body"></div>' +
-        "</div>"
-  });
+  template:
+    '<div class="popover" role="tooltip">' +
+    '<div class="arrow"></div>' +
+    '<div class="popover-header py-2 px-0 mx-5"></div>' +
+    '<div class="popover-body"></div>' +
+    "</div>"
+})

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -3,3 +3,12 @@ import "jquery"
 import "bootstrap"
 import "video.js"
 import "videojs-youtube/dist/Youtube"
+import $ from 'jquery'
+$(".dates-tooltip").popover({
+    template:
+        '<div class="popover" role="tooltip">' +
+        '<div class="arrow"></div>' +
+        '<div class="popover-header py-2 px-0 mx-5"></div>' +
+        '<div class="popover-body"></div>' +
+        "</div>"
+  });


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #767

#### What's this PR do?
The PR enables to select another date if available for enrollment.

#### How should this be manually tested?
- Checkout the branch.
- Visit `Course Enrollment page`.
- In `Start Date` box there should be link `More Dates` by clicking it should show the tooltip box
- In Tooltip by clicking any date should update the `Start Date` box
- Clicking on `Enroll now` should perform the Enrollment according to selected date
- If product is available in selected date of `Course Run` it should display Purchase Modal otherwise perform enrollment
- Test if you are enrolled in the selected date of `Course Run`
#### Screenshots
<img width="1791" alt="Screenshot 2022-08-04 at 9 11 15 PM" src="https://user-images.githubusercontent.com/77275478/182900087-1b0c6203-50a9-44fb-8ee7-1b3d56d7412a.png">
<img width="1791" alt="Screenshot 2022-08-04 at 9 11 24 PM" src="https://user-images.githubusercontent.com/77275478/182900244-50aca2f0-3bb9-45e4-b577-a85946fe4c84.png">
<img width="1791" alt="Screenshot 2022-08-04 at 9 11 43 PM" src="https://user-images.githubusercontent.com/77275478/182900306-b654075a-7b39-41ee-bc7d-d39be8a8fc83.png">
<img width="1791" alt="Screenshot 2022-08-04 at 9 12 14 PM" src="https://user-images.githubusercontent.com/77275478/182900317-19415f75-9c80-4bd9-a3fe-3300e6615945.png">
<img width="1791" alt="Screenshot 2022-08-04 at 9 12 24 PM" src="https://user-images.githubusercontent.com/77275478/182900332-9b7bf975-b54b-4ba1-a3e8-78b97d584563.png">
