### PR TITLE
Online-664 Add additional data to Financial Assistance Request Table and Dialog

### DIFF
--- a/flexiblepricing/serializers.py
+++ b/flexiblepricing/serializers.py
@@ -1,14 +1,11 @@
+from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
-from mitol.common.utils.datetime import now_in_utc
 
+from courses.models import Course, Program
+from courses.serializers import BaseCourseSerializer, BaseProgramSerializer
+from ecommerce.models import Discount
+from ecommerce.serializers import DiscountSerializer
 from flexiblepricing import models
-from flexiblepricing.api import (
-    determine_income_usd,
-    determine_auto_approval,
-)
-from flexiblepricing.constants import FlexiblePriceStatus
-from flexiblepricing.exceptions import NotSupportedException
 from users.serializers import UserSerializer
 
 
@@ -50,3 +47,98 @@ class FlexiblePriceSerializer(serializers.ModelSerializer):
             "justification",
             "country_of_residence",
         ]
+
+
+class FlexiblePriceAdminSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Financial Assistance Requests
+    """
+
+    COURSEWARE_SERIALIZER_CLASSES = {
+        Course: BaseCourseSerializer,
+        Program: BaseProgramSerializer,
+    }
+
+    courseware = serializers.SerializerMethodField()
+    discount = serializers.SerializerMethodField()
+    user = UserSerializer(read_only=True)
+    applicable_discounts = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.FlexiblePrice
+        fields = [
+            "id",
+            "user",
+            "status",
+            "income_usd",
+            "original_income",
+            "original_currency",
+            "country_of_income",
+            "date_exchange_rate",
+            "date_documents_sent",
+            "justification",
+            "country_of_residence",
+            "courseware",
+            "discount",
+            "applicable_discounts",
+        ]
+
+    def update(self, instance, validated_data):
+        """
+        Updates Flexible price tier if staff has changed the discount while approving a financial assistance request.
+        """
+        selected_discount = self.initial_data.get("discount", None)
+        discount_id = selected_discount.get("id", None) if selected_discount else None
+
+        if discount_id and discount_id != instance.tier.discount_id:
+            courseware_content_type = ContentType.objects.get_for_model(
+                instance.courseware_object
+            )
+            flexible_price_tier = models.FlexiblePriceTier.objects.filter(
+                current=True,
+                courseware_content_type=courseware_content_type,
+                courseware_object_id=instance.courseware_object_id,
+                discount_id=discount_id,
+            ).first()
+            instance.tier = flexible_price_tier
+
+        return super().update(instance, validated_data)
+
+    def get_courseware(self, instance):
+        """
+        Returns serialized courseware object.
+        """
+        courseware_content_type = ContentType.objects.get_for_model(
+            instance.courseware_object
+        )
+        courseware_serializer_class = self.COURSEWARE_SERIALIZER_CLASSES.get(
+            courseware_content_type.model_class(), None
+        )
+        if courseware_serializer_class:
+            return courseware_serializer_class(instance=instance.courseware_object).data
+
+        return None
+
+    def get_discount(self, instance):
+        """
+        Returns applied discount information for a Financial Assistance Request.
+        """
+        return DiscountSerializer(instance=instance.tier.discount).data
+
+    def get_applicable_discounts(self, instance):
+        """
+        Returns discount options for a Financial Assistance Request.
+        """
+        courseware_content_type = ContentType.objects.get_for_model(
+            instance.courseware_object
+        )
+        discounts = Discount.objects.filter(
+            flexible_price_tiers__current=True,
+            flexible_price_tiers__courseware_content_type=courseware_content_type,
+            flexible_price_tiers__courseware_object_id=instance.courseware_object_id,
+        )
+
+        return DiscountSerializer(
+            discounts,
+            many=True,
+        ).data

--- a/flexiblepricing/views/v0/__init__.py
+++ b/flexiblepricing/views/v0/__init__.py
@@ -1,16 +1,15 @@
 """
 MITxOnline Flexible Pricing/Financial Aid views
 """
-from rest_framework.viewsets import ModelViewSet
-from rest_framework.authentication import SessionAuthentication, TokenAuthentication
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
-from django_filters.rest_framework import DjangoFilterBackend
 from django.db import transaction
-from main.views import RefinePagination
 from django.db.models import Q
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.viewsets import ModelViewSet
 
 from flexiblepricing import models, serializers
 from flexiblepricing.tasks import notify_flexible_price_status_change_email
+from main.views import RefinePagination
 
 
 class CurrencyExchangeRateViewSet(ModelViewSet):
@@ -38,7 +37,7 @@ class FlexiblePriceViewSet(ModelViewSet):
 
 
 class FlexiblePriceAdminViewSet(ModelViewSet):
-    serializer_class = serializers.FlexiblePriceSerializer
+    serializer_class = serializers.FlexiblePriceAdminSerializer
     authentication_classes = (SessionAuthentication, TokenAuthentication)
     permission_classes = (IsAdminUser,)
     pagination_class = RefinePagination

--- a/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
+++ b/frontend/staff-dashboard/src/components/flexiblepricing/statusmodal.tsx
@@ -6,7 +6,8 @@ import {
     Modal
 } from "@pankod/refine-antd";
 
-import { IFlexiblePriceRequest, IFlexiblePriceStatusModalProps } from "interfaces";
+import {IDiscount, IFlexiblePriceRequest, IFlexiblePriceStatusModalProps} from "interfaces";
+import { formatDiscount } from "utils";
 
 const All_Justifications = [
     {
@@ -43,8 +44,18 @@ export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps
     const { mutate } = mutationResult;
 
     let [ justification, setJustification ] = useState(modaldata.justification);
-
     !justification && status === "approved" ? setJustification("Documents in order") : null
+
+    const [ discount, setDiscount ] = useState(modaldata.discount);
+    let discount_choices = [];
+    for (let applicable_discount of modaldata.applicable_discounts) {
+        discount_choices.push(
+            {
+                "value": applicable_discount.id,
+                "label": formatDiscount(applicable_discount)
+            }
+        )
+    }
 
     const handleCancel = () => {
         onClose();
@@ -52,6 +63,13 @@ export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps
 
     const handleChangeJustification = (e: string) => {
         setJustification(e);
+    }
+
+    const handleChangeDiscount = (e: number) => {
+        const selected_discount_label = modaldata.applicable_discounts.find(discount_option => {
+            return discount_option.id === e
+        })
+        setDiscount(selected_discount_label as IDiscount);
     }
 
     const handleOk = () => {
@@ -67,7 +85,7 @@ export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps
             return;
         }
 
-        const sendableData = { ...modaldata, status: status, justification: justification };
+        const sendableData = { ...modaldata, status: status, justification: justification, discount: discount };
 
         mutate({ 
             resource: "flexible_pricing/applications_admin",
@@ -85,6 +103,10 @@ export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps
                 {status == "denied" ? <div>User will be notified by email of the denial </div> : null}
             </div>
             <br></br>
+            <p>
+                <strong>Courseware:</strong>
+                <div>{modaldata.courseware.readable_id}</div>
+            </p>
             <p>
                 <strong>Current Status:</strong>
                 <div>{modaldata.status}</div>
@@ -104,6 +126,20 @@ export const FlexiblePricingStatusModal: React.FC<IFlexiblePriceStatusModalProps
             <p>
                 <strong>Country of Income:</strong>
                 <div>{modaldata.country_of_income}</div>
+            </p>
+            <p>
+                <span><strong>Discount:</strong></span>
+                {
+                    status !== "approved" ?
+                        <div>{ formatDiscount(modaldata.discount) }</div> :
+                        <Select
+                            onChange={(e) => handleChangeDiscount(e)}
+                            style={{ marginLeft: "44px", 'width': '20rem' }}
+                            options={discount_choices}
+                            defaultValue={modaldata.discount.id}
+                        >
+                        </Select>
+                }
             </p>
             <p>
                 <span>

--- a/frontend/staff-dashboard/src/interfaces/index.d.ts
+++ b/frontend/staff-dashboard/src/interfaces/index.d.ts
@@ -9,7 +9,7 @@ export interface IProduct {
 export interface IDiscount {
     id: number;
     discount_code: string;
-    amount: float;
+    amount: string;
     discount_type: string;
     redemption_type: string;
     max_redemptions: number;
@@ -41,19 +41,29 @@ export interface IDiscountProductRaw {
     product_id: number|null;
 }
 
+export interface ICourseware {
+    id: number;
+    title: string;
+    readable_id: string;
+}
+
+
 export interface IFlexiblePriceRequest {
     id: number;
     user: number;
+    courseware: ICourseware;
     status: string;
     income_usd: number;
     original_income: number;
     original_currency: string;
     country_of_income: null;
     date_exchange_rate: Date;
+    discount: IDiscount;
     date_documents_sent: Date;
     justification: string;
     country_of_residence: string;
-    action: string
+    action: string;
+    applicable_discounts: IDiscount[]
 }
 
 export interface IFlexiblePriceStatus {

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -20,6 +20,7 @@ import {
 
 import { IFlexiblePriceRequest, IFlexiblePriceRequestFilters } from "interfaces";
 import { FlexiblePricingStatusModal } from "components/flexiblepricing/statusmodal";
+import { formatDiscount } from "utils";
 
 const FlexiblePricingStatuses = [
     {
@@ -145,6 +146,11 @@ export const FlexiblePricingList: React.FC = () => {
                                 render={(value) => formatStatus(value)}
                             />
                             <Table.Column
+                                dataIndex="courseware"
+                                title="Courseware"
+                                render={(value) => value.readable_id}
+                            />
+                            <Table.Column
                                 dataIndex="income_usd"
                                 title="Income (USD)"
                                 render={(value) => parseFloat(value).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
@@ -153,6 +159,11 @@ export const FlexiblePricingList: React.FC = () => {
                                 dataIndex="date_exchange_rate"
                                 title="Date Calculated"
                                 render={(value) => <DateField format="LLL" value={value} />}
+                            />
+                            <Table.Column
+                                dataIndex="discount"
+                                title="Discount"
+                                render={(value) => <div>{ formatDiscount(value) }</div>}
                             />
                             <Table.Column
                                 dataIndex="original_currency"

--- a/frontend/staff-dashboard/src/utils.ts
+++ b/frontend/staff-dashboard/src/utils.ts
@@ -1,0 +1,18 @@
+import {IDiscount} from "./interfaces";
+
+export const formatDiscount = (discount: IDiscount) => {
+    let formattedDiscount = discount.amount;
+
+    switch (discount.discount_type) {
+        case "percent-off":
+            formattedDiscount = parseFloat(discount.amount).toFixed(2) + "% off"
+            break
+        case "dollars-off":
+            formattedDiscount = parseFloat(discount.amount).toLocaleString('en-US', { style: 'currency', currency: 'USD' }) + " off"
+            break
+        case "fixed-price":
+            formattedDiscount = parseFloat(discount.amount).toLocaleString('en-US', { style: 'currency', currency: 'USD' }) + " fixed-price"
+            break
+    }
+    return formattedDiscount;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/664

#### What's this PR do?
Adds additional data in the staff dashboard for Financial Assistance requests. This PR adds courseware information and discount information for a financial assistance request. While approving a request admin can also change the discount from the dropdown.

#### How should this be manually tested?
(Required)

- Setup financial assistance for a course/program using https://github.com/mitodl/hq/discussions/133.
- Submit a financial assistance request.
- Visit flexible pricing in Refine dashboard.
- In the flexible pricing list, you can see the `courseware readable id` and `Discount` information.
- When you click on approve button for a request, courseware information is displayed. Also, a dropdown for discounts is displayed. So, you can change the discount for a request. You can change it from the refine dashboard and verify it from Django-admin.
- While denying or resetting a request, the discount is a static field.


#### Screenshots (if appropriate)
(Optional)
<img width="520" alt="Screenshot 2022-08-12 at 11 17 54 AM" src="https://user-images.githubusercontent.com/52656433/184295862-069add59-52eb-4894-bd01-a3e79a5d64fc.png">
<img width="520" alt="Screenshot 2022-08-12 at 11 18 00 AM" src="https://user-images.githubusercontent.com/52656433/184295875-7749d6cb-548a-4fe0-9429-f7eb7714582d.png">
<img width="520" alt="Screenshot 2022-08-12 at 11 18 05 AM" src="https://user-images.githubusercontent.com/52656433/184295883-4191dbc2-0d15-478c-9205-7f9cccf27235.png">
<img width="520" alt="Screenshot 2022-08-12 at 11 18 11 AM" src="https://user-images.githubusercontent.com/52656433/184295888-2b0fbbed-6c19-47e7-af2c-92310a795164.png">
<img width="1177" alt="Screenshot 2022-08-12 at 11 18 52 AM" src="https://user-images.githubusercontent.com/52656433/184295944-50e6bf48-67db-43a3-8d2d-2904657e6940.png">
