### PR TITLE
Updates status filtering to send an undefined if there's nothing selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ celerybeat-schedule
 
 # Local Docker customizations
 docker-compose.*.yml
+
+.python-version

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -23,10 +23,6 @@ import { FlexiblePricingStatusModal } from "components/flexiblepricing/statusmod
 
 const FlexiblePricingStatuses = [
     {
-        label: null,
-        value: null,
-    },
-    {
         label: 'Created',
         value: 'created'
     },
@@ -64,7 +60,8 @@ const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formPro
                 <Select
                     style={{ minWidth: 200 }}
                     placeholder={FlexiblePricingStatusText}
-                    options={FlexiblePricingStatuses} />
+                    options={FlexiblePricingStatuses}
+                    allowClear={true} />
             </Form.Item>
             <Form.Item>
                 <Button htmlType="submit" type="primary">


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #731

#### What's this PR do?

Updates the filter processing code in the Staff Dashboard's Flexible Pricing list screen to clear the Status filter when the blank option is selected. 

#### How should this be manually tested?

You will need to have some Flexible Price requests in the system to test. For best results, they should be a mix of statuses. 

1. Navigate to Flexible Pricing in the Staff Dashboard.
2. Filter by any status. Only the requests matching the status you selected should be shown.
3. Clear the filter by selecting the blank option at the top. Upon selecting the Filter button, all requests should be shown (i.e., it shouldn't be filtering by Status). 

#### Any background context you want to provide?

Implementation detail: clearing the filter requires passing `undefined` as the option. So, the change here was just to check for something non-true and explicitly set the filter argument as `undefined`. Simply omitting the filter does not work. 

#### Screenshots (if appropriate)
(Optional)
