### PR TITLE
Switch some settings to use urljoin

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -1008,17 +1008,17 @@ MITX_ONLINE_REFINE_OIDC_CONFIG_CLIENT_ID = get_string(
 )
 MITX_ONLINE_REFINE_OIDC_CONFIG_AUTHORITY = get_string(
     name="MITX_ONLINE_REFINE_OIDC_CONFIG_AUTHORITY",
-    default=f"{SITE_BASE_URL}/oauth2/",
+    default=urljoin(SITE_BASE_URL, "/oauth2/"),
     description="open exchange app id for fetching currency exchange rate",
 )
 MITX_ONLINE_REFINE_OIDC_CONFIG_REDIRECT_URI = get_string(
     name="MITX_ONLINE_REFINE_OIDC_CONFIG_REDIRECT_URI",
-    default=f"{SITE_BASE_URL}/staff-dashboard/oauth2/login/",
+    default=urljoin(SITE_BASE_URL, "/staff-dashboard/oauth2/login/"),
     description="Url to redirect the user to",
 )
 MITX_ONLINE_REFINE_MITX_ONLINE_DATASOURCE = get_string(
     name="MITX_ONLINE_REFINE_MITX_ONLINE_DATASOURCE",
-    default=f"{SITE_BASE_URL}/api",
+    default=urljoin(SITE_BASE_URL, "/api"),
     description="open exchange app id for fetching currency exchange rate",
 )
 GOOGLE_DOMAIN_VERIFICATION_TAG_VALUE = get_string(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

N/A - this fixes a small avoidable issue w/ configuration

#### What's this PR do?
This fixes the refine dashboard settings to have correct urls regardless of `SITE_BASE_URL` having a trailing slash or not. I wasted a bit of time trying to debug oauth issues related to this.

#### How should this be manually tested?
You should be able to login to the refine dashboard having a base url with and without a trailing slash.