### PR TITLE
794-flexible-pricing-program-level-discount-isnt-reflected-in-enrollment-pop-up

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -761,7 +761,7 @@ class FlexiblePricingRequestForm(AbstractForm):
             flexible_price.status = FlexiblePriceStatus.PENDING_MANUAL_APPROVAL
         flexible_price.save()
         if flexible_price.courseware_content_type != tier.courseware_content_type:
-            flexible_price.courseware_content_type=tier.courseware_content_type
+            flexible_price.courseware_content_type = tier.courseware_content_type
             flexible_price.save()
 
     # Matches the standard page path that Wagtail returns for this page type.

--- a/cms/models.py
+++ b/cms/models.py
@@ -760,6 +760,9 @@ class FlexiblePricingRequestForm(AbstractForm):
         else:
             flexible_price.status = FlexiblePriceStatus.PENDING_MANUAL_APPROVAL
         flexible_price.save()
+        if flexible_price.courseware_content_type != tier.courseware_content_type:
+            flexible_price.courseware_content_type=tier.courseware_content_type
+            flexible_price.save()
 
     # Matches the standard page path that Wagtail returns for this page type.
     slugged_page_path_pattern = re.compile(r"(^.*/)([^/]+)(/?$)")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/794

#### What's this PR do?
Forces an additional save of the Flexible Price when the Flexible Price form is completed by a user on a Course page for a Flexible Price Tier which is associated Program.  This allows us to override the generic relation which influences the ContentType associated with the Flexible Price.

#### How should this be manually tested?

- Submit a Flexible Pricing request for a Course which is associated Program (the Program should have two related Courses), and for which all Flexible Price Tiers are defined for the `Course | Program` content type. 
- Approve the Flexible Price request.
- Navigate to the other Course associated with the Program.
- Verify that you see a discounted price for the second Course associated with the Program.

#### Any background context you want to provide?
My solution here feels a bit _hacky_ and I don't like that it requires the Flexible Price to be saved twice.  Feel free to make any suggestions, I'd like to learn of a better way this can be done.