### PR TITLE
Adds some more time to the docker-compose watches

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,8 +99,8 @@ services:
       test: curl -f http://watch:8012/health || exit 1
       interval: 5s
       timeout: 1s
-      retries: 3
-      start_period: 30s
+      retries: 4
+      start_period: 45s
 
   celery:
     build:


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
n/a

#### What's this PR do?
Increases the startup period to 45 seconds and adds in another retry to give the JavaScript containers more time to complete initial build processes. 

#### How should this be manually tested?

Restart the service. The JavaScript containers should be able to complete their tasks before the healthcheck gives up on them (i.e., it should start successfully). The `refine` container is typically the one that takes the longest, so keeping an eye on that (`docker compose log -f refine` or `docker inspect --format "{{json .State.Health}}" mitxonline-refine-1 | jq` if you have `jq` installed) is a good idea.
