### PR TITLE
Fixes scrolling when the program drawer has items that extend beyond the bottom of the screen

### DIFF
--- a/frontend/public/scss/dashboard.scss
+++ b/frontend/public/scss/dashboard.scss
@@ -160,6 +160,7 @@ $program-badge-bg: #DBF2F3;
   background-color: $sidenav-bg;
   transition: right 0.2s ease-in-out ;
   padding: 15px 36px;
+  overflow-y: scroll;
 
   &.open {
     box-shadow: 0 3px 0 10px rgba(0,0,0,.2);

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -40,7 +40,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
     return (
       <>
         <div className={backgroundClass}></div>
-        <div className={drawerClass}>
+        <div className={drawerClass} id="program_enrollment_drawer">
           <div className="row chrome">
             <button type="button" className="close" aria-label="Close" onClick={closeDrawer}>
               <span aria-hidden="true">


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #826 

#### What's this PR do?

Changes the `overflow-y` on the program drawer to `hidden`, which allows the content to be scrollable, and adds an event handler if the drawer is visible to sync the scrolling of the drawer with the dashboard page. The event handler is removed when the drawer is toggled back off. 

#### How should this be manually tested?

Enroll in a program with many courses. You will need to enroll in a sufficient number of courses to extend the card list past the bottom edge of the viewport. Then, load the dashboard and activate the program drawer - the drawer should activate and scrolling should work.

