### PR TITLE
Online-815 Fix styling for income field

### DIFF
--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -147,7 +147,7 @@ export const FlexiblePricingList: React.FC = () => {
                             <Table.Column
                                 dataIndex="income_usd"
                                 title="Income (USD)"
-                                render={(value) => parseFloat(value).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                                render={(value) => <div className="income-usd"><span>{parseFloat(value).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}</span></div>}
                             />
                             <Table.Column
                                 dataIndex="date_exchange_rate"

--- a/frontend/staff-dashboard/src/styles/antd.less
+++ b/frontend/staff-dashboard/src/styles/antd.less
@@ -6,3 +6,13 @@
 // https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
 
 @primary-color: #A31F34;
+
+.income-usd {
+  max-width: 100px;
+  overflow-x: scroll;
+  height: 35px;
+
+  span {
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/815

#### What's this PR do?
Fixed width for Income field in financial assistance requests list. Also, for too long income number horizontal scrolling is added.

#### How should this be manually tested?
- Add a very long number in the income field for Financial assistance requests.
- Visit Flexible prices in the refine dashboard. Too long Income number is scrollable with fixed width.


#### Screenshots (if appropriate)
(Optional)
<img width="1177" alt="Screenshot 2022-08-12 at 5 31 07 PM" src="https://user-images.githubusercontent.com/52656433/184355141-7dd4d090-b580-4a94-9b9f-23e68335234e.png">
<img width="720" alt="Screenshot 2022-08-12 at 5 31 57 PM" src="https://user-images.githubusercontent.com/52656433/184355166-130df8f6-d4bf-4dfa-bf26-455ae61290f4.png">
<img width="423" alt="Screenshot 2022-08-12 at 5 32 14 PM" src="https://user-images.githubusercontent.com/52656433/184355172-afb7ce75-7bc1-4b7a-85be-c8511403ba9e.png">
