### PR TITLE
Update refine callback URL to remove double slash

### DIFF
--- a/docs/source/configuration/refine_admin.rst
+++ b/docs/source/configuration/refine_admin.rst
@@ -37,7 +37,7 @@ Step 2: Configuring MITxOnline
 You will need to add a new Application in the Django Oauth Toolkit section in Django Admin (``/admin/oauth2_provider/application/``). Navigate there and create a new Application. Use these values (overwriting the defaults where necessary):
 
 * **Client Id**: ``refine-local-client-id``
-* **Redirect uris**: ``http://mitxonline.odl.local:8013//staff-dashboard/oauth2/login/``
+* **Redirect uris**: ``http://mitxonline.odl.local:8013/staff-dashboard/oauth2/login/``
 * **Client type**: Public
 * **Authorization grants**: Authorization Code
 * **Skip authorization**: checked


### PR DESCRIPTION
#### What's this PR do?
Previously you need to use a double slash for the oauth callback URL used when configuring the refine connection.  With https://github.com/mitodl/mitxonline/pull/802, the double slash hack is no longer needed.

#### How should this be manually tested?
- Open the refine oauth configuration at http://mitxonline.odl.local:8013/admin/oauth2_provider/application/ and set the redirect URI to `http://mitxonline.odl.local:8013//staff-dashboard/oauth2/login/`.
- Confirm that the refine dashboard does not allow you to login successfully as an admin user.
- Update the redirect URI to `http://mitxonline.odl.local:8013/staff-dashboard/oauth2/login/`
- Confirm that the refine dashboard does allow you to login successfully as an admin user.
