### PR TITLE
Purges the Fastly cache for a page once the page has been modified

### DIFF
--- a/app.json
+++ b/app.json
@@ -99,6 +99,14 @@
       "description": "Timeout (in seconds) for requests made via the edX API client",
       "required": false
     },
+    "FASTLY_AUTH_TOKEN": {
+      "description": "Optional token for the Fastly purge API.",
+      "required": false
+    },
+    "FASTLY_URL": {
+      "description": "The URL to the Fastly API.",
+      "required": false
+    },
     "GA_TRACKING_ID": {
       "description": "Google analytics tracking ID",
       "required": false

--- a/cms/api.py
+++ b/cms/api.py
@@ -12,6 +12,8 @@ from wagtail.core.models import Page, Site
 
 from cms import models as cms_models
 from cms.exceptions import WagtailSpecificPageError
+from cms.models import Page
+
 
 log = logging.getLogger(__name__)
 DEFAULT_HOMEPAGE_PROPS = dict(

--- a/cms/apps.py
+++ b/cms/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class CmsConfig(AppConfig):
+    name = "cms"
+
+    def ready(self):
+        from . import signalreceivers
+
+        pass

--- a/cms/signalreceivers.py
+++ b/cms/signalreceivers.py
@@ -1,0 +1,30 @@
+from wagtail.core.signals import page_published, page_unpublished, post_page_move
+from cms.tasks import queue_fastly_purge_url
+import logging
+
+
+def fastly_purge_url_receiver(sender, **kwargs):
+    """
+    Generic receiver for the Wagtail page_published, page_unpublished, and
+    post_page_move signals. The most important part of the kwargs passed in all
+    of these is the page instance so we can use the same receiver for all of them.
+
+    For post_page_move, we also look for the url_path_before arg and only
+    process this if the path_before and path_after are different.
+    """
+    logger = logging.getLogger("cms.signalreceiver")
+
+    instance = kwargs["instance"]
+
+    if "url_path_before" in kwargs:
+        if kwargs["url_path_before"] == kwargs["url_path_after"]:
+            return
+
+    logger.info(f"Queueing Fastly purge for {instance.id} - {instance.title}")
+
+    queue_fastly_purge_url.delay(instance.id)
+
+
+page_published.connect(fastly_purge_url_receiver)
+page_unpublished.connect(fastly_purge_url_receiver)
+post_page_move.connect(fastly_purge_url_receiver)

--- a/cms/tasks.py
+++ b/cms/tasks.py
@@ -1,0 +1,52 @@
+from main.celery import app
+from main.settings import (
+    SITE_BASE_URL,
+    MITX_ONLINE_FASTLY_AUTH_TOKEN,
+    MITX_ONLINE_FASTLY_URL,
+)
+from cms.models import Page
+from urllib.parse import urljoin, urlparse
+import fastly
+import logging
+
+
+@app.task
+def queue_fastly_purge_url(page_id):
+    """
+    Purges the given page_id from the Fastly cache. This should happen on a
+    handful of Wagtail signals:
+    - page_published
+    - page_unpublished
+    - post_page_move
+    """
+    logger = logging.getLogger("fastly_purge")
+
+    logger.info(f"Processing purge request for {page_id}")
+
+    page = Page.objects.get(pk=page_id)
+
+    if page is None:
+        raise Exception(f"Page {page_id} not found.")
+
+    (scheme, netloc, path, params, query, fragment) = urlparse(SITE_BASE_URL)
+
+    api = fastly.API()
+
+    if MITX_ONLINE_FASTLY_AUTH_TOKEN is not None:
+        api.authenticate_by_key(MITX_ONLINE_FASTLY_AUTH_TOKEN)
+
+    target_url = urljoin(MITX_ONLINE_FASTLY_URL, page.get_url())
+
+    try:
+        if not api.purge_url(netloc, target_url, soft=True):
+            logger.error(f"Fastly purge of {page.title} failed.")
+    except fastly.errors.AuthenticationError:
+        logger.error(f"Fastly purge of {page.title} failed: authenticaiton error")
+    except fastly.errors.InternalServerError:
+        logger.error(f"Fastly purge of {page.title} failed: internal server error")
+    except fastly.errors.BadRequestError as e:
+        logger.error(f"Fastly purge of {page.title} failed: bad request. {e}")
+    except fastly.errors.NotFoundError:
+        logger.error(f"Fastly purge of {page.title} failed: not found")
+    except:
+        logger.error(f"Fastly purge of {page.title} failed: threw a generic exception")

--- a/main/settings.py
+++ b/main/settings.py
@@ -1028,3 +1028,17 @@ GOOGLE_DOMAIN_VERIFICATION_TAG_VALUE = get_string(
 )
 
 MITOL_GOOGLE_SHEETS_REFUNDS_PLUGINS = ["sheets.plugins.RefundPlugin"]
+
+
+# Fastly configuration
+MITX_ONLINE_FASTLY_AUTH_TOKEN = get_string(
+    name="FASTLY_AUTH_TOKEN",
+    default=None,
+    description="Optional token for the Fastly purge API.",
+)
+
+MITX_ONLINE_FASTLY_URL = get_string(
+    name="FASTLY_URL",
+    default="https://api.fastly.com",
+    description="The URL to the Fastly API.",
+)

--- a/requirements.in
+++ b/requirements.in
@@ -25,6 +25,7 @@ django-reversion==4.0.1
 django-storages==1.11.1
 djoser==2.1.0
 edx-api-client==1.1.0
+fastly~=0.5.1
 ipython
 mitol-django-common~=2.5.0
 mitol-django-mail~=3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -200,6 +200,8 @@ factory-boy==3.2.0
     #   mitol-django-google-sheets
 faker==8.8.2
     # via factory-boy
+fastly==0.5.1
+    # via -r requirements.in
 google-api-python-client==1.7.11
     # via
     #   mitol-django-google-sheets
@@ -392,6 +394,7 @@ six==1.16.0
     #   click-repl
     #   cybersource-rest-client-python
     #   django-compat
+    #   fastly
     #   google-api-python-client
     #   google-auth
     #   google-auth-httplib2


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested
- [X] Settings
  - [X] New settings are documented and present in `app.json`
  - [X] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

Fixes #749 

#### What's this PR do?

Adds some receivers for some Wagtail signals that are sent when a page is (un)published or moved to invalidate the Fastly cache for the affected pages. This should ensure that new edits made in the CMS override the cache when they happen.

#### How should this be manually tested?

Fully testing this manually will attempt to invalidate pages in the Fastly cache. This will fail unless your system is configured to look like a system it knows about (e.g. you need to set up your testing machine to respond to `rc.mitxonline.mit.edu` locally for it to really work). However, you should be able to see log entries where the app queues and then invalidates the cache regardless of your local instance's settings.

Do any number of these operations:
1. Publish a page.
2. Move a page such that the URL for it will change.
3. Unpublish a page. 

Each of these should cause Wagtail to signal, which should then be picked up by the code in this PR and will queue a Fastly purge request via Celery. 

#### Other

It doesn't appear that the purge API is set up to require authentication at the moment - this (can be changed)[https://docs.fastly.com/en/guides/authenticating-api-purge-requests] and if/when it does, the `MITX_ONLINE_FASTLY_AUTH_TOKEN` setting will need to be set. 