### PR TITLE
Online-829 Open program drawer when program title is clicked

### DIFF
--- a/frontend/public/src/components/ProgramEnrollmentCard.js
+++ b/frontend/public/src/components/ProgramEnrollmentCard.js
@@ -115,8 +115,8 @@ export class ProgramEnrollmentCard extends React.Component<
     const title = (
       <a
         href="#"
-        target="_blank"
         rel="noopener noreferrer"
+        onClick={() => this.hndOpenDrawer()}
       >
         {enrollment.program.title}
       </a>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/829

#### What's this PR do?
Clicking on the Program title opens the course drawer.

#### How should this be manually tested?

- Enroll in a course that belongs to a program i.e. DEDP.
- Clicking on the program title opens the program drawer instead of page reloading.

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/52656433/184620437-916e16a4-2046-403f-9df3-bd64fe6d62cb.mov

