### PR TITLE
Online-860 Calculate flexible price discount instead of using BasketDiscount

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -163,6 +163,9 @@ def apply_user_discounts(request):
     user = request.user
     discount = None
 
+    BasketDiscount.objects.filter(
+        redeemed_basket=basket, redeemed_discount__for_flexible_pricing=True
+    ).delete()
     if BasketDiscount.objects.filter(redeemed_basket=basket).count() > 0:
         return
 

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -396,10 +396,7 @@ class CheckoutApiViewSet(ViewSet):
         except ObjectDoesNotExist:
             return Response("No basket", status=status.HTTP_406_NOT_ACCEPTABLE)
 
-        # don't auto-apply user discounts if they've added their own code
-        # this may need to be revisited
-        if BasketDiscount.objects.filter(redeemed_basket=basket).count() == 0:
-            api.apply_user_discounts(request)
+        api.apply_user_discounts(request)
 
         return Response(BasketWithProductSerializer(basket).data)
 

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -538,6 +538,7 @@ class CheckoutProductView(LoginRequiredMixin, RedirectView):
                 user=self.request.user
             )
             basket.basket_items.all().delete()
+            BasketDiscount.objects.filter(redeemed_basket=basket).delete()
 
             # Incoming product ids from internal checkout
             all_product_ids = self.request.GET.getlist("product_id")


### PR DESCRIPTION

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/860

#### What's this PR do?
Recalculates financial assistance discount for a basket each time the checkout page is loaded. Also, delete old BasketDiscount objects on the checkout page reload, and when the basket items are cleared.

#### How should this be manually tested?

- Visit the course detail page.
- Enroll modal will display the course price.
- Continue with enrollment.
- Cart will show the total price.
- Apply for financial assistance in the course. Try that the request is auto-approved.
- Visit the checkout page. You can see financial assistance applied.
- Update discount for the request from the staff dashboard.
- Visit the cart and the price is updated.
- Reset or Deny a request and visit the cart, you will see the total price for the course.

#### Screenshots (if appropriate)
Course 1 with a total price:
<img width="546" alt="Screenshot 2022-08-17 at 5 22 48 PM" src="https://user-images.githubusercontent.com/52656433/185120228-d1376c80-c671-4182-9701-e2bfc40815a9.png">

Course 1 added to cart with a total price:
<img width="1396" alt="Screenshot 2022-08-17 at 5 23 18 PM" src="https://user-images.githubusercontent.com/52656433/185120290-c8038078-d2e9-47f9-89f6-89df37bb41bd.png">

Applied non-flexible price discount on Cart:
<img width="1396" alt="Screenshot 2022-08-17 at 5 23 50 PM" src="https://user-images.githubusercontent.com/52656433/185120307-05f2c963-399e-4a4e-ac4f-19cfc512c397.png">

Cleared non-flexible price discount:
<img width="1396" alt="Screenshot 2022-08-17 at 5 23 57 PM" src="https://user-images.githubusercontent.com/52656433/185120322-530783e4-ea0e-466c-8ed9-50881569adf6.png">

Approving financial assistance request and new price should be $750 for course 1:
<img width="1396" alt="Screenshot 2022-08-17 at 5 24 06 PM" src="https://user-images.githubusercontent.com/52656433/185120333-faf80780-b20a-4867-8da6-5e87b53e853e.png">

Course 1 new price is $750:
<img width="1396" alt="Screenshot 2022-08-17 at 5 24 23 PM" src="https://user-images.githubusercontent.com/52656433/185120348-95614961-39d1-4f8a-bdfb-f8f3d91ab382.png">

Course 1 was added to the cart and financial assistance is approved with a new price of $750:
<img width="1396" alt="Screenshot 2022-08-17 at 5 24 32 PM" src="https://user-images.githubusercontent.com/52656433/185120370-13d715af-cd9d-47d3-9631-2f2128ba505d.png">

Applied non-flexible price discount with less price:
<img width="1396" alt="Screenshot 2022-08-17 at 5 24 39 PM" src="https://user-images.githubusercontent.com/52656433/185120410-4e13d951-1b7e-4381-900d-cb7e2f5513bb.png">

Course 2 with a total price of $1500:
<img width="1396" alt="Screenshot 2022-08-17 at 5 24 54 PM" src="https://user-images.githubusercontent.com/52656433/185120427-f6b79c42-fe14-4190-ab3c-dad9e4aa74a7.png">

Course 2 added to cart with a total price:
<img width="1396" alt="Screenshot 2022-08-17 at 5 24 59 PM" src="https://user-images.githubusercontent.com/52656433/185120451-1ec6fe50-075f-4a7f-9e18-0ee6da9fac6b.png">

Applied non-flexible price discount on the cart for course 2:
<img width="1396" alt="Screenshot 2022-08-17 at 5 25 05 PM" src="https://user-images.githubusercontent.com/52656433/185120468-74880a6e-a16f-4c14-9476-ec42f392dcc2.png">

Financial assistance is approved and the new price for course 2 is $99:
<img width="1396" alt="Screenshot 2022-08-17 at 5 25 25 PM" src="https://user-images.githubusercontent.com/52656433/185120484-45b13ead-e860-44ae-9ae6-556d2ff3c45d.png">

The price in the cart is updated for course 2:
<img width="1396" alt="Screenshot 2022-08-17 at 5 25 31 PM" src="https://user-images.githubusercontent.com/52656433/185120512-db0c3421-8969-4a4a-a7fb-8fec1af9f9a9.png">

