### PR TITLE
fix: datetime issue in flexible price form

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1203,7 +1203,7 @@ class FlexiblePricingRequestForm(AbstractForm):
         flexible_price.original_currency = form.cleaned_data["income_currency"]
         flexible_price.country_of_income = form.user.legal_address.country
         flexible_price.income_usd = income_usd
-        flexible_price.date_exchange_rate = datetime.datetime.now()
+        flexible_price.date_exchange_rate = datetime.now()
         flexible_price.cms_submission = form_submission
         flexible_price.tier = tier
         flexible_price.justification = ""


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
None, Just noticed this sentry error https://sentry.io/organizations/mit-office-of-digital-learning/issues/3509592346/?project=5864687&referrer=slack

#### What's this PR do?
Fixes the usage of `datetime.now`, since the import was changed

#### How should this be manually tested?
Submit a Flexible pricing form

#### Any background context you want to provide?
This seems to be a side effect of a recent PR Rebase/Merge https://github.com/mitodl/mitxonline/pull/740, which changed the datetime import.

