### PR TITLE
fix: active products to cart only

### DIFF
--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -278,6 +278,17 @@ def test_product_delete_protection_inactive():
     )  # Additional 1 from above
 
 
+def test_product_managers():
+    """Test that the default manager returns only active products and the 'all_objects' manager returns all the
+    products
+    """
+    in_active_products = ProductFactory.create_batch(3, is_active=False)
+    active_products = ProductFactory.create_batch(2, is_active=True)
+
+    assert list(Product.objects.all()) == active_products
+    assert list(Product.all_objects.all()) == in_active_products + active_products
+
+
 def test_product_multiple_active_for_single_purchasable_object():
     """Test that creating multiple Products with the same course/program
     and are active is not allowed"""

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -119,6 +119,7 @@ class BasketItemSerializer(serializers.ModelSerializer):
 
     def perform_create(self, validated_data):
         basket = Basket.objects.get(user=validated_data["user"])
+        # Product queryset returns active Products by default
         product = Product.objects.get(id=validated_data["product"])
         item, _ = BasketItem.objects.get_or_create(basket=basket, product=product)
         return item
@@ -232,7 +233,7 @@ class LineSerializer(serializers.ModelSerializer):
     product = serializers.SerializerMethodField()
 
     def get_product(self, instance):
-        product = models.Product.objects.get(
+        product = models.Product.all_objects.get(
             pk=instance.product_version.field_dict["id"]
         )
 
@@ -382,7 +383,7 @@ class OrderHistorySerializer(serializers.ModelSerializer):
         titles = []
 
         for line in instance.lines.all():
-            product = models.Product.objects.get(
+            product = models.Product.all_objects.get(
                 pk=line.product_version.field_dict["id"]
             )
             if product.content_type.model == "courserun":

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -149,7 +149,6 @@ class ProductViewSet(ReadOnlyModelViewSet):
                     & Q(content_type__model="programrun")
                 )
             )
-            .exclude(is_active__exact=False)
             .select_related("content_type")
             .prefetch_related("purchasable_object")
         )
@@ -394,6 +393,11 @@ class CheckoutApiViewSet(ViewSet):
         except ObjectDoesNotExist:
             return Response("No basket", status=status.HTTP_406_NOT_ACCEPTABLE)
 
+        if not basket.get_products():
+            return Response(
+                "No product in basket", status=status.HTTP_406_NOT_ACCEPTABLE
+            )
+
         api.apply_user_discounts(request)
 
         return Response(BasketWithProductSerializer(basket).data)
@@ -425,7 +429,7 @@ class CheckoutCallbackView(View):
         if order is None:
             return HttpResponse("Order not found")
         # We only want to process responses related to orders which are PENDING
-        # otherwise we can conclude that we already received a resonse through
+        # otherwise we can conclude that we already received a response through
         # BackofficeCallbackView.
         order_state = None
         if order.state == Order.STATE.PENDING:

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -41,7 +41,8 @@ def generate_flexible_price_email(flexible_price):
         courserun = CourseRun.objects.filter(
             course=flexible_price.courseware_object
         ).first()
-        product = Product.objects.get(object_id=courserun.id, is_active=True)
+        # Product queryset returns active Products by default
+        product = Product.objects.get(object_id=courserun.id)
         price = DiscountType.get_discounted_price(
             [flexible_price.tier.discount], product
         )


### PR DESCRIPTION
#### Pre-Flight checklist


#### What are the relevant tickets?
#873

#### What's this PR do?
Some of the refactors were quite straightforward, e.g. The places we were filtering products based on `is_active` should use `objects`. For the places where were won't care for `is-active` were likely to use `all_objects`.

- Makes the default Model manager for Product to return active products only
- For all products uses `all_objects`
- Refactors the usage of Product query set on multiple places to either use `all_objects` or `objects` based on its usage

#### How should this be manually tested?
- Majorly this relies on code coverage but testing is needed
- In general checking, everything works just like before in every place the product is used
    - I can think of `Cart`, `Dashboard`, `Course Details`, `Order History`, `Payment`, `Discounts`, `Flexible Pricing`

#### Where should the reviewer start?
Try to reproduce the issue by putting the URL add URL manually with the course id:
- Uncheck `is_active` for a Product
- Now for this product run, something like `http://mitxonline.odl.local:8013/cart/add/?course_id=<courseware_id>` (make sure your courseware_id is quoted before being sent to URL An example of that is `course-v1:Arbisoft+CT_AR_001+1` it should be sent as `course-v1%3AArbisoft%2BCT_AR_001%2B1` it should add the product without this PR, With this PR, it shouldn't.

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)
