### PR TITLE
Check for program page before checking for child pages

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -41,7 +41,7 @@ class CoursePageSerializer(serializers.ModelSerializer):
             financial_assistance_page = FlexiblePricingRequestForm.objects.filter(
                 selected_program=instance.product.program
             ).first()
-            if financial_assistance_page is None:
+            if financial_assistance_page is None and program_page:
                 financial_assistance_page = (
                     program_page.get_children()
                     .type(FlexiblePricingRequestForm)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What's this PR do?
When trying to find the financial assistance form which may be a child of a program page, before checking a program page's child pages we need to make sure that the program page we are checking actually exists!
