### PR TITLE
Fixes some issues with the Fastly API code

### DIFF
--- a/cms/management/commands/purge_fastly_cache.py
+++ b/cms/management/commands/purge_fastly_cache.py
@@ -1,0 +1,13 @@
+"""Purges all pages from the Fastly cache."""
+from django.core.management.base import BaseCommand
+
+from cms.tasks import queue_fastly_full_purge
+
+
+class Command(BaseCommand):
+    """Purges all pages from the Fastly cache."""
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        queue_fastly_full_purge.delay()

--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,6 @@ django-reversion==4.0.1
 django-storages==1.11.1
 djoser==2.1.0
 edx-api-client==1.1.0
-fastly~=0.5.1
 ipython
 mitol-django-common~=2.5.0
 mitol-django-mail~=3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -202,8 +202,6 @@ factory-boy==3.2.0
     #   mitol-django-google-sheets
 faker==8.8.2
     # via factory-boy
-fastly==0.5.1
-    # via -r requirements.in
 google-api-python-client==1.7.11
     # via
     #   mitol-django-google-sheets
@@ -397,7 +395,6 @@ six==1.16.0
     #   click-repl
     #   cybersource-rest-client-python
     #   django-compat
-    #   fastly
     #   google-api-python-client
     #   google-auth
     #   google-auth-httplib2


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #749 

#### What's this PR do?

Fixes some bugs in the original PR https://github.com/mitodl/mitxonline/pull/838 namely:
- Doesn't use the Fastly API library anymore (the stable version is outdated and the updated version is pre-release and doesn't allow for single pages to be purged)
- Adds some better logging if it does fail (which it definitely will locally without proper setup)

This also adds in a management command to purge the entire cache. Purging everything results in a hard purge, where a single page request is handled with a soft purge. See [the documentation](https://developer.fastly.com/reference/api/purging/) for info but the gist of it is a hard purge removes everything right now where a soft one doesn't. 

#### How should this be manually tested?

To properly test, you will need to have your test instance set up to respond as `rc.mitxonline.mit.edu` on port 80. This involves:
- Adding a `HOSTS` file entry for that hostname
- Setting `MITX_ONLINE_BASE_URL` to `http://rc.mitxonline.mit.edu` in your `.env` file
- Either modifying the `docker-compose.yml` file to redirect local port 80 to 8013 in the `nginx` container, making a `docker-compose-override.yml` that does the same, or doing some other sort of proxy thing so it responds on port 80. (This may not be strictly necessary but skipping this step means that generated URLs may be wrong.) 

The cache purge will be requested whenever a page in the CMS is published or moved, so, to test, just do that - it should queue a task and Celery should go do it. If you're using the RC URL, it should be successful; otherwise, you should get a `421 Misdirected Request` error. 

The hard purge can be triggered by running `manage.py purge_fastly_cache`. The log output from this should be pretty similar to the single page call. 
