### PR TITLE
Update flexible pricing approval email to eliminate errors when sending

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -22,6 +22,9 @@ from ecommerce.constants import (
     REDEMPTION_TYPE_ONE_TIME,
     REDEMPTION_TYPE_ONE_TIME_PER_USER,
     REDEMPTION_TYPE_UNLIMITED,
+    DISCOUNT_TYPE_DOLLARS_OFF,
+    DISCOUNT_TYPE_FIXED_PRICE,
+    DISCOUNT_TYPE_PERCENT_OFF,
 )
 from users.models import User
 from decimal import Decimal
@@ -295,6 +298,18 @@ class Discount(TimestampedModel):
             return False
 
         return True
+
+    def friendly_format(self):
+        amount = "{:.2f}".format(self.amount)
+
+        if self.discount_type == DISCOUNT_TYPE_PERCENT_OFF:
+            return f"{amount}% off"
+        elif self.discount_type == DISCOUNT_TYPE_DOLLARS_OFF:
+            return f"${amount} off"
+        elif self.discount_type == DISCOUNT_TYPE_FIXED_PRICE:
+            return f"a fixed price of ${amount}"
+
+        return "Indeterminate Discount"
 
 
 class DiscountProduct(TimestampedModel):

--- a/flexiblepricing/constants.py
+++ b/flexiblepricing/constants.py
@@ -49,8 +49,8 @@ FLEXIBLE_PRICE_EMAIL_APPROVAL_SUBJECT = (
     "Your personalized course price for {program_name} MITxOnline"
 )
 FLEXIBLE_PRICE_EMAIL_APPROVAL_MESSAGE = (
-    "After reviewing your income documentation, the {program_name} MITxOnline team has determined "
-    "that your personalized course price is ${price}.\n\n"
+    "After reviewing your income documentation, the {program_name} team has awarded you financial "
+    "assistance in the amount of {price}.\n\n"
     "You can pay for MITxOnline courses through the MITxOnline portal "
     "(https://MITxOnline.mit.edu/dashboard). All coursework will be conducted on mitxonline.mit.edu"
 )

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -6,9 +6,7 @@ import logging
 from django.core.exceptions import ValidationError
 from mitol.mail.api import get_message_sender
 
-from courses.models import CourseRun
-from ecommerce.discounts import DiscountType
-from ecommerce.models import Product
+from courses.models import Course
 from flexiblepricing.constants import (
     FLEXIBLE_PRICE_EMAIL_APPROVAL_MESSAGE,
     FLEXIBLE_PRICE_EMAIL_APPROVAL_SUBJECT,
@@ -38,14 +36,7 @@ def generate_flexible_price_email(flexible_price):
         dict: {"subject": (str), "body": (str)}
     """
     if flexible_price.status == FlexiblePriceStatus.APPROVED:
-        courserun = CourseRun.objects.filter(
-            course=flexible_price.courseware_object
-        ).first()
-        # Product queryset returns active Products by default
-        product = Product.objects.get(object_id=courserun.id)
-        price = DiscountType.get_discounted_price(
-            [flexible_price.tier.discount], product
-        )
+        price = flexible_price.tier.discount.friendly_format()
         message = FLEXIBLE_PRICE_EMAIL_APPROVAL_MESSAGE.format(
             program_name=flexible_price.courseware_object.title, price=price
         )


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #852

#### What's this PR do?

Updates the approval email text as noted in #852. This also updates the code to not assume the flexible pricing submission's courseware object is a Course. 

#### How should this be manually tested?

Approve a Flexible Pricing request. (For a full test, make sure to approve it with a discount for each of the three types - percent off, amount off, and fixed price.) The email should send successfully and the text in it should be correct. 

