### PR TITLE
add query to migrate grades from MicroMaster

### DIFF
--- a/micromasters_import/management/commands/queries/003_import_enrollment.sql
+++ b/micromasters_import/management/commands/queries/003_import_enrollment.sql
@@ -1,4 +1,5 @@
 --courserun Enrollment migration from MicroMaster to MITxOnline
+-- Limit to those who have taken exam and passed
 INSERT INTO public.courses_courserunenrollment(
     run_id,
     user_id,
@@ -10,6 +11,7 @@ INSERT INTO public.courses_courserunenrollment(
     created_on,
     updated_on)
 SELECT
+    DISTINCT
     mo_courserun.id,
     mo_user.id,
     '' AS change_status,
@@ -22,6 +24,9 @@ SELECT
 FROM micromasters.dashboard_cachedenrollment AS mm_enrollment
 JOIN micromasters.courses_courserun AS mm_courserun
   ON mm_enrollment.course_run_id = mm_courserun.id
+JOIN micromasters.grades_proctoredexamgrade AS mm_exam
+  ON mm_courserun.course_id = mm_exam.course_id
+ AND mm_enrollment.user_id = mm_exam.user_id
 JOIN micromasters.social_auth_usersocialauth AS mm_social
   ON mm_enrollment.user_id = mm_social.user_id
 JOIN public.users_user AS mo_user
@@ -29,4 +34,5 @@ JOIN public.users_user AS mo_user
 JOIN public.courses_courserun AS mo_courserun
   ON mm_courserun.edx_course_key = mo_courserun.courseware_id
 WHERE mm_social.provider = 'mitxonline'
+  AND mm_exam.passed = True
 ON CONFLICT DO NOTHING;

--- a/micromasters_import/management/commands/queries/008_import_combined_final_grade.sql
+++ b/micromasters_import/management/commands/queries/008_import_combined_final_grade.sql
@@ -1,0 +1,103 @@
+----This script is to migrate the grades for course run from MicroMaster:
+----  It computes score from FinalGrade and ProctoredExamGrade using formula - course run grade * 0.4 + exam grade * 0.6
+----  grades need to exist in both FinalGrade (course run) and ProctoredExamGrade (exam)
+----  grades need to be 'passed'
+
+WITH courses_have_exam AS (
+    SELECT
+        DISTINCT mm_examrun.course_id
+    FROM micromasters.exams_examrun AS mm_examrun
+    JOIN micromasters.courses_course AS mm_course
+        ON mm_examrun.course_id = mm_course.id
+),
+ --- this is to compute the best grade learner gets for the course runs they have enrolled
+best_courserun_grades AS (
+    SELECT
+        mm_grade.user_id,
+        mm_grade.course_run_id,
+        MAX(mm_grade.grade) AS max_grade
+    FROM micromasters.grades_finalgrade AS mm_grade
+    JOIN micromasters.courses_courserun AS mm_courserun
+        ON mm_grade.course_run_id = mm_courserun.id
+    JOIN courses_have_exam
+        ON mm_courserun.course_id = courses_have_exam.course_id
+    WHERE mm_grade.status = 'complete'
+      AND mm_grade.passed = True
+    GROUP BY mm_grade.user_id, mm_grade.course_run_id
+),
+--- this is to compute the best exam grades learner get for every course run in the exam they signed up for
+best_exam_grades AS (
+    SELECT
+        mm_exam_grade.user_id,
+        mm_exam_grade.course_id,
+        mm_courserun.id AS course_run_id,
+        MAX(mm_exam_grade.score) AS max_score
+    FROM micromasters.grades_proctoredexamgrade AS mm_exam_grade
+    JOIN micromasters.courses_courserun AS mm_courserun
+       ON mm_exam_grade.course_id = mm_courserun.course_id
+    JOIN courses_have_exam
+       ON mm_exam_grade.course_id = courses_have_exam.course_id
+    WHERE mm_exam_grade.passed = true
+    GROUP BY mm_exam_grade.user_id, mm_courserun.id, mm_exam_grade.course_id
+),
+combined_final_grades AS (
+    SELECT
+        best_grade.user_id,
+        best_grade.course_run_id,
+        ROUND(CAST(best_grade.max_grade * 100 * 0.4 + best_exam.max_score * 0.6 AS numeric), 1) AS calculated_grade,
+        mm_courserun.course_id,
+        mm_courserun.edx_course_key,
+        mm_grade.created_on,
+        mm_grade.updated_on,
+        True AS passed  -- because both course run and exam are passed
+    FROM best_courserun_grades AS best_grade
+    JOIN best_exam_grades AS best_exam
+       ON (best_grade.course_run_id = best_exam.course_run_id
+           AND best_grade.user_id = best_exam.user_id)
+    JOIN micromasters.courses_courserun AS mm_courserun
+       ON best_grade.course_run_id = mm_courserun.id
+    --- The following joins are to get the corresponding passed and metadate fields matched with previous aggregated CTEs
+    JOIN micromasters.grades_finalgrade AS mm_grade
+       ON (best_grade.course_run_id = mm_grade.course_run_id
+           AND best_grade.user_id = mm_grade.user_id
+           AND best_grade.max_grade = mm_grade.grade)
+    JOIN micromasters.grades_proctoredexamgrade AS mm_exam
+       ON (best_exam.course_id = mm_exam.course_id
+           AND best_exam.user_id = mm_exam.user_id
+           AND best_exam.max_score = mm_exam.score)
+)
+
+INSERT INTO public.courses_courserungrade(
+   created_on,
+   updated_on,
+   passed,
+   grade,
+   letter_grade,
+   set_by_admin,
+   course_run_id,
+   user_id
+)
+SELECT
+  combined_grades.created_on,
+  combined_grades.updated_on,
+  combined_grades.passed,
+  combined_grades.calculated_grade,
+  CASE
+      WHEN combined_grades.calculated_grade >= 82.5 THEN 'A'
+      WHEN combined_grades.calculated_grade >= 65 THEN 'B'
+      WHEN combined_grades.calculated_grade >= 55 THEN 'C'
+      WHEN combined_grades.calculated_grade >= 50 THEN 'D'
+      ELSE 'F'
+  END AS letter_grade,
+  False AS set_by_admin,
+  mo_courserun.id,
+  mo_user.id
+FROM combined_final_grades AS combined_grades
+JOIN public.courses_courserun AS mo_courserun
+    ON combined_grades.edx_course_key = mo_courserun.courseware_id
+JOIN micromasters.social_auth_usersocialauth AS mm_social
+    ON combined_grades.user_id = mm_social.user_id
+JOIN public.users_user AS mo_user
+    ON mm_social.uid = mo_user.username
+WHERE mm_social.provider = 'mitxonline'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/658

#### What's this PR do?

- Adding a migration script to bring over grades from MicroMaster
    - Limit to learners who have taken the exam and passed

- Modify the enrollment query to those who have taken the exam and passed

#### How should this be manually tested?

- Similar setup foreign data connection as https://github.com/mitodl/mitxonline/pull/859
- It needs the mapped course id http://mitxonline.odl.local:8013/admin/micromasters_import/courseid/
- Run docker-compose run --rm web ./manage.py import_micromasters_data
- Check the imported course run grade http://mitxonline.odl.local:8013/admin/courses/courserungrade/

**Test result**

- Migrated 1 enrollment from MicroMaster RC

![image](https://user-images.githubusercontent.com/3138890/189401394-0be89e90-769d-4633-b734-967b062bdae5.png)


- Migrated 2 grades from MicroMaster RC 
  (Note that there isn't a migrated enrollment for MITx/14.73x/2013_Spring because there is no user enrollment for this course on MicroMaster)

![image](https://user-images.githubusercontent.com/3138890/189401840-530f213d-3426-45de-9bc5-71f4d7d13633.png)


![image](https://user-images.githubusercontent.com/3138890/189402596-ef214dab-ad77-41e6-81d1-2e33761c728b.png)

Sources of the grade for "MITx/14.73x/2013_Spring"

-  [best proctored exam grade](https://micromasters-rc.odl.mit.edu/admin/grades/proctoredexamgrade/9/change/)

 - [Best Final grade ](https://micromasters-rc.odl.mit.edu/admin/grades/finalgrade/215/change/)
  
Formula: (0.68 * 100 * **0.4** + 46 * **0.6**) = 54.8
Passed: True (because grade and exam both passed on MicroMaster

The migrated grade is a bit weird but I assume that's just test data?




