### PR TITLE
feat: Add command for certificate management

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -36,7 +36,7 @@ from courses.models import (
     Course,
 )
 from courses.tasks import subscribe_edx_course_emails
-from courses.utils import exception_logging_generator
+from courses.utils import exception_logging_generator, is_grade_valid
 from openedx.api import (
     enroll_in_edx_course_runs,
     get_edx_api_course_detail_client,
@@ -784,7 +784,7 @@ def override_user_grade(user, override_grade, courseware_id, should_force_pass=F
         (CourseRunGrade): The updates grade of the user
     """
 
-    if override_grade and (override_grade < 0.0 or override_grade > 1.0):
+    if not is_grade_valid(override_grade):
         raise ValidationError("Invalid value for grade. Allowed range: 0.0 - 1.0")
 
     with transaction.atomic():

--- a/courses/api.py
+++ b/courses/api.py
@@ -637,13 +637,13 @@ def is_program_text_id(item_text_id):
     return item_text_id.startswith(PROGRAM_TEXT_ID_PREFIX)
 
 
-def process_course_run_grade_certificate(course_run_grade):
+def process_course_run_grade_certificate(course_run_grade, should_force_create=False):
     """
     Ensure that the course run certificate is in line with the values in the course run grade
 
     Args:
         course_run_grade (courses.models.CourseRunGrade): The course run grade for which to generate/delete the certificate
-
+        should_force_create (bool): If True, it will force the certificate creation without matching criteria
     Returns:
         Tuple[ CourseRunCertificate, bool, bool ]: A Tuple containing None or CourseRunCertificate object,
             A bool representing if the certificate is created, A bool representing if a certificate is deleted
@@ -653,7 +653,7 @@ def process_course_run_grade_certificate(course_run_grade):
 
     # A grade of 0.0 indicates that the certificate should be deleted
     should_delete = not bool(course_run_grade.grade)
-    should_create = course_run_grade.is_certificate_eligible
+    should_create = course_run_grade.is_certificate_eligible or should_force_create
 
     if should_delete:
         delete_count, _ = CourseRunCertificate.objects.filter(
@@ -737,3 +737,64 @@ def generate_course_run_certificates():
         log.info(
             f"Finished processing course run {run}: created grades for {created_grades_count} users, updated grades for {updated_grades_count} users, generated certificates for {generated_certificates_count} users"
         )
+
+
+def manage_course_run_certificate_access(user, courseware_id, revoke_state):
+    """
+    Revokes/Un-Revokes a course run certificate.
+
+    Args:
+        user (User): a Django user.
+        courseware_id (str): A string representing the course run's courseware_id.
+        revoke_state (bool): A flag representing True(Revoke), False(Un-Revoke)
+
+    Returns:
+        bool: A boolean representing the revoke/unrevoke success
+    """
+    course_run = CourseRun.objects.get(courseware_id=courseware_id)
+
+    try:
+        course_run_certificate = CourseRunCertificate.all_objects.get(
+            user=user, course_run=course_run
+        )
+    except CourseRunCertificate.DoesNotExist:
+        log.warning(
+            "Course run certificate for user: %s and course_run: %s does not exist.",
+            user.username,
+            course_run,
+        )
+        return False
+
+    course_run_certificate.is_revoked = revoke_state
+    course_run_certificate.save()
+
+    return True
+
+
+def override_user_grade(user, override_grade, courseware_id, should_force_pass=False):
+    """Override grade for a user
+
+    Args:
+        user (User): a Django user.
+        courseware_id (str): A string representing the course run's courseware_id.
+        override_grade (float): A float value for the grade override between (0.0 and 1.0) - 0.0 would mean passed=False
+        should_force_pass (bool): A flag representing if user should mark as passed forcefully (In this case we don't know
+        the grading policy based in edX so we manually take a value for forcing the passed status)
+    Returns:
+        (CourseRunGrade): The updates grade of the user
+    """
+
+    if override_grade and (override_grade < 0.0 or override_grade > 1.0):
+        raise ValidationError("Invalid value for grade. Allowed range: 0.0 - 1.0")
+
+    with transaction.atomic():
+        course_run_grade = CourseRunGrade.objects.select_for_update().get(
+            user=user, course_run__courseware_id=courseware_id
+        )
+        course_run_grade.grade = override_grade
+        course_run_grade.passed = bool(override_grade) if should_force_pass else False
+        course_run_grade.letter_grade = None
+        course_run_grade.set_by_admin = True
+        course_run_grade.save_and_log(None)
+
+    return course_run_grade

--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -1,0 +1,189 @@
+"""
+Management command to revoke and un revoke a certificate for a course run or program for the given user.
+"""
+from django.core.management.base import BaseCommand, CommandError
+from users.api import fetch_user
+from courses.api import (
+    manage_course_run_certificate_access,
+    ensure_course_run_grade,
+    process_course_run_grade_certificate,
+    override_user_grade,
+)
+from courses.models import CourseRun
+from openedx.api import get_edx_grades_with_users
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Command to revoke/un-revoke a course run or program certificate for a specified user.
+    """
+
+    help = "Revoke and un revoke a certificate for a specified user against a program or course run."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="The id, email or username of the enrolled User",
+            required=False,
+        )
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--run", type=str, help="The 'courseware_id' value for a CourseRun"
+        )
+        parser.add_argument(
+            "--grade",
+            type=float,
+            help="Override a grade. Setting grade to 0.0 blocks certificate creation. Setting a passing grade \
+                (>0.0) allows certificate creation. Range: 0.0 - 1.0",
+            required=False,
+        )
+        parser.add_argument(
+            "--revoke", dest="revoke", action="store_true", required=False
+        )
+        parser.add_argument(
+            "--unrevoke", dest="unrevoke", action="store_true", required=False
+        )
+        parser.add_argument(
+            "--create", dest="create", action="store_true", required=False
+        )
+
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # pylint: disable=too-many-locals
+        """Handle command execution"""
+
+        revoke = options.get("revoke")
+        unrevoke = options.get("unrevoke")
+        create = options.get("create")
+        run = options.get("run")
+
+        if not (revoke or unrevoke) and not create:
+            raise CommandError(
+                "The command needs a valid action e.g. --revoke, --unrevoke, --create"
+            )
+        try:
+            user = fetch_user(options["user"]) if options["user"] else None
+        except User.DoesNotExist:
+            user = None
+
+        # A run is needed for revoke/un-revoke and certificate creation
+        if not run:
+            raise CommandError("The command needs a valid course run")
+
+        # Unable to obtain a run object based on the provided courseware id
+        try:
+            course_run = CourseRun.objects.get(courseware_id=options["run"])
+        except CourseRun.DoesNotExist:
+            raise CommandError(
+                "Could not find run with courseware_id={}".format(options["run"])
+            )
+
+        # Handle revoke/un-revoke of a certificate
+        if revoke or unrevoke:
+            if not user:
+                raise CommandError("Revoke/Un-revoke operation needs a valid user")
+
+            revoke_status = manage_course_run_certificate_access(
+                user=user,
+                courseware_id=course_run.courseware_id,
+                revoke_state=True if revoke else False,
+            )
+
+            if revoke_status:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "Certificate for {} has been {}".format(
+                            "run: {}".format(run), "revoked" if revoke else "un-revoked"
+                        )
+                    )
+                )
+            else:
+                self.stdout.write(self.style.WARNING("No changes made."))
+
+        # Handle the creation of the certificates
+        elif create:
+            override_grade = options.get("grade")
+
+            if override_grade and (override_grade < 0.0 or override_grade > 1.0):
+                raise CommandError("Invalid value for grade. Allowed range: 0.0 - 1.0")
+
+            if override_grade and not user:
+                raise CommandError(
+                    "Override grade needs a user (The grade override operation is not supported for multiple users)"
+                )
+
+            # If user=None, Grades for all users in this runs will be fetched
+            edx_grade_user_iter = get_edx_grades_with_users(course_run, user=user)
+
+            results = []
+            is_grade_override = override_grade is not None
+            for edx_grade, user in edx_grade_user_iter:
+                (
+                    course_run_grade,
+                    created_grade,
+                    updated_grade,
+                ) = ensure_course_run_grade(
+                    user=user,
+                    course_run=course_run,
+                    edx_grade=edx_grade,
+                    should_update=True,
+                )
+
+                if is_grade_override:
+                    # While creating certificates with grade override, we mark the user force passed if the grade is not
+                    # 0.0. We don't know the grading policy set in admin for this e.g. At which percentage of marks a
+                    # user can be marked passed.
+                    override_user_grade(
+                        user=user,
+                        override_grade=override_grade,
+                        courseware_id=run,
+                        should_force_pass=True,
+                    )
+
+                # While overriding grade we force create the certificate
+                _, created_cert, deleted_cert = process_course_run_grade_certificate(
+                    course_run_grade=course_run_grade,
+                    should_force_create=is_grade_override,
+                )
+
+                if created_grade:
+                    grade_status = "created"
+                elif updated_grade:
+                    grade_status = "updated"
+                else:
+                    grade_status = "already exists"
+
+                grade_summary = ["passed: {}".format(course_run_grade.passed)]
+                if override_grade is not None:
+                    grade_summary.append(
+                        "value override: {}".format(course_run_grade.grade)
+                    )
+
+                if created_cert:
+                    cert_status = "created"
+                elif deleted_cert:
+                    cert_status = "deleted"
+                elif course_run_grade.passed:
+                    cert_status = "already exists"
+                else:
+                    cert_status = "ignored"
+
+                result_summary = "Grade: {} ({}), Certificate: {}".format(
+                    grade_status, ", ".join(grade_summary), cert_status
+                )
+
+                results.append(
+                    "Processed user {} ({}) in course run {}. Result - {}".format(
+                        user.username,
+                        user.email,
+                        course_run.courseware_id,
+                        result_summary,
+                    )
+                )
+
+            for result in results:
+                self.stdout.write(self.style.SUCCESS(result))

--- a/courses/management/commands/test_manage_certificate.py
+++ b/courses/management/commands/test_manage_certificate.py
@@ -10,6 +10,7 @@ from courses.factories import (
     CourseRunFactory,
     CourseRunCertificateFactory,
     CourseRunEnrollmentFactory,
+    CourseRunGradeFactory,
 )
 from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 from edx_api.grades.models import CurrentGrade
@@ -34,7 +35,7 @@ def test_certificate_management_no_argument():
         manage_certificates.Command().handle()
     assert (
         str(command_error.value)
-        == "The command needs a valid action e.g. --revoke, --unrevoke, --create"
+        == "The command needs a valid action e.g. --revoke, --unrevoke, --create."
     )
 
 
@@ -44,13 +45,13 @@ def test_certificate_management_invalid_run():
     test_user = UserFactory.create()
     with pytest.raises(CommandError) as command_error:
         manage_certificates.Command().handle(user=test_user.username, create=True)
-    assert str(command_error.value) == "The command needs a valid course run"
+    assert str(command_error.value) == "The command needs a valid course run."
 
     with pytest.raises(CommandError) as command_error:
         manage_certificates.Command().handle(
             user=test_user.username, create=True, run="test"
         )
-    assert str(command_error.value) == "Could not find run with courseware_id=test"
+    assert str(command_error.value) == "Could not find run with courseware_id=test."
 
 
 def test_certificate_override_grade_no_user():
@@ -63,7 +64,7 @@ def test_certificate_override_grade_no_user():
         )
     assert (
         str(command_error.value)
-        == "Override grade needs a user (The grade override operation is not supported for multiple users)"
+        == "Override grade needs a user (The grade override operation is not supported for multiple users)."
     )
 
 
@@ -89,7 +90,7 @@ def test_certificate_management_revoke_unrevoke_invalid_args(
             unrevoke=unrevoke,
             run=course_run.courseware_id,
         )
-    assert str(command_error.value) == "Revoke/Un-revoke operation needs a valid user"
+    assert str(command_error.value) == "Revoke/Un-revoke operation needs a valid user."
 
 
 @pytest.mark.parametrize(

--- a/courses/management/commands/test_manage_certificate.py
+++ b/courses/management/commands/test_manage_certificate.py
@@ -1,0 +1,180 @@
+"""Tests for Certificates management command"""
+
+import pytest
+import factory
+from courses.management.commands import manage_certificates
+from courses.models import CourseRun, CourseRunCertificate, CourseRunGrade
+from django.core.management.base import CommandError
+from users.factories import UserFactory
+from courses.factories import (
+    CourseRunFactory,
+    CourseRunCertificateFactory,
+    CourseRunEnrollmentFactory,
+)
+from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
+from edx_api.grades.models import CurrentGrade
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def edx_grade_json(user):
+    return {
+        "passed": True,
+        "course_id": "test_course_id",
+        "username": user.username,
+        "percent": 0.5,
+    }
+
+
+def test_certificate_management_no_argument():
+    """Test that command throws error when no input is provided"""
+
+    with pytest.raises(CommandError) as command_error:
+        manage_certificates.Command().handle()
+    assert (
+        str(command_error.value)
+        == "The command needs a valid action e.g. --revoke, --unrevoke, --create"
+    )
+
+
+def test_certificate_management_invalid_run():
+    """Test that certificate management command throws proper error when no valid run is supplied"""
+
+    test_user = UserFactory.create()
+    with pytest.raises(CommandError) as command_error:
+        manage_certificates.Command().handle(user=test_user.username, create=True)
+    assert str(command_error.value) == "The command needs a valid course run"
+
+    with pytest.raises(CommandError) as command_error:
+        manage_certificates.Command().handle(
+            user=test_user.username, create=True, run="test"
+        )
+    assert str(command_error.value) == "Could not find run with courseware_id=test"
+
+
+def test_certificate_override_grade_no_user():
+    """Test that overriding grade for all users is not supported"""
+
+    course_run = CourseRunFactory.create()
+    with pytest.raises(CommandError) as command_error:
+        manage_certificates.Command().handle(
+            create=True, run=course_run.courseware_id, grade=0.5, user=None
+        )
+    assert (
+        str(command_error.value)
+        == "Override grade needs a user (The grade override operation is not supported for multiple users)"
+    )
+
+
+@pytest.mark.parametrize(
+    "username, revoke, unrevoke",
+    [
+        (None, True, None),
+        ("test", True, None),
+        (None, None, True),
+        ("test", None, True),
+    ],
+)
+def test_certificate_management_revoke_unrevoke_invalid_args(
+    username, revoke, unrevoke
+):
+    """Test that the command throws proper error when revoke, un-revoke operations are not given proper arguments"""
+    course_run = CourseRunFactory.create()
+
+    with pytest.raises(CommandError) as command_error:
+        manage_certificates.Command().handle(
+            user=username,
+            revoke=revoke,
+            unrevoke=unrevoke,
+            run=course_run.courseware_id,
+        )
+    assert str(command_error.value) == "Revoke/Un-revoke operation needs a valid user"
+
+
+@pytest.mark.parametrize(
+    "revoke, unrevoke",
+    [
+        (True, None),
+        (None, True),
+    ],
+)
+def test_certificate_management_revoke_unrevoke_success(user, revoke, unrevoke):
+    """Test that certificate revoke, un-revoke work as expected and manage the certificate access properly"""
+    course_run = CourseRunFactory.create()
+    certificate = CourseRunCertificateFactory(
+        course_run=course_run, user=user, is_revoked=False if revoke else True
+    )
+    manage_certificates.Command().handle(
+        revoke=revoke,
+        unrevoke=unrevoke,
+        run=course_run.courseware_id,
+        user=user.username,
+    )
+    certificate.refresh_from_db()
+    assert certificate.is_revoked is (True if revoke else False)
+    assert certificate.is_revoked is (False if unrevoke else True)
+
+
+def test_certificate_management_create(mocker, user, edx_grade_json):
+    """Test that create operation for certificate management command creates the certificates for a single user
+    when a user is provided"""
+    edx_grade = CurrentGrade(edx_grade_json)
+    course_run = CourseRunFactory.create()
+    CourseRunEnrollmentFactory.create(
+        user=user, run=course_run, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
+
+    mocker.patch(
+        "courses.management.commands.manage_certificates.get_edx_grades_with_users",
+        return_value=[
+            (edx_grade, user),
+        ],
+    )
+    manage_certificates.Command().handle(
+        create=True, run=course_run.courseware_id, user=user.username
+    )
+
+    generated_certificates = CourseRunCertificate.objects.filter(
+        user=user, course_run=course_run
+    )
+    generated_grades = CourseRunGrade.objects.filter(user=user, course_run=course_run)
+
+    assert generated_certificates.count() == 1
+    assert generated_grades.count() == 1
+
+
+def test_certificate_management_create_no_user(mocker, edx_grade_json, user):
+    """Test that create operation for certificate management command attempts to creates the certificates for all the
+    enrolled users in a run when no user is provided"""
+    passed_edx_grade = CurrentGrade(edx_grade_json)
+    course_run = CourseRunFactory.create()
+    users = UserFactory.create_batch(4)
+    CourseRunEnrollmentFactory.create_batch(
+        3,
+        user=factory.Iterator(users),
+        run=course_run,
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+    )
+    CourseRunEnrollmentFactory.create(
+        user=users[3], run=course_run, enrollment_mode=EDX_DEFAULT_ENROLLMENT_MODE
+    )
+
+    mocker.patch(
+        "courses.management.commands.manage_certificates.get_edx_grades_with_users",
+        return_value=[
+            (passed_edx_grade, users[0]),
+            (passed_edx_grade, users[1]),
+            (passed_edx_grade, users[2]),
+            (passed_edx_grade, users[3]),
+        ],
+    )
+    manage_certificates.Command().handle(
+        create=True, run=course_run.courseware_id, user=None
+    )
+
+    generated_certificates = CourseRunCertificate.objects.filter(course_run=course_run)
+    generated_grades = CourseRunGrade.objects.filter(course_run=course_run)
+
+    assert generated_certificates.count() == 3
+    assert generated_grades.count() == 4

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -18,3 +18,7 @@ def exception_logging_generator(generator):
             log.exception("EdX API error for fetching user grades %s:", exc)
         except Exception as exp:  # pylint: disable=broad-except
             log.exception("Error fetching user grades from edX %s:", exp)
+
+
+def is_grade_valid(override_grade: float):
+    return 0.0 <= override_grade <= 1.0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#881 

#### What's this PR do?
Adds a command to manage below operations:

- Certificate revoke/unrevoke
- Grade override/Certificate creation
- Certifiicate creation

**Criteria & Conditions (For operations in the command)**
1. A course run (Course Run's `courseware_id`) is needed for all the operations in the command
2. _Grade override and revoke/un-revoke_ operations are supported for a single user only, so for these operations, the command will specifically need a user
3. The _Create_ operation is supported for single or all users
    1. If a user is provided while running `--create` the operation will run only for that specific user
    2. If a user is not provided while running `--create` the operation will for all the enrolled users

**Overall behavior**
1. The command will not check the eligibility of the course run like the regular 24 hours task for certificates, it will just perform the operation specifically for the provided run
2. In the case of `--grade=` if the grade is greater than `0.0` the command will override the grade and mark the user passed and generate the certificate
3. In case the grade is not provided, the command will check the eligibility criteria of certificates e.g. (Passed in edX + Paid enrollment - `Verified`)

#### How should this be manually tested?

To test the command you can follow three paths defined below:

**Revoke, Un-Revoke (This needs a user, it only works for a single user)**

1. `./mange.py manage_certificates --revoke --user=<username or email> --run=<course_run_courseware_id> `(Revokes the user certificate for a specific run)
2. `./mange.py manage_certificates --unrevoke --user=<username or email> --run=<course_run_courseware_id>` (Un-Revokes the user certificate for a specific run) 

**Create certificates (This supports single users or multiple users if no user is provided, If a user is provided it runs for that single user only):**

1. `./manage.py manage_certificates --create --user=<username or email> --run=<course_run_courseware_id>` (This should create/update the grades for the user and create the certificate for the provided user if the user has passed grade from edX and enrolled in Verified/paid mode)
2. `./manage.py manage_certificates --create --run=<course_run_courseware_id>` (This should create/update the grades for the users and create the certificate for all the users (Passed in edX + Enrolled in Verified/Paid) enrolled in the provided course run if the user has passed grade from edX and enrolled in Verified/paid mode)

**Override Grade & create a certificate(This operation needs a user and works only for a single user):**
1. `./manage.py manage_certificates --create --user=<username or email> --run=<course_run_courseware_id> --grade=<a float value between 0.0-1.0>` (This should override the grades for the user with the provided grade in parameters and create the certificate for the provided user regardless of the passing grade and paid enrollment) - This will not create the certificate for the user in the case when `grade=0.0` otherwise it will override the grade+create certificate
