### PR TITLE
Adds setup command to bootstrap financial aid for DEDP

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -287,6 +287,10 @@ class Discount(TimestampedModel):
         ):
             return False
 
+        return self.valid_now()
+
+    def valid_now(self):
+        """Returns True if the discount is valid right now"""
         if self.activation_date is not None and self.activation_date > datetime.now(
             pytz.timezone(TIME_ZONE)
         ):

--- a/flexiblepricing/management/commands/configure_for_dedp.py
+++ b/flexiblepricing/management/commands/configure_for_dedp.py
@@ -1,0 +1,196 @@
+"""
+Ensures there's a basic set of records present for financial aid to work for
+DEDP courses. This includes:
+- A DEDP program (required for the tiers to be set up)
+- A set of discounts, specific to DEDP
+- Tiers that are tied to these discounts
+
+The defaults for this are:
+
+Program:
+- Readable ID is `program-v1:MITx+DEDP`
+- Name is `Data, Economics and Development Policy`
+
+Discounts: (year is the current year)
+Code               | Type        | Amount
+-----------------------------------------
+DEDP-fa-tier1-year | dollars-off | 750
+DEDP-fa-tier2-year | dollars-off | 650
+DEDP-fa-tier3-year | dollars-off | 500
+DEDP-fa-tier4-year | percent-off | 0
+-----------------------------------------
+
+Tiers:
+Threshold | Discount
+------------------------------
+0         | DEDP-fa-tier1-year
+25,000    | DEDP-fa-tier2-year
+50,000    | DEDP-fa-tier3-year
+75,000    | DEDP-fa-tier4-year
+------------------------------
+
+If discounts and tiers exist for the current year, this command will leave them
+alone. If they exist for prior years, they will be disabled (current=False for
+tiers and expiration date set to the past for discounts).
+
+If a program exists with the readable ID specified, that will be used.
+
+"""
+from datetime import date, datetime
+from django.core.management import BaseCommand
+from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
+import pytz
+
+from courses.models import Program
+from flexiblepricing.models import FlexiblePriceTier
+from ecommerce.models import Discount
+from ecommerce.constants import REDEMPTION_TYPE_UNLIMITED
+
+
+class Command(BaseCommand):
+    """
+    Sets up some basic records for DEDP Financial Assistance
+    """
+
+    help = "Sets up some basic records for DEDP Financial Assistance"
+    PROGRAM_READABLE_ID = "program-v1:MITx+DEDP"
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+        current_year = date.today().year
+        last_year = datetime(
+            current_year - 1, 1, 1, tzinfo=pytz.timezone(settings.TIME_ZONE)
+        )
+        discounts_and_tiers = [
+            {
+                "tier": {"threshold": 0},
+                "discount": {
+                    "discount_code": f"DEDP-fa-tier1-{current_year}",
+                    "discount_type": "dollars-off",
+                    "amount": 750,
+                },
+            },
+            {
+                "tier": {"threshold": 25000},
+                "discount": {
+                    "discount_code": f"DEDP-fa-tier2-{current_year}",
+                    "discount_type": "dollars-off",
+                    "amount": 650,
+                },
+            },
+            {
+                "tier": {"threshold": 50000},
+                "discount": {
+                    "discount_code": f"DEDP-fa-tier3-{current_year}",
+                    "discount_type": "dollars-off",
+                    "amount": 500,
+                },
+            },
+            {
+                "tier": {"threshold": 75000},
+                "discount": {
+                    "discount_code": f"DEDP-fa-tier4-{current_year}",
+                    "discount_type": "percent-off",
+                    "amount": 0,
+                },
+            },
+        ]
+        content_type = ContentType.objects.filter(
+            app_label="courses", model="program"
+        ).first()
+
+        # Step one: get the DEDP program
+        self.stdout.write(self.style.NOTICE("Setting up the program..."))
+        (program, created) = Program.objects.update_or_create(
+            readable_id=self.PROGRAM_READABLE_ID,
+            defaults={"title": "Data, Economics and Development Policy", "live": True},
+        )
+        if created:
+            self.stdout.write(self.style.NOTICE(f"Created new program {program.id}"))
+        else:
+            self.stdout.write(self.style.NOTICE(f"Using existing program {program.id}"))
+
+        # Step two: get existing discounts
+        discounts = Discount.objects.filter(
+            discount_code__startswith="DEDP-fa-tier",
+            discount_code__endswith=str(current_year),
+        ).all()
+        self.stdout.write(
+            self.style.NOTICE(f"{len(discounts)} existing DEDP discounts")
+        )
+
+        matched_discounts = []
+
+        # Step three: process any extant discounts
+        # We need one each with the settings noted in the docs above
+        for tier_config in discounts_and_tiers:
+            self.stdout.write(
+                self.style.NOTICE(
+                    f"Looking for {tier_config['discount']['amount']} {tier_config['discount']['discount_type']} discount for threshold {tier_config['tier']['threshold']}"
+                )
+            )
+            found_discount = None
+
+            for discount in discounts:
+                if (
+                    discount.valid_now()
+                    and tier_config["discount"]["discount_type"]
+                    == discount.discount_type
+                    and tier_config["discount"]["amount"] == discount.amount
+                ):
+                    found_discount = discount
+                    self.stdout.write(
+                        self.style.NOTICE(
+                            f"\tFound a discount ({discount.discount_code})"
+                        )
+                    )
+                    break
+
+            if not found_discount:
+                found_discount = Discount(
+                    **tier_config["discount"],
+                    for_flexible_pricing=True,
+                    redemption_type=REDEMPTION_TYPE_UNLIMITED,
+                )
+                found_discount.save()
+                self.stdout.write(
+                    self.style.NOTICE(f"\tCreated new discount ID {found_discount.id}")
+                )
+
+            matched_discounts.append(found_discount)
+
+            (tier, created) = FlexiblePriceTier.objects.update_or_create(
+                income_threshold_usd=tier_config["tier"]["threshold"],
+                courseware_object_id=program.id,
+                courseware_content_type=content_type,
+                defaults={"discount": found_discount, "current": True},
+            )
+
+            if created:
+                self.stdout.write(
+                    self.style.NOTICE(
+                        f"\tCreated new tier for threshold {tier_config['tier']['threshold']} - ID {tier.id}"
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.NOTICE(
+                        f"\tUpdated existing tier ID {tier.id} for threshold {tier_config['tier']['threshold']}"
+                    )
+                )
+
+        unmatched_discounts_qset = Discount.objects.filter(
+            discount_code__startswith="DEDP-fa-tier"
+        ).exclude(id__in=[discount.id for discount in matched_discounts])
+
+        unmatched_discounts = unmatched_discounts_qset.update(expiration_date=last_year)
+
+        self.stdout.write(self.style.NOTICE(f"{unmatched_discounts} discounts expired"))
+
+        unmatched_tiers = FlexiblePriceTier.objects.filter(
+            courseware_object_id=program.id,
+            courseware_content_type=content_type,
+            discount__in=unmatched_discounts_qset.all(),
+        ).update(current=False)
+
+        self.stdout.write(self.style.NOTICE(f"{unmatched_tiers} tiers deactivated"))

--- a/flexiblepricing/management/commands/configure_for_dedp_test.py
+++ b/flexiblepricing/management/commands/configure_for_dedp_test.py
@@ -1,0 +1,81 @@
+import pytest
+import pytz
+from datetime import date, datetime
+from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
+
+from flexiblepricing.management.commands import configure_for_dedp
+from courses.models import Program
+from flexiblepricing.models import FlexiblePriceTier
+from ecommerce.models import Discount
+from ecommerce.factories import DiscountFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.mark.parametrize("with_existing_records", [False, True])
+def test_dedp_setup(with_existing_records):
+    """
+    Runs the setup command and then makes sure the result is correct.
+    This tests specifically a setup where there's no existing DEDP records.
+    """
+    this_year = date.today().year
+    content_type = ContentType.objects.filter(
+        app_label="courses", model="program"
+    ).first()
+
+    Program.objects.filter(readable_id="program-v1:MITx+DEDP").all().delete()
+    Discount.objects.filter(
+        discount_code__startswith="DEDP-fa-tier", discount_code__endswith=this_year
+    ).all().delete()
+
+    if with_existing_records:
+        existing_program = Program(
+            readable_id="program-v1:MITx+DEDP", title="A Custom Title"
+        )
+        existing_program.save()
+        existing_discount = DiscountFactory.create(
+            discount_code="DEDP-fa-tier1-1999", for_flexible_pricing=True
+        )
+        existing_tier = FlexiblePriceTier(
+            courseware_content_type=content_type,
+            courseware_object_id=existing_program.id,
+            current=True,
+            income_threshold_usd=24129,
+            discount=existing_discount,
+        )
+        existing_tier.save()
+
+    configure_for_dedp.Command().handle()
+
+    assert Program.objects.filter(readable_id="program-v1:MITx+DEDP").exists()
+
+    program = Program.objects.filter(readable_id="program-v1:MITx+DEDP").first()
+    discounts_qset = Discount.objects.filter(
+        discount_code__startswith="DEDP-fa-tier", discount_code__endswith=this_year
+    )
+
+    assert discounts_qset.count() == 4
+
+    assert (
+        FlexiblePriceTier.objects.filter(
+            current=True,
+            discount__in=discounts_qset.all(),
+            courseware_object_id=program.id,
+            courseware_content_type=content_type,
+        ).count()
+        == 4
+    )
+
+    if with_existing_records:
+        existing_discount.refresh_from_db()
+        existing_tier.refresh_from_db()
+        existing_program.refresh_from_db()
+
+        assert program == existing_program
+        assert (
+            existing_discount.expiration_date is not None
+            and existing_discount.expiration_date
+            < datetime.now(tz=pytz.timezone(settings.TIME_ZONE))
+        )
+        assert existing_tier.current is False


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #883

#### What's this PR do?

Adds a management command that bootstraps DEDP financial aid. This includes:
- making sure a DEDP program exists
- creating discounts for the tiers (or identifying and reusing discounts that already exist, if their parameters are correct)
- creating tiers for DEDP financial assistance requests

The command will also deactivate (by setting the expiration date to a date in the past) discounts that follow the naming scheme (`DEDP-fa-tierX-YYYY` where YYYY is the year), and will deactivate tiers that aren't associated with a current set of DEDP discounts. 

#### How should this be manually tested?

Automated tests should pass.

See the comment block at the top of the command `flexiblepricing/management/commands/configure_for_dedp.py` for an explanation of what your database should have in it after running the command. 

To test full-stop bootstrapping, ensure you do not have any discounts that follow the `DEDP-fa-tier` naming scheme, nor tiers that use them, nor a DEDP program (`program-v1:MITx+DEDP`). Then, run the command. You should have a DEDP program, a set of four DEDP discounts, and a set of four tiers for the program that use the discounts. 

To test partial bootstrapping, run the command after first having any of these conditions:
- an existing DEDP program
- existing DEDP discounts for the current year
- tiers that use the discounts

The command should run successfully and the existing data should be kept if it matches the parameters. 

To test invalidation, run the command after first having any of these conditions:
- a DEDP discount for a prior year (so, for 2022, a discount with a code of `DEDP-fa-tierX-2021` or before)
- tiers that use the prior year discount

The discounts should be invalidated and the tiers should be turned off (`current=False`). 
