### PR TITLE
add error log for transactions' reason code any number other than 100

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -276,6 +276,12 @@ def process_cybersource_payment_response(request, order):
         ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
     )
 
+    # Log error message if reason_code is any number other than 100 (successful transaction)
+    reason_code = processor_response.response_code
+    if reason_code and reason_code != "100":
+        log.error(
+            f"Transaction was not successful. Reason Code:  {reason_code}  \t Message: {processor_response.message}"
+        )
     return_message = ""
 
     if processor_response.state == ProcessorResponse.STATE_DECLINED:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/894

#### What's this PR do?
Log error message when reason_code in cybersource payload is any number other than 100 

#### How should this be manually tested?
Not sure the best way to see the log for the payment failure locally. But I modify the code ```if reason_code and reason_code == "100":```to confirm it's logged in mitxonline-web-1 container

