### PR TITLE
Fixes nav issues when a course date is selected

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -48,7 +48,7 @@
               </div>
               {% if course_runs|length > 1 %}
                 <strong class="more-dates">
-                  <a tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
+                  <span tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="focus" onClick="event.preventDefault();"
                     data-toggle="popover" data-placement="auto" title="More dates available" data-html="true"
                     data-content="
                       <div>
@@ -56,12 +56,12 @@
                       </div>
                       {% for course_run in course_runs %}
                           <div>
-                            <a class='date-link' id='{{ course_run.courseware_id }}' href='#' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                            <span class='date-link' id='{{ course_run.courseware_id }}' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</span>
                           </div>
                       {% endfor %}
                     ">
                     More Dates
-                  </a>
+                  </span>
                 </strong>
               {% endif %}
             </div>

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -242,6 +242,7 @@
         .dates-tooltip {
           color: $link-blue !important;
           text-decoration: underline;
+          cursor: pointer;
         }
       }
 
@@ -456,4 +457,10 @@
 .popover-header {
   text-align: center;
   background: $white;
+}
+
+.date-link {
+  color: $link-blue !important;
+  text-decoration: underline;
+  cursor: pointer;
 }

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -56,16 +56,13 @@ export class ProductDetailEnrollApp extends React.Component<
   }
 
   setCurrentCourseRun = (courseRun: EnrollmentFlaggedCourseRun) => {
-    sessionStorage.setItem('currentCourseRun', JSON.stringify(courseRun))
     this.setState({
       currentCourseRun: courseRun
     })
   }
 
   getCurrentCourseRun = (): EnrollmentFlaggedCourseRun => {
-    const courseRun = sessionStorage.getItem('currentCourseRun')
-    const sessionCourseRun = courseRun ? JSON.parse(courseRun) : null
-    return sessionCourseRun ? sessionCourseRun : this.state.currentCourseRun
+    return this.state.currentCourseRun
   }
 
   renderUpgradeEnrollmentDialog() {


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #854 

#### What's this PR do?

Swaps clickable elements in the course run date picker from `<a>` tags to `<span>` so they don't cause the URL to change. Also removes the dependence on `localStorage` for storing the selected course run (as noted, it should default to the most recent course run). 

#### How should this be manually tested?

Load a course page that has multiple active course runs. Clicking the More Dates link should not cause the URL to change. Selecting a date in the popover should, additionally, not cause the URL to change. The selection should not survive a page refresh. 
