### PR TITLE
Program Flexible Pricing approval page

### DIFF
--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -60,19 +60,23 @@
           {{ page.application_approved_text|richtext }}
         </div>
         {% endif %}{# end discount amount text #}
-          <form action="/cart/add/" method="get" className="text-center">
-          {% if page.selected_program %}
-            <input type="hidden" name="program_id" value={{ page.selected_program.id }} />
-          {% elif page.selected_course %}
+
+          {% if page.selected_course %}
+            <form action="/cart/add/" method="get" className="text-center">
              <input type="hidden" name="course_id" value={{ page.selected_course.id }} />
-          {% endif %}
-            <button
+              <button
               type="submit"
-              class="btn btn-primary btn-gradient-red flexible-price-certificate-btn"
-            >
+              class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
               Get Certificate
-            </button>
-          </form>
+              </button>
+              </form>
+          {% elif page.selected_program %}
+            <a href="/dashboard" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+            Go to Dashboard
+            </a>
+          {% endif %}
+
+
       {% elif prior_request.is_denied %}
         <div class="flexible-pricing-head">
           {{ page.application_denied_text|richtext }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/mitxonline/pull/856

#### What's this PR do?
When the user fills out a flexible pricing form for a program the approval message shows a button to go to dashboard. For comparison, an individual course flexible pricing request shows the user "Get Certificate" button, that adds the course to the basket and takes user to checkout.

To test this Fill out the flexible pricing form( once for a course and another for a program), receive a discount and test:
1)For a course the Get Certificate button. It should take you to checkout page with the product in the cart.
2) For a program Go to Dashboard button

Flexible pricing form for course:
<img width="710" alt="Screen Shot 2022-08-31 at 1 45 18 PM" src="https://user-images.githubusercontent.com/7574259/187689719-115e358d-eb44-45d2-964f-07a19faa6b7c.png">

After clicking Get Certificate:
<img width="1517" alt="Screen Shot 2022-08-31 at 1 34 48 PM" src="https://user-images.githubusercontent.com/7574259/187670786-1575a86b-2b20-4f07-9dfc-f6d2bdabba14.png">
Flexible Pricing for program:
<img width="1264" alt="Screen Shot 2022-08-31 at 1 34 05 PM" src="https://user-images.githubusercontent.com/7574259/187670793-cabe44a0-067c-4829-a766-b1d36f5357b7.png">

