### PR TITLE
Hide description if certificate is also hidden

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -266,9 +266,17 @@ export class EnrolledItemCard extends React.Component<
       enrollment.enrollment_mode === "audit" &&
       enrollment.run.is_upgradable
     ) ? (
-        <div className="enrollment-extra-links d-flex">
-          {financialAssistanceLink}
-          <GetCertificateButton productId={enrollment.run.products[0].id} />
+        <div>
+          <div className="upgrade-item-description">
+            <p>
+              <strong>Upgrade today</strong> and, upon passing, receive your certificate signed by MIT faculty
+              to highlight the knowledge and skills you've gained from this MITx course.
+            </p>
+          </div>
+          <div className="enrollment-extra-links d-flex">
+            {financialAssistanceLink}
+            <GetCertificateButton productId={enrollment.run.products[0].id} />
+          </div>
         </div>
       ) : null
 
@@ -336,14 +344,6 @@ export class EnrolledItemCard extends React.Component<
                 ) : null}
               </div>
               <br/>
-              {enrollment.enrollment_mode === "audit" ? (
-                <div className="upgrade-item-description">
-                  <p>
-                    <strong>Upgrade today</strong> and, upon passing, receive your certificate signed by MIT faculty
-                    to highlight the knowledge and skills you've gained from this MITx course.
-                  </p>
-                </div>
-              ) : null}
               {certificateLinks}
             </div>
             <div className="d-flex justify-content-between align-content-start flex-nowrap w-100 enrollment-mode-container re-order">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/884

#### What's this PR do?
Refer to the screenshot - if the "Get Certificate" button is hidden, then we should also hide the upgrade description (shown with the grey background).

#### How should this be manually tested?

1.  Create a Course and Course Run but no Product.
2. Enroll in the Course Run from step 1.
3. View your Dashboard and ensure that you don't see the "Get Certificate" button or upgrade description.
4. Create a Product associated with your Course Run.
5. View your Dashboard and ensure that you do see the "Get Certificate" button and upgrade description.
6. Change your Course Run Enrollment's mode to any value other than "audit"
7. View your Dashboard and ensure that you don't see the "Get Certificate" button or upgrade description.
8. Revert the Course Run Enrollment's mode back to "audit"
9. Set the `upgrade_deadline` for the Course Run from step 1 to a date prior to today's date.
10. View your Dashboard and ensure that you don't see the "Get Certificate" button or upgrade description.

Without this PR, if the Course Run has an upgrade deadline in the past, and the course run enrollment is audit, and there is an associated product, then the "Get Certificate" button is hidden but the upgrade description is shown.

#### Screenshots (if appropriate)
![Screen Shot 2022-08-31 at 14 30 11](https://user-images.githubusercontent.com/8311573/187753270-880155df-2bd9-4f9e-ab34-074ece8677fb.png)
