### PR TITLE
fix: certificate error when end_date is not set

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -669,7 +669,7 @@ def generate_course_run_certificates():
             # Check certificate generation eligibility
             #   1. For self_paced course runs we generate certificates right away irrespective of end_date
             #   2. For others course runs we generate the certificates if the end of course run has passed
-            if run.is_self_paced or (run.end_date <= now):
+            if run.is_self_paced or (run.end_date and run.end_date <= now):
                 _, created, deleted = process_course_run_grade_certificate(
                     course_run_grade=course_run_grade
                 )

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -911,6 +911,7 @@ def test_generate_course_certificates_self_paced_course(
     [
         (True, now_in_utc() + timedelta(hours=2)),
         (False, now_in_utc()),
+        (False, None),
     ],
 )
 def test_course_certificates_with_course_end_date_self_paced_combination(
@@ -942,7 +943,7 @@ def test_course_certificates_with_course_end_date_self_paced_combination(
 
     generate_course_run_certificates()
     assert (
-        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1} users"
+        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1 if end_date else 0} users"
         in courses_api_logs.info.call_args[0][0]
     )
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None, FIxes sentry error https://sentry.io/organizations/mit-office-of-digital-learning/issues/3549741560/?project=5864687&referrer=slack

#### What's this PR do?
Fixes a sentry error with certificate generation when course run end_date is not set or None.

#### How should this be manually tested?
Just checking that certificate generation handles end dates now when not set.

