### PR TITLE
Adds OFAC messaging to the bottom of the course about page

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -145,5 +145,12 @@
         </div>
       </section>
       {% endif %}
+      <section class="ofac-message">
+        <div class="container">
+          <p><em>Who can take this course?</em></p>
+
+          <p>Due to U.S. Office of Foreign Assets Control (OFAC) restrictions and other U.S. federal regulations, learners residing in one or more of the following countries or regions will not be able to register for this course: Iran, Cuba, Syria, North Korea and the Crimea, Donetsk People's Republic and Luhansk People's Republic regions of Ukraine.</p>
+        </div>
+      </section>
     </div>
 {% endblock %}

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -373,6 +373,10 @@
       padding-bottom: 20px;
     }
   }
+
+  .ofac-message {
+    clear: both;
+  }
 }
 
 .upgrade-enrollment-modal {


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #885 

#### What's this PR do?

Adds the text specified in #885 to the bottom of the course about page. This is currently constructed with `clear:both` on the container so that it falls underneath everything above it. (Notably, it should fall beneath the upsell card on a course about page that's very short and also has an upsell card. See screenshot.) 

#### How should this be manually tested?

Observe any course about page. The text should be at the bottom, before the footer.

#### Screenshots (if appropriate)

![Screen Shot 2022-09-01 at 1 38 59 PM](https://user-images.githubusercontent.com/945611/187989420-ef6ac4db-85ca-4af3-ac26-a763b7a512e6.png)

Demonstrating flow:
![Screen Shot 2022-09-01 at 1 46 27 PM](https://user-images.githubusercontent.com/945611/187989748-305cb058-b59c-43ac-b188-267a98808282.png)

Mobile:
![Screen Shot 2022-09-01 at 1 47 12 PM](https://user-images.githubusercontent.com/945611/187989841-37e2421a-0911-48ab-91cc-08cbfb27f30b.png)
