### PR TITLE
910 dashboard doesnt refresh when user unenrolls from course in a program

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -30,7 +30,8 @@ type EnrolledItemCardProps = {
     enrollmentId: number,
     emailsSubscription: string
   ) => Promise<any>,
-  addUserNotification: Function
+  addUserNotification: Function,
+  closeDrawer:Function,
 }
 
 type EnrolledItemCardState = {
@@ -73,7 +74,7 @@ export class EnrolledItemCard extends React.Component<
   }
 
   async onDeactivate(enrollment: RunEnrollment) {
-    const { deactivateEnrollment, addUserNotification } = this.props
+    const { deactivateEnrollment, addUserNotification, closeDrawer } = this.props
 
     if (enrollment.enrollment_mode === "verified") {
       this.toggleVerifiedUnenrollmentModalVisibility()
@@ -91,6 +92,9 @@ export class EnrolledItemCard extends React.Component<
         messageType = ALERT_TYPE_DANGER
         userMessage = `Something went wrong with your request to unenroll. Please contact support at ${SETTINGS.support_email}.`
       }
+      if (typeof closeDrawer === "function") {
+        closeDrawer()
+      }
       addUserNotification({
         "unenroll-status": {
           type:  messageType,
@@ -107,7 +111,7 @@ export class EnrolledItemCard extends React.Component<
   }
 
   async onSubmit(payload: Object) {
-    const { courseEmailsSubscription, addUserNotification } = this.props
+    const { courseEmailsSubscription, addUserNotification, closeDrawer } = this.props
     this.setState({ submittingEnrollmentId: payload.enrollmentId })
     this.toggleEmailSettingsModalVisibility()
     try {
@@ -126,6 +130,9 @@ export class EnrolledItemCard extends React.Component<
       } else {
         messageType = ALERT_TYPE_DANGER
         userMessage = `Something went wrong with your request to course ${payload.courseNumber} emails subscription. Please contact support at ${SETTINGS.support_email}.`
+      }
+      if (typeof closeDrawer === "function") {
+        closeDrawer()
       }
       addUserNotification({
         "subscription-status": {

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -19,7 +19,8 @@ describe("EnrolledItemCard", () => {
     currentUser,
     isLinkableStub,
     enrollmentCardProps,
-    isFinancialAssistanceAvailableStub
+    isFinancialAssistanceAvailableStub,
+    closeDrawer
 
 
   beforeEach(() => {
@@ -56,6 +57,7 @@ describe("EnrolledItemCard", () => {
             enrollmentCardProps.courseEmailsSubscription
           }
           addUserNotification={enrollmentCardProps.addUserNotification}
+          closeDrawer={closeDrawer}
         />
       )
   })

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -59,6 +59,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
                   currentUser={currentUser}
                   deactivateEnrollment={deactivateEnrollment}
                   courseEmailsSubscription={courseEmailsSubscription}
+                  closeDrawer = {closeDrawer}
                   addUserNotification={addUserNotification}>
                 </EnrolledItemCard>
               ))) : (

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -64,7 +64,8 @@ type DashboardPageProps = {
     enrollmentId: number,
     emailsSubscription: string
   ) => Promise<any>,
-  addUserNotification: Function
+  addUserNotification: Function,
+  closeDrawer: Function,
 }
 
 type DashboardPageState = {
@@ -259,6 +260,7 @@ export class DashboardPage extends React.Component<
       deactivateEnrollment,
       courseEmailsSubscription,
       addUserNotification,
+      closeDrawer,
     } = this.props
 
     if (isProgramUIEnabled() && programEnrollments) {
@@ -277,6 +279,7 @@ export class DashboardPage extends React.Component<
         deactivateEnrollment={deactivateEnrollment}
         courseEmailsSubscription={courseEmailsSubscription}
         addUserNotification={addUserNotification}
+        closeDrawer={closeDrawer}
       ></EnrolledItemCard>
     )
   }

--- a/frontend/public/src/lib/queries/enrollment.js
+++ b/frontend/public/src/lib/queries/enrollment.js
@@ -55,7 +55,14 @@ export const deactivateEnrollmentMutation = (enrollmentId: number) => ({
       return emptyOrNil(prevEnrollments)
         ? []
         : prevEnrollments.filter(enrollment => enrollment.id !== enrollmentId)
-    }
+    },
+    program_enrollments: prevProgramEnrollments => {
+      return emptyOrNil(prevProgramEnrollments)
+        ? []
+        : prevProgramEnrollments.map(programEnrollment => {
+          return {...programEnrollment, enrollments: programEnrollment.enrollments.filter(enrollment => enrollment.id !== enrollmentId)}
+        })
+    },
   }
 })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/910

#### What's this PR do?
Fixing issue when user enrolls from course in a program 
 - Close the program drawer so that user can see the confirmation message
 - Program enrollment card is updated to reflect unenrollment on the dashboard

#### How should this be manually tested?

- Enroll a course from program and a course that's _not_ program

- Unenroll from a course in a program should now looks like this:

(# course is updated as well)
![image](https://user-images.githubusercontent.com/3138890/188137412-af162b42-d8fe-4df9-8308-a01fc59aa640.png)

- unenroll from a course that is not a program should still work 

(i made this course not part of a program)
![image](https://user-images.githubusercontent.com/3138890/188137696-a7b38f8c-869e-42ce-9a1b-eacb8635c4da.png)



#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)
