### PR TITLE
Fixes API error when learner is enrolled in a courserun with no related page

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -371,11 +371,14 @@ class CourseRunEnrollmentSerializer(serializers.ModelSerializer):
 
         # No need to include a certificate if there is no corresponding wagtail page
         # to support the render
-        if (
-            not enrollment
-            or not enrollment.run.course.page
-            or not enrollment.run.course.page.certificate_page
-        ):
+        try:
+            if (
+                not enrollment
+                or not enrollment.run.course.page
+                or not enrollment.run.course.page.certificate_page
+            ):
+                return None
+        except models.Course.page.RelatedObjectDoesNotExist:
             return None
 
         # Using IDs because we don't need the actual record and this avoids redundant queries


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #920

#### What's this PR do?

Wraps the check for a courserun's related course page in a `try/except` - if the learner is enrolled in a course run that doesn't have a page (like, for instance, a proctored exam), the check for the page will end up throwing a `RelatedObjectDoesNotExist` exception. 

#### How should this be manually tested?

Create and enroll in a course that does not have a CMS page. Then, view the dashboard. You should see course cards as per usual and you should not see the invite to enroll in courses.
