### PR TITLE
add is_self_paced to MicroMaster courserun import script

### DIFF
--- a/micromasters_import/management/commands/queries/002_import_courserun.sql
+++ b/micromasters_import/management/commands/queries/002_import_courserun.sql
@@ -12,7 +12,8 @@ INSERT INTO public.courses_courserun(
     live,
     created_on,
     updated_on,
-    course_id)
+    course_id,
+    is_self_paced)
 SELECT
     mm_courserun.title,
     mm_courserun.edx_course_key,
@@ -26,7 +27,8 @@ SELECT
     true, --live
     coalesce(mm_courserun.enrollment_start, now()),
     coalesce(mm_courserun.enrollment_end, now()),
-    pk_map.course_id
+    pk_map.course_id,
+    false  -- self_paced
 FROM micromasters.courses_courserun AS mm_courserun
 JOIN public.micromasters_import_courseid AS pk_map
   ON mm_courserun.course_id = pk_map.micromasters_id


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No new ticket, but the closed ticket is https://github.com/mitodl/mitxonline/issues/701

#### What's this PR do?
I ran into an error when running MicroMaster migration queries on RC
```psycopg2.errors.NotNullViolation: null value in column "is_self_paced" violates not-null constraint```

It looks like we added is_self_paced to the CourseRun model as part of [this PR ](https://github.com/mitodl/mitxonline/pull/722). The default value false is handled at django model level, not SQL level, so we would need to add is_self_paced = false in the migration query

#### How should this be manually tested?
Run ```docker-compose run --rm web ./manage.py import_micromasters_data``` and make sure no error
