### PR TITLE
fix 500 error on external course checkout

### DIFF
--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -499,6 +499,7 @@ class CheckoutProductView(LoginRequiredMixin, RedirectView):
             all_product_ids = self.request.GET.getlist("product_id")
 
             # If the request is from an external source we would have course_id as query param
+            # Note that course_id passed in param corresponds to course run's courseware_id on mitxonline
             course_run_ids = self.request.GET.getlist("course_run_id")
             course_ids = self.request.GET.getlist("course_id")
             program_ids = self.request.GET.getlist("program_id")
@@ -507,7 +508,7 @@ class CheckoutProductView(LoginRequiredMixin, RedirectView):
                 list(
                     CourseRun.objects.filter(
                         Q(courseware_id__in=course_run_ids)
-                        | Q(course__id__in=course_ids)
+                        | Q(courseware_id__in=course_ids)
                     ).values_list("products__id", flat=True)
                 )
             )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/935

#### What's this PR do?
Fixing 500 error when checking out course from external source - edx  

#### How should this be manually tested?

- The external checkout instruction can be found in this [PR ](https://github.com/mitodl/mitxonline/pull/626)

- As instructed in other PR, you could manually pass course_id to URL like this:  http://mitxonline.odl.local:8013/cart/add?course_id=course-v1%3AMITx%2B14.310x%2B3T2022 (make sure courserun and product setup locally)

- It should then directs you to the checkout page instead of receiving 500 error

<img width="1283" alt="image" src="https://user-images.githubusercontent.com/3138890/188911814-edee7dca-d0c1-4dfb-88ed-07d243161a44.png">
