### PR TITLE
Online-943 Update course start string

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -291,7 +291,6 @@ export class EnrolledItemCard extends React.Component<
       ) : null
 
     const startDateDescription = generateStartDateText(enrollment.run)
-    console.log("StartDateDesc", startDateDescription)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
     const enrollmentMode = enrollment.enrollment_mode

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -291,6 +291,7 @@ export class EnrolledItemCard extends React.Component<
       ) : null
 
     const startDateDescription = generateStartDateText(enrollment.run)
+    console.log("StartDateDesc", startDateDescription)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
     const enrollmentMode = enrollment.enrollment_mode
@@ -359,7 +360,7 @@ export class EnrolledItemCard extends React.Component<
             </div>
             <div className="detail pt-1">
               {courseId}
-              {startDateDescription !== null && startDateDescription.active ? (
+              {startDateDescription !== null && !startDateDescription.active ? (
                 <span> | <b>Starts</b> - {startDateDescription.datestr}</span>
               ) : (
                 <span>

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -365,8 +365,7 @@ export class EnrolledItemCard extends React.Component<
                 <span>
                   {startDateDescription === null ? null : (
                     <span> |
-                      <strong> Active</strong> from{" "}
-                      {startDateDescription.datestr}
+                      <strong> Active</strong> - {startDateDescription.datestr}
                     </span>
                   )}
                 </span>

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -114,8 +114,8 @@ describe("EnrolledItemCard", () => {
     const inner = await renderedCard()
     const detail = inner.find(".enrolled-item").find(".detail")
     assert.isTrue(detail.exists())
-    const detail_text = detail.find("span").find("span").at(1).text()
-    assert.isTrue(detail_text.startsWith(" | Active"))
+    const detailText = detail.find("span").find("span").at(1).text()
+    assert.isTrue(detailText.startsWith(" | Active"))
   })
 
   it("Course detail shows `Starts` when start date in future", async () => {
@@ -123,8 +123,8 @@ describe("EnrolledItemCard", () => {
     const inner = await renderedCard()
     const detail = inner.find(".enrolled-item").find(".detail")
     assert.isTrue(detail.exists())
-    const detail_text = detail.find("span").at(0).text()
-    assert.isTrue(detail_text.startsWith(" | Starts"))
+    const detailText = detail.find("span").at(0).text()
+    assert.isTrue(detailText.startsWith(" | Starts"))
   })
 
   it("renders the unenrollment verification modal", async () => {

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -1,6 +1,7 @@
 /* global SETTINGS: false */
 // @flow
 import React from "react"
+import moment from "moment"
 
 import { assert } from "chai"
 import { shallow } from "enzyme"
@@ -106,6 +107,24 @@ describe("EnrolledItemCard", () => {
       const pricingLinks = inner.find(".pricing-links")
       assert.isFalse(pricingLinks.exists())
     })
+  })
+
+  it("Course detail shows `Active` when start date in past", async () => {
+    enrollmentCardProps.enrollment.run.start_date = moment("2021-02-08")
+    const inner = await renderedCard()
+    const detail = inner.find(".enrolled-item").find(".detail")
+    assert.isTrue(detail.exists())
+    const detail_text = detail.find("span").find("span").at(1).text()
+    assert.isTrue(detail_text.startsWith(" | Active"))
+  })
+
+  it("Course detail shows `Starts` when start date in future", async () => {
+    enrollmentCardProps.enrollment.run.start_date = moment().add(7, "d")
+    const inner = await renderedCard()
+    const detail = inner.find(".enrolled-item").find(".detail")
+    assert.isTrue(detail.exists())
+    const detail_text = detail.find("span").at(0).text()
+    assert.isTrue(detail_text.startsWith(" | Starts"))
   })
 
   it("renders the unenrollment verification modal", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/943

#### What's this PR do?
Updates enrolled course text. If a course is started then `Active -` with Red color is displayed with the course start date else `Starts -` is displayed with the course date.

#### How should this be manually tested?

- Enroll in a course run with a start date in the Past.
- Visit the dashboard and the course description shows `Active -` with the start date.
- Now enroll in a future course run.
- Visit the dashboard and the course description shows `Starts -` with the start date.

#### Screenshots (if appropriate)
Course Started:
<img width="1116" alt="Screenshot 2022-09-08 at 2 27 09 PM" src="https://user-images.githubusercontent.com/52656433/189086952-d43a9883-074c-446d-aa94-235d6d63000d.png">
Course Start Date in Future:
<img width="1116" alt="Screenshot 2022-09-08 at 2 21 01 PM" src="https://user-images.githubusercontent.com/52656433/189085639-20f73c8b-810f-4d22-aeb8-47bd8955902e.png">

