### PR TITLE
Adds a check to make sure flexible pricing forms have the right fields in them

### DIFF
--- a/flexiblepricing/utils.py
+++ b/flexiblepricing/utils.py
@@ -1,0 +1,82 @@
+from cms.models import FlexiblePricingRequestForm, FormField
+from django.db.models import Q
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_flexprice_form_fields(form_instance: FlexiblePricingRequestForm):
+    """
+    Checks the supplied form instance for the proper Flexible Pricing Request Form
+    fields and adds them if it needs to, or logs if it gets confused. This is
+    meant to be called by the signal receiver (see cms/signalreceivers.py) or by
+    a management command.
+
+    Args:
+    - form_instance (FlexiblePricingForm) - the form to work on
+
+    Returns:
+    - boolean - True if the form was OK, False otherwise
+    """
+
+    currency_field = False
+    income_field = False
+
+    relevant_fields = form_instance.form_fields.filter(
+        Q(field_type__in=["country", "number"])
+        | Q(clean_name__in=["your_income", "income_currency"])
+    ).all()
+
+    if len(relevant_fields) != 2:
+        logger.warning(
+            f"Improper length {len(relevant_fields)} returned; was expecting 2"
+        )
+
+    for field in relevant_fields:
+        if field.field_type == "country":
+            if field.clean_name == "income_currency":
+                currency_field = True
+                continue
+            else:
+                logger.error(
+                    f"Found a currency field for {form_instance} but its clean name is wrong: {field.clean_name} - {field.label}"
+                )
+                return False
+
+        # Country has a specialized purpose; Number does not, so we ignore any other
+        # number field.
+        if field.field_type == "number":
+            if field.clean_name == "your_income":
+                income_field = True
+                continue
+
+    if currency_field and income_field:
+        logger.info(
+            f"Flexible Pricing Request Form {form_instance} has the right fields in it"
+        )
+        return True
+
+    if not income_field:
+        FormField.objects.create(
+            page=form_instance,
+            clean_name="your_income",
+            label="Your Income",
+            field_type="number",
+            required=True,
+            sort_order=1,
+        )
+
+    if not currency_field:
+        FormField.objects.create(
+            page=form_instance,
+            clean_name="income_currency",
+            label="Income Currency",
+            field_type="country",
+            required=True,
+            sort_order=2,
+        )
+
+    logger.warning(
+        f"Added {'currency' if not currency_field else ''} {'income' if not income_field else ''} field(s) to {form_instance}"
+    )
+    return False

--- a/flexiblepricing/utils_test.py
+++ b/flexiblepricing/utils_test.py
@@ -1,0 +1,93 @@
+import pytest
+import factory
+
+from flexiblepricing.utils import ensure_flexprice_form_fields
+from cms.factories import FlexiblePricingFormFactory
+from cms.models import FormField
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture()
+def flex_price_form():
+    return FlexiblePricingFormFactory.create()
+
+
+def test_form_with_no_fields(flex_price_form):
+    """
+    Tests a form that has no fields defined in it at all. This is the default
+    state of a form created by the factory; if that changes then this test also
+    needs to change.
+    """
+
+    assert flex_price_form.form_fields.count() == 0
+
+    assert ensure_flexprice_form_fields(flex_price_form) is False
+
+    flex_price_form.refresh_from_db()
+
+    assert flex_price_form.form_fields.count() == 2
+
+    for field in flex_price_form.form_fields.all():
+        assert (
+            field.clean_name == "income_currency" or field.clean_name == "your_income"
+        )
+
+
+@pytest.mark.parametrize("field_type", ["income", "currency"])
+def test_form_with_misnamed_fields(flex_price_form, field_type):
+    """
+    Tests a form that has a field with clean_name set right but the label isn't.
+    This should still work and the defined field should be left alone.
+    """
+
+    assert flex_price_form.form_fields.count() == 0
+
+    new_field = FormField(
+        page=flex_price_form,
+        required=True,
+        label=factory.fuzzy.FuzzyText("Form Field "),
+    )
+
+    if field_type == "income":
+        new_field.clean_name = "your_income"
+        new_field.field_type = "number"
+    else:
+        new_field.clean_name = "income_currency"
+        new_field.field_type = "country"
+
+    new_field.save()
+    new_field.refresh_from_db()
+
+    flex_price_form.refresh_from_db()
+
+    assert ensure_flexprice_form_fields(flex_price_form) is False
+
+    for field in flex_price_form.form_fields.all():
+        if field == new_field:
+            assert field.clean_name == new_field.clean_name
+            assert field.label == new_field.label
+
+
+def test_form_with_proper_fields(flex_price_form):
+    """
+    Tests a form that has the fields already in it as it should.
+    """
+
+    FormField.objects.create(
+        page=flex_price_form,
+        clean_name="your_income",
+        label="Your Income",
+        field_type="number",
+        required=True,
+    )
+
+    FormField.objects.create(
+        page=flex_price_form,
+        clean_name="income_currency",
+        label="Income Currency",
+        field_type="country",
+        required=True,
+    )
+
+    assert ensure_flexprice_form_fields(flex_price_form) is True


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

n/a so far

#### What's this PR do?

Adds a signal receiver to check FlexiblePricingRequestForms for the required fields when one is published. If the fields aren't in there, the receiver will add them in for you.

The fields in question are the Your Income and Income Currency fields. 

#### How should this be manually tested?

There are three different ways to test:
1. Create a new Flexible Pricing Request Form with no form fields defined. After publishing it, edit it; the required fields should be in there.
2. Create a Flexible Pricing Request Form with only one of the fields defined. After publishing it, edit it; the missing field should be added. 
3. Edit a Flexible Pricing Request Form that has the form fields already in it and rename one of the required fields. No change to the form should be made (but there will be a log message from the signal receiver if your logging is verbose enough).
4. Edit a Flexible Pricing Request Form and remove a required field. Then, save it as draft, and publish it. The required field should be added back. (In local testing, just removing the field and saving it neither removed the field nor triggered the signal. Not sure why that is - maybe a bug in the (old) version of Wagtail we're using currently.) 

#### Any background context you want to provide?

This seemed to be a point of confusion and an easily missed step so this should make dealing with flex pricing forms a bit easier.

This does not do anything else with flexible pricing form fields - any additional fields added to the form will still not be displayed. (That seemed like a separate issue.) 
