### PR TITLE
Online-941 Filter zero value discounts on checkout

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -218,7 +218,7 @@ class BasketWithProductSerializer(serializers.ModelSerializer):
 
     def get_discounts(self, instance):
         """
-        Exclude zero value discounts and return applicable discounts on the basket. .
+        Exclude zero value discounts and return applicable discounts on the basket.
         """
         discounts = []
         for discount_record in instance.discounts.all():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/941

#### What's this PR do?

- Hides discount of 0 value. Only Fixed price type zero value discounts are applied to the cart.

#### How should this be manually tested?
1 - Manual
- Create a discount from admin and do not check `for flexible pricing option`.
- Add a product to the cart. Visit the cart and apply the discount coupon.
- Zero-value discounts won't show up unless they are Fixed price type discounts.

2 - Financial assistance
- Another method is to create financial assistance tier and create a discount for that tier with zero value. 
- Submit financial assistance request so that the 0 value discount is applied. 
- Discount won't show up on checkout unless it is of fixed price type.


#### Screenshots (if appropriate)
Fixed Price - 0 Value
<img width="1153" alt="Screenshot 2022-09-09 at 4 53 50 PM" src="https://user-images.githubusercontent.com/52656433/189344367-7d33f3f9-2739-423f-88ed-4362c0cd766a.png">
Percent/Dollars off - 0 Value
<img width="1153" alt="Screenshot 2022-09-09 at 4 54 12 PM" src="https://user-images.githubusercontent.com/52656433/189344394-18f3600d-70e6-4201-823b-9022efe09696.png">
Percent off - 100 Value
<img width="1153" alt="Screenshot 2022-09-09 at 4 54 28 PM" src="https://user-images.githubusercontent.com/52656433/189344404-e19872bb-667d-4efb-842c-1a1391fa74bd.png">
Dollars off - 100 Value
<img width="1153" alt="Screenshot 2022-09-09 at 4 54 45 PM" src="https://user-images.githubusercontent.com/52656433/189344413-47c2cf24-f059-46fb-87bc-89b909542aff.png">

