### PR TITLE
Adds a refresh button to the Flexible Pricing Request list page in staff dashboard

### DIFF
--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -1,4 +1,4 @@
-import { CrudFilters, HttpError } from "@pankod/refine-core";
+import { CrudFilters, HttpError, useInvalidate } from "@pankod/refine-core";
 import React from "react"
 const { useState } = React;
 import {
@@ -17,6 +17,8 @@ import {
     Col,
     Card
 } from "@pankod/refine-antd";
+import { ReloadOutlined } from "@ant-design/icons"
+import { Spin } from "antd"
 
 import { IFlexiblePriceRequest, IFlexiblePriceRequestFilters } from "interfaces";
 import { FlexiblePricingStatusModal } from "components/flexiblepricing/statusmodal";
@@ -74,8 +76,32 @@ const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formPro
     )
 }
 
+interface RefreshTableButtonProps {
+    refreshList: any;
+    isFetching: boolean;
+}
+
+const RefreshTableButton: React.FC<RefreshTableButtonProps> = (props) => {
+    const { isFetching, refreshList } = props
+
+    if (props.isFetching) {
+        return (
+            <Button onClick={props.refreshList}>
+                <ReloadOutlined spin /> Refreshing...
+            </Button>
+        )
+    }
+
+    return (
+        <Button onClick={props.refreshList}>
+           <ReloadOutlined /> Refresh
+        </Button>
+    )
+}
+
 export const FlexiblePricingList: React.FC = () => {
-    const {tableProps, searchFormProps} = useTable<
+    const invalidate = useInvalidate()
+    const {tableQueryResult, tableProps, searchFormProps} = useTable<
         IFlexiblePriceRequest,
         HttpError, 
         IFlexiblePriceRequestFilters
@@ -122,6 +148,10 @@ export const FlexiblePricingList: React.FC = () => {
         return null
     }
 
+    const refreshList = () => {
+        tableQueryResult.refetch()
+    }
+
     return (
         <div>
             <Row gutter={[10, 10]}>
@@ -134,7 +164,15 @@ export const FlexiblePricingList: React.FC = () => {
 
             <Row gutter={[10, 10]}>
                 <Col sm={24}>
-                    <List title="Flexible Pricing Requests">
+                </Col>
+            </Row>
+
+            <Row gutter={[10, 10]}>
+                <Col sm={24}>
+                    <List 
+                        title="Flexible Pricing Requests"
+                        pageHeaderProps={{ subTitle: <RefreshTableButton isFetching={tableQueryResult.isFetching} refreshList={refreshList} /> }}
+                    >
                         <Table {...tableProps} rowKey="id">
                             <Table.Column 
                                 dataIndex="user" 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

Fixes #940 

#### What's this PR do?

Provides a refresh button for the Flexible Price list view in the staff dashboard, so you don't have to reload the page (and, currently, log back in) to see new requests.

#### How should this be manually tested?

You will need to have some flexible price form submissions to make this work. Additionally, it would be advisable to throttle your speed (using the Network tab in the dev tools) so the API call takes a sec; at least for me locally, the API call finished too fast to notice the changes to the button.

Log into the Staff Dashboard, then navigate to Flexible Pricing. You should see a button next to the table title that says "Refresh". Clicking the button should change the text to "Refreshing..." and cause the icon in the button to spin until the table has reloaded.

#### Screenshots (if appropriate)

![Screen Shot 2022-09-09 at 1 13 47 PM](https://user-images.githubusercontent.com/945611/189417128-f858044e-a100-4058-997b-8d8d52fd1a55.png)
![Screen Shot 2022-09-09 at 1 13 49 PM](https://user-images.githubusercontent.com/945611/189417135-c5a0e664-39ea-4e0b-9897-a5b9c90f7012.png)


#### Other

* Should there also be a Last Refreshed timestamp on the page?
* Should this refresh itself on a regular basis (every 5 minutes maybe)? 