### PR TITLE
adding course/program as filter on flexible pricing staff dashboard

### DIFF
--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -46,6 +46,7 @@ def test_base_program_serializer():
         "title": program.title,
         "readable_id": program.readable_id,
         "id": program.id,
+        "type": "program",
     }
 
 
@@ -99,6 +100,7 @@ def test_base_course_serializer():
         "title": course.title,
         "readable_id": course.readable_id,
         "id": course.id,
+        "type": "course",
     }
 
 
@@ -183,6 +185,7 @@ def test_serialize_course_with_page_fields(
             "title": course.title,
             "readable_id": course.readable_id,
             "id": course.id,
+            "type": "course",
             "feature_image_src": fake_image_src,
             "page_url": None,
             "financial_assistance_form_url": expected_financial_assistance_url,

--- a/flexiblepricing/views/v0/__init__.py
+++ b/flexiblepricing/views/v0/__init__.py
@@ -3,6 +3,7 @@ MITxOnline Flexible Pricing/Financial Aid views
 """
 from django.db import transaction
 from django.db.models import Q
+from django.contrib.contenttypes.models import ContentType
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
@@ -48,7 +49,6 @@ class FlexiblePriceAdminViewSet(ModelViewSet):
 
     def get_queryset(self):
         queryset = models.FlexiblePrice.objects.all()
-
         name_search = self.request.query_params.get("q")
 
         if name_search is not None:
@@ -62,6 +62,19 @@ class FlexiblePriceAdminViewSet(ModelViewSet):
 
         if status_search is not None:
             queryset = queryset.filter(status=status_search)
+
+        courseware_search = self.request.query_params.get("courseware")
+        if courseware_search is not None:
+            courseware_content_type, courseware_object_id = courseware_search.split(":")
+            content_type = ContentType.objects.get(
+                app_label="courses", model=courseware_content_type
+            )
+            queryset = queryset.filter(
+                Q(
+                    courseware_object_id=courseware_object_id,
+                    courseware_content_type=content_type,
+                )
+            )
 
         return queryset.order_by("-created_on")
 

--- a/frontend/staff-dashboard/src/interfaces/index.d.ts
+++ b/frontend/staff-dashboard/src/interfaces/index.d.ts
@@ -45,6 +45,7 @@ export interface ICourseware {
     id: number;
     title: string;
     readable_id: string;
+    type:string;
 }
 
 
@@ -79,6 +80,7 @@ export interface IFlexiblePriceStatus {
 export interface IFlexiblePriceRequestFilters {
     q: string;
     status: string;
+    courseware: string;
 }
 
 export interface IFlexiblePriceStatusModalProps {

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -1,4 +1,4 @@
-import { CrudFilters, HttpError, useInvalidate } from "@pankod/refine-core";
+import { CrudFilters, HttpError, useInvalidate, useList } from "@pankod/refine-core";
 import React from "react"
 const { useState } = React;
 import {
@@ -54,7 +54,26 @@ const FlexiblePricingStatuses = [
 
 const FlexiblePricingStatusText = "Select Status";
 
+const FlexiblePricingSelectCoursewareText = "Select Course/Program";
+
 const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formProps }) => {
+
+    const FlexiblePricingCoursewareList: any[] | undefined = [];
+    const CoursewareList = useList({
+        resource: "flexible_pricing/applications_admin",
+    });
+    if (CoursewareList.data) {
+        CoursewareList.data.data.map(item => {
+            const index = FlexiblePricingCoursewareList.findIndex(object => object.label === item.courseware.readable_id);
+            if (index === -1) {
+                FlexiblePricingCoursewareList.push({
+                    'label': item.courseware.readable_id,
+                    'value': item.courseware.type + ':' + item.courseware.id
+                })
+            }
+        })
+    }
+
     return (
         <Form layout="inline" {...formProps}>
             <Form.Item label="Search by Name" name="q">
@@ -65,6 +84,13 @@ const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formPro
                     style={{ minWidth: 200 }}
                     placeholder={FlexiblePricingStatusText}
                     options={FlexiblePricingStatuses}
+                    allowClear={true} />
+            </Form.Item>
+            <Form.Item label="Search by Course/Program" name="courseware">
+                <Select
+                    style={{ minWidth: 250 }}
+                    placeholder={FlexiblePricingSelectCoursewareText}
+                    options={FlexiblePricingCoursewareList}
                     allowClear={true} />
             </Form.Item>
             <Form.Item>
@@ -109,7 +135,7 @@ export const FlexiblePricingList: React.FC = () => {
         resource: 'flexible_pricing/applications_admin',
         onSearch: (params) => {
             const filters: CrudFilters = [];
-            const { q, status } = params;
+            const { q, status, courseware } = params;
 
             filters.push({
                 field: 'q',
@@ -121,6 +147,12 @@ export const FlexiblePricingList: React.FC = () => {
                 field: 'status',
                 operator: 'eq',
                 value: status
+            });
+
+            filters.push({
+                field: 'courseware',
+                operator: 'eq',
+                value: courseware
             });
 
             return filters;
@@ -169,7 +201,7 @@ export const FlexiblePricingList: React.FC = () => {
 
             <Row gutter={[10, 10]}>
                 <Col sm={24}>
-                    <List 
+                    <List
                         title="Flexible Pricing Requests"
                         pageHeaderProps={{ subTitle: <RefreshTableButton isFetching={tableQueryResult.isFetching} refreshList={refreshList} /> }}
                     >


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/950

#### What's this PR do?
Adding a static field 'type' to courseware object in /api/flexible_pricing/applications_admin/. (Identity as program or course)
```       
         "courseware": {
                "title": "Data, Economics and Development Policy",
                "readable_id": "program-v1:MITx+DEDP",
                "id": 1,
                "type": "program"
            },
```
Adding a drop-down for choosing from existing courses/programs with financial aid requests

#### How should this be manually tested?
Go to Flexible pricing from the staff dashboard: http://mitxonline.odl.local:8013/staff-dashboard/flexible_pricing
![image](https://user-images.githubusercontent.com/3138890/189725449-0bf7ef93-6163-4799-8a62-49e7c1d25de6.png)

The dropdown "Search by Course/Program" should list all the existing courses/programs from flexible pricing requests
![image](https://user-images.githubusercontent.com/3138890/189775557-64f450fb-05ae-4337-936f-e7e686db72fa.png)

Search a specific course or program, flexible pricing requests table should only display that course or program
![image](https://user-images.githubusercontent.com/3138890/189725808-4b8036a0-653a-4526-bb71-22fdcd7e5c33.png)


The clear icon is also added to deselect a course/program (same as status)
![image](https://user-images.githubusercontent.com/3138890/189724186-8187006d-4498-46fb-84b3-6374355f28e5.png)
