### PR TITLE
Updates product pages to display approved flexible pricing amounts if one exists

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -82,8 +82,20 @@
               </div>
             </div>
             {% endif %}
-            {% if page.price %}
-            <div class="stat-col">
+            {% if finaid_price %}
+            <div class="stat-col small">
+              <div class="title">price</div>
+              <div class="text">
+                <strong>
+                  <a target="_blank" href="{% url 'checkout-product' %}?product_id={{product.id}}">
+                    ${{finaid_price.1}}
+                  </a>
+                </strong>
+              </div>
+            </div>  
+            {% endif %}
+            {% if not finaid_price and page.price %}
+            <div class="stat-col small">
               <div class="title">price</div>
               <div class="text">
                 <strong>

--- a/courses/models.py
+++ b/courses/models.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models
 from django.utils.functional import cached_property
+from django.contrib.contenttypes.models import ContentType
 from django_countries.fields import CountryField
 from mitol.common.models import TimestampedModel
 from mitol.common.utils.collections import first_matching_item
@@ -214,6 +215,18 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
     def page(self):
         """Gets the associated CoursePage"""
         return getattr(self, "coursepage", None)
+
+    @property
+    def active_products(self):
+        """
+        Gets active products for the first unexpired courserun for this course
+
+        Returns:
+        - ProductsQuerySet
+        """
+        relevant_run = self.first_unexpired_run
+
+        return relevant_run.products.filter(is_active=True).all()
 
     @cached_property
     def next_run_date(self):

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -317,6 +317,23 @@ class Discount(TimestampedModel):
 
         return "Indeterminate Discount"
 
+    def discount_product(self, product, user=None):
+        """
+        Returns the calculated discount amount for a given product.
+
+        Args:
+            product (Product): the product to discount
+            user (User or None): the current user
+        Returns:
+            Number; the calculated amount of the discounts
+        """
+        from ecommerce.discounts import DiscountType
+
+        if (user is None and self.valid_now()) or self.check_validity(user):
+            return DiscountType.get_discounted_price([self], product).quantize(
+                Decimal("0.01")
+            )
+
 
 class DiscountProduct(TimestampedModel):
     discount = models.ForeignKey(

--- a/flexiblepricing/api.py
+++ b/flexiblepricing/api.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
+from django.contrib.auth.models import AnonymousUser
 
 from main.settings import TIME_ZONE
 from main.constants import DISALLOWED_CURRENCY_TYPES
@@ -288,6 +289,9 @@ def is_courseware_flexible_price_approved(course_run, user):
                 False if the user does not have a Flexible Price that is APPROVED or AUTO_APPROVED
                 and associated with the CourseRun.
     """
+
+    if isinstance(user, AnonymousUser):
+        return False
 
     for eligible_courseware in get_ordered_eligible_coursewares(course_run):
         content_type = ContentType.objects.get_for_model(eligible_courseware)


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #954 

#### What's this PR do?

Adjusts the code for the Price box on a product page (i.e., a course page) to display the learner's approved flexible pricing amount if they have requested flexible pricing and the request has been approved. This also changes the link so that it adds the course to the cart, rather than directing them to the flexible pricing request form. If the learner does not have a flexible pricing request (or it's been denied or reset), or if an anonymous user is viewing the page, the text specified in the CMS is displayed as per usual.

#### How should this be manually tested?

To test, you will need a course with a page and a relevant flexible pricing request form (either for the course itself or for the program it's in).

1. View the course page while logged out. The text for the Price card should be displayed (but it should not be linked). 
2. Log in as a user without a flexible pricing request submission and view the course page again. The text for the Price card should be displayed and the link should be to what it's set to in the CMS.
3. Request flexible pricing. You should be able to replicate step 2 if the request hasn't been auto approved.
4. Approve your flexible pricing request, and load the course page. You should now see your adjusted price for the course. Clicking the link should bring you to the checkout page and the course should be in your cart. 
5. Deny or reset your flexible pricing request, and load the course page again. You should see the CMS text and link in the Price card again.

#### Screenshots (if appropriate)
No sub/denied sub/etc:

![Screen Shot 2022-09-12 at 2 31 05 PM](https://user-images.githubusercontent.com/945611/189739802-be3b5535-ea14-4784-bcc5-5edaf46f8409.png)

Approved sub:

![Screen Shot 2022-09-12 at 2 31 21 PM](https://user-images.githubusercontent.com/945611/189739815-7770bea4-57dd-4036-bc52-cf500b4c2584.png)
