### PR TITLE
942: unauthorized user can access staff dashboard

### DIFF
--- a/frontend/staff-dashboard/src/App.tsx
+++ b/frontend/staff-dashboard/src/App.tsx
@@ -2,7 +2,8 @@ import { Refine } from "@pankod/refine-core";
 import { Icons, notificationProvider } from "@pankod/refine-antd";
 import routerProvider from "@pankod/refine-react-router-v6";
 import "@pankod/refine-antd/dist/styles.min.css";
-import { useAuthProvider } from "hooks/useAuthProvider";
+import {useAuthProvider } from "hooks/useAuthProvider";
+import {useAuth} from "react-oidc-context";
 import {
   Title,
   Header,
@@ -43,7 +44,10 @@ export default function App() {
   const dataURI = DATASOURCES_CONFIG?.mitxOnline ?? "";
   const authProvider = useAuthProvider();
   const xonlineProvider = useDrfDataProvider(dataURI);
-
+  const auth = useAuth()
+  if (auth.isLoading) {
+    return <span>loading...</span>;
+  }
   return (
     <Refine
       routerProvider={{

--- a/frontend/staff-dashboard/src/App.tsx
+++ b/frontend/staff-dashboard/src/App.tsx
@@ -2,8 +2,8 @@ import { Refine } from "@pankod/refine-core";
 import { Icons, notificationProvider } from "@pankod/refine-antd";
 import routerProvider from "@pankod/refine-react-router-v6";
 import "@pankod/refine-antd/dist/styles.min.css";
-import {useAuthProvider } from "hooks/useAuthProvider";
-import {useAuth} from "react-oidc-context";
+import { useAuthProvider } from "hooks/useAuthProvider";
+import { useAuth } from "react-oidc-context";
 import {
   Title,
   Header,

--- a/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
@@ -1,23 +1,30 @@
 import { AuthProvider } from "@pankod/refine-core";
-import {useAuth} from "react-oidc-context";
+import {useAuth, hasAuthParams} from "react-oidc-context";
+import { User } from "oidc-client-ts";
 
 export function useAuthProvider(): AuthProvider {
   const auth = useAuth()
   return {
     login: async () => {
-      let result = await auth.signinPopup();
-      return Promise.resolve();
+      if (!hasAuthParams() &&
+        !auth.isAuthenticated && !auth.activeNavigator && !auth.isLoading) {
+        await auth.signinPopup()
+        return Promise.resolve();
+      }
     },
     logout: async () => {
       await auth.removeUser();
       return Promise.resolve();
     },
-    checkError: async () => Promise.resolve(),
+    checkError: async () => {
+      return Promise.resolve();
+    },
     checkAuth: async () => {
-      if (auth.isAuthenticated) {
+      let _ = require("lodash");
+      if (auth.isAuthenticated && auth.user && _.get(auth.user, "profile.is_staff")) {
         return Promise.resolve();
       }
-      return Promise.reject()
+      return Promise.reject();
     },
     getPermissions: () => Promise.resolve(),
     getUserIdentity: async () => {

--- a/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
@@ -1,13 +1,12 @@
 import { AuthProvider } from "@pankod/refine-core";
-import { useAuth, hasAuthParams } from "react-oidc-context";
+import { useAuth } from "react-oidc-context";
 import { User } from "oidc-client-ts";
 
 export function useAuthProvider(): AuthProvider {
   const auth = useAuth()
   return {
     login: async () => {
-      if (!hasAuthParams() &&
-        !auth.isAuthenticated && !auth.activeNavigator && !auth.isLoading) {
+      if (!auth.isAuthenticated && !auth.activeNavigator && !auth.isLoading) {
         let result = await auth.signinPopup()
         if (result && result.profile["is_staff"] === true) {
           return Promise.resolve();

--- a/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
@@ -1,5 +1,5 @@
 import { AuthProvider } from "@pankod/refine-core";
-import {useAuth, hasAuthParams} from "react-oidc-context";
+import { useAuth, hasAuthParams } from "react-oidc-context";
 import { User } from "oidc-client-ts";
 
 export function useAuthProvider(): AuthProvider {
@@ -8,9 +8,13 @@ export function useAuthProvider(): AuthProvider {
     login: async () => {
       if (!hasAuthParams() &&
         !auth.isAuthenticated && !auth.activeNavigator && !auth.isLoading) {
-        await auth.signinPopup()
-        return Promise.resolve();
+        let result = await auth.signinPopup()
+        if (result && result.profile["is_staff"] === true) {
+          return Promise.resolve();
+        }
       }
+      return Promise.reject();
+
     },
     logout: async () => {
       await auth.removeUser();
@@ -21,7 +25,7 @@ export function useAuthProvider(): AuthProvider {
     },
     checkAuth: async () => {
       let _ = require("lodash");
-      if (auth.isAuthenticated && auth.user && _.get(auth.user, "profile.is_staff")) {
+      if (auth.isAuthenticated && auth.user && _.get(auth.user, "profile.is_staff") === true) {
         return Promise.resolve();
       }
       return Promise.reject();

--- a/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
@@ -1,6 +1,5 @@
 import { AuthProvider } from "@pankod/refine-core";
 import { useAuth } from "react-oidc-context";
-import { User } from "oidc-client-ts";
 
 export function useAuthProvider(): AuthProvider {
   const auth = useAuth()

--- a/frontend/staff-dashboard/src/index.tsx
+++ b/frontend/staff-dashboard/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {AuthProvider} from "react-oidc-context";
+import { User } from "oidc-client-ts";
 
 import reportWebVitals from "./reportWebVitals";
 import App from "./App";

--- a/main/oidc_provider_settings.py
+++ b/main/oidc_provider_settings.py
@@ -1,9 +1,7 @@
 from django.utils.translation import ugettext as _
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
-class CustomOAuth2Validator(OAuth2Validator):
 
+class CustomOAuth2Validator(OAuth2Validator):
     def get_additional_claims(self, request):
-        return {
-            "is_staff": request.user.is_staff
-        }
+        return {"is_staff": request.user.is_staff}

--- a/main/oidc_provider_settings.py
+++ b/main/oidc_provider_settings.py
@@ -1,4 +1,3 @@
-from django.utils.translation import ugettext as _
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
 

--- a/main/oidc_provider_settings.py
+++ b/main/oidc_provider_settings.py
@@ -1,0 +1,11 @@
+from django.utils.translation import ugettext as _
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
+class CustomOAuth2Validator(OAuth2Validator):
+    # Set `oidc_claim_scope = None` to ignore scopes that limit which claims to return,
+    # otherwise the OIDC standard scopes are used.
+
+    def get_additional_claims(self, request):
+        return {
+            "is_staff": request.user.is_staff
+        }

--- a/main/oidc_provider_settings.py
+++ b/main/oidc_provider_settings.py
@@ -2,8 +2,6 @@ from django.utils.translation import ugettext as _
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
 class CustomOAuth2Validator(OAuth2Validator):
-    # Set `oidc_claim_scope = None` to ignore scopes that limit which claims to return,
-    # otherwise the OIDC standard scopes are used.
 
     def get_additional_claims(self, request):
         return {

--- a/main/settings.py
+++ b/main/settings.py
@@ -873,10 +873,6 @@ OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = "oauth2_provider.AccessToken"
 OAUTH2_PROVIDER_APPLICATION_MODEL = "oauth2_provider.Application"
 OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL = "oauth2_provider.RefreshToken"
 
-OIDC_USERINFO = 'myproject.oidc_provider_settings.userinfo'
-OIDC_IDTOKEN_INCLUDE_CLAIMS = True
-OIDC_IDTOKEN_PROCESSING_HOOK = OIDC_USERINFO = 'myproject.oidc_provider_settings.idtoken_processing_hook'
-
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,
     "OIDC_RSA_PRIVATE_KEY": get_string(

--- a/main/settings.py
+++ b/main/settings.py
@@ -873,6 +873,10 @@ OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = "oauth2_provider.AccessToken"
 OAUTH2_PROVIDER_APPLICATION_MODEL = "oauth2_provider.Application"
 OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL = "oauth2_provider.RefreshToken"
 
+OIDC_USERINFO = 'myproject.oidc_provider_settings.userinfo'
+OIDC_IDTOKEN_INCLUDE_CLAIMS = True
+OIDC_IDTOKEN_PROCESSING_HOOK = OIDC_USERINFO = 'myproject.oidc_provider_settings.idtoken_processing_hook'
+
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,
     "OIDC_RSA_PRIVATE_KEY": get_string(
@@ -889,6 +893,7 @@ OAUTH2_PROVIDER = {
         # "digitalcredentials": "Can read and write Digital Credentials data",
     },
     "DEFAULT_SCOPES": ["user:read"],
+    "OAUTH2_VALIDATOR_CLASS": "main.oidc_provider_settings.CustomOAuth2Validator",
     # "SCOPES_BACKEND_CLASS": "mitol.oauth_toolkit_extensions.backends.ApplicationAccessOrSettingsScopes",
     "ERROR_RESPONSE_WITH_SCOPES": DEBUG,
     "ALLOWED_REDIRECT_URI_SCHEMES": get_delimited_list(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/942

#### What's this PR do?
A user who does not have `is_staff` == `true` will receive an error message and be unable to login to the staff dashboard (http://mitxonline.odl.local:8013/staff-dashboard/).  A user with `is_staff` == `true` will be able to login to the staff dashboard.

This PR also allows the user to refresh the browser tab and not be forced to login again.  This is done by only checking if the user is authenticated after the auth has loaded.  While the auth is loading, the text "loading..." is shown.

#### How should this be manually tested?

1. Configure the refine application in `mitxonline`
2. From within an Incognito window, attempt to login to the refine/staff dashboard with a user who has `is_staff` = `false`.  Verify that you are unable to login and receive an error message.
3. From within a new Incognito window, attempt to login to the refine/staff dashboard with a user who has `is_staff` = `true`.  Verify that you are able to login and don't receive any error message.
4. Ensure that when you refresh the browser tab you are not forced to login again.

#### Where should the reviewer start?
Configure refine for `mitxonline`: https://github.com/mitodl/mitxonline/blob/main/docs/source/configuration/refine_admin.rst

#### Any background context you want to provide?
This PR adds an additional claim to the `openid` scope.  The additional claim, `is_staff`, is populated with the User's `is_staff` value.  

This new claim is checked at the front-end of the refine/staff dashboard.  If `is_staff` is false, then the user will not be able to login and will be shown an error message.
