### PR TITLE
Adding list_display for FlexiblePriceAdmin

### DIFF
--- a/flexiblepricing/admin.py
+++ b/flexiblepricing/admin.py
@@ -55,6 +55,7 @@ class FlexiblePricingRequestSubmissionAdmin(admin.ModelAdmin):
 
 class FlexiblePriceTierAdmin(admin.ModelAdmin):
     """Admin for FlexiblePriceTier"""
+
     model = FlexiblePriceTier
     list_display = (
         "id",
@@ -62,7 +63,7 @@ class FlexiblePriceTierAdmin(admin.ModelAdmin):
         "courseware_content_type",
         "discount",
         "income_threshold_usd",
-        "current"
+        "current",
     )
 
 

--- a/flexiblepricing/admin.py
+++ b/flexiblepricing/admin.py
@@ -32,6 +32,13 @@ class FlexiblePriceAdmin(VersionAdmin):
     """Admin for FlexiblePrice"""
 
     model = FlexiblePrice
+    list_display = (
+        "id",
+        "user",
+        "courseware_object_id",
+        "courseware_content_type",
+        "tier",
+    )
     raw_id_fields = ("user",)
 
     def has_delete_permission(
@@ -47,7 +54,16 @@ class FlexiblePricingRequestSubmissionAdmin(admin.ModelAdmin):
 
 
 class FlexiblePriceTierAdmin(admin.ModelAdmin):
+    """Admin for FlexiblePriceTier"""
     model = FlexiblePriceTier
+    list_display = (
+        "id",
+        "courseware_object_id",
+        "courseware_content_type",
+        "discount",
+        "income_threshold_usd",
+        "current"
+    )
 
 
 admin.site.register(CountryIncomeThreshold, CountryIncomeThresholdAdmin)


### PR DESCRIPTION


#### What are the relevant tickets?
none
I found it difficult to test and debug while not able to see which flexible price was for which course and tier.

#### What's this PR do?
Adding list_display for FlexiblePriceAdmin and FlexiblePriceTierAdmin

#### How should this be manually tested?
Go to /admin/flexiblepricing/flexibleprice/ and see the display

<img width="1508" alt="Screen Shot 2022-09-14 at 11 48 11 AM" src="https://user-images.githubusercontent.com/7574259/190155045-462e09f8-2ed4-4ee9-b0fe-fafe15a48222.png">


<img width="1498" alt="Screen Shot 2022-09-14 at 11 47 56 AM" src="https://user-images.githubusercontent.com/7574259/190155184-15ba1e54-21dd-4743-90ca-bb7cd8457ade.png">

