### PR TITLE
display certificate start and end date on template

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -73,15 +73,21 @@
                     {% endif %}
                     {% if page.CEUs %}
                         <span class="award-text">Awarded {{ CEUs }} Continuing Education Units (CEUs) <br>
+                            {% if is_program_certificate %}
+                                {{ end_date|date }}
+                            {% else %}
+                                {{ start_date|date }} - {{ end_date|date }}
+                            {% endif %}
+                        </span>
+                    {% else %}
+                        <span class="award-text">
+                            {% if is_program_certificate %}
+                                {{ end_date|date }}
+                            {% else %}
+                                {{ start_date|date }} - {{ end_date|date }}
+                            {% endif %}
                         </span>
                     {% endif %}
-                    <span>
-                        {% if is_program_certificate %}
-                            {{ end_date|date }}
-                        {% else %}
-                            {{ start_date|date }} - {{ end_date|date }}
-                        {% endif %}
-                    </span>
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
                             <div class="col-sm-4 col-24 certify-by">

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -71,23 +71,15 @@
                     {% if is_program_certificate %}
                         <span class="program-degree-text">Professional Certificate Program<br></span>
                     {% endif %}
-                    {% if page.CEUs %}
-                        <span class="award-text">Awarded {{ CEUs }} Continuing Education Units (CEUs) <br>
-                            {% if is_program_certificate %}
-                                {{ end_date|date }}
-                            {% else %}
-                                {{ start_date|date }} - {{ end_date|date }}
-                            {% endif %}
-                        </span>
-                    {% else %}
-                        <span class="award-text">
-                            {% if is_program_certificate %}
-                                {{ end_date|date }}
-                            {% else %}
-                                {{ start_date|date }} - {{ end_date|date }}
-                            {% endif %}
-                        </span>
-                    {% endif %}
+                    <span class="award-text">
+                        {% if page.CEUs %} Awarded {{ CEUs }} Continuing Education Units (CEUs) <br> {% endif %}
+                        
+                        {% if is_program_certificate %}
+                            {{ end_date|date }}
+                        {% else %}
+                            {{ start_date|date }} - {{ end_date|date }}
+                        {% endif %}
+                    </span>
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
                             <div class="col-sm-4 col-24 certify-by">

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -73,13 +73,15 @@
                     {% endif %}
                     {% if page.CEUs %}
                         <span class="award-text">Awarded {{ CEUs }} Continuing Education Units (CEUs) <br>
-                            {% if is_program_certificate %}
-                                {{ end_date|date }}
-                            {% else %}
-                                {{ start_date|date }} - {{ end_date|date }}
-                            {% endif %}
                         </span>
                     {% endif %}
+                    <span>
+                        {% if is_program_certificate %}
+                            {{ end_date|date }}
+                        {% else %}
+                            {{ start_date|date }} - {{ end_date|date }}
+                        {% endif %}
+                    </span>
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
                             <div class="col-sm-4 col-24 certify-by">

--- a/courses/models.py
+++ b/courses/models.py
@@ -596,6 +596,8 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
     @property
     def start_end_dates(self):
         """Returns the start and end date for courseware object duration"""
+        if self.course_run.is_self_paced:
+            return self.course_run.start_date, self.created_on
         return self.course_run.start_date, self.course_run.end_date
 
     def __str__(self):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#967 

#### How should this be manually tested?
- Open certificate page
- Validate start and end date on certificate template page
- If the course run is self-paced the end date should be the created date of certificate

#### Screenshots
In below screenshot the end date is certificate created date because the course run is self-paced (I've manually set `is_self_paced` flag as `True`)

<img width="1100" alt="Screenshot 2022-09-15 at 3 16 14 AM" src="https://user-images.githubusercontent.com/77275478/190273301-7b75f075-873c-4456-a709-60f12fe1c695.png">



In below screenshot the end date is course run end date because the course run is not self-paced (I've manually set `is_self_paced` flag as `False`)

<img width="1100" alt="Screenshot 2022-09-15 at 3 16 49 AM" src="https://user-images.githubusercontent.com/77275478/190273316-51b4d714-d1a6-4808-93fe-920b982115be.png">

