### PR TITLE
get complete list of courseware in flexible pricing request

### DIFF
--- a/flexiblepricing/serializers.py
+++ b/flexiblepricing/serializers.py
@@ -161,3 +161,58 @@ class FlexiblePriceAdminSerializer(serializers.ModelSerializer):
         Returns income information associated with a flexible price request.
         """
         return FlexiblePriceIncomeSerializer(instance=instance).data
+
+
+class FlexiblePriceCoursewareAdminSerializer(serializers.ModelSerializer):
+    """
+    Serializer for coursewares in flexible price requests
+    """
+
+    id = serializers.SerializerMethodField()
+    title = serializers.SerializerMethodField()
+    readable_id = serializers.SerializerMethodField()
+    type = serializers.SerializerMethodField()
+
+    def get_courseware_object(self, instance):
+        course_content_type = ContentType.objects.get(
+            app_label="courses", model="course"
+        ).id
+        program_content_type = ContentType.objects.get(
+            app_label="courses", model="program"
+        ).id
+        if instance["courseware_content_type"] == course_content_type:
+            return BaseCourseSerializer(
+                Course.objects.filter(id=instance["courseware_object_id"]).first()
+            ).data
+        elif instance["courseware_content_type"] == program_content_type:
+            return BaseProgramSerializer(
+                Program.objects.filter(id=instance["courseware_object_id"]).first()
+            ).data
+
+    def get_id(self, instance):
+        """
+        Returns serialized courseware id.
+        """
+        return self.get_courseware_object(instance)["id"]
+
+    def get_type(self, instance):
+        """
+        Returns serialized courseware type.
+        """
+        return self.get_courseware_object(instance)["type"]
+
+    def get_readable_id(self, instance):
+        """
+        Returns serialized courseware readable id.
+        """
+        return self.get_courseware_object(instance)["readable_id"]
+
+    def get_title(self, instance):
+        """
+        Returns serialized courseware title.
+        """
+        return self.get_courseware_object(instance)["title"]
+
+    class Meta:
+        model = models.FlexiblePrice
+        fields = ["id", "title", "readable_id", "type"]

--- a/flexiblepricing/urls.py
+++ b/flexiblepricing/urls.py
@@ -7,6 +7,7 @@ from flexiblepricing.views.v0 import (
     CountryIncomeThresholdViewSet,
     FlexiblePriceViewSet,
     FlexiblePriceAdminViewSet,
+    FlexiblePriceCoursewareViewSet,
 )
 
 
@@ -30,6 +31,12 @@ router.register(
     r"applications_admin",
     FlexiblePriceAdminViewSet,
     basename="fp_admin_flexiblepricing_api",
+)
+
+router.register(
+    r"coursewares",
+    FlexiblePriceCoursewareViewSet,
+    basename="fp_flexiblepricing_coursewares_api",
 )
 
 urlpatterns = [

--- a/flexiblepricing/views/v0/__init__.py
+++ b/flexiblepricing/views/v0/__init__.py
@@ -41,6 +41,20 @@ class FlexiblePriceViewSet(ModelViewSet):
         return models.FlexiblePrice.objects.filter(user=self.request.user).all()
 
 
+class FlexiblePriceCoursewareViewSet(ModelViewSet):
+    serializer_class = serializers.FlexiblePriceCoursewareAdminSerializer
+    authentication_classes = (SessionAuthentication, TokenAuthentication)
+    permission_classes = (IsAdminUser,)
+
+    def get_queryset(self):
+        return (
+            models.FlexiblePrice.objects.all()
+            .values("courseware_content_type", "courseware_object_id")
+            .distinct()
+            .order_by("courseware_content_type", "courseware_object_id")
+        )
+
+
 class FlexiblePriceAdminViewSet(ModelViewSet):
     serializer_class = serializers.FlexiblePriceAdminSerializer
     authentication_classes = (SessionAuthentication, TokenAuthentication)

--- a/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
+++ b/frontend/staff-dashboard/src/pages/flexible_pricing/list.tsx
@@ -60,17 +60,14 @@ const FlexiblePricingFilterForm: React.FC<{ formProps: FormProps }> = ({ formPro
 
     const FlexiblePricingCoursewareList: any[] | undefined = [];
     const CoursewareList = useList({
-        resource: "flexible_pricing/applications_admin",
+        resource: "flexible_pricing/coursewares",
     });
     if (CoursewareList.data) {
         CoursewareList.data.data.map(item => {
-            const index = FlexiblePricingCoursewareList.findIndex(object => object.label === item.courseware.readable_id);
-            if (index === -1) {
-                FlexiblePricingCoursewareList.push({
-                    'label': item.courseware.readable_id,
-                    'value': item.courseware.type + ':' + item.courseware.id
-                })
-            }
+            FlexiblePricingCoursewareList.push({
+                'label': item.readable_id,
+                'value': item.type + ':' + item.id
+            })
         })
     }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/950

#### What's this PR do?
This is to fix the course/program filter implemented in https://github.com/mitodl/mitxonline/pull/965
On RC https://rc.mitxonline.mit.edu/staff-dashboard/flexible_pricing, it only displays one course in the dropdown, there should be 12 courses/programs there 
It appears to only return the distinct course/program from https://rc.mitxonline.mit.edu/api/flexible_pricing/applications_admin/?l=3&o=0
![image](https://user-images.githubusercontent.com/3138890/190475169-6104c206-0643-4ee5-a178-861cb9db43bd.png)

The previous approach is also flawed as it's computing the DISTINCT course/program from the result of ` api/flexible_pricing/applications_admin/, ` in the frontend

This PR is to fix the dropdown "Search by Course/Program",  it should return a complete list of DISTINCT courses/programs from flexible pricing requests, with no limit.

#### How should this be manually tested?
Go to Flexible pricing from the staff dashboard: http://mitxonline.odl.local:8013/staff-dashboard/flexible_pricing
The dropdown "Search by Course/Program" should display a unique list of courses/programs from flexible pricing requests
![image](https://user-images.githubusercontent.com/3138890/190477600-fbbd132b-06c7-4127-9b64-90aaf8815174.png)
It should filter out requests based on the selected course/program
