### PR TITLE
Adds an email message that is sent when an order is refunded.

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -499,6 +499,11 @@ class CourseRun(TimestampedModel):
         """
         return get_course_number(self.courseware_id)
 
+    @property
+    def readable_id(self):
+        """Alias for the courseware_id so this is consistent with Course and Program"""
+        return self.courseware_id
+
     def __str__(self):
         title = f"{self.courseware_id} | {self.title}"
         return title if len(title) <= 100 else title[:97] + "..."

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -1,6 +1,8 @@
 import pytest
 import reversion
 
+from decimal import Decimal
+
 from ecommerce.serializers_test import create_order_receipt
 from ecommerce.factories import ProductFactory
 from ecommerce.tasks import send_ecommerce_order_receipt
@@ -57,3 +59,34 @@ def test_mail_api_receipt_generation(mocker, user, products, user_client):
 
     lines = order.lines.all()
     assert str(lines[0].unit_price) in rendered_template.body
+
+
+def test_mail_api_refund_email_generation(mocker, user, products, user_client):
+    """
+    Tests email generation for the refund message. Generates a fulfilled order,
+    then attemps to refund it after mocking the mail sender.
+    """
+    order = create_order_receipt(mocker, user, products, user_client)
+
+    mock_send_message = mocker.patch("mitol.mail.api.send_message")
+
+    transaction_data = {"id": "refunded-transaction"}
+    refund_amount = order.total_price_paid / 2
+
+    transaction = order.refund(
+        api_response_data=transaction_data, amount=refund_amount, reason="testing"
+    )
+
+    mock_send_message.assert_called()
+
+    rendered_template = mock_send_message.call_args[0][0]
+
+    assert (
+        "{} {}".format(
+            order.purchaser.legal_address.first_name,
+            order.purchaser.legal_address.last_name,
+        )
+        in rendered_template.body
+    )
+    assert order.reference_number in rendered_template.body
+    assert str(refund_amount.quantize(Decimal("0.01"))) in rendered_template.body

--- a/ecommerce/messages.py
+++ b/ecommerce/messages.py
@@ -5,3 +5,8 @@ from mitol.mail.messages import TemplatedMessage
 class OrderReceiptMessage(TemplatedMessage):
     template_name = "mail/product_order_receipt"
     name = "Order Receipt"
+
+
+class OrderRefundMessage(TemplatedMessage):
+    template_name = "mail/order_refund_message"
+    name = "Refund of MITx Online Order"

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -31,7 +31,7 @@ from ecommerce.constants import (
 from users.models import User
 from decimal import Decimal
 from courses.api import create_run_enrollments
-from ecommerce.tasks import send_ecommerce_order_receipt
+from ecommerce.tasks import send_ecommerce_order_receipt, send_order_refund_email
 from main.settings import TIME_ZONE
 
 from mitol.common.utils.datetime import now_in_utc
@@ -666,6 +666,9 @@ class FulfilledOrder(Order):
         )
         self.state = Order.STATE.REFUNDED
         self.save()
+
+        send_order_refund_email.delay(self.id)
+
         return refund_transaction
 
     class Meta:

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -22,3 +22,13 @@ def perform_unenrollment_from_order(order_id):
     from ecommerce.api import unenroll_learner_from_order
 
     unenroll_learner_from_order(order_id)
+
+
+@app.task
+def send_order_refund_email(order_id):
+    from ecommerce.mail_api import send_ecommerce_refund_message
+    from ecommerce.models import Order
+
+    order = Order.objects.get(pk=order_id)
+
+    send_ecommerce_refund_message(order)

--- a/ecommerce/tasks_test.py
+++ b/ecommerce/tasks_test.py
@@ -29,6 +29,30 @@ def test_delayed_order_receipt_sends_email(mocker, user, products, user_client):
     mock_send_ecommerce_order_receipt.assert_called()
 
 
+def test_delayed_order_refund_sends_email(mocker, user, products, user_client):
+    """
+    Tests that the Order model is properly calling the order refund email task
+    rather than calling the mail_api version directly. The create_order_receipt
+    function creates a fulfilled order, then we refund it and make sure the
+    right task got called.
+    """
+
+    mock_send_refund_email = mocker.patch(
+        "ecommerce.mail_api.send_ecommerce_refund_message"
+    )
+
+    order = create_order_receipt(mocker, user, products, user_client)
+
+    transaction_data = {"id": "refunded-transaction"}
+    refund_amount = order.total_price_paid / 2
+
+    order.refund(
+        api_response_data=transaction_data, amount=refund_amount, reason="testing"
+    )
+
+    mock_send_refund_email.assert_called()
+
+
 @pytest.mark.django_db
 def test_delayed_unenrollment_unenrolls_user(mocker, user):
     """

--- a/ecommerce/templates/mail/order_refund_message/body.html
+++ b/ecommerce/templates/mail/order_refund_message/body.html
@@ -1,0 +1,28 @@
+{% extends "email_base.html" %}
+
+{% block content %}
+<!-- 1 Column Text + Button : BEGIN -->
+  <tr>
+      <td style="background-color: #ffffff;">
+          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+              <tr>
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                      <p style="margin: 0 0 10px;">Dear {{ order.purchaser.legal_address.first_name }} {{ order.purchaser.legal_address.last_name }},</p>
+                      <p style="margin: 0 0 10px;">
+                        We've processed your request for a refund of order {{order.reference_number}}. You should receive your credit in the amount of ${{transaction_amount}} for the course {{readable_id}} {{title}} within 5-10 business days.</p>
+
+                      <p style="margin: 0 0 10px;">
+                        If you have questions or concerns, please submit a support request at <a href="https://mitxonline.zendesk.com/hc/en-us/requests/new">https://mitxonline.zendesk.com/hc/en-us/requests/new</a>. When you request assistance for billing-related matters, remember to include your order number, {{order.reference_number}}.</p>
+                      
+                      <p style="margin: 0 0 10px;">
+                        Thanks,<br />
+                        The MITx Online Support Team
+                      </p>
+                  </td>
+              </tr>
+
+          </table>
+      </td>
+  </tr>
+<!-- 1 Column Text + Button : END -->
+{% endblock %}

--- a/ecommerce/templates/mail/order_refund_message/subject.txt
+++ b/ecommerce/templates/mail/order_refund_message/subject.txt
@@ -1,0 +1,1 @@
+Refund of MITxOnline Order {{order.reference_number}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #957

#### What's this PR do?

Adds a new email message that gets sent when an order is refunded. The text of the messages is in the issue (#957). 

#### How should this be manually tested?

Automated tests should work.

The easiest way to trigger the refund is through a Django shell; this method does not require that your system be able to accept callbacks from CyberSource. (Refunding through the Django Admin does attempt to perform the refund through CyberSource.) 

From a shell, load a FulfilledOrder, then call the "refund" method:
```
from ecommerce.models import FulfilledOrder

order = FulfilledOrder.objects.first() # change this accordingly

response_data = { "id": "an id" } # the only required field here is id 

order.refund(api_response_data=response_data, amount="50", reason="testing") # change amount and reason accordingly
```
This should trigger the email. Note that this will change the status of the order in the system. 

If your system can receive callbacks from CyberSource, you can post a refund through the EBC. That should also trigger the refund email.