### PR TITLE
Fix factory-boy package name and pin

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ bpython
 codecov
 ddt
 django-debug-toolbar
-factory_boy~=3.2
+factory-boy==3.2.0
 faker
 flaky
 freezegun==0.3.14


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This is an attempt to fix the requirements so that #980 can be generated successfully, currently it's conflicting on two points: a) it's pinning to 3.2.1, which conflicts with requirements.txt which is pinned to 3.2.0 b) it's using the legacy `factory_boy` package.

#### How should this be manually tested?
Tests should pass.
