### PR TITLE
934 add user to sync enrollments with edx error log and pass send_default_pii to sentry configuration

### DIFF
--- a/main/sentry.py
+++ b/main/sentry.py
@@ -29,7 +29,9 @@ def before_send(event, hint):
     return event
 
 
-def init_sentry(*, dsn, environment, version, log_level, heroku_app_name):
+def init_sentry(
+    *, dsn, environment, version, send_default_pii, log_level, heroku_app_name
+):
     """
     Initializes sentry
 
@@ -37,6 +39,7 @@ def init_sentry(*, dsn, environment, version, log_level, heroku_app_name):
         dsn (str): the sentry DSN key
         environment (str): the application environment
         version (str): the version of the application
+        send_default_pii (bool): enable sending PII data to associate users to errors
         log_level (str): the sentry log level
         heroku_app_name (str or None): the name of the heroku review app
     """
@@ -45,6 +48,7 @@ def init_sentry(*, dsn, environment, version, log_level, heroku_app_name):
         environment=environment,
         release=version,
         before_send=before_send,
+        send_default_pii=send_default_pii,
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),

--- a/main/settings.py
+++ b/main/settings.py
@@ -55,6 +55,7 @@ init_sentry(
     dsn=SENTRY_DSN,
     environment=ENVIRONMENT,
     version=VERSION,
+    send_default_pii=True,
     log_level=SENTRY_LOG_LEVEL,
     heroku_app_name=HEROKU_APP_NAME,
 )

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -669,7 +669,8 @@ def sync_enrollments_with_edx(
     # Log an error if any enrollments exist locally but not in edX
     if local_only_ids:
         log.error(
-            "Found local enrollments with no equivalent enrollment in edX (CourseRunEnrollment ids: %s)",
+            "Found local enrollments with no equivalent enrollment in edX for User - %s (CourseRunEnrollment ids: %s)",
+            user.username,
             str(local_only_ids),
         )
     return results


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/934

#### What's this PR do?
This PR is just to add username to the error log in sync_enrollments_with_edx, and also add [send_default_pii](https://docs.sentry.io/platforms/python/guides/django/#configure) to sentry configuration to associate user to errors in general.
I will fix the bug in next PR

#### How should this be manually tested?
For the sentry configuration, we can't test it locally. 
For the error log, it can be ran like this
``` docker-compose run --rm web ./manage.py sync_enrollments --user rlougee@mit.edu```
In my case, it complains about my _unenrolled_ course that couldn't find a match on edx. It's marked inactive on both local and edx. I will fix this bug in next PR, but you could see the username is logged here
```Syncing enrollments for user 'rlougee' (rlougee@mit.edu)
[2022-09-21 14:18:22] ERROR 1 [openedx.api] api.py:671 - [45280882e66a] - Found local enrollments with no equivalent enrollment in edX for User - rlougee (CourseRunEnrollment ids: {'course-v1:MITxT+14.310x+3T2022'})
```
