### PR TITLE
fix: product discount calculation for inactive product

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -862,7 +862,7 @@ class CoursePage(ProductPage):
                 ecommerce_product, request.user
             )
 
-            if discount.check_validity(request.user):
+            if discount and discount.check_validity(request.user):
                 log.debug(
                     f"price is {ecommerce_product.price}, discount is {discount.discount_product(ecommerce_product)}"
                 )

--- a/flexiblepricing/api.py
+++ b/flexiblepricing/api.py
@@ -236,7 +236,7 @@ def determine_courseware_flexible_price_discount(product, user):
     Returns:
         discount: the discount provided in the flexible price tier
     """
-    if not user.is_authenticated:
+    if not user.is_authenticated or not product:
         return None
 
     for eligible_courseware in get_ordered_eligible_coursewares(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1024 

#### What's this PR do?
- Adds checks for inactive products (None) for discount calculation on course details page

#### How should this be manually tested?
- Follow the instruction on #1024 , along with below:
1. Make sure you have a discount with flexible pricing and associate it with a product discount
2. Make sure to have an approved flexible pricing request for that course run and user

After the above steps, upon visiting the course you should not see any errors



