### PR TITLE
Wraps a call to get_order_from_cybersource_payment_response in a transaction

### DIFF
--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -467,17 +467,18 @@ class BackofficeCallbackView(APIView):
         Raises:
             - Http404 if the Order is not found.
         """
-        order = api.get_order_from_cybersource_payment_response(request)
+        with transaction.atomic():
+            order = api.get_order_from_cybersource_payment_response(request)
 
-        # We only want to process responses related to orders which are PENDING
-        # otherwise we can conclude that we already received a response through
-        # the user's browser.
-        if order is None:
-            raise Http404
-        elif order.state == Order.STATE.PENDING:
-            api.process_cybersource_payment_response(request, order)
+            # We only want to process responses related to orders which are PENDING
+            # otherwise we can conclude that we already received a response through
+            # the user's browser.
+            if order is None:
+                raise Http404
+            elif order.state == Order.STATE.PENDING:
+                api.process_cybersource_payment_response(request, order)
 
-        return Response(status=status.HTTP_200_OK)
+            return Response(status=status.HTTP_200_OK)
 
 
 class CheckoutProductView(LoginRequiredMixin, RedirectView):


### PR DESCRIPTION

#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

#1019 (related)

#### What's this PR do?

Fixes `BackofficeCallbackView` to wrap its call to `get_order_from_cybersource_payment_response` in a transaction. This was done in #1029 but this one call got missed.

#### How should this be manually tested?

not real sure, you'd have to have some way for Cybersource to send you a callback
