### PR TITLE
Updates the order fulfillment code to wait for the transaction to complete before sending message

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -517,6 +517,9 @@ class FulfillableOrder:
             keep_failed_enrollments=True,
         )
 
+    def send_ecommerce_order_receipt(self):
+        send_ecommerce_order_receipt.delay(self.id)
+
     @transition(
         field="state",
         source=(Order.STATE.PENDING, Order.STATE.REVIEW),
@@ -533,7 +536,7 @@ class FulfillableOrder:
         self.create_paid_courseruns()
 
         # send the receipt emails
-        send_ecommerce_order_receipt.delay(self.id)
+        transaction.on_commit(self.send_ecommerce_order_receipt)
 
 
 class PendingOrder(FulfillableOrder, Order):

--- a/ecommerce/tasks_test.py
+++ b/ecommerce/tasks_test.py
@@ -12,7 +12,9 @@ def products():
         return ProductFactory.create_batch(5)
 
 
-def test_delayed_order_receipt_sends_email(mocker, user, products, user_client):
+def test_delayed_order_receipt_sends_email(
+    mocker, user, products, user_client, django_capture_on_commit_callbacks
+):
     """
     Tests that the Order model is properly calling the send email receipt task
     rather than calling the mail_api version directly. The create_order_receipt
@@ -24,7 +26,8 @@ def test_delayed_order_receipt_sends_email(mocker, user, products, user_client):
         "ecommerce.mail_api.send_ecommerce_order_receipt"
     )
 
-    create_order_receipt(mocker, user, products, user_client)
+    with django_capture_on_commit_callbacks(execute=True):
+        create_order_receipt(mocker, user, products, user_client)
 
     mock_send_ecommerce_order_receipt.assert_called()
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

n/a

#### What's this PR do?

Adds the call to queue the order receipt email to the post-commit hook for the transaction when fulfilling an order, so the email task gets the order after the state has changed (rather than in the middle, which means it processes it as pre-transaction and throws an error). 

#### How should this be manually tested?

Complete an order. You should get the receipt email. 
