### PR TITLE
Cleans up some extraneous messaging when running management commands

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -5,7 +5,6 @@ from audioop import add
 from decimal import Decimal
 
 from rest_framework import serializers
-from this import d
 
 from cms.serializers import CoursePageSerializer
 from courses.models import Course, CourseRun, ProgramRun

--- a/main/settings.py
+++ b/main/settings.py
@@ -7,6 +7,7 @@ import os
 import platform
 from datetime import timedelta
 from urllib.parse import urljoin, urlparse
+import cssutils
 
 import dj_database_url
 from celery.schedules import crontab
@@ -32,6 +33,9 @@ from main.sentry import init_sentry
 VERSION = "0.45.7"
 
 log = logging.getLogger()
+
+# set log level on cssutils - should be fairly high or it will log messages for Outlook-specific styling
+cssutils.log.setLevel(logging.CRITICAL)
 
 ENVIRONMENT = get_string(
     name="MITX_ONLINE_ENVIRONMENT",


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1050 

#### What's this PR do?

This removes an import that was causing the Zen of Python to be printed when running management commands. It also adjusts the logging settings for `cssutils` so that it doesn't visibly complain about the non-standard but necessary CSS rules for email clients when a command sends an email. 

#### How should this be manually tested?

Run a management command that results in an email being sent. (`create_enrollment` was the one noted in the original issue.) The command should run and whatever output it's supposed to generate should appear, but you should _not_ get the Zen of Python or a bunch of warnings.