### PR TITLE
1036 enrolled button on about page links to course before it has started

### DIFF
--- a/frontend/public/scss/common.scss
+++ b/frontend/public/scss/common.scss
@@ -135,6 +135,11 @@ a.link-button {
   }
 }
 
+a.btn.disabled {
+  color: grey;
+  border: 2px solid grey;
+}
+
 .btn-gradient-red {
   background: linear-gradient(174deg, $brand-darker-bg, $brand-darker-bg) !important;
   border: 2px solid $brand-darker-bg;

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -195,6 +195,12 @@ export class ProductDetailEnrollApp extends React.Component<
       })
     }
 
+
+    const startDate = run && !emptyOrNil(run.start_date) ? moment(new Date(run.start_date)) : null
+    const disableEnrolledBtn = moment().isBefore(startDate) ? "" : "disabled"
+    const waitingForCourseToBeginMessage = moment().isBefore(startDate) ? null : <p style={{ fontSize: "16px" }}>Enrolled and waiting for the course to begin.</p>
+
+
     return (
       // $FlowFixMe: isLoading null or undefined
       <Loader isLoading={isLoading}>
@@ -203,17 +209,18 @@ export class ProductDetailEnrollApp extends React.Component<
             {run.courseware_url ? (
               <a
                 href={run.courseware_url}
-                className="btn btn-primary btn-gradient-red highlight outline"
+                className={`btn btn-primary btn-gradient-red highlight outline ${disableEnrolledBtn}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 Enrolled &#10003;
               </a>
             ) : (
-              <div className="btn btn-primary btn-gradient-red highlight outline">
+              <div className={`btn btn-primary btn-gradient-red highlight outline ${disableEnrolledBtn}`}>
                 Enrolled &#10003;
               </div>
             )}
+            {waitingForCourseToBeginMessage}
           </Fragment>
         ) : (
           <Fragment>

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -197,8 +197,8 @@ export class ProductDetailEnrollApp extends React.Component<
 
 
     const startDate = run && !emptyOrNil(run.start_date) ? moment(new Date(run.start_date)) : null
-    const disableEnrolledBtn = moment().isBefore(startDate) ? "" : "disabled"
-    const waitingForCourseToBeginMessage = moment().isBefore(startDate) ? null : <p style={{ fontSize: "16px" }}>Enrolled and waiting for the course to begin.</p>
+    const disableEnrolledBtn = moment().isBefore(startDate) ? "disabled" : ""
+    const waitingForCourseToBeginMessage = moment().isBefore(startDate) ? <p style={{ fontSize: "16px" }}>Enrolled and waiting for the course to begin.</p> : null
 
 
     return (

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -2,7 +2,6 @@
 // @flow
 import { assert } from "chai"
 import moment from "moment-timezone"
-import React from "react"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import ProductDetailEnrollApp, {

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -2,6 +2,7 @@
 // @flow
 import { assert } from "chai"
 import moment from "moment-timezone"
+import React from "react"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import ProductDetailEnrollApp, {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1036

#### What's this PR do?
Disables (grey out) the "Enrolled" button and adds some text informing the user they are enrolled but the course has not started yet on the Course about page when a user is enrolled in a course before the CourseRun start_date.

#### How should this be manually tested?

1. Create a course run with a start date in the future.
2. Enroll your test user in the course run from step 1
3. Visit the Course about page (Dashboard -> "course details" on the course card)
4. Ensure the "Enrolled" button is greyed out and the additional text below the button is shown.


#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/8311573/192342632-e5b0154e-7162-4b1b-868a-2ccff19b4bce.png)
![Screen Shot 2022-09-26 at 13 36 44](https://user-images.githubusercontent.com/8311573/192343502-3a62401e-4de8-4020-b251-5fc1825db408.png)

