### PR TITLE
1051: Don't display "active" on the dashboard when it is past the course run's course_end date

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -17,7 +17,7 @@ import { partial } from "ramda"
 
 import { ALERT_TYPE_DANGER, ALERT_TYPE_SUCCESS } from "../constants"
 import GetCertificateButton from './GetCertificateButton'
-import { isFinancialAssistanceAvailable, isLinkableCourseRun, generateStartDateText } from "../lib/courseApi"
+import { isFinancialAssistanceAvailable, isLinkableCourseRun, generateStartDateText, courseRunStatusMessage } from "../lib/courseApi"
 import { isSuccessResponse } from "../lib/util"
 
 import type { RunEnrollment } from "../flow/courseTypes"
@@ -298,21 +298,7 @@ export class EnrolledItemCard extends React.Component<
     const pageLocation = enrollment.run.page
     const menuTitle = `Course options for ${enrollment.run.course.title}`
 
-    let courseRunStatusMessage = null
-
-    if (startDateDescription !== null) {
-      if (startDateDescription.active) {
-        if (moment(enrollment.run.end_date).isBefore(moment())) {
-          courseRunStatusMessage = <span> | <b>Ended</b> - {enrollment.run.end_date}</span>
-        } else {
-          courseRunStatusMessage = <span> |
-            <strong> Active</strong> - {startDateDescription.datestr}
-          </span>
-        }
-      } else {
-        courseRunStatusMessage = <span> | <b>Starts</b> - {startDateDescription.datestr}</span>
-      }
-    }
+    const courseRunStatusMessageText = courseRunStatusMessage(enrollment.run)
 
     return (
       <div
@@ -377,7 +363,7 @@ export class EnrolledItemCard extends React.Component<
             <div className="detail pt-1">
               {courseId}
               {startDateDescription === null}
-              {courseRunStatusMessage}
+              {courseRunStatusMessageText}
               <div className="enrollment-extra-links d-flex">
                 {pageLocation ? (
                   <a href={pageLocation.page_url}>Course details</a>

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -2,6 +2,7 @@
 /* global SETTINGS:false */
 import React from "react"
 import { Formik, Form, Field } from "formik"
+import moment from "moment"
 import {
   Dropdown,
   DropdownToggle,
@@ -297,6 +298,23 @@ export class EnrolledItemCard extends React.Component<
     const pageLocation = enrollment.run.page
     const menuTitle = `Course options for ${enrollment.run.course.title}`
 
+    let courseRunStatusMessage = null
+
+    if (startDateDescription !== null) {
+      if (startDateDescription.active) {
+        console.log("here")
+        if (moment(enrollment.run.end_date).isBefore(moment())) {
+          courseRunStatusMessage = <span> | <b>Ended</b> - {enrollment.run.end_date}</span>
+        } else {
+          courseRunStatusMessage = <span> |
+            <strong> Active</strong> - {startDateDescription.datestr}
+          </span>
+        }
+      } else {
+        courseRunStatusMessage = <span> | <b>Starts</b> - {startDateDescription.datestr}</span>
+      }
+    }
+
     return (
       <div
         className="enrolled-item container card mb-4 rounded-0 pb-0 pt-md-3"
@@ -359,17 +377,8 @@ export class EnrolledItemCard extends React.Component<
             </div>
             <div className="detail pt-1">
               {courseId}
-              {startDateDescription !== null && !startDateDescription.active ? (
-                <span> | <b>Starts</b> - {startDateDescription.datestr}</span>
-              ) : (
-                <span>
-                  {startDateDescription === null ? null : (
-                    <span> |
-                      <strong> Active</strong> - {startDateDescription.datestr}
-                    </span>
-                  )}
-                </span>
-              )}
+              {startDateDescription === null}
+              {courseRunStatusMessage}
               <div className="enrollment-extra-links d-flex">
                 {pageLocation ? (
                   <a href={pageLocation.page_url}>Course details</a>

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -302,7 +302,6 @@ export class EnrolledItemCard extends React.Component<
 
     if (startDateDescription !== null) {
       if (startDateDescription.active) {
-        console.log("here")
         if (moment(enrollment.run.end_date).isBefore(moment())) {
           courseRunStatusMessage = <span> | <b>Ended</b> - {enrollment.run.end_date}</span>
         } else {

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -111,10 +111,11 @@ describe("EnrolledItemCard", () => {
 
   it("Course detail shows `Active` when start date in past", async () => {
     enrollmentCardProps.enrollment.run.start_date = moment("2021-02-08")
+    enrollmentCardProps.enrollment.run.end_date = moment().add(7, "d")
     const inner = await renderedCard()
     const detail = inner.find(".enrolled-item").find(".detail")
     assert.isTrue(detail.exists())
-    const detailText = detail.find("span").find("span").at(1).text()
+    const detailText = detail.find("span").find("span").at(0).text()
     assert.isTrue(detailText.startsWith(" | Active"))
   })
 
@@ -125,6 +126,15 @@ describe("EnrolledItemCard", () => {
     assert.isTrue(detail.exists())
     const detailText = detail.find("span").at(0).text()
     assert.isTrue(detailText.startsWith(" | Starts"))
+  })
+
+  it("Course detail shows `Ended` when end date in past", async () => {
+    enrollmentCardProps.enrollment.run.end_date = moment().add(-7, "d")
+    const inner = await renderedCard()
+    const detail = inner.find(".enrolled-item").find(".detail")
+    assert.isTrue(detail.exists())
+    const detailText = detail.find("span").at(0).text()
+    assert.isTrue(detailText.startsWith(" | Ended"))
   })
 
   it("renders the unenrollment verification modal", async () => {

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -36,6 +36,26 @@ export const isWithinEnrollmentPeriod = (run: CourseRunDetail): boolean => {
   )
 }
 
+export const courseRunStatusMessage = (run: CourseRun) => {
+  const startDateDescription = generateStartDateText(run)
+  if (startDateDescription !== null) {
+    if (startDateDescription.active) {
+      if (moment(run.end_date).isBefore(moment())) {
+        const dateString = parseDateString(run.start_date)
+        return (<span> | <b>Ended</b> - {formatPrettyDateTimeAmPmTz(dateString)}</span>)
+      } else {
+        return (<span> |
+          <strong> Active</strong> - {startDateDescription.datestr}
+        </span>)
+      }
+    } else {
+      return (<span> | <b>Starts</b> - {startDateDescription.datestr}</span>)
+    }
+  } else {
+    return null
+  }
+}
+
 export const generateStartDateText = (run: CourseRunDetail) => {
   if (run.start_date) {
     const now = moment()

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -7,7 +7,7 @@ import { isNil } from "ramda"
 import { notNil, parseDateString, formatPrettyDateTimeAmPmTz } from "./util"
 
 import type Moment from "moment"
-import type { CourseRunDetail } from "../flow/courseTypes"
+import type { CourseRunDetail, CourseRun } from "../flow/courseTypes"
 import type { CurrentUser } from "../flow/authTypes"
 
 export const isLinkableCourseRun = (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1051

#### What's this PR do?
When viewing the dashboard, any course cards for a course which have an `end_date` which is prior to the current date will display "Ended" and then the date on which they ended.

#### How should this be manually tested?

1. Create a Course Run with an `end_date` in the past.
2. enroll your test user in the Course Run.
3. Go to the Dashboard page.
4. Verify that the course card on the dashboard shows "Ended" and the `end_date` from the Course Run.

#### Screenshots (if appropriate)
![Screen Shot 2022-09-26 at 15 05 28](https://user-images.githubusercontent.com/8311573/192359291-e9c8df8b-2456-4067-8419-19642a01cace.png)
![Screen Shot 2022-09-26 at 15 05 34](https://user-images.githubusercontent.com/8311573/192359304-6295b5bd-fec5-444c-a767-16c6783bf8e4.png)
