### PR TITLE
1044: when referring to a course in email don't include the full course

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -211,7 +211,7 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
     topics = models.ManyToManyField(CourseTopic, blank=True)
     flexible_prices = GenericRelation("flexiblepricing.FlexiblePrice")
     tiers = GenericRelation("flexiblepricing.FlexiblePriceTier")
-    
+
     @property
     def course_number(self):
         """

--- a/courses/models.py
+++ b/courses/models.py
@@ -211,6 +211,14 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
     topics = models.ManyToManyField(CourseTopic, blank=True)
     flexible_prices = GenericRelation("flexiblepricing.FlexiblePrice")
     tiers = GenericRelation("flexiblepricing.FlexiblePriceTier")
+    
+    @property
+    def course_number(self):
+        """
+        Returns:
+            str: Course number (last part of readable_id, after the final +)
+        """
+        return get_course_number(self.courseware_id)
 
     @property
     def page(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -218,7 +218,7 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
         Returns:
             str: Course number (last part of readable_id, after the final +)
         """
-        return get_course_number(self.courseware_id)
+        return get_course_number(self.readable_id)
 
     @property
     def page(self):

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -87,9 +87,7 @@ def send_ecommerce_refund_message(order_record):
                 recipient,
                 {
                     "order": order_record,
-                    "readable_id": line.purchased_object.readable_id
-                    if line and len(line.purchased_object.readable_id.split("+")) < 2
-                    else line.purchased_object.readable_id.split("+")[1],
+                    "readable_id": line.purchased_object.course_number,
                     "title": line.purchased_object.title if line else None,
                     "transaction_amount": transaction.amount.quantize(Decimal("0.01")),
                 },

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -87,7 +87,7 @@ def send_ecommerce_refund_message(order_record):
                 recipient,
                 {
                     "order": order_record,
-                    "readable_id": line.purchased_object.readable_id if line else None,
+                    "readable_id": line.purchased_object.readable_id.split('+')[1] if line else None,
                     "title": line.purchased_object.title if line else None,
                     "transaction_amount": transaction.amount.quantize(Decimal("0.01")),
                 },

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -87,7 +87,9 @@ def send_ecommerce_refund_message(order_record):
                 recipient,
                 {
                     "order": order_record,
-                    "readable_id": line.purchased_object.readable_id.split('+')[1] if line else None,
+                    "readable_id": line.purchased_object.readable_id.split("+")[1]
+                    if line
+                    else None,
                     "title": line.purchased_object.title if line else None,
                     "transaction_amount": transaction.amount.quantize(Decimal("0.01")),
                 },

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -87,9 +87,9 @@ def send_ecommerce_refund_message(order_record):
                 recipient,
                 {
                     "order": order_record,
-                    "readable_id": line.purchased_object.readable_id.split("+")[1]
-                    if line
-                    else None,
+                    "readable_id": line.purchased_object.readable_id
+                    if line and len(line.purchased_object.readable_id.split("+")) < 2
+                    else line.purchased_object.readable_id.split("+")[1],
                     "title": line.purchased_object.title if line else None,
                     "transaction_amount": transaction.amount.quantize(Decimal("0.01")),
                 },

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,7 +35,11 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
-    courseware_readable_id_formatted = flexible_price.courseware_object.course_number if isinstance(flexible_price.courseware_object, Course) else flexible_price.courseware_object.readable_id
+    courseware_readable_id_formatted = (
+        flexible_price.courseware_object.course_number
+        if isinstance(flexible_price.courseware_object, Course)
+        else flexible_price.courseware_object.readable_id
+    )
     program_name_with_course_number = (
         courseware_readable_id_formatted + " " + flexible_price.courseware_object.title
     )

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,9 +35,7 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
-    courseware_readable_id_formatted = (
-        flexible_price.courseware_object.course_number
-    )
+    courseware_readable_id_formatted = flexible_price.courseware_object.course_number
     program_name_with_course_number = (
         courseware_readable_id_formatted + " " + flexible_price.courseware_object.title
     )

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,7 +35,11 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
-    program_name_with_course_number = flexible_price.courseware_object.readable_id.split('+')[1] + " " + flexible_price.courseware_object.title
+    program_name_with_course_number = (
+        flexible_price.courseware_object.readable_id.split("+")[1]
+        + " "
+        + flexible_price.courseware_object.title
+    )
     if flexible_price.status == FlexiblePriceStatus.APPROVED:
         price = flexible_price.tier.discount.friendly_format()
         message = FLEXIBLE_PRICE_EMAIL_APPROVAL_MESSAGE.format(

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,25 +35,26 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
+    program_name_with_course_number = flexible_price.courseware_object.readable_id.split('+')[1] + " " + flexible_price.courseware_object.title
     if flexible_price.status == FlexiblePriceStatus.APPROVED:
         price = flexible_price.tier.discount.friendly_format()
         message = FLEXIBLE_PRICE_EMAIL_APPROVAL_MESSAGE.format(
-            program_name=flexible_price.courseware_object.title, price=price
+            program_name=program_name_with_course_number, price=price
         )
         subject = FLEXIBLE_PRICE_EMAIL_APPROVAL_SUBJECT.format(
-            program_name=flexible_price.courseware_object.title
+            program_name=program_name_with_course_number
         )
     elif flexible_price.status == FlexiblePriceStatus.PENDING_MANUAL_APPROVAL:
         message = FLEXIBLE_PRICE_EMAIL_DOCUMENTS_RECEIVED_MESSAGE
         subject = FLEXIBLE_PRICE_EMAIL_DOCUMENTS_RECEIVED_SUBJECT.format(
-            program_name=flexible_price.courseware_object.title
+            program_name=program_name_with_course_number
         )
     elif flexible_price.status == FlexiblePriceStatus.RESET:
         message = FLEXIBLE_PRICE_EMAIL_RESET_MESSAGE.format(
-            program_name=flexible_price.courseware_object.title
+            program_name=program_name_with_course_number
         )
         subject = FLEXIBLE_PRICE_EMAIL_RESET_SUBJECT.format(
-            program_name=flexible_price.courseware_object.title
+            program_name=program_name_with_course_number
         )
     else:
         raise ValidationError(
@@ -67,7 +68,7 @@ def generate_flexible_price_email(flexible_price):
                     "subject": subject,
                     "first_name": flexible_price.user.legal_address.first_name,
                     "message": message,
-                    "program_name": flexible_price.courseware_object.title,
+                    "program_name": program_name_with_course_number,
                 },
             )
     except:

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,10 +35,13 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
+    courseware_readable_id_formatted = (
+        flexible_price.courseware_object.readable_id
+        if len(flexible_price.courseware_object.readable_id.split("+")) < 2
+        else flexible_price.courseware_object.readable_id.split("+")[1]
+    )
     program_name_with_course_number = (
-        flexible_price.courseware_object.readable_id.split("+")[1]
-        + " "
-        + flexible_price.courseware_object.title
+        courseware_readable_id_formatted + " " + flexible_price.courseware_object.title
     )
     if flexible_price.status == FlexiblePriceStatus.APPROVED:
         price = flexible_price.tier.discount.friendly_format()

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,7 +35,7 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
-    courseware_readable_id_formatted = flexible_price.courseware_object.course_number
+    courseware_readable_id_formatted = flexible_price.courseware_object.course_number if isinstance(flexible_price.courseware_object, Course) else flexible_price.courseware_object.readable_id
     program_name_with_course_number = (
         courseware_readable_id_formatted + " " + flexible_price.courseware_object.title
     )

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -36,9 +36,7 @@ def generate_flexible_price_email(flexible_price):
         dict: {"subject": (str), "body": (str)}
     """
     courseware_readable_id_formatted = (
-        flexible_price.courseware_object.readable_id
-        if len(flexible_price.courseware_object.readable_id.split("+")) < 2
-        else flexible_price.courseware_object.readable_id.split("+")[1]
+        flexible_price.courseware_object.course_number
     )
     program_name_with_course_number = (
         courseware_readable_id_formatted + " " + flexible_price.courseware_object.title

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,11 +35,13 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
-    courseware_course_number_formatted = flexible_price.courseware_object.course_number
+    courseware_readable_id_formatted = (
+        flexible_price.courseware_object.readable_id
+        if len(flexible_price.courseware_object.readable_id.split("+")) < 2
+        else flexible_price.courseware_object.readable_id.split("+")[1]
+    )
     program_name_with_course_number = (
-        courseware_course_number_formatted
-        + " "
-        + flexible_price.courseware_object.title
+        courseware_readable_id_formatted + " " + flexible_price.courseware_object.title
     )
     if flexible_price.status == FlexiblePriceStatus.APPROVED:
         price = flexible_price.tier.discount.friendly_format()

--- a/flexiblepricing/mail_api.py
+++ b/flexiblepricing/mail_api.py
@@ -35,13 +35,11 @@ def generate_flexible_price_email(flexible_price):
     Returns:
         dict: {"subject": (str), "body": (str)}
     """
-    courseware_readable_id_formatted = (
-        flexible_price.courseware_object.readable_id
-        if len(flexible_price.courseware_object.readable_id.split("+")) < 2
-        else flexible_price.courseware_object.readable_id.split("+")[1]
-    )
+    courseware_course_number_formatted = flexible_price.courseware_object.course_number
     program_name_with_course_number = (
-        courseware_readable_id_formatted + " " + flexible_price.courseware_object.title
+        courseware_course_number_formatted
+        + " "
+        + flexible_price.courseware_object.title
     )
     if flexible_price.status == FlexiblePriceStatus.APPROVED:
         price = flexible_price.tier.discount.friendly_format()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1044

#### What's this PR do?
Formats all of the emails from `mitxonline` where the courseware title is shown to include the courseware number in the format of <courseware number> <courseware title>.

This change impacts the following emails:

1. Refund email
2. Flexible Price email (accepted, reset, pending manual approval) 

#### How should this be manually tested?
Trigger a refund email following the instructions listed on this [PR](https://github.com/mitodl/mitxonline/pull/1000).
Trigger flexible price emails by setting up a Flexible Price following [these instructions ](https://github.com/mitodl/mitxonline/blob/main/docs/source/ecommerce/flexible_pricing.rst).  Then submit a flexible price request for your user and change the flexible price request status through the [refine-staff dashboard](http://mitxonline.odl.local:8013/staff-dashboard/).

Ensure that wherever the courseware title is shown, the courseware number is also shown.  You should also test that this works with a Flexible Price which is associated to a Program and a Course without a Program.

#### Screenshots (if appropriate)
![Screen Shot 2022-09-27 at 14 47 00](https://user-images.githubusercontent.com/8311573/192618564-487a6324-8632-44e5-92ce-99cc2b27d046.png)
![Screen Shot 2022-09-27 at 14 46 52](https://user-images.githubusercontent.com/8311573/192618566-bba96452-d62f-4440-827f-6063ad095216.png)

