### PR TITLE
add webpack-bundle-analyzer

### DIFF
--- a/frontend/public/package.json
+++ b/frontend/public/package.json
@@ -117,6 +117,7 @@
     "videojs-youtube": "2.6.1",
     "waait": "1.0.5",
     "webpack": "5.71.0",
+    "webpack-bundle-analyzer": "^4.6.1",
     "webpack-bundle-tracker": "1.4.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-middleware": "5.3.1",

--- a/frontend/public/webpack.config.js
+++ b/frontend/public/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path")
 const webpack = require("webpack")
 const BundleTracker = require("webpack-bundle-tracker")
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
 
 module.exports = function(env, argv) {
   const mode = argv.mode || process.env.NODE_ENV || "production"
@@ -10,7 +11,7 @@ module.exports = function(env, argv) {
     mode,
     context: __dirname,
     devtool: "source-map",
-    entry: {
+    entry:   {
       root:         "./src/entry/root",
       header:       "./src/entry/header",
       style:        "./src/entry/style",
@@ -22,11 +23,11 @@ module.exports = function(env, argv) {
         filename:           "[name]-[chunkhash].js",
         chunkFilename:      "[id]-[chunkhash].js",
         crossOriginLoading: "anonymous",
-        hashFunction: "xxhash64"
+        hashFunction:       "xxhash64"
       } : {
         filename: "[name].js",
       }),
-      publicPath: isProduction ? "/static/mitx-online/" : process.env.PUBLIC_PATH 
+      publicPath: isProduction ? "/static/mitx-online/" : process.env.PUBLIC_PATH
     },
     module: {
       rules: [
@@ -35,8 +36,8 @@ module.exports = function(env, argv) {
           type: "asset/inline"
         },
         {
-          test: require.resolve('jquery'),
-          loader: "expose-loader",
+          test:    require.resolve('jquery'),
+          loader:  "expose-loader",
           options: {
             exposes: ["jQuery", "$"]
           }
@@ -48,12 +49,12 @@ module.exports = function(env, argv) {
             path.resolve(__dirname, "../../node_modules/query-string"),
             path.resolve(__dirname, "../../node_modules/strict-uri-encode"),
           ],
-          loader:  "babel-loader",
+          loader: "babel-loader",
         },
         {
           test: /\.css$|\.scss$/,
           use:  [
-            { loader: isProduction ? MiniCssExtractPlugin.loader :"style-loader" },
+            { loader: isProduction ? MiniCssExtractPlugin.loader : "style-loader" },
             "css-loader",
             "postcss-loader",
             "sass-loader"
@@ -72,6 +73,9 @@ module.exports = function(env, argv) {
       new webpack.optimize.AggressiveMergingPlugin(),
       new MiniCssExtractPlugin({
         filename: "[name]-[contenthash].css"
+      }),
+      new BundleAnalyzerPlugin({
+        analyzerMode: "static",
       })
     ] : []),
     resolve: {
@@ -86,39 +90,39 @@ module.exports = function(env, argv) {
       hints: false
     },
     optimization: {
-      moduleIds: "named",
+      moduleIds:   "named",
       splitChunks:  {
         name:      "common",
         minChunks: 2,
         ...(isProduction ? {
-            cacheGroups: {
+          cacheGroups: {
             common: {
-              test: /[\\/]node_modules[\\/]/,
-              name: 'common',
+              test:   /[\\/]node_modules[\\/]/,
+              name:   'common',
               chunks: 'all',
             }
           }
         } : {})
       },
-      minimize: isProduction,
+      minimize:     isProduction,
       emitOnErrors: false
     },
     devServer: {
       allowedHosts: "all",
-      headers: {
+      headers:      {
         'Access-Control-Allow-Origin': '*'
       },
-      host: "::",
-      setupMiddlewares: function (middlewares, devServer) {
+      host:             "::",
+      setupMiddlewares: function(middlewares, devServer) {
         if (!devServer) {
-          throw new Error('webpack-dev-server is not defined');
+          throw new Error('webpack-dev-server is not defined')
         }
-    
-        devServer.app.get('/health', function (req, res) {
-          res.json({ success: true, server: "webpack" });
-        });
 
-        return middlewares;
+        devServer.app.get('/health', function(req, res) {
+          res.json({ success: true, server: "webpack" })
+        })
+
+        return middlewares
       },
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,6 +2736,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polka/url@npm:^1.0.0-next.20":
+  version: 1.0.0-next.21
+  resolution: "@polka/url@npm:1.0.0-next.21"
+  checksum: c7654046d38984257dd639eab3dc770d1b0340916097b2fac03ce5d23506ada684e05574a69b255c32ea6a144a957c8cd84264159b545fca031c772289d88788
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-babel@npm:^5.2.0":
   version: 5.3.1
   resolution: "@rollup/plugin-babel@npm:5.3.1"
@@ -4272,7 +4279,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.1.1":
+"acorn-walk@npm:^8.0.0, acorn-walk@npm:^8.1.1":
   version: 8.2.0
   resolution: "acorn-walk@npm:8.2.0"
   checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
@@ -4312,6 +4319,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 1860f23c2107c910c6177b7b7be71be350db9e1080d814493fae143ae37605189504152d1ba8743ba3178d0b37269ce1ffc42b101547fdc1827078f82671e407
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.0.4":
+  version: 8.8.0
+  resolution: "acorn@npm:8.8.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
   languageName: node
   linkType: hard
 
@@ -13517,6 +13533,7 @@ __metadata:
     videojs-youtube: 2.6.1
     waait: 1.0.5
     webpack: 5.71.0
+    webpack-bundle-analyzer: ^4.6.1
     webpack-bundle-tracker: 1.4.0
     webpack-cli: 4.10.0
     webpack-dev-middleware: 5.3.1
@@ -13669,6 +13686,13 @@ __metadata:
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
   checksum: 83f515abbcff60150873e424894a2f65d68037e5a7fcde8a9e2b285ee9c13ac581b63cfc1e6826c4732de3aeb84902f7c1e16b7aff46cd3f897a0f757a894e85
+  languageName: node
+  linkType: hard
+
+"mrmime@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mrmime@npm:1.0.1"
+  checksum: cc979da44bbbffebaa8eaf7a45117e851f2d4cb46a3ada6ceb78130466a04c15a0de9a9ce1c8b8ba6f6e1b8618866b1352992bf1757d241c0ddca558b9f28a77
   languageName: node
   linkType: hard
 
@@ -14277,6 +14301,15 @@ __metadata:
     is-docker: ^2.1.1
     is-wsl: ^2.2.0
   checksum: e9545bec64cdbf30a0c35c1bdc310344adf8428a117f7d8df3c0af0a0a24c513b304916a6d9b11db0190ff7225c2d578885080b761ed46a3d5f6f1eebb98b63c
+  languageName: node
+  linkType: hard
+
+"opener@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "opener@npm:1.5.2"
+  bin:
+    opener: bin/opener-bin.js
+  checksum: 33b620c0d53d5b883f2abc6687dd1c5fd394d270dbe33a6356f2d71e0a2ec85b100d5bac94694198ccf5c30d592da863b2292c5539009c715a9c80c697b4f6cc
   languageName: node
   linkType: hard
 
@@ -18579,6 +18612,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sirv@npm:^1.0.7":
+  version: 1.0.19
+  resolution: "sirv@npm:1.0.19"
+  dependencies:
+    "@polka/url": ^1.0.0-next.20
+    mrmime: ^1.0.0
+    totalist: ^1.0.0
+  checksum: c943cfc61baf85f05f125451796212ec35d4377af4da90ae8ec1fa23e6d7b0b4d9c74a8fbf65af83c94e669e88a09dc6451ba99154235eead4393c10dda5b07c
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -19728,6 +19772,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"totalist@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "totalist@npm:1.1.0"
+  checksum: dfab80c7104a1d170adc8c18782d6c04b7df08352dec452191208c66395f7ef2af7537ddfa2cf1decbdcfab1a47afbbf0dec6543ea191da98c1c6e1599f86adc
+  languageName: node
+  linkType: hard
+
 "tough-cookie@npm:^4.0.0":
   version: 4.0.0
   resolution: "tough-cookie@npm:4.0.0"
@@ -20744,6 +20795,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-bundle-analyzer@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "webpack-bundle-analyzer@npm:4.6.1"
+  dependencies:
+    acorn: ^8.0.4
+    acorn-walk: ^8.0.0
+    chalk: ^4.1.0
+    commander: ^7.2.0
+    gzip-size: ^6.0.0
+    lodash: ^4.17.20
+    opener: ^1.5.2
+    sirv: ^1.0.7
+    ws: ^7.3.1
+  bin:
+    webpack-bundle-analyzer: lib/bin/analyzer.js
+  checksum: 4bc97ac6a1d9cd1f133444b0fc9d9091c97f4bd8388f97636ce27abd1ebffaa7dd45d29f6693661a666e77bcc08dff43ab7c2f5e2600a3101b956c94c1d038d0
+  languageName: node
+  linkType: hard
+
 "webpack-bundle-tracker@npm:1.4.0":
   version: 1.4.0
   resolution: "webpack-bundle-tracker@npm:1.4.0"
@@ -21467,6 +21537,21 @@ __metadata:
   dependencies:
     mkdirp: ^0.5.1
   checksum: 91bf45a4cf5c2a23fb56ca6cd3b1583295dafe7633f5fdf247f45ca212364cb2bcfe0c3040775b9c1efea613a49104da73d4ae5c28accb9d822aeb176fc7731e
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7.3.1":
+  version: 7.5.9
+  resolution: "ws@npm:7.5.9"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1061

#### What's this PR do?
This PR adds [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer) to help us understand what's in the bundles generated by the webpack build process.

Right now it is configured only to run for the production webpack build. (It doesn't affect the production bundles, though, just generates a sibling report.html file.) 

#### How should this be manually tested?
1. Run
    ```sh
    docker compose run --rm --env NODE_ENV=production watch yarn workspace mitx-online-public run build
    ```
    The build should succeed.
2. In yoour browser, open `/frontend/public/build/report.html`. It should show something like the diagram below.

#### Any background context you want to provide?
We recently added this to ocw-hugo-themes in https://github.com/mitodl/ocw-hugo-themes/pull/855

#### Screenshots (if appropriate)

<img width="1725" alt="Screen Shot 2022-09-27 at 3 12 39 PM" src="https://user-images.githubusercontent.com/9010790/192619844-be46aa47-5cbe-418b-bb1e-a0afc3ef7cf0.png">
