### PR TITLE
Online-1035 Display upgrade dialog when Ecommerce enabled

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -271,7 +271,8 @@ export class EnrolledItemCard extends React.Component<
     const certificateLinks = (
       enrollment.run.products.length > 0 &&
       enrollment.enrollment_mode === "audit" &&
-      enrollment.run.is_upgradable
+      enrollment.run.is_upgradable &&
+      SETTINGS.features.upgrade_dialog
     ) ? (
         <div className="upgrade-item-description detail d-md-flex justify-content-between pb-2">
           <div className="mr-0">

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -29,6 +29,7 @@ describe("EnrolledItemCard", () => {
     userEnrollment = makeCourseRunEnrollment()
     currentUser = makeUser()
     isLinkableStub = helper.sandbox.stub(courseApi, "isLinkableCourseRun")
+    SETTINGS.features = { upgrade_dialog: true, disable_discount_ui: false, enable_program_ui: false }
     enrollmentCardProps = {
       enrollment:           userEnrollment,
       currentUser:          currentUser,
@@ -84,6 +85,33 @@ describe("EnrolledItemCard", () => {
         userEnrollment.run.course.title
       )
       if (mode === "verified") {
+        const pricingLinks = inner.find(".pricing-links")
+        assert.isFalse(pricingLinks.exists())
+      }
+    })
+  })
+
+  ;[
+    "audit",
+    "verified"
+  ].forEach(([mode]) => {
+    it("renders the card without upsell message when ecommerce disabled", async () => {
+      const testEnrollment = makeCourseRunEnrollmentWithProduct()
+      userEnrollment = testEnrollment
+      enrollmentCardProps.enrollment = testEnrollment
+      const inner = await renderedCard()
+      const enrolledItems = inner.find(".enrolled-item")
+      assert.lengthOf(enrolledItems, 1)
+      const enrolledItem = enrolledItems.at(0)
+      assert.equal(
+        enrolledItem.find("h2").text(),
+        userEnrollment.run.course.title
+      )
+      if (mode === "verified") {
+        const pricingLinks = inner.find(".pricing-links")
+        assert.isFalse(pricingLinks.exists())
+      } else {
+        SETTINGS.features = { upgrade_dialog: false, disable_discount_ui: false, enable_program_ui: false }
         const pricingLinks = inner.find(".pricing-links")
         assert.isFalse(pricingLinks.exists())
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1035

#### What's this PR do?
Display upsell messages in the dashboard when e-commerce is enabled.

#### How should this be manually tested?

- Set `ENABLE_UPGRADE_DIALOG` to False.
- Enroll in the audit version of a course. 
- Visit the dashboard, Enrolled card should not display the upsell message.


#### Screenshots (if appropriate)
Flag Disabled:
<img width="1216" alt="Screenshot 2022-09-28 at 2 03 07 PM" src="https://user-images.githubusercontent.com/52656433/192738042-14f99091-8c9e-4fb0-8607-de56b9349018.png">
Flag Enabled:
<img width="1115" alt="Screenshot 2022-09-28 at 2 04 48 PM" src="https://user-images.githubusercontent.com/52656433/192738060-4a0099c1-b71f-47eb-9023-87681c78bb53.png">

