### PR TITLE
update local only enrollments error to filter out unenrolled

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -666,12 +666,19 @@ def sync_enrollments_with_edx(
                 ].is_active,
             )
             results.created.append(local_enrollment)
+
+    # Confirm if local_only_ids are actually active enrollments before logging these as error
+    local_only_active_ids = (
+        user.courserunenrollment_set(manager="all_objects")
+        .filter(user=user, run__courseware_id__in=local_only_ids, active=True)
+        .values_list("run__courseware_id", flat=True)
+    )
     # Log an error if any enrollments exist locally but not in edX
-    if local_only_ids:
+    if local_only_active_ids:
         log.error(
             "Found local enrollments with no equivalent enrollment in edX for User - %s (CourseRunEnrollment ids: %s)",
             user.username,
-            str(local_only_ids),
+            str(local_only_active_ids),
         )
     return results
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/934

#### What's this PR do?
Fixes the error log "Found local enrollments with no equivalent enrollment in edX" which contains _unenrolled_ courses from edx and locally. This PR is to filter out the unenrolled courses from local_only_ids with minimal side effects, so these don't get logged as errors 

Examples: 
https://sentry.io/organizations/mit-office-of-digital-learning/issues/3612208558/events/bc0d92f3212f4963bf87033adc75efda/?project=5864687
https://sentry.io/organizations/mit-office-of-digital-learning/issues/3612208558/events/a53c870c4aa545ac954a09c32e699b25/?project=5864687

Additional Notes:
The edx API `get_student_enrollments() `seems only return active enrollments, It's also being used in other repo like MicroMaster, if it's intended to include inactive enrollments, it might require some research
`get_enrollments(usernames)` return a complete list of enrollments including inactive ones, but it requires certain permission to call it, it couldn't be used as far as I can tell.


#### How should this be manually tested?
If there is any course you unenrolled from edx and locally, run ```./manage.py sync_enrollments --user YOUR EMAIL```
should now filter out these unenrolled courses
