### PR TITLE
fix: show zero for negative prices

### DIFF
--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -227,7 +227,7 @@ export const getErrorMessages = (
 }
 
 export const formatLocalePrice = (amount: number | null) => {
-  if (amount === null) amount = 0
+  if (amount === null || amount < 0) amount = 0
 
   return amount.toLocaleString("en-US", { style: "currency", currency: "USD" })
 }

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -337,5 +337,9 @@ describe("utility functions", () => {
     it("formatLocalePrice returns a US-formatted price string equalling zero when the input is null", () => {
       assert.equal(formatLocalePrice(null), "$0.00")
     })
+
+    it("formatLocalePrice returns a US-formatted price string equalling zero when the input is negative", () => {
+      assert.equal(formatLocalePrice(null), "$0.00")
+    })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1069 

#### What's this PR do?
 - Fixes the frontend when discount price is more then actual price and the price shows negative value.

#### How should this be manually tested?
Good steps mentioned in #1069 

#### For Reviewer
Are there any other places you think this should be fixed too?

#### Screenshots (if appropriate)
<img width="848" alt="image" src="https://user-images.githubusercontent.com/34372316/193262563-7ed0f074-db41-4177-b1a9-13bd0b31eda7.png">

<img width="628" alt="image" src="https://user-images.githubusercontent.com/34372316/193262639-dcd5e8c6-f12a-4c11-a312-91ca50f67510.png">



