### PR TITLE
convert the migrated combined grades to float field with 3 decimals

### DIFF
--- a/micromasters_import/management/commands/queries/008_import_combined_final_grade.sql
+++ b/micromasters_import/management/commands/queries/008_import_combined_final_grade.sql
@@ -44,7 +44,7 @@ combined_final_grades AS (
     SELECT
         best_grade.user_id,
         best_grade.course_run_id,
-        ROUND(CAST(best_grade.max_grade * 100 * 0.4 + best_exam.max_score * 0.6 AS numeric), 1) AS calculated_grade,
+        CAST(best_grade.max_grade * 100 * 0.4 + best_exam.max_score * 0.6 AS numeric) AS calculated_grade,
         mm_courserun.course_id,
         mm_courserun.edx_course_key,
         mm_grade.created_on,
@@ -81,13 +81,10 @@ SELECT
   combined_grades.created_on,
   combined_grades.updated_on,
   combined_grades.passed,
-  combined_grades.calculated_grade,
+  ROUND(CAST(combined_grades.calculated_grade/100 AS decimal), 3),
   CASE
-      WHEN combined_grades.calculated_grade >= 82.5 THEN 'A'
-      WHEN combined_grades.calculated_grade >= 65 THEN 'B'
-      WHEN combined_grades.calculated_grade >= 55 THEN 'C'
-      WHEN combined_grades.calculated_grade >= 50 THEN 'D'
-      ELSE 'F'
+      WHEN combined_grades.passed = true THEN 'Pass'
+      ELSE NULL
   END AS letter_grade,
   False AS set_by_admin,
   mo_courserun.id,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR is to fix the `letter_grade` and `grade` for CouseRunGrade in the MM migration query to match with production 
- letter_grade: It's either 'Pass' or null 
- grade: It's between 0 to 1 with 2 decimals (Per discussion with Nathan, we round it to 3 decimals. We can cleanup later if needed)

Example from production:
Not passed: https://mitxonline.mit.edu/admin/courses/courserungrade/24600/change/
Passed: https://mitxonline.mit.edu/admin/courses/courserungrade/2421/change/

Example response from edx
{"username":"xxxxx","email":"","course_id":"course-v1:MITxT+11.S952x+2T2022","passed":true,**"percent":0.55,**"letter_grade":"Pass"}

Current on RC
https://rc.mitxonline.mit.edu/admin/courses/courserungrade/232/change/

#### How should this be manually tested?
Run ```./manage.py import_micromasters_data```
Go to django admin, the grade should be between 0 and 1 with 2 decimals 

![image](https://user-images.githubusercontent.com/3138890/193823146-98391b96-6f73-412e-9cb4-d80c8be19ddb.png)



#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)
