### PR TITLE
Save users with no enrollment into file

### DIFF
--- a/courses/management/commands/upgrade_eligible_users.py
+++ b/courses/management/commands/upgrade_eligible_users.py
@@ -94,15 +94,15 @@ class Command(BaseCommand):
                         )
                     )
         if users_no_enrollment:
-            file_name = 'users_eligible_for_coupon.csv'
-            path = '{}/{}'.format(settings.BASE_DIR, file_name)
-            with open(path, 'w') as f:
+            file_name = "users_eligible_for_coupon.csv"
+            path = "{}/{}".format(settings.BASE_DIR, file_name)
+            with open(path, "w") as f:
                 for email, course_id in users_no_enrollment:
-                    f.write(f'{email},{course_id}\n')
+                    f.write(f"{email},{course_id}\n")
 
             self.stdout.write(
                 self.style.SUCCESS(
-                    f'{len(users_no_enrollment)} are missing enrollments. Successfully created {file_name}.'
+                    f"{len(users_no_enrollment)} are missing enrollments. Successfully created {file_name}."
                 )
             )
 

--- a/courses/management/commands/upgrade_eligible_users.py
+++ b/courses/management/commands/upgrade_eligible_users.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
                     user=user, run=course_run
                 ).first()
                 if enrollment is None:
-                    users_no_enrollment.append((row[0], course_run.course_id))
+                    users_no_enrollment.append((row[0], row[1]))
                     self.stderr.write(
                         self.style.ERROR(
                             f"Can't find enrollment for user {row[0]}, course run {row[1]} skipping row"


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Update the management command `upgrade_eligible_users` to save users that are not currently enrolled in mitxonline, so that they can receive coupons.

#### How should this be manually tested?
The input file should look something like:
```
useremail@example.com,course-v1:MITxT+14.310x+3T2022
```
To test this PR you would need an existing user in your local instance but not enrolled in this course. Then you
run the command `./manage.py upgrade_eligible_users <file_name.csv>`.
It should create a file with your record that is missing the enrollment.



