### PR TITLE
842: sync coursrun upgrade deadline with edx

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -613,13 +613,17 @@ def sync_course_mode(runs: List[CourseRun]) -> List[str]:
             log.error("%s: %s", str(e), run.courseware_id)
         else:
             for course_mode in course_modes:
-                if course_mode.mode_slug == "verified" and run.upgrade_deadline != course_mode.expiration_datetime:
+                if (
+                    course_mode.mode_slug == "verified"
+                    and run.upgrade_deadline != course_mode.expiration_datetime
+                ):
                     run.upgrade_deadline = course_mode.expiration_datetime
                     try:
                         run.save()
                         success_count += 1
                         log.info(
-                            "Updated upgrade deadline for course run: %s", run.courseware_id
+                            "Updated upgrade deadline for course run: %s",
+                            run.courseware_id,
                         )
                     except Exception as e:  # pylint: disable=broad-except
                         # Report any validation or otherwise model errors

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ drf-extensions==0.7.1
 django-reversion==4.0.1
 django-storages==1.11.1
 djoser==2.1.0
-edx-api-client==1.3.0
+edx-api-client==1.4.0
 ipython
 mitol-django-common~=2.5.2
 mitol-django-mail~=3.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ drf-extensions==0.7.1
 django-reversion==4.0.1
 django-storages==1.11.1
 djoser==2.1.0
-edx-api-client==1.4.0
+edx-api-client==1.4.1
 ipython
 mitol-django-common~=2.5.2
 mitol-django-mail~=3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -190,7 +190,7 @@ draftjs-exporter==2.1.7
     # via wagtail
 drf-extensions==0.7.1
     # via -r requirements.in
-edx-api-client==1.4.0
+edx-api-client==1.4.1
     # via -r requirements.in
 edx-opaque-keys==2.2.2
     # via mitol-django-openedx

--- a/requirements.txt
+++ b/requirements.txt
@@ -190,7 +190,7 @@ draftjs-exporter==2.1.7
     # via wagtail
 drf-extensions==0.7.1
     # via -r requirements.in
-edx-api-client==1.3.0
+edx-api-client==1.4.0
     # via -r requirements.in
 edx-opaque-keys==2.2.2
     # via mitol-django-openedx


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/842

#### What's this PR do?
Adds additional logic to handle receiving a list of CourseModes from the `edx-api-client` as well as only updating `mitxonline` CourseRuns if there is an edx CourseMode with a "verified" mode.

#### How should this be manually tested?
I would follow all of the steps listed in this prior PR: https://github.com/mitodl/mitxonline/pull/919.
I would then add two CourseModes in edx for a single CourseRun in `mitxonline` while ensuring that the CourseMode with a higher `ID` has a mode equal to `audit` and no upgrade_deadline value.

#### Any background context you want to provide?
Because we were previously only looking at the first CourseMode returned from the edx API, there could be instances where that CourseMode had an upgrade_deadline that was empty or did not match the verified upgrade_deadline which we intended to have synchronized with the corresponding CourseRun in `mitxonline`.
