### PR TITLE
Fix course model course number property

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -218,7 +218,7 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
         Returns:
             str: Course number (last part of readable_id, after the final +)
         """
-        return get_course_number(self.readable_id)
+        return self.readable_id.split("+")[-1]
 
     @property
     def page(self):

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -597,3 +597,10 @@ def test_course_run_certificate_start_end_dates():
     start_date, end_date = certificate.start_end_dates
     assert start_date == certificate.course_run.start_date
     assert end_date == certificate.course_run.end_date
+    
+def test_course_course_number():
+    """
+    Test that the Course course_number property works correctly with the readable_id.
+    """
+    course = CourseFactory.build(readable_id='course-v1:TestX+Test101')
+    assert "Test101" == course.course_number

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -597,10 +597,11 @@ def test_course_run_certificate_start_end_dates():
     start_date, end_date = certificate.start_end_dates
     assert start_date == certificate.course_run.start_date
     assert end_date == certificate.course_run.end_date
-    
+
+
 def test_course_course_number():
     """
     Test that the Course course_number property works correctly with the readable_id.
     """
-    course = CourseFactory.build(readable_id='course-v1:TestX+Test101')
+    course = CourseFactory.build(readable_id="course-v1:TestX+Test101")
     assert "Test101" == course.course_number


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What's this PR do?
Adjusts the Course model's `course_number` property to no longer call the `get_course_number` method from `ol-django` and instead extract the course number from the Course's `readable_id` attribute.  

The reason why `get_course_number` cannot be used is because that requires the `courseware_id` which is a property of `CourseRun` only.  

#### How should this be manually tested?
Unit tests should pass.
I tested this by generating an Acceptance email related to a Financial Assistance request (https://github.com/mitodl/mitxonline/pull/1076), but you could also just open an Django shell, retrieve the first Course object, and read that Course object's `course_number`.
In both cases, if the Course has a `readable_id` equal to 'course-v1:TestX+Test101', then the `course_number` should be equal to 'Test101'.

#### Where should the reviewer start?
The unit test is pretty basic and shows a solid check.
