### PR TITLE
Adds course pages to the "don't cache" list

### DIFF
--- a/main/middleware.py
+++ b/main/middleware.py
@@ -7,6 +7,6 @@ class CachelessAPIMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         """Add a Cache-Control header to an API response"""
-        if request.path.startswith("/api/"):
+        if request.path.startswith("/api/") or request.path.startswith("/courses/"):
             response["Cache-Control"] = "private, no-store"
         return response


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1006 
(potentially)

#### What's this PR do?

Adds URLs with `/courses/` to the `CachelessAPIMiddleware`. This should turn off Fastly caching for the course pages. (Since the course pages have some server-generated output on them, we don't want Fastly caching them.) 

#### How should this be manually tested?

Open devtools and load a course page. You should see the `Cache-Control: private, no-store` header in the response for the request. 
