### PR TITLE
1102 Use raw id field for discount in admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -89,7 +89,7 @@ class DiscountProductAdmin(admin.ModelAdmin):
     model = DiscountProduct
     search_fields = ["discount", "product"]
     list_display = ["id", "discount", "product"]
-    raw_id_fields = ('discount',)
+    raw_id_fields = ("discount",)
 
 
 @admin.register(UserDiscount)
@@ -97,7 +97,7 @@ class UserDiscountAdmin(admin.ModelAdmin):
     model = UserDiscount
     search_fields = ["discount", "user"]
     list_display = ["id", "discount", "user"]
-    raw_id_fields = ('discount',)
+    raw_id_fields = ("discount",)
 
 
 @admin.register(DiscountRedemption)

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -89,6 +89,7 @@ class DiscountProductAdmin(admin.ModelAdmin):
     model = DiscountProduct
     search_fields = ["discount", "product"]
     list_display = ["id", "discount", "product"]
+    raw_id_fields = ('discount',)
 
 
 @admin.register(UserDiscount)
@@ -96,6 +97,7 @@ class UserDiscountAdmin(admin.ModelAdmin):
     model = UserDiscount
     search_fields = ["discount", "user"]
     list_display = ["id", "discount", "user"]
+    raw_id_fields = ('discount',)
 
 
 @admin.register(DiscountRedemption)

--- a/flexiblepricing/admin.py
+++ b/flexiblepricing/admin.py
@@ -65,7 +65,7 @@ class FlexiblePriceTierAdmin(admin.ModelAdmin):
         "income_threshold_usd",
         "current",
     )
-    raw_id_fields = ('discount',)
+    raw_id_fields = ("discount",)
 
 
 admin.site.register(CountryIncomeThreshold, CountryIncomeThresholdAdmin)

--- a/flexiblepricing/admin.py
+++ b/flexiblepricing/admin.py
@@ -65,6 +65,7 @@ class FlexiblePriceTierAdmin(admin.ModelAdmin):
         "income_threshold_usd",
         "current",
     )
+    raw_id_fields = ('discount',)
 
 
 admin.site.register(CountryIncomeThreshold, CountryIncomeThresholdAdmin)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1102

#### What's this PR do?
Uses raw_id_fields for discount in Django admin.

#### How should this be manually tested?

- Visit `/admin/flexiblepricing/flexiblepricetier/`,  `/admin/ecommerce/userdiscount/` and `/admin/ecommerce/discountproduct/`.
- Add a new instance  or edit an existing one. The discount should be a raw id field with a search as well.


#### Screenshots (if appropriate)
<img width="1052" alt="Screenshot 2022-10-10 at 6 02 36 PM" src="https://user-images.githubusercontent.com/52656433/194873307-38ecf6c6-d92e-4e81-b97b-9d77220aabab.png">
<img width="1052" alt="Screenshot 2022-10-10 at 6 02 56 PM" src="https://user-images.githubusercontent.com/52656433/194873351-697fb944-3e2f-4c1f-b17d-a0c7402f8f06.png">
<img width="1052" alt="Screenshot 2022-10-10 at 6 03 01 PM" src="https://user-images.githubusercontent.com/52656433/194873368-7392534b-e34c-4b2f-8aaf-117bd2c57838.png">

