### PR TITLE
Adds additional error reporting; accepts transactions with status code 100

### DIFF
--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -455,7 +455,7 @@ class CheckoutCallbackView(View):
                     processor_response = PaymentGateway.get_formatted_response(
                         ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
                     )
-                log.info(
+                log.error(
                     "Checkout callback unknown error for transaction_id %s, state %s, reason_code %s, message %s, and ProcessorResponse %s",
                     processor_response.transaction_id,
                     order.state,


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1116

#### What's this PR do?

Adds a status code check alongside the reason code check when processing the CyberSource payload post-payment. If the reason is `ACCEPT` _or_ the status code is `100`, the `process_cybersource_payment_response` call should fulfill the order. 

This also updates the status code check to log an error message if it falls through the bottom, so we can see what it's doing. (The "unknown error" only occurs if the order isn't in one of the states that we expect, and it was only logging to info so errors weren't being captured on production.) 

#### How should this be manually tested?

Submit an order. It should work as expected - you should be redirected to the dashboard and you should see the successfully enrolled message. You should only receive one set of enrollment and receipt emails. 
