### PR TITLE
1115 Use raw id field for order in transactions admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -38,6 +38,7 @@ class TransactionAdmin(VersionAdmin):
     """Admin for Product"""
 
     model = Transaction
+    raw_id_fields = ("order",)
 
 
 @admin.register(Product)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1115

#### What's this PR do?
Uses raw_id_fields for order in Transaction admin for Django Admin.

#### How should this be manually tested?
Visit a transaction object in Django Admin. The order should be a raw id field.
