### PR TITLE
Updates the checkout redirect code to handle processed orders

### DIFF
--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -391,6 +391,72 @@ class CheckoutCallbackView(View):
 
         self.logger = logging.getLogger(__name__)
 
+    def post_checkout_redirect(self, order_state, order, request):
+        """
+        Redirect the user with a message depending on the provided state.
+
+        Args:
+            - order_state (str): the order state to consider
+            - order (Order): the order itself
+            - request (HttpRequest): the request
+
+        Returns: HttpResponse
+        """
+        if order_state == Order.STATE.CANCELED:
+            return redirect_with_user_message(
+                reverse("cart"), {"type": USER_MSG_TYPE_PAYMENT_CANCELLED}
+            )
+        elif order_state == Order.STATE.ERRORED:
+            return redirect_with_user_message(
+                reverse("cart"), {"type": USER_MSG_TYPE_PAYMENT_ERROR}
+            )
+        elif order_state == Order.STATE.DECLINED:
+            return redirect_with_user_message(
+                reverse("cart"), {"type": USER_MSG_TYPE_PAYMENT_DECLINED}
+            )
+        elif order_state == Order.STATE.REVIEW:
+            basket = Basket.objects.filter(user=order.purchaser).first()
+            if basket:
+                if basket.has_user_blocked_products(order.purchaser):
+                    return redirect_with_user_message(
+                        reverse("user-dashboard"),
+                        {"type": USER_MSG_TYPE_ENROLL_BLOCKED},
+                    )
+                else:
+                    return redirect_with_user_message(
+                        reverse("user-dashboard"),
+                        {"type": USER_MSG_TYPE_PAYMENT_REVIEW},
+                    )
+        elif order_state == Order.STATE.FULFILLED:
+            return redirect_with_user_message(
+                reverse("user-dashboard"),
+                {
+                    "type": USER_MSG_TYPE_PAYMENT_ACCEPTED,
+                    "run": order.lines.first().purchased_object.course.title,
+                },
+            )
+        else:
+            if not PaymentGateway.validate_processor_response(
+                ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
+            ):
+                log.info("Could not validate payment response for order")
+            else:
+                processor_response = PaymentGateway.get_formatted_response(
+                    ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
+                )
+            log.error(
+                "Checkout callback unknown error for transaction_id %s, state %s, reason_code %s, message %s, and ProcessorResponse %s",
+                processor_response.transaction_id,
+                order_state,
+                processor_response.response_code,
+                processor_response.message,
+                processor_response,
+            )
+            return redirect_with_user_message(
+                reverse("user-dashboard"),
+                {"type": USER_MSG_TYPE_PAYMENT_ERROR_UNKNOWN},
+            )
+
     def post(self, request, *args, **kwargs):
         """
         This is where customers should land when they have completed the
@@ -406,67 +472,22 @@ class CheckoutCallbackView(View):
             order = api.get_order_from_cybersource_payment_response(request)
             if order is None:
                 return HttpResponse("Order not found")
-            # We only want to process responses related to orders which are PENDING
-            # otherwise we can conclude that we already received a response through
-            # BackofficeCallbackView.
-            order_state = None
-            if order.state == Order.STATE.PENDING:
-                order_state = api.process_cybersource_payment_response(request, order)
 
-            if order_state == Order.STATE.CANCELED:
-                return redirect_with_user_message(
-                    reverse("cart"), {"type": USER_MSG_TYPE_PAYMENT_CANCELLED}
+            # Only process the response if the database record in pending status
+            # If it is, then we can process the response as per usual.
+            # If it isn't, then we just need to redirect the user with the
+            # proper message.
+
+            if order.state == Order.STATE.PENDING:
+                processed_order_state = api.process_cybersource_payment_response(
+                    request, order
                 )
-            elif order_state == Order.STATE.ERRORED:
-                return redirect_with_user_message(
-                    reverse("cart"), {"type": USER_MSG_TYPE_PAYMENT_ERROR}
-                )
-            elif order_state == Order.STATE.DECLINED:
-                return redirect_with_user_message(
-                    reverse("cart"), {"type": USER_MSG_TYPE_PAYMENT_DECLINED}
-                )
-            elif order_state == Order.STATE.REVIEW:
-                basket = Basket.objects.filter(user=order.purchaser).first()
-                if basket:
-                    if basket.has_user_blocked_products(order.purchaser):
-                        return redirect_with_user_message(
-                            reverse("user-dashboard"),
-                            {"type": USER_MSG_TYPE_ENROLL_BLOCKED},
-                        )
-                    else:
-                        return redirect_with_user_message(
-                            reverse("user-dashboard"),
-                            {"type": USER_MSG_TYPE_PAYMENT_REVIEW},
-                        )
-            elif order_state == Order.STATE.FULFILLED:
-                return redirect_with_user_message(
-                    reverse("user-dashboard"),
-                    {
-                        "type": USER_MSG_TYPE_PAYMENT_ACCEPTED,
-                        "run": order.lines.first().purchased_object.course.title,
-                    },
+
+                return self.post_checkout_redirect(
+                    processed_order_state, order, request
                 )
             else:
-                if not PaymentGateway.validate_processor_response(
-                    ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
-                ):
-                    log.info("Could not validate payment response for order")
-                else:
-                    processor_response = PaymentGateway.get_formatted_response(
-                        ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
-                    )
-                log.error(
-                    "Checkout callback unknown error for transaction_id %s, state %s, reason_code %s, message %s, and ProcessorResponse %s",
-                    processor_response.transaction_id,
-                    order.state,
-                    processor_response.response_code,
-                    processor_response.message,
-                    processor_response,
-                )
-                return redirect_with_user_message(
-                    reverse("user-dashboard"),
-                    {"type": USER_MSG_TYPE_PAYMENT_ERROR_UNKNOWN},
-                )
+                return self.post_checkout_redirect(order.state, order, request)
 
 
 @method_decorator(csrf_exempt, name="dispatch")


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1116 (moreso)

#### What's this PR do?

If the learner's order is already processed (as it might be if the callback is hit before the learner completes loading the redirect back to MITxOnline from CyberSource), the `CheckoutCallbackView` should now redirect the user to the dashboard with the proper result message, rather than getting confused (since the order's no longer Pending in that case). 

#### How should this be manually tested?

Automated tests should pass. Callbacks really need to work for this to be tested manually. 

Attempt to purchase a course. You should see the correct message when you've completed your order.
