### PR TITLE
1114 Add /checkout/ to no cache urls

### DIFF
--- a/main/middleware.py
+++ b/main/middleware.py
@@ -7,6 +7,10 @@ class CachelessAPIMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         """Add a Cache-Control header to an API response"""
-        if request.path.startswith("/api/") or request.path.startswith("/courses/"):
+        if (
+            request.path.startswith("/api/")
+            or request.path.startswith("/courses/")
+            or request.path.startswith("/checkout/")
+        ):
             response["Cache-Control"] = "private, no-store"
         return response


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1114

#### What's this PR do?
Adds URLs with `/checkout/` to the CachelessAPIMiddleware. This should turn off caching for `/checkout/to_payment`.

#### How should this be manually tested?

- Visit checkout page.
- Place an order and monitor network.
- You should see the `Cache-Control: private, no-store` header in the response for the request `/checkout/to_payment`.