### PR TITLE
1141 Display end date when course ends on dashboard

### DIFF
--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -40,7 +40,7 @@ export const courseRunStatusMessage = (run: CourseRun) => {
   if (startDateDescription !== null) {
     if (startDateDescription.active) {
       if (moment(run.end_date).isBefore(moment())) {
-        const dateString = parseDateString(run.start_date)
+        const dateString = parseDateString(run.end_date)
         return (<span> | <b>Ended</b> - {formatPrettyDateTimeAmPmTz(dateString)}</span>)
       } else {
         return (<span> |


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1141

#### What's this PR do?
Displays the end date when the course ended instead of the start date.

#### How should this be manually tested?

- Enroll in a course.
- Set course end to a past date.
- Visit the dashboard.
- It should display `Ended - {end_date}`


#### Screenshots (if appropriate)
<img width="1123" alt="Screenshot 2022-10-17 at 3 26 06 PM" src="https://user-images.githubusercontent.com/52656433/196154954-fe794b66-79a1-4f70-80e8-7c62500584bf.png">

