### PR TITLE
1148: course-enrollment-upgrading-is-not-ever-synchronized-with-edx-if-the-original-update-request-fails

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -275,6 +275,7 @@ def create_run_enrollments(
                 # Case (Upgrade): When user was enrolled in free mode and now enrolls in paid mode (e.g. Verified)
                 # So, User has an active enrollment and the only changing thing is going to be enrollment mode
                 if enrollment.active and enrollment_mode_changed:
+                    enrollment.edx_enrolled = edx_request_success
                     enrollment.update_mode_and_save(mode=mode)
 
                 elif not enrollment.active:

--- a/courses/api.py
+++ b/courses/api.py
@@ -272,14 +272,13 @@ def create_run_enrollments(
 
             if not created:
                 enrollment_mode_changed = mode != enrollment.enrollment_mode
+                enrollment.edx_enrolled = edx_request_success
                 # Case (Upgrade): When user was enrolled in free mode and now enrolls in paid mode (e.g. Verified)
                 # So, User has an active enrollment and the only changing thing is going to be enrollment mode
                 if enrollment.active and enrollment_mode_changed:
-                    enrollment.edx_enrolled = edx_request_success
                     enrollment.update_mode_and_save(mode=mode)
 
                 elif not enrollment.active:
-                    enrollment.edx_enrolled = edx_request_success
                     if enrollment_mode_changed:
                         enrollment.enrollment_mode = mode
                     enrollment.reactivate_and_save()

--- a/courses/api.py
+++ b/courses/api.py
@@ -229,7 +229,7 @@ def create_run_enrollments(
 
     Returns:
         (list of CourseRunEnrollment, bool): A list of enrollment objects that were successfully
-            created, paired with a boolean indicating whether or not edX enrollment was successful
+            created in mitxonline, paired with a boolean indicating whether or not the edX enrollment API call was successful
             for all of the given course runs
     """
     successful_enrollments = []

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -26,9 +26,10 @@ from courses.api import (
     manage_course_run_certificate_access,
     override_user_grade,
 )
-from courses.constants import (
-    ENROLL_CHANGE_STATUS_DEFERRED,
-    ENROLL_CHANGE_STATUS_REFUNDED,
+from openedx.constants import (
+    EDX_DEFAULT_ENROLLMENT_MODE,
+    EDX_ENROLLMENT_AUDIT_MODE,
+    EDX_ENROLLMENT_VERIFIED_MODE,
 )
 from courses.factories import (
     CourseFactory,
@@ -1091,3 +1092,52 @@ def test_override_user_grade(grade, should_force_pass, is_passed):
     assert test_grade.grade == grade
     assert test_grade.passed is is_passed
     assert test_grade.set_by_admin is True
+
+
+def test_create_run_enrollments_upgrade(mocker, user):
+    """
+    create_run_enrollments should call the edX API to create/update enrollments, and set the enrollment mode properly
+    on mitxonline.  If the edx API call to update the course_mode from audit -> verified fails, then edx_request_success
+    should return as False and the course_run_enrollment's edx_enrolled value should be set to False.
+    In addition, tests to make sure there's a ProgramEnrollment for the course.
+    """
+    test_course_run = CourseRunFactory.create()
+    patched_edx_enroll = mocker.patch("courses.api.enroll_in_edx_course_runs")
+    patched_send_enrollment_email = mocker.patch(
+        "courses.api.mail_api.send_course_run_enrollment_email"
+    )
+    mocker.patch("courses.tasks.subscribe_edx_course_emails.delay")
+
+    successful_enrollments, edx_request_success = create_run_enrollments(
+        user,
+        runs=[test_course_run],
+        keep_failed_enrollments=True,
+        mode=EDX_ENROLLMENT_AUDIT_MODE,
+    )
+    patched_edx_enroll.assert_called_once_with(
+        user, [test_course_run], mode=EDX_ENROLLMENT_AUDIT_MODE
+    )
+
+    patched_send_enrollment_email.assert_called_once()
+    assert edx_request_success is True
+    assert successful_enrollments[0].enrollment_mode == EDX_ENROLLMENT_AUDIT_MODE
+
+    patched_edx_enroll = mocker.patch(
+        "courses.api.enroll_in_edx_course_runs",
+        side_effect=UnknownEdxApiEnrollException(user, test_course_run, Exception()),
+    )
+    patched_log_exception = mocker.patch("courses.api.log.exception")
+    successful_enrollments, edx_request_success = create_run_enrollments(
+        user,
+        runs=[test_course_run],
+        keep_failed_enrollments=True,
+        mode=EDX_ENROLLMENT_VERIFIED_MODE,
+    )
+
+    patched_edx_enroll.assert_called_once_with(
+        user, [test_course_run], mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
+
+    assert edx_request_success is False
+    assert successful_enrollments[0].enrollment_mode == EDX_ENROLLMENT_VERIFIED_MODE
+    assert successful_enrollments[0].edx_enrolled == False

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -30,11 +30,7 @@ from courses.constants import (
     ENROLL_CHANGE_STATUS_DEFERRED,
     ENROLL_CHANGE_STATUS_REFUNDED,
 )
-from openedx.constants import (
-    EDX_DEFAULT_ENROLLMENT_MODE,
-    EDX_ENROLLMENT_AUDIT_MODE,
-    EDX_ENROLLMENT_VERIFIED_MODE,
-)
+
 from courses.factories import (
     CourseFactory,
     CourseRunEnrollmentFactory,
@@ -48,7 +44,7 @@ from courses.factories import (
 # pylint: disable=redefined-outer-name
 from courses.models import CourseRunEnrollment, ProgramEnrollment
 from main.test_utils import MockHttpError
-from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
+from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE, EDX_ENROLLMENT_AUDIT_MODE,
 from openedx.exceptions import (
     EdxApiEnrollErrorException,
     NoEdxApiAuthError,

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -44,7 +44,11 @@ from courses.factories import (
 # pylint: disable=redefined-outer-name
 from courses.models import CourseRunEnrollment, ProgramEnrollment
 from main.test_utils import MockHttpError
-from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE, EDX_ENROLLMENT_AUDIT_MODE
+from openedx.constants import (
+    EDX_DEFAULT_ENROLLMENT_MODE,
+    EDX_ENROLLMENT_VERIFIED_MODE,
+    EDX_ENROLLMENT_AUDIT_MODE,
+)
 from openedx.exceptions import (
     EdxApiEnrollErrorException,
     NoEdxApiAuthError,

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -44,7 +44,7 @@ from courses.factories import (
 # pylint: disable=redefined-outer-name
 from courses.models import CourseRunEnrollment, ProgramEnrollment
 from main.test_utils import MockHttpError
-from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE, EDX_ENROLLMENT_AUDIT_MODE,
+from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE, EDX_ENROLLMENT_AUDIT_MODE
 from openedx.exceptions import (
     EdxApiEnrollErrorException,
     NoEdxApiAuthError,

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -26,6 +26,10 @@ from courses.api import (
     manage_course_run_certificate_access,
     override_user_grade,
 )
+from courses.constants import (
+    ENROLL_CHANGE_STATUS_DEFERRED,
+    ENROLL_CHANGE_STATUS_REFUNDED,
+)
 from openedx.constants import (
     EDX_DEFAULT_ENROLLMENT_MODE,
     EDX_ENROLLMENT_AUDIT_MODE,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
 
#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1148

#### What's this PR do?
Sets the course_run_enrollment's `edx_enrolled` value equal to False when the edx API call, to modify an existing course_enrollment record's `mode` from `audit` to `verified`, fails.  This ensures that the edx API call is attempted again when the `retry-failed-edx-enrollments` task is performed periodically.  Ultimately this ensure that we synchronize the enrollment mode between `mitxonline` and edx even if the edx API calls fail.

#### How should this be manually tested?
Tester should have `devstack` and `mitxonline` running locally.

- Before starting `mitxonline`, I modified this section [here](https://github.com/mitodl/mitxonline/blob/7f4246df904f3557e28f3c662f2780bfd810b100/main/settings.py#L797-L801) so that the task to sync course modes runs more often.   
- Create a course, course_run, associated product, associated course CMS page all within `mitxonline`.  To make things easier, I used the default course that is created in `devstack` ([E2E Test Course](http://localhost:18000/courses/course-v1:edX+E2E-101+course).
- Enroll your user through `mitxonline` into the free version of the course.
- Ensure that both `mitxonline` and `devstack` show a course mode value for the user's enrollment with a value of `audit`.
- Perform a `docker-compose stop` on your `devstack`.
- Upgrade your user's enrollment through `mitxonline` by paying for the course.
- Perform a `make dev.up.large-and-slow on your `devstack` to start it again.
- Wait until the `retry_failed_edx_enrollments` task is run again.  You should be able to see this mention in the `celery` logs for `mitxonline`.
- Once the `retry_failed_edx_enrollments` task is run, verify the course mode for the enrollment on `devstack` has changed from `audit` to `verified`.
