### PR TITLE
Changes staff dashboard to use Django sessions rather than OAuth2

### DIFF
--- a/frontend/staff-dashboard/src/App.tsx
+++ b/frontend/staff-dashboard/src/App.tsx
@@ -1,9 +1,8 @@
-import { Refine } from "@pankod/refine-core";
+import { Refine, useGetIdentity } from "@pankod/refine-core";
 import { Icons, notificationProvider } from "@pankod/refine-antd";
 import routerProvider from "@pankod/refine-react-router-v6";
 import "@pankod/refine-antd/dist/styles.min.css";
 import { useAuthProvider } from "hooks/useAuthProvider";
-import { useAuth } from "react-oidc-context";
 import {
   Title,
   Header,
@@ -35,6 +34,7 @@ axiosInterface.interceptors.request.use((config: any) => {
   return config;
 }, (error: any) => Promise.reject(error));
 
+const _ = require("lodash");
 
 const { RouterComponent : RefineRouterComponent } = routerProvider;
 
@@ -44,10 +44,7 @@ export default function App() {
   const dataURI = DATASOURCES_CONFIG?.mitxOnline ?? "";
   const authProvider = useAuthProvider();
   const xonlineProvider = useDrfDataProvider(dataURI);
-  const auth = useAuth()
-  if (auth.isLoading) {
-    return <span>loading...</span>;
-  }
+  
   return (
     <Refine
       routerProvider={{
@@ -57,6 +54,28 @@ export default function App() {
       notificationProvider={notificationProvider}
       dataProvider={xonlineProvider}
       authProvider={authProvider}
+      accessControlProvider={{ 
+        can: async ({ action, params, resource }) => {
+          let profile = localStorage.getItem("mitx-online-staff-profile");
+          if (profile) {
+            profile = JSON.parse(profile);
+          } else {
+            return Promise.resolve({ can: false, reason: "You don't have a valid session." });
+          }
+
+          if (_.get(profile, 'is_superuser')) {
+            return Promise.resolve({ can: true });
+          }
+
+          if (_.get(profile, 'is_staff')) {
+            if (resource == 'dashboard' || resource == 'flexible_pricing') {
+              return Promise.resolve({ can: true });
+            }
+          } 
+
+          return Promise.resolve({ can: false, reason: 'Your account is not allowed to do that.' });
+        }
+      }}
       LoginPage={LoginPage}
       DashboardPage={DashboardPage}
       resources={[

--- a/frontend/staff-dashboard/src/components/layout/sider/index.tsx
+++ b/frontend/staff-dashboard/src/components/layout/sider/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { useLogout, useTitle, useNavigation } from "@pankod/refine-core";
+import { CanAccess, useLogout, useTitle, useNavigation } from "@pankod/refine-core";
 import { AntdLayout, Menu, Grid, Icons, useMenu, Typography, Space, Divider } from "@pankod/refine-antd";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 
@@ -33,7 +33,10 @@ export const Sider: React.FC = () => {
         mode="inline"
         onClick={({ key }) => {
           if (key === "logout") {
-            logout();
+            localStorage.removeItem("mitx-online-staff-profile");
+            const logoutPath = (new URL(DATASOURCES_CONFIG.mitxOnline)).origin + "/logout/";
+            window.location.href = logoutPath;
+      
             return;
           }
 
@@ -44,27 +47,33 @@ export const Sider: React.FC = () => {
           push(key as string);
         }}
       >
-        {menuItems.map(({ icon, label, route }) => {
+        {menuItems.map(({ icon, label, route, name }) => {
           const isSelected = route === selectedKey;
           return (
-            <Menu.Item
-              style={{
-                fontWeight: isSelected ? "bold" : "normal",
-              }}
+            <CanAccess
               key={route}
-              icon={icon}
-            >
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                }}
+              resource={name.toLowerCase()}
+              action="list"
               >
-                {label}
-                {!collapsed && isSelected && <RightOutlined />}
-              </div>
-            </Menu.Item>
+              <Menu.Item
+                style={{
+                  fontWeight: isSelected ? "bold" : "normal",
+                }}
+                key={route}
+                icon={icon}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  {label}
+                  {!collapsed && isSelected && <RightOutlined />}
+                </div>
+              </Menu.Item>
+            </CanAccess>
           );
         })}
 

--- a/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useAuthProvider.ts
@@ -1,36 +1,86 @@
 import { AuthProvider } from "@pankod/refine-core";
-import { useAuth } from "react-oidc-context";
+import axios from "axios";
 
 export function useAuthProvider(): AuthProvider {
-  const auth = useAuth()
+  const http = axios.create({
+    baseURL: DATASOURCES_CONFIG.mitxOnline
+  });
+  const _ = require("lodash");
+
+  const getProfile = async () => {
+    const profile = await http.get('users/me');
+
+    return Promise.resolve(profile.data);
+  }
+
   return {
     login: async () => {
-      if (!auth.isAuthenticated && !auth.activeNavigator && !auth.isLoading) {
-        let result = await auth.signinPopup()
-        if (result && result.profile["is_staff"] === true) {
-          return Promise.resolve();
-        }
-      }
-      return Promise.reject();
+      const profile = await getProfile();
 
+      if (_.get(profile, "data.is_staff") === true) {
+        localStorage.setItem('mitx-online-staff-profile', JSON.stringify(profile.data));
+        return Promise.resolve();
+      }
+
+      localStorage.removeItem("mitx-online-staff-profile");
+
+      return Promise.reject({
+        name: "Not Authenticated",
+        message: "Your account doesn't have permission to view this page."
+      });
     },
     logout: async () => {
-      await auth.removeUser();
+      localStorage.removeItem("mitx-online-staff-profile");
+      const logoutPath = (new URL(DATASOURCES_CONFIG.mitxOnline)).origin + "/logout/";
+      window.location.href = logoutPath;
       return Promise.resolve();
     },
     checkError: async () => {
       return Promise.resolve();
     },
     checkAuth: async () => {
-      let _ = require("lodash");
-      if (auth.isAuthenticated && auth.user && _.get(auth.user, "profile.is_staff") === true) {
+      const profile = await http.get('users/me');
+      
+      if (
+        _.get(profile, "data.is_superuser") === true ||
+        _.get(profile, "data.is_staff") === true
+      ) {
+        localStorage.setItem('mitx-online-staff-profile', JSON.stringify(profile.data));
         return Promise.resolve();
       }
-      return Promise.reject();
+      return Promise.reject({
+        redirectPath: (new URL(DATASOURCES_CONFIG.mitxOnline)).origin + "/signin"
+      });
     },
-    getPermissions: () => Promise.resolve(),
+    getPermissions: async () => {
+      /* 
+      For MITx Online currently, the only permissions we care about are the 
+      'is_staff' and 'is_superuser' flags. 
+      
+      Future enhancement: The current profile API returns a list of all user 
+      permissions (as in, from the default Django permissions code), so the app
+      could use this to determine permissions outside of those two flags. (This
+      data is visible here.)
+      */
+      let profile = localStorage.getItem("mitx-online-staff-profile");
+
+      if (profile) {
+        profile = JSON.parse(profile);
+
+        if (_.get(profile, "is_superuser")) {
+          return Promise.resolve(["superuser"]);
+        }
+
+        if (_.get(profile, "is_staff")) {
+          return Promise.resolve(["staff"]);
+        }
+      }
+
+      return Promise.resolve([]);
+    },
     getUserIdentity: async () => {
-      return auth.user ? Promise.resolve(auth.user) : Promise.reject()
+      let profile = localStorage.getItem("mitx-online-staff-profile");
+      return profile ? Promise.resolve(JSON.parse(profile)) : Promise.reject()
     },
   };
 };

--- a/frontend/staff-dashboard/src/index.tsx
+++ b/frontend/staff-dashboard/src/index.tsx
@@ -1,20 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import {AuthProvider} from "react-oidc-context";
-import { User } from "oidc-client-ts";
-
 import reportWebVitals from "./reportWebVitals";
 import App from "./App";
 
 ReactDOM.render(
   <React.StrictMode>
-    <AuthProvider
-      {...OIDC_CONFIG}
-      monitorAnonymousSession={false}
-      prompt="login"
-    >
-      <App />
-    </AuthProvider>
+    <App />
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/frontend/staff-dashboard/src/pages/login.tsx
+++ b/frontend/staff-dashboard/src/pages/login.tsx
@@ -1,33 +1,8 @@
-
-import { useLogin, useTitle } from "@pankod/refine-core";
-import { AntdLayout, Button, Icons, Space, Typography } from "@pankod/refine-antd";
-
-const { LoginOutlined } = Icons;
-
-
 export default function LoginPage() {
-    const Title = useTitle();
-    const { mutate: login, isLoading } = useLogin();
-    return (
-        <AntdLayout>
-            <div style={{ height: "100vh", display: "flex" }}>
-                <div style={{ maxWidth: "300px", margin: "auto", textAlign: "center" }}>
-                    {Title && <Title collapsed={false} />}
-                    <Space/>
-                    <Typography.Title>MITx Online<br/>Staff Dashboard</Typography.Title>
-                    <Space/>
-                    <Button
-                        type="primary"
-                        size="large"
-                        block
-                        icon={<LoginOutlined />}
-                        loading={isLoading}
-                        onClick={() => login({})}
-                    >
-                        Sign in
-                    </Button>
-                </div>
-            </div>
-        </AntdLayout>
-    );
+    const sign_in_url = (new URL(DATASOURCES_CONFIG.mitxOnline)).origin + "/signin/?next=/staff-dashboard/";
+
+    document.location = sign_in_url;
+    
+    return (<>Please wait while we redirect you to the sign in page...</>);
+    
 };

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -110,6 +110,7 @@ class UserSerializer(serializers.ModelSerializer):
         required=False,
     )
     legal_address = LegalAddressSerializer(allow_null=True)
+    grants = serializers.SerializerMethodField(read_only=True, required=False)
 
     def validate_email(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
@@ -144,6 +145,9 @@ class UserSerializer(serializers.ModelSerializer):
     def get_username(self, instance):
         """Returns the username or None in the case of AnonymousUser"""
         return getattr(instance, "username", None)
+
+    def get_grants(self, instance):
+        return instance.get_all_permissions()
 
     def validate(self, data):
         request = self.context.get("request", None)
@@ -220,16 +224,22 @@ class UserSerializer(serializers.ModelSerializer):
             "is_anonymous",
             "is_authenticated",
             "is_editor",
+            "is_staff",
+            "is_superuser",
             "created_on",
             "updated_on",
+            "grants",
         )
         read_only_fields = (
             "username",
             "is_anonymous",
             "is_authenticated",
             "is_editor",
+            "is_staff",
+            "is_superuser",
             "created_on",
             "updated_on",
+            "grants",
         )
 
 

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -68,6 +68,9 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, show_enrollment_code
             "legal_address": None,
             "is_anonymous": True,
             "is_authenticated": False,
+            "is_staff": False,
+            "is_superuser": False,
+            "grants": [],
         }
         # patched_unused_coupon_api.assert_not_called()
     elif not is_anonymous and show_enrollment_codes:
@@ -86,6 +89,9 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, show_enrollment_code
             "is_editor": False,
             "created_on": drf_datetime(user.created_on),
             "updated_on": drf_datetime(user.updated_on),
+            "is_staff": user.is_staff,
+            "is_superuser": user.is_superuser,
+            "grants": list(user.get_all_permissions()),
         }
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1089 

#### What's this PR do?

Updates the Staff Dashboard Refine application to use Django sessions rather than having its own OAuth2 integration:
- This eliminates the need to log into the Staff Dashboard separately from the main MITx Online application. (To that end, the login screen is removed, and the logout functionality logs you out of MITx Online entirely. We may want to revisit that.) 
- Some minor changes were made to the User serializer to add the necessary authorization flags to the session check endpoint (`/api/users/me`). 
- Some more minor changes were made to the User serializer to report back the Django permissions set for the current user. We don't use this as of yet but this provides the ability to use the standard Django permissions system to define access for the Staff Dashboard app (amongst other things).
- The OAuth2 code was removed from the app. (The libraries are still there, but the app doesn't use them.) 

With regard to access control: the app uses the standard session check call to determine the state of your `is_staff` and `is_superuser` flags. Superusers are unrestricted in the app. Staff can only view the Dashboard and the Flexible Pricing screen. The app only considers those two flags right now; it would be pretty trivial to update the `accessControlProvider` to make it look at the Django permissions that are now passed through the session check API. We should ideally do this with more of a plan, though, both with regard to an authorization system and to the scope of the Staff Dashboard application. 

The [original issue](https://github.com/mitodl/mitxonline/issues/1089) links to the Refine docs for authorization controls, which lists a few authorization control libraries that could be used for RBAC/ABAC. For the short term, I've made this work by using the flags noted above; one of these systems seemed to be a bit much for this one PR (and would be something I'd rather have some consensus via a discussion post rather than just going with, say, Casbin, especially since there can also be a server-side component to these). 

#### How should this be manually tested?

Use the staff dashboard as normal. You should no longer be required to log in separately, and the Log Out button should completely log you out of the app (not just from the Staff Dashboard). 

If you test with a staff user, you should additionally only have the Dashboard and Flexible Pricing options available to you. A superuser account should also see Discounts. 

Because we're now loading a profile for the currently logged in user, your username should be shown at the top right of the screen. (This is a Refine thing - we just didn't load a profile before now, so it didn't do it.) 