### PR TITLE
Adding simple Varnish config file and service block to the Compose environment

### DIFF
--- a/config/default.vcl
+++ b/config/default.vcl
@@ -1,0 +1,22 @@
+# specify the VCL syntax version to use
+vcl 4.1;
+
+# import vmod_dynamic for better backend name resolution
+import dynamic;
+
+# we won't use any static backend, but Varnish still need a default one
+backend default none;
+
+# set up a dynamic director
+# for more info, see https://github.com/nigoroll/libvmod-dynamic/blob/master/src/vmod_dynamic.vcc
+sub vcl_init {
+        new d = dynamic.director(port = "8013");
+}
+
+sub vcl_recv {
+	# force the host header to match the backend (not all backends need it,
+	# but example.com does)
+	set req.http.host = "nginx";
+	# set the backend
+	set req.backend_hint = d.backend("mitxonline.odl.local");
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
   nginx:
     build:
       context: ./nginx
-    ports:
-      - "8013:8013"
     links:
       - web
     volumes:
@@ -97,10 +95,10 @@ services:
       - yarn-cache:/home/mitodl/.cache/yarn
     healthcheck:
       test: curl -f http://watch:8012/health || exit 1
-      interval: 5s
+      interval: 30s
       timeout: 1s
       retries: 4
-      start_period: 45s
+      start_period: 180s
 
   celery:
     build:
@@ -140,10 +138,10 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl -f http://refine:8016/health || exit 1
-      interval: 5s
+      interval: 30s
       timeout: 1s
-      retries: 3
-      start_period: 30s
+      retries: 4
+      start_period: 180s
 
   notebook:
     build:
@@ -162,6 +160,17 @@ services:
       jupyter notebook --no-browser --ip=0.0.0.0 --port=8080'
     ports:
       - "8080:8080"
+
+  varnish:
+    image: varnish:fresh
+    links: 
+      - nginx
+    ports: 
+      - "8013:80"
+    volumes:
+      - ./config/default.vcl:/etc/varnish/default.vcl:ro
+    depends_on:
+      - nginx
 
 volumes:
   npm-cache: {}


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #205 

#### What's this PR do?

Adds a [Varnish cache](https://varnish-cache.org/) container that sits in front of the nginx container for development. The Varnish cache is to replicate the Fastly cache that exists on the RC and production instance. It only caches Django content (so we don't muck with any reloading stuff that happens with the JavaScript/React assets). 

This also increases the `start_period` and `interval` for the `watch` and `refine` containers - on my machine at least, either one of these can take over 2 minutes to start up cold so this should ensure everything actually starts up. 

#### How should this be manually tested?

After restarting (you will need to bring your stuff down and then re-`docker compose up` it), you should be able to load your local instance normally. Inspecting the network tab in devtools should show the Varnish headers in place (`Via: 1.1 varnish (Varnish/7.1)` for instance). The app should work normally otherwise.
