### PR TITLE
add a migration to backfill PaidCourseRun for the legacy orders

### DIFF
--- a/micromasters_import/management/commands/queries/010_backfill_paidcourserun.sql
+++ b/micromasters_import/management/commands/queries/010_backfill_paidcourserun.sql
@@ -1,0 +1,21 @@
+----This script is to back-fill courses_paidcourserun for the imported MicroMaster orders (course runs)
+
+INSERT INTO public.courses_paidcourserun (
+    created_on,
+    updated_on,
+    course_run_id,
+    order_id,
+    user_id
+)
+SELECT
+    mo_order.created_on,
+    mo_order.updated_on,
+    mo_line.purchased_object_id,
+    mo_order.id,
+    mo_order.purchaser_id
+FROM public.ecommerce_order AS mo_order
+JOIN public.ecommerce_line AS mo_line
+    ON mo_order.id = mo_line.order_id
+WHERE mo_order.reference_number LIKE 'MM%'
+    AND mo_order.state = 'fulfilled'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1167

#### What's this PR do?
This PR is to back-fill PaidCourseRun for any migrated MicroMasters orders.

#### How should this be manually tested?
Run `./manage.py import_micromasters_data --num 010`
Then check http://mitxonline.odl.local:8013/admin/courses/paidcourserun/, it should list all the paid courseruns for _imported_ MicroMaster orders where is in fulfilled
