### PR TITLE
Adding management command to create a really basic courseware about page

### DIFF
--- a/cms/management/commands/create_courseware_page.py
+++ b/cms/management/commands/create_courseware_page.py
@@ -1,0 +1,59 @@
+"""
+Creates a basic courseware about page. This can be for programs or courses.
+"""
+from django.core.management import BaseCommand
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+
+from cms.api import create_default_courseware_page
+from cms.models import Course, Program
+
+
+class Command(BaseCommand):
+    """
+    Creates a basic about page for the given courseware object.
+    """
+
+    help = "Creates a basic draft about page for the given courseware object."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "courseware_id",
+            type=str,
+            help="The courseware object to work with (a Course or Program).",
+        )
+
+        parser.add_argument(
+            "--live", action="store_true", help="Make the page live. (Defaults to not.)"
+        )
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+        try:
+            courseware = Course.objects.filter(
+                readable_id=kwargs["courseware_id"]
+            ).first()
+
+            if courseware is None:
+                courseware = Program.objects.filter(
+                    readable_id=kwargs["courseware_id"]
+                ).get()
+        except ObjectDoesNotExist:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Can't find courseware object for {kwargs['courseware_id']}, stopping."
+                )
+            )
+            return
+
+        try:
+            create_default_courseware_page(courseware, kwargs["live"])
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"About page created successfully for {courseware.readable_id}"
+                )
+            )
+        except ValidationError as e:
+            self.stderr.write(
+                self.style.ERROR(
+                    f"An error occurred creating the about page for {courseware.readable_id}: {e}"
+                )
+            )


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Part 2 of #1152 

#### What's this PR do?

Adds a command in to make a really simple about page for the specified courseware object. The object must exist, as well as the index page that it should reside under. The Title and Description will be pulled from the object and the page will be created as a draft. The user will have to go in and fill out the rest of the info on the page to make it live (there's only so much content data in the a course or program record). 

#### How should this be manually tested?

Automated tests should pass.

1. Create a new course and/or program. (This doesn't have to exist in edX. Don't create a CMS page manually for it.)
2. Run `create_courseware_page <coursewareid>`. It should create the courseware page successfully.
3. Run the same command again. It should fail as there should already be a courseware page set up.
4. Check the CMS - the new page should exist, but should be a Draft. 
