### PR TITLE
Adds wrapper command to bootstrap a fresh MITxOnline instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run through those steps **including the addition of `/etc/hosts` aliases and the
 
 ### Configure mitxonline and Open edX
 
-See [Configure Open edX](docs/source/configuration/open_edx.rst)
+See [MITx Online Quick Start](docs/source/configuration/quickstart.rst) and [Configure Open edX](docs/source/configuration/open_edx.rst)
 
 ### Configuring the CMS
 

--- a/docs/source/commands/configure_instance.rst
+++ b/docs/source/commands/configure_instance.rst
@@ -1,0 +1,19 @@
+``configure_instance``
+======================
+
+Configures a fresh MITx Online instance. For more information, see :doc:`MITx Online Quick Start<../configuration/quickstart>`.
+
+Syntax
+------
+
+``configure_instance <platform> [--dont-enroll|-D] [--dont-create-superuser|-S] [--edx-oauth-client <client id>] [--edx-oauth-secret <client secret>] [--gateway <ip>]``
+
+Options
+-------
+
+* ``<platform>`` - One of ``macos``, ``linux``, or ``none``. Specifying ``none`` will additionaly stop creation of the OAuth2 application record for edX. Defaults to ``none``.
+* ``--dont-enroll|-D`` - Don't enroll the test learner account in any courses. (Defaults to enrolling the account in ``course-v1:edX+DemoX+Demo_Course``.)
+* ``--dont-create-superuser|-S`` - Don't create a superuser account.
+* ``--gateway <ip>`` - The Docker gateway IP. Required on Linux. See :doc:`Configure Open edX<../configuration/open_edx>` for more info.
+* ``--edx-oauth-client <client id>`` - Use the specified client ID for the edX OAuth2 client. (Useful if you're redoing your MITx Online instance and you've already created the corresponding record in edX, since you're not allowed to edit it there.) 
+* ``--edx-oauth-secret <client secret>`` - Use the specified client secret for the edX OAuth2 client. (Useful if you're redoing your MITx Online instance and you've already created the corresponding record in edX, since you're not allowed to edit it there.) 

--- a/docs/source/commands/create_courseware.rst
+++ b/docs/source/commands/create_courseware.rst
@@ -1,0 +1,42 @@
+``create_courseware``
+=====================
+
+Creates a new courseware object. 
+
+**For programs**, this creates the basic program record.
+**For courses**, this creates the course, and then optionally adds it to the specified program. It will also optionally create an initial course run for the course. 
+**For courseruns**, this creates the course run and associates it with the specified course.
+
+This will not run ``sync_course_run`` for you, so for best results, ensure the course run is set up on the edX side, use this command, then run ``sync_course_run`` to pull dates and other information from edX. 
+
+Syntax
+------
+
+``create_courseware <object> <readable id> <title> [--live] [--self-paced] [--create-run [create_run]] [--run-url [RUN_URL]] [--program [PROGRAM]] [--program-position [PROGRAM_POSITION]] [--run-tag [run-tag]]``
+
+Options
+-------
+
+* ``object`` - One of ``program``, ``course``, or ``courserun``
+* ``readable id`` - The readable ID of the object. Note: do not specify the run tag for course runs. 
+* ``title`` - The title of the object.
+* ``--live`` - Makes the object live (default is not).
+
+Programs have no additional options (any specified will be ignored).
+
+Courses can take the following options:
+
+* ``--program <PROGRAM>`` - The program to assign the course to.
+* ``--program-position <PROGRAM_POSITION>`` - The program position to set (default none).
+* ``--create-run <run tag>`` - Create a course run for this course with the specified run tag. 
+* ``--run-url <url>`` - The courseware URL for the course run. (Only if ``--create-run`` is specified.)
+* ``--self-paced`` - The course run is self-paced. (Only if ``--create-run`` is specified.)
+
+Course runs can take the following options:
+
+* ``--program <PROGRAM>`` - The program to assign the course to. **Required.**
+* ``--run-tag <run tag>`` - The run tag to use. **Required.**
+* ``--program-position <PROGRAM_POSITION>`` - The program position to set (default none).
+* ``--run-url <url>`` - The courseware URL for the course run.
+* ``--self-paced`` - The course run is self-paced.
+

--- a/docs/source/commands/create_courseware_page.rst
+++ b/docs/source/commands/create_courseware_page.rst
@@ -1,0 +1,17 @@
+``create_courseware_page``
+==========================
+
+Creates a very basic About page in the CMS for the given courseware object.
+
+The about page will only have the handful of fields that are required to be there, and will be linked to the specified courseware object. If the courseware object is a course, it will also be added to the Featured Products section on the homepage. By default, the CMS page will be saved in a draft state.
+
+Syntax
+------
+
+``create_courseware_page <courseware id> [--live]``
+
+Options
+-------
+
+* ``courseware id`` - The courseware object to make a CMS page for.
+* ``--live`` - Makes the resulting page live.

--- a/docs/source/commands/create_product.rst
+++ b/docs/source/commands/create_product.rst
@@ -1,0 +1,19 @@
+``create_product``
+==================
+
+Creates a product for the given courseware ID. (For now, this only works with course runs.)
+
+By default, the product description will be the courseware ID. This is the recommended setting for this to make it easy to determine which products are for what courseware objects. 
+
+Syntax
+------
+
+``create_product <courserun> <price> [--description|-d <description>] [--inactive]``
+
+Options
+-------
+
+* ``courserun`` - The course run to use.
+* ``price`` - The price (numbers only) of the product.
+* ``--description <description>`` (or ``-d``) - Optionally specify the product description. (Defaults to the courseware ID.)
+* ``--inactive`` - Makes the product inactive. (Defaults to active.)

--- a/docs/source/commands/create_user.rst
+++ b/docs/source/commands/create_user.rst
@@ -1,0 +1,20 @@
+``create_user``
+===============
+
+Creates a learner account in the system. You will be prompted for the account password. 
+
+Syntax
+------
+
+``create_user username email firstname lastname displayname countrycode [--enroll <courseid>]``
+
+Options
+-------
+
+* ``username`` - Username for the learner to create.
+* ``email`` - Email address of the learner to create.
+* ``firstname`` - The learner's first name.
+* ``lastname`` - The learner's last name.
+* ``displayname`` - The learner's display name.
+* ``countrycode`` - The country code to use. (Default US)
+* ``--enroll <courseid>`` - Optionally enroll the user in the specified course run. The enrollment will be an audit enrollment.

--- a/docs/source/commands/index.rst
+++ b/docs/source/commands/index.rst
@@ -1,0 +1,19 @@
+MITx Online Commands
+====================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   configure_instance
+   create_courseware
+   create_courseware_page
+   create_product
+   create_user
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/docs/source/configuration/ecommerce.rst
+++ b/docs/source/configuration/ecommerce.rst
@@ -1,12 +1,12 @@
 Configure eCommerce
 ===================
 
-To use the eCommerce subsystem, some configuration is required. These instructions will also set up a course in your MITxOnline environment that you can use for enrollment.
+To use the eCommerce subsystem, some configuration is required. These instructions will also set up a course in your MITx Online environment that you can use for enrollment.
 
-You'll need a working MITxOnline setup and a working devstack setup to begin, and superuser accounts for each.
+You'll need a working MITx Online setup and a working devstack setup to begin, and superuser accounts for each.
 
-Set Up MITxOnline eCommerce Config
-##################################
+Set Up MITx Online eCommerce Config
+###################################
 
 The CyberSource configuration for the app can be lifted out of Heroku. **Make sure you use values from RC - otherwise, you will actually be charged for purchases (and test credit card numbers will fail).** For best results, you should also have an account for the test Enterprise Business Center (``https://ebc2test.cybersource.com/ebc2/``). 
 
@@ -33,8 +33,8 @@ In Open edX
 2. Find a course from the `Course Overviews <http://edx.odl.local:18000/admin/course_overviews/courseoverview/>`_ page.
 3. Note the *Display name* and *Id* fields. 
 
-In MITxOnline
--------------
+In MITx Online
+--------------
 
 1. Log into the Django Admin interface.
 2. Under Courses, open Programs and add a Program. (The specifics here aren't important - there just needs to be a Program.)
@@ -48,12 +48,12 @@ In MITxOnline
 10. Under the Featured Products section, select Add. You will be given a button to choose a page, and the page chooser there should list the page you created. 
 11. Publish the Home Page when ready. 
 
-You should now be able to see the course under the hero image on the MITxOnline homepage, and navigating into the course should give you the option to Enroll. (At this point, you won't have a Product set up, so enrolling now should just enroll you in the course.)
+You should now be able to see the course under the hero image on the MITx Online homepage, and navigating into the course should give you the option to Enroll. (At this point, you won't have a Product set up, so enrolling now should just enroll you in the course.)
 
 Setting Up a Product
 ####################
 
-1. Log into MITxOnline Django Admin.
+1. Log into MITx Online Django Admin.
 2. Under Ecommerce, open Products and create a new Product. Set *Content type* to Course Run and *Object Id* to the ID of the course run you created earlier (it's probably 1 if you're working from a new install). Price should ideally be set to a non-zero value, that is less than $999, in RC/Sandbox environments. Description needs to be filled in but can be anything - for clarity, it's recommended to use the course name. Make sure Is active is checked.
 
 You should now be able to enroll in the upgraded course. 

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -7,3 +7,4 @@ Configuration
    open_edx
    ecommerce
    refine_admin
+   quickstart

--- a/docs/source/configuration/quickstart.rst
+++ b/docs/source/configuration/quickstart.rst
@@ -1,0 +1,81 @@
+MITx Online Quick Start
+=======================
+
+You can use the ``configure_instance`` management command to perform a quick-start of a fresh MITx Online instance. This command takes care of a lot of the boilerplate required to set up an instance. It:
+
+* Creates a superuser account (if you want)
+* Creates the OAuth2 application record for edX (if you want, and optionally with an existing secret)
+* Creates a set of courseware objects, including a DEDP program and courses with runs that match what ships with a standard devstack instance
+* Creates a set of CMS pages for the courseware objects that it creates
+* Sets up financial assistance appropriately
+* Adds a couple of products in for the courses it creates
+* Creates a learner account for the system
+
+It does not:
+
+* Run migrations
+* Completely set up integration with devstack
+
+In addition, there are a handful of tasks that you'll need to perform afterwards:
+
+* The CMS pages (course about pages and the financial assistance form) need to be reviewed for content.
+* The financial assistance form will need to be published, and linked into the appropriate course. 
+* You may want to adjust the products that are created.
+
+The ``configure_instance`` command has a few flags you can use to customize how it works. For more details on this, either run it with ``--help`` or read the :doc:`configure_instance<../commands/configure_instance>` command documentation. (Do this especially if you're using the command to **reset** your MITx Online instance - you can provide an existing OAuth client ID and secret.)
+
+Performing a Quick Start
+------------------------
+
+To quick-start your MITx Online instance:
+
+1. Run the ``migrate`` command. 
+2. Run the ``createsuperuser`` command. 
+3. Follow the steps in the :doc:`Configure Open edX<open_edx>` documentation
+4. Run ``configure_instance <platform>``, where ``platform`` is ``macos``, ``linux``, or ``none``. (If you don't want it to create OAuth2 records, set this to ``none`` or leave it blank. The default is ``none``.)
+
+``configure_instance`` will prompt you to enter a password for the test learner account and will prompt you to enter account information for the superuser account. At the end, you'll see your edX OAuth2 application credentials, which can then be plugged into Open edX (if you haven't specified ``none`` for your platform). 
+
+Results
+-------
+
+Running ``configure_instance`` will peform these tasks in order:
+
+1. Runs ``createsuperuser`` to create the superuser account (unless disabled with ``--dont-create-superuser``).
+2. Creates the OAuth2 application record. (This is the one part of this that doesn't rely on an existing management command.)
+3. Runs ``configure_wagtail`` to set up the CMS. 
+4. Runs ``configure_tiers`` to add the DEDP program and configure financial assistance tiers and discounts.
+5. Runs ``create_courseware_page`` to add a basic about page for the DEDP program (required for the financial assistance form). 
+6. Runs ``create_finaid_form`` to create a financial assistance form for the DEDP program.
+7. Runs ``create_courseware`` twice to create two courses, each with a course run, that correspond to the demo courses in devstack. (Details below.)
+8. Runs ``sync_course_run`` to sync the courses with the devstack instance. 
+9. Runs ``create_product`` twice to create two products for the courses.
+10. Runs ``create_courseware_page`` twice to add course pages for the two courses. (These are marked as live.)
+11. Runs ``create_user`` to create the learner account. 
+
+The courses that are created are:
+
++----------------------+-----------------------+-------------+-------------+
+| Course               | Readable ID           | Run Tag     | Price       |
++======================+=======================+=============+=============+
+| Demonstration Course | course-v1:edX+DemoX   | Demo_Course | $999        |
++----------------------+-----------------------+-------------+-------------+
+| E2E Test Course      | course-v1:edX+E2E-101 | course      | $999        |
++----------------------+-----------------------+-------------+-------------+
+
+The learner account that is created is:
+
+* Username: testlearner
+* Email: testlearner@mitxonline.odl.local
+* Display Name (split in half for first/last names): Test learner
+* Country Code: US
+* Enrollments: ``course-v1:edX+DemoX+Demo_Course``
+
+The program that gets created is the standard DEDP program (``program-v1:MITx+DEDP``). The *Demonstration Course* is added to the DEDP program; *E2E Test Course* is not. 
+
+Notes
+-----
+
+The steps that involve communication with edX may not work if your environment isn't set up properly. In these cases, the attempts will be queued to be run later. 
+
+If you've set your platform to ``macos`` or ``linux``, the command will do the first part of the *Configure MITx Online as an OAuth provider for Open edX* section in the :doc:`Configure Open edX<open_edx>` documentation. 

--- a/docs/source/configuration/refine_admin.rst
+++ b/docs/source/configuration/refine_admin.rst
@@ -1,7 +1,7 @@
 Refine Admin
 ############
 
-Some administrative functionality is built out using `Refine <https://refine.dev>`_. The Refine admin is a separate application that uses OAuth2/OIDC for authentication and communicates with MITxOnline via the standard REST API. It compliments the Django Admin interface, providing an interface for operations that would otherwise be hard to implement in Django Admin, and for users that don't necessarily need the level of access that Django Admin provides.
+Some administrative functionality is built out using `Refine <https://refine.dev>`_. The Refine admin is a separate application that uses OAuth2/OIDC for authentication and communicates with MITx Online via the standard REST API. It compliments the Django Admin interface, providing an interface for operations that would otherwise be hard to implement in Django Admin, and for users that don't necessarily need the level of access that Django Admin provides.
 
 Accessing
 *********
@@ -16,7 +16,7 @@ Development
 -----------
 
 
-You will need to make some adjustments to the MITxOnline configuration to allow the Refine admin to work.  
+You will need to make some adjustments to the MITx Online configuration to allow the Refine admin to work.  
 
   Currently, the application expects to be accessible at ``mitxonline.odl.local``. 
 
@@ -31,8 +31,8 @@ This will generate the key and then output it to the terminal in a format that c
 
 The key generation process is from the `Django OAuth Toolkit <https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#creating-rsa-private-key>`_ docs.
 
-Step 2: Configuring MITxOnline
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 2: Configuring MITx Online
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You will need to add a new Application in the Django Oauth Toolkit section in Django Admin (``/admin/oauth2_provider/application/``). Navigate there and create a new Application. Use these values (overwriting the defaults where necessary):
 
@@ -63,7 +63,7 @@ This will generate the key and then output it to the terminal. Copy everything i
 
 The key generation process is from the `Django OAuth Toolkit <https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#creating-rsa-private-key>`_ docs.
 
-**Step 2: Configuring MITxOnline OAuth Provider** 
+**Step 2: Configuring MITx Online OAuth Provider** 
 
 You will need to add a new Application in the Django OAuth Toolkit section in Django Admin (``/admin/oauth2_provider/application/``). Navigate there and create a new Application. Use these values (overwriting the defaults where necessary):
 

--- a/docs/source/ecommerce/flexible_pricing.rst
+++ b/docs/source/ecommerce/flexible_pricing.rst
@@ -1,7 +1,7 @@
 Flexible Pricing
 ================
 
-The Flexible Pricing system allows learners to request alternative pricing for MITxOnline courses based on their location and annual income. These requests can be made through a customizable form in the Wagtail CMS system.
+The Flexible Pricing system allows learners to request alternative pricing for MITx Online courses based on their location and annual income. These requests can be made through a customizable form in the Wagtail CMS system.
 
 When the learner accesses the Flexible Pricing request form, they will see one of the following:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Welcome to MITx Online Documentation's documentation!
    authentication
    configuration/index
    ecommerce/index
+   commands/index
 
 Indices and tables
 ==================

--- a/ecommerce/management/commands/create_product.py
+++ b/ecommerce/management/commands/create_product.py
@@ -1,0 +1,67 @@
+"""
+Creates a product for the given courseware ID. This only supports course runs
+for right now (since we don't really do program runs).
+"""
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import BaseCommand
+
+from courses.models import CourseRun
+from ecommerce.models import Product
+
+
+class Command(BaseCommand):
+    """
+    Creates a product for the given courseware ID.
+    """
+
+    help = "Creates a product for the given courseware ID."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "courseware",
+            type=str,
+            help="The courseware object to make the product for.",
+        )
+
+        parser.add_argument("price", type=str, help="The product's price.")
+
+        parser.add_argument(
+            "--description",
+            "-d",
+            nargs="?",
+            type=str,
+            help="The product's description. Defaults to the courseware object's readable ID.",
+            metavar="description",
+        )
+
+        parser.add_argument(
+            "--inactive", action="store_false", help="Make the product inactive."
+        )
+
+    def handle(self, *args, **kwargs):
+        try:
+            courserun = CourseRun.objects.filter(
+                courseware_id=kwargs["courseware"]
+            ).get()
+        except Exception as e:
+            self.stderr.write(f"Could not retrieve {kwargs['courseware']}: {e}")
+            exit(-1)
+
+        content_type = ContentType.objects.filter(
+            app_label="courses", model="courserun"
+        ).get()
+
+        description = courserun.readable_id
+
+        if "description" in kwargs and kwargs["description"] is not None:
+            description = kwargs["description"]
+
+        product = Product.objects.create(
+            object_id=courserun.id,
+            content_type=content_type,
+            price=kwargs["price"],
+            description=description,
+            is_active=kwargs["inactive"],
+        )
+
+        self.stdout.write(f"Created product {product}.")

--- a/main/management/commands/configure_instance.py
+++ b/main/management/commands/configure_instance.py
@@ -1,0 +1,270 @@
+"""
+Meta-command to help set up a freshly configured MITxOnline instance. 
+
+Running this will perform the following functions:
+- Configures a superuser account.
+- Creates the OAuth2 application record for edX (optionally with an existing 
+  client ID and secret).
+- Creating a program.
+- Creating financial assistance tiers, and a flexible price request form for 
+  the program.
+- Creating course entries for the default courses that come with devstack. 
+- Creating product entries and course about pages for these courses.
+- Creating a new learner account, and optionally enrolling them in the course. 
+
+The default program is "program-v1:MITx+DEDP" (Data, Economics and Development
+Policy), and the two courses that it will make are:
+- Demonstration Course (course-v1:edX+DemoX+Demo_Course)
+- E2E Test Course (course-v1:edX+E2E-101+course)
+
+The Demonstration Course will be added to the DEDP program but E2E Test Course
+will not. 
+
+The learner account will have these parameters:
+- Username: testlearner
+- Email Address: testlearner@mitxonline.odl.local
+- Password: you will be prompted for this
+- Name: Test Learner
+- Country Code: US
+- Enrollments: course-v1:edX+DemoX+Demo_Course
+
+The product for the courses will both be $999 so they are under the limit
+for test CyberSource transactions.
+
+This uses other management commands to complete these tasks. So, if you just 
+want to run part of this, use one of these commands:
+- createsuperuser to create the super user
+- configure_wagtail for initial setup of Wagtail assets
+- configure_tiers for creating the program tiers and discounts
+- create_course for creating the courses and runs
+- create_user for creating the learner account (which also uses 
+  create_enrollment internally)
+- sync_courserun for syncing course run data with devstack
+
+There are some steps that this command won't do for you:
+- Creating any additional courses/programs/etc. 
+- Completing the integration between MITxOnline and devstack - there are still
+  steps that you need to take to finish that process
+
+"""
+
+from django.core.management import BaseCommand, call_command
+from oauth2_provider.models import Application
+
+
+class Command(BaseCommand):
+    """
+    Bootstraps a fresh MITxOnline instance.
+    """
+
+    def add_arguments(self, parser):
+        """Parses command line arguments."""
+
+        parser.add_argument(
+            "platform",
+            help="Your platform (none, macos, or linux; defaults to none). None skips OAuth2 record creation.",
+            type=str,
+            choices=["none", "macos", "linux"],
+            nargs="?",
+            const="none",
+        )
+
+        parser.add_argument(
+            "--dont-enroll",
+            "-D",
+            help="Don't enroll the learner in course-v1:edX+DemoX+Demo_Course.",
+            action="store_true",
+            dest="dont_enroll",
+        )
+
+        parser.add_argument(
+            "--dont-create-superuser",
+            "-S",
+            help="Don't create a superuser account.",
+            action="store_false",
+            dest="superuser",
+        )
+
+        parser.add_argument(
+            "--edx-oauth-client",
+            help="Use the provided OAuth2 client ID, rather than making a new one.",
+            type=str,
+            nargs="?",
+        )
+
+        parser.add_argument(
+            "--edx-oauth-secret",
+            help="Use the provided OAuth2 client secret, rather than making a new one.",
+            type=str,
+            nargs="?",
+        )
+
+        parser.add_argument(
+            "--gateway",
+            help="Specify the gateway IP. (Required for Linux users.)",
+            type=str,
+            nargs="?",
+        )
+
+    def handle(self, *args, **kwargs):
+        """Coordinates the other commands."""
+
+        # Step -1: run createsuperuesr
+        if kwargs["superuser"]:
+            self.stdout.write(self.style.SUCCESS("Creating superuser..."))
+
+            call_command("createsuperuser")
+
+        # Step 0: create OAuth2 provider records
+        if kwargs["platform"] != "none":
+            self.stdout.write(self.style.SUCCESS("Creating OAuth2 app..."))
+
+            if kwargs["platform"] == "macos":
+                redirects = "\n".join(
+                    [
+                        "http://edx.odl.local:18000/auth/complete/mitxpro-oauth2/",
+                        "http://host.docker.internal:18000/auth/complete/mitxpro-oauth2/",
+                    ]
+                )
+            else:
+                if kwargs["gateway"] is None:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Gateway required for platform type {kwargs['platform']}."
+                        )
+                    )
+                    exit(-1)
+
+                redirects = "\n".join(
+                    [
+                        "http://edx.odl.local:18000/auth/complete/mitxpro-oauth2/",
+                        f"http://{kwargs['gateway']}:18000/auth/complete/mitxpro-oauth2/",
+                    ]
+                )
+
+            (oauth2_app, created) = Application.objects.get_or_create(
+                name="edx-oauth-app",
+                defaults={
+                    "client_type": "confidential",
+                    "authorization_grant_type": "authorization-code",
+                    "skip_authorization": True,
+                },
+            )
+
+            if kwargs["edx_oauth_client"] is not None:
+                oauth2_app.client_id = kwargs["edx_oauth_client"]
+
+            if kwargs["edx_oauth_secret"] is not None:
+                oauth2_app.client_secret = kwargs["edx_oauth_secret"]
+
+            oauth2_app.save()
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Created OAuth2 app {oauth2_app.name} for edX. Your client ID is \n{oauth2_app.client_id}\nand your secret is\n{oauth2_app.client_secret}\n\n"
+                )
+            )
+
+        # Step 1: run configure_wagtail
+        self.stdout.write(self.style.SUCCESS("Configuring Wagtail..."))
+
+        call_command("configure_wagtail")
+
+        # Step 2: create the program
+        self.stdout.write(self.style.SUCCESS("Creating the DEDP program..."))
+
+        # by default, this will create the DEDP program and tiers
+        call_command("configure_tiers")
+
+        # Step 3: create the program page
+        self.stdout.write(self.style.SUCCESS("Creating the DEDP program about page..."))
+
+        call_command("create_courseware_page", "program-v1:MITx+DEDP")
+
+        # Step 4: create the financial aid form
+        self.stdout.write(
+            self.style.SUCCESS("Creating the DEDP financial asistance form...")
+        )
+
+        call_command("create_finaid_form", "program-v1:MITx+DEDP")
+
+        # Step 5: create the courses (incld. course runs and syncing)
+        self.stdout.write(
+            self.style.SUCCESS("Creating courses and runs to match devstack...")
+        )
+
+        call_command(
+            "create_courseware",
+            "course",
+            "course-v1:edX+DemoX",
+            "Demonstration Course",
+            live=True,
+            create_run="Demo_Course",
+            run_url="http://edx.odl.local:18000/courses/course-v1:edX+DemoX+Demo_Course/",
+            program="program-v1:MITx+DEDP",
+            program_position=1,
+        )
+
+        call_command(
+            "create_courseware",
+            "course",
+            "course-v1:edX+E2E-101",
+            "E2E Test Course",
+            live=True,
+            create_run="course",
+            run_url="http://edx.odl.local:18000/courses/course-v1:edX+E2E-101+course/",
+        )
+
+        self.stdout.write(self.style.SUCCESS("Syncing course runs (this may fail)..."))
+
+        call_command("sync_courserun", all="ALL")
+
+        # Step 6: create course about pages
+        self.stdout.write(
+            self.style.SUCCESS("Creating the devstack course about pages...")
+        )
+
+        call_command("create_courseware_page", "course-v1:edX+DemoX", live=True)
+        call_command("create_courseware_page", "course-v1:edX+E2E-101", live=True)
+
+        # Step 7: create the products
+        self.stdout.write(
+            self.style.SUCCESS("Creating the devstack course products...")
+        )
+
+        call_command("create_product", "course-v1:edX+E2E-101+course", 999)
+        call_command("create_product", "course-v1:edX+DemoX+Demo_Course", 999)
+
+        # Step 8: create the learner and enroll them (unless told not to)
+        self.stdout.write(self.style.SUCCESS("Creating the learner..."))
+
+        if "dont_enroll" in kwargs and kwargs["dont_enroll"]:
+            call_command(
+                "create_user",
+                "testlearner",
+                "testlearner@mitxonline.odl.local",
+                "Test",
+                "Learner",
+                "Test Learner",
+                "US",
+            )
+        else:
+            call_command(
+                "create_user",
+                "testlearner",
+                "testlearner@mitxonline.odl.local",
+                "Test",
+                "Learner",
+                "Test Learner",
+                "US",
+                enroll="course-v1:edX+DemoX+Demo_Course",
+            )
+
+        self.stdout.write(self.style.SUCCESS("Done!"))
+
+        if kwargs["platform"] != "none":
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"== edX OAuth2 Application Details ==\nClient ID: {oauth2_app.client_id}\nSecret: {oauth2_app.client_secret}\n\n"
+                )
+            )


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1152 (this is the last part of that issue)

#### What's this PR do?

Adds a management command that will bootstrap a fresh MITxOnline instance. This involves:
* Running `configure_wagtail`
* Creating a new DEDP program
* Creating two courses to match the default ones you get with devstack (one of which gets added to the DEDP program), with a run for each, and then syncing that up with devstack (if that's configured)
* Creating product pages for the program and courses
* Creating a financial assistance form for the program
* Creating a new learner account and enrolling them in one of the courses
* Creating products for the course runs

So, the only steps you would need to do after checking out MITxOnline for the first time would be:
* Running migrate
* Running createsuperuser
* Performing the setup to talk to devstack (this can't really be automated via a management command, as you need to make records in the edX database)

By default, the learner account will have these parameters:
| Param | Setting |
|--------|--------|
| username | testlearner |
| email | testlearner@mitxonline.odl.local |
| name | Test Learner |
| password | you'll be prompted for this | 
| enrollments | `course-v1:edX+DemoX+Demo_Course` |

You can optionally have it not create the enrollment by supplying `--dont-enroll`. 

The courses that come with devstack are:
| Course Title | Courseware ID | Run Tag | Price |
| --- | --- | --- | --- | 
| Demonstration Course | course-v1:edX+DemoX | Demo_Course | $999 |
| E2E Test Course | course-v1:edX+E2E-101 | course | $999 |

The Demonstration Course is added to the DEDP program `program-v1:MITx+DEDP` when it's created. 

This uses a number of commands internally to accomplish its functions. See the `configure_instance.py` code for details. If you need to perform any of these tasks individually on the command line, you can do that by running just that command. 

*In addition*, this adds a `create_product` command that creates a product for the specified courseware. This works on a course run, and will default to creating an active product with the specified price and with the description set to the courseware ID. The product can be optionally be made inactive, or you can manually specify the description.

#### How should this be manually tested?

(For testing, I used the `dumpdata` command to grab a snapshot of my actually useful database first before testing, as you really need to have a clear database to test this. You may want to use `dumpdata` to grab OAuth2 config separately and re-apply it to your database after running migrations so you don't have to totally re-do the edX integration.)

1. Clear your database - I usually start up `dbshell` and run `drop schema public cascade; create schema public;` 
2. Run `migrate`
3. (Optionally) run `createsuperuser`
4. Run `configure_instance`
5. When prompted, enter the password you want for the test learner account. 
6. Review output. Depending on what the state of your devstack integration was, you may have some errors; in my case, the service account worker was already set up OK so the course run syncing worked fine. If that's not set up, though, course run sync will fail. 
7. Check out the site - you should be able to log in as the learner, they should have one enrollment on their dashboard, and you should be able to see the mostly empty about pages for the demo courses.  

To test `create_product`:

1. Run `create_product`, specifying a course run ID and price. (A product can exist for the course run - the system allows for multiple products for a course run.) 
2. Re-run 1, but specify `--description` to set the product description and/or `--inactive` to make the product inactive by default.

#### Other thoughts

* Should this maybe go ahead and do `migrate` and/or `createsuperuser`? It could also generate the MITxOnline side of the OAuth2 config for devstack too (but that'd be all, it wouldn't be able to make changes on the edX side). 