### PR TITLE
Add honor code link to account creation dialog

### DIFF
--- a/frontend/public/src/components/forms/RegisterEmailForm.js
+++ b/frontend/public/src/components/forms/RegisterEmailForm.js
@@ -51,6 +51,14 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
           <p className="py-2">
             By creating an account I agree to the{" "}
             <a
+              href={routes.informationLinks.honorCode}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Honor Code
+            </a>
+            {", "}
+            <a
               href={routes.informationLinks.termsOfService}
               target="_blank"
               rel="noopener noreferrer"

--- a/frontend/public/src/lib/urls.js
+++ b/frontend/public/src/lib/urls.js
@@ -43,6 +43,7 @@ export const routes = {
 
   informationLinks: include("", {
     termsOfService: "terms-of-service",
-    privacyPolicy:  "privacy-policy"
+    privacyPolicy:  "privacy-policy",
+    honorCode:      "honor-code"
   })
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots

#### What are the relevant tickets?
Fix #1181 

#### What's this PR do?

Add honor code link to account creation dialog
#### How should this be manually tested?
Try to create a new account, in the dialog you should be able to see the Honor Code link.
Before:
<img width="675" alt="Screen Shot 2022-11-02 at 10 20 24 AM" src="https://user-images.githubusercontent.com/7574259/199513927-7acea41c-612b-4dde-a686-acc4a84c88f1.png">

After:
<img width="643" alt="Screen Shot 2022-11-02 at 10 15 02 AM" src="https://user-images.githubusercontent.com/7574259/199513527-1e74d246-815c-47c4-8156-a4a26f22e53b.png">

