### PR TITLE
Enhance Product admin search and List display

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -7,20 +7,20 @@ import uuid
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models
 from django.db.models import Q
 from django.db.models.constraints import CheckConstraint, UniqueConstraint
 from django.utils.functional import cached_property
-from django.contrib.contenttypes.models import ContentType
 from django_countries.fields import CountryField
-from treebeard.mp_tree import MP_Node
-
 from mitol.common.models import TimestampedModel
 from mitol.common.utils.collections import first_matching_item
 from mitol.common.utils.datetime import now_in_utc
 from mitol.openedx.utils import get_course_number
+from treebeard.mp_tree import MP_Node
+from wagtail.core.models import PageRevision
 
 from courses.constants import (
     ENROLL_CHANGE_STATUS_CHOICES,
@@ -31,8 +31,6 @@ from main.models import AuditableModel, AuditModel, ValidateOnSaveMixin
 from main.utils import serialize_model_object
 from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENTS_PAID_MODES
 from openedx.utils import edx_redirect_url
-from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE
-from wagtail.core.models import PageRevision
 
 User = get_user_model()
 
@@ -209,7 +207,7 @@ class ProgramRun(TimestampedModel, ValidateOnSaveMixin):
         )
 
     def __str__(self):
-        return f"{self.program.readable_id} | {self.run_tag}"
+        return f"{self.program.readable_id} | {self.program.title}"
 
 
 class CourseTopic(TimestampedModel):

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -3,7 +3,6 @@
 from django.contrib import admin, messages
 from django.contrib.admin.decorators import display
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -13,7 +12,6 @@ from fsm_admin.mixins import FSMTransitionMixin
 from mitol.common.admin import TimestampedModelAdmin
 from reversion.admin import VersionAdmin
 
-from courses.models import CourseRun, ProgramRun
 from ecommerce.api import refund_order
 from ecommerce.forms import AdminRefundOrderForm
 from ecommerce.models import (
@@ -67,12 +65,7 @@ class ProductAdmin(VersionAdmin):
 
     def content_object(self, obj):
         """Return the content object details"""
-        if obj.content_type == ContentType.objects.get_for_model(CourseRun):
-            course_run = obj.purchasable_object
-            return f"{course_run.courseware_id} | {course_run.title}"
-        elif obj.content_type == ContentType.objects.get_for_model(ProgramRun):
-            program = obj.purchasable_object.program
-            return f"{program.readable_id} | {program.title}"
+        return str(obj.purchasable_object)
 
     def has_delete_permission(self, request, obj=None):
         """Disable the delete permission for Product models"""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1191

#### What's this PR do?
Adds the following Enhancements for Product Admin:
- Adds read-only field in the list display which shows the Readable ID/Courseware ID and Title of the object.
- Allows search on CourseRun/Program Title and Courseware/Readable ID.
- Updates the product change view and displays Courseware/Readable ID and Title of the CourseRun/Program.
- Adds a couple of list filters.

#### How should this be manually tested?

- Visit Product admin
- Verify that the `Content Object` field is visible in the List view. Also, Search should work for it as well.
- Verify the list filters.
- Change a product.
- Verify that the Object subtitle is updated with its Courseware/Readable ID and Title.



#### Screenshots (if appropriate)
<img width="1077" alt="Screenshot 2022-11-04 at 3 21 03 PM" src="https://user-images.githubusercontent.com/52656433/199950983-bda7dafc-4c5f-4bf8-9070-1c4cb104df44.png">
<img width="1077" alt="Screenshot 2022-11-04 at 3 21 13 PM" src="https://user-images.githubusercontent.com/52656433/199951014-cab09d39-bc1f-4069-a3b0-e72243cce488.png">
<img width="1077" alt="Screenshot 2022-11-04 at 3 21 21 PM" src="https://user-images.githubusercontent.com/52656433/199951020-d9e871f1-d73f-414f-9782-3388e3a639c6.png">

