### PR TITLE
Re-groups and tags enrollments in the program drawer

### DIFF
--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -19,8 +19,9 @@ from courses.factories import (
     CourseRunFactory,
     ProgramEnrollmentFactory,
     ProgramFactory,
+    CourseRunGradeFactory,
 )
-from courses.models import CourseTopic, ProgramRequirementNodeType
+from courses.models import CourseTopic, ProgramRequirementNodeType, ProgramRequirement
 from courses.serializers import (
     BaseCourseSerializer,
     BaseProgramSerializer,
@@ -32,6 +33,7 @@ from courses.serializers import (
     ProgramSerializer,
     ProgramRequirementSerializer,
     ProgramRequirementTreeSerializer,
+    CourseRunGradeSerializer,
 )
 from ecommerce.serializers import BaseProductSerializer
 from ecommerce.factories import ProductFactory
@@ -70,6 +72,16 @@ def test_serialize_program(mock_context):
 
     data = ProgramSerializer(instance=program, context=mock_context).data
 
+    formatted_reqs = {"required": [], "electives": []}
+
+    req_root = program.get_requirements_root()
+
+    for node in req_root.get_children():
+        if node.operator == ProgramRequirement.Operator.ALL_OF:
+            formatted_reqs["required"] = [req.course.id for req in node.get_children()]
+        else:
+            formatted_reqs["electives"] = [req.course.id for req in node.get_children()]
+
     assert_drf_json_equal(
         data,
         {
@@ -90,6 +102,7 @@ def test_serialize_program(mock_context):
                 sorted(runs, key=lambda run: run.enrollment_start)[0].enrollment_start
             ),
             "topics": [{"name": topic.name} for topic in topics],
+            "requirements": formatted_reqs,
         },
     )
 
@@ -268,6 +281,7 @@ def test_serialize_course_run_enrollments(settings, receipts_enabled):
         "enrollment_mode": "audit",
         "certificate": None,
         "approved_flexible_price_exists": False,
+        "grades": [],
     }
 
 
@@ -318,7 +332,9 @@ def test_serialize_program_enrollments(settings, receipts_enabled):
 
 
 @pytest.mark.parametrize("approved_flexible_price_exists", [True, False])
-def test_serialize_course_run_enrollments(approved_flexible_price_exists):
+def test_serialize_course_run_enrollments_with_flexible_pricing(
+    approved_flexible_price_exists,
+):
     """Test that CourseRunEnrollmentSerializer has correct data"""
     course_run_enrollment = CourseRunEnrollmentFactory.create()
     if approved_flexible_price_exists:
@@ -339,6 +355,27 @@ def test_serialize_course_run_enrollments(approved_flexible_price_exists):
         "enrollment_mode": "audit",
         "approved_flexible_price_exists": approved_flexible_price_exists,
         "certificate": None,
+        "grades": [],
+    }
+
+
+def test_serialize_course_run_enrollments_with_grades():
+    """Test that CourseRunEnrollmentSerializer has correct data"""
+    course_run_enrollment = CourseRunEnrollmentFactory.create()
+
+    grade = CourseRunGradeFactory.create(
+        course_run=course_run_enrollment.run, user=course_run_enrollment.user
+    )
+
+    serialized_data = CourseRunEnrollmentSerializer(course_run_enrollment).data
+    assert serialized_data == {
+        "run": CourseRunDetailSerializer(course_run_enrollment.run).data,
+        "id": course_run_enrollment.id,
+        "edx_emails_subscription": True,
+        "enrollment_mode": "audit",
+        "approved_flexible_price_exists": False,
+        "certificate": None,
+        "grades": CourseRunGradeSerializer([grade], many=True).data,
     }
 
 

--- a/docs/source/commands/create_courseware.rst
+++ b/docs/source/commands/create_courseware.rst
@@ -4,7 +4,7 @@
 Creates a new courseware object. 
 
 **For programs**, this creates the basic program record.
-**For courses**, this creates the course, and then optionally adds it to the specified program. It will also optionally create an initial course run for the course. 
+**For courses**, this creates the course, and then optionally adds it to the specified program (and can add it as an elective or required course). It will also optionally create an initial course run for the course. Finally, it will also add the course to the program's requirements or electives list. 
 **For courseruns**, this creates the course run and associates it with the specified course.
 
 This will not run ``sync_course_run`` for you, so for best results, ensure the course run is set up on the edX side, use this command, then run ``sync_course_run`` to pull dates and other information from edX. 
@@ -12,7 +12,16 @@ This will not run ``sync_course_run`` for you, so for best results, ensure the c
 Syntax
 ------
 
-``create_courseware <object> <readable id> <title> [--live] [--self-paced] [--create-run [create_run]] [--run-url [RUN_URL]] [--program [PROGRAM]] [--program-position [PROGRAM_POSITION]] [--run-tag [run-tag]]``
+``create_courseware <object> <readable id> <title> [--live] [--self-paced] [--create-run [create_run]] [--run-url [RUN_URL]] [--program [PROGRAM]] [--program-position [PROGRAM_POSITION]] [--run-tag [run-tag]] [--required] [--elective] [--force]``
+
+Checks
+------
+
+The command performs two checks:
+* It checks to see if ``readable_id`` contains ``course`` or ``program`` at the front - if it doesn't, it will assume you've swapped the title and readable ID mistakenly and stop.
+* It checks to see if the course will be live before adding it to the requirements tree. If ``--live`` isn't specified, it will ignore your request. This only applies to course creation.
+
+Both of these checks can be overridden with the ``--force`` flag. 
 
 Options
 -------
@@ -21,6 +30,7 @@ Options
 * ``readable id`` - The readable ID of the object. Note: do not specify the run tag for course runs. 
 * ``title`` - The title of the object.
 * ``--live`` - Makes the object live (default is not).
+* ``--force|-f`` - Force the creation of the object. (See "Checks" section for details.)
 
 Programs have no additional options (any specified will be ignored).
 
@@ -31,6 +41,8 @@ Courses can take the following options:
 * ``--create-run <run tag>`` - Create a course run for this course with the specified run tag. 
 * ``--run-url <url>`` - The courseware URL for the course run. (Only if ``--create-run`` is specified.)
 * ``--self-paced`` - The course run is self-paced. (Only if ``--create-run`` is specified.)
+* ``--required`` - The course is a requirement for the program.
+* ``--elective`` - The course is an elective for the program.
 
 Course runs can take the following options:
 

--- a/frontend/public/scss/dashboard.scss
+++ b/frontend/public/scss/dashboard.scss
@@ -10,6 +10,12 @@ $sidenav-separator: rgba(255, 255, 255, 0.2);
 $program-badge-fg: #305987;
 $program-badge-bg: #DBF2F3;
 
+$enrolled-verified-fg: #3E775D;
+$enrolled-verified-bg: #DBF3E9;
+
+$enrolled-passed-bg: #3E775D;
+$enrolled-passed-fg: #ffffff;
+
 .enrolled-items {
   .card {
     display: flex;
@@ -29,6 +35,7 @@ $program-badge-bg: #DBF2F3;
 
     h2 {
       font-size: 26px;
+      line-height: 27px;
     }
 
     h2 a {
@@ -75,6 +82,10 @@ $program-badge-bg: #DBF2F3;
         color: $primary;
       }
     }
+
+    strong.active-enrollment-text {
+      color: #139556;
+    }
   }
 
   button.dot-menu {
@@ -93,7 +104,28 @@ $program-badge-bg: #DBF2F3;
       padding: 0.35rem !important;
       margin-bottom: .25rem !important;
       margin-right: .5rem;
+
     }
+    .badge-in-progress {
+      color: black;
+      background-color: transparent;
+      border-color: black;
+      border: 1px;
+      border-radius: 4px;
+      border-style: solid;
+    }
+
+    .badge-enrolled-verified {
+      color: $enrolled-verified-fg;
+      border-color: $enrolled-verified-fg;
+      background-color: $enrolled-verified-bg;
+    }
+
+    .badge-enrolled-passed {
+      color: $enrolled-passed-fg;
+      background-color: $enrolled-passed-bg;
+    }
+
     span.badge.badge-red {
         color: $red-darker;
         background-color: #FAE8E8;
@@ -140,6 +172,7 @@ $program-badge-bg: #DBF2F3;
     form button.btn-primary {
       font-size: 14px;
       padding: 9px 18px;
+      min-width: 145px;
     }
 
     .pricing-links {

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -33,7 +33,8 @@ import {
   isFinancialAssistanceAvailable,
   isLinkableCourseRun,
   generateStartDateText,
-  courseRunStatusMessage
+  courseRunStatusMessage,
+  enrollmentHasPassingGrade
 } from "../lib/courseApi"
 import { isSuccessResponse } from "../lib/util"
 
@@ -50,7 +51,8 @@ type EnrolledItemCardProps = {
   ) => Promise<any>,
   addUserNotification: Function,
   isLoading: boolean,
-  toggleProgramDrawer: Function | null
+  toggleProgramDrawer: Function | null,
+  isProgramCard: boolean
 }
 
 type EnrolledItemCardState = {
@@ -262,7 +264,7 @@ export class EnrolledItemCard extends React.Component<
   }
 
   renderCourseEnrollment() {
-    const { enrollment, currentUser } = this.props
+    const { enrollment, currentUser, isProgramCard } = this.props
 
     const { menuVisibility } = this.state
 
@@ -285,11 +287,19 @@ export class EnrolledItemCard extends React.Component<
           Financial assistance?
           </a>
         ) : null
+
+    const certificateLinksStyles = isProgramCard
+      ? "upgrade-item-description detail d-md-flex justify-content-between pb-2 flex-column px-4"
+      : "upgrade-item-description detail d-md-flex justify-content-between pb-2"
+    const certificateLinksIntStyles = isProgramCard
+      ? "enrollment-extra-links d-flex d-md-flex w-100 justify-content-center"
+      : "enrollment-extra-links d-flex d-md-flex col-auto pr-0 justify-content-end"
+
     const certificateLinks =
       enrollment.run.products.length > 0 &&
       enrollment.enrollment_mode === "audit" &&
       enrollment.run.is_upgradable ? (
-          <div className="upgrade-item-description detail d-md-flex justify-content-between pb-2">
+          <div className={certificateLinksStyles}>
             <div className="mr-0">
               <p>
                 <strong>Upgrade today</strong> and, upon passing, receive your
@@ -297,7 +307,7 @@ export class EnrolledItemCard extends React.Component<
               skills you've gained from this MITx course.
               </p>
             </div>
-            <div className="enrollment-extra-links d-flex d-md-flex justify-content-end col-auto pr-0">
+            <div className={certificateLinksIntStyles}>
               <div className="pr-4 my-auto">{financialAssistanceLink}</div>
               <div className="my-auto">
                 <GetCertificateButton productId={enrollment.run.products[0].id} />
@@ -313,6 +323,8 @@ export class EnrolledItemCard extends React.Component<
     const menuTitle = `Course options for ${enrollment.run.course.title}`
 
     const courseRunStatusMessageText = courseRunStatusMessage(enrollment.run)
+
+    const hasPassed = enrollmentHasPassingGrade(enrollment)
 
     return (
       <div
@@ -344,8 +356,30 @@ export class EnrolledItemCard extends React.Component<
           )}
 
           <div className="col-12 col-md px-3 py-3 py-md-0 box">
-            <div className="d-flex justify-content-between align-content-start flex-nowrap w-100 enrollment-mode-container">
-              <h2 className="my-0 mr-3">{title}</h2>
+            <div className="d-flex justify-content-between align-content-start flex-nowrap w-100">
+              <div className="d-flex flex-column">
+                <div className="align-content-start d-flex enrollment-mode-container flex-wrap pb-1">
+                  {hasPassed ? (
+                    <span className="badge badge-enrolled-passed mr-2">
+                      <img src="/static/images/done.svg" alt="Check" /> Course
+                      passed
+                    </span>
+                  ) : null}
+                  {enrollment.enrollment_mode === "verified" ? (
+                    <span className="badge badge-enrolled-verified mr-2">
+                      Enrolled in certificate track
+                    </span>
+                  ) : null}
+                  {startDateDescription !== null &&
+                  startDateDescription.active ? (
+                      <span className="badge badge-in-progress mr-2">
+                      In Progress
+                      </span>
+                    ) : null}
+                </div>
+
+                <h2 className="my-0 mr-3">{title}</h2>
+              </div>
               <Dropdown
                 isOpen={menuVisibility}
                 toggle={this.toggleMenuVisibility.bind(this)}

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -62,6 +62,7 @@ describe("EnrolledItemCard", () => {
           addUserNotification={enrollmentCardProps.addUserNotification}
           toggleProgramDrawer={toggleProgramDrawer}
           isLoading={false}
+          isProgramCard={false}
         />
       )
   })

--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react"
 
-import { generateStartDateText } from "../lib/courseApi"
+import { generateStartDateText, courseRunStatusMessage } from "../lib/courseApi"
 
 import type { CourseDetailWithRuns } from "../flow/courseTypes"
 
@@ -13,16 +13,28 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
   render() {
     const { course } = this.props
 
-    let startDateDescription = null
     let featuredImage = null
     let courseDetailsPage = null
+    let financialAssistanceForm = null
+    let courseRunStatusMessageText = null
+    let courseRunStatusDetail = null
 
     if (course.courseruns.length > 0) {
-      startDateDescription = generateStartDateText(course.courseruns[0])
+      courseRunStatusDetail = generateStartDateText(course.courseruns[0])
+
+      if (courseRunStatusDetail) {
+        courseRunStatusMessageText = courseRunStatusMessage(
+          course.courseruns[0]
+        )
+      }
 
       if (course.courseruns[0].page) {
         courseDetailsPage = course.courseruns[0].page.page_url
       }
+    }
+
+    if (course.financial_assistance_form_url) {
+      financialAssistanceForm = course.financial_assistance_form_url
     }
 
     if (course.feature_image_src) {
@@ -43,23 +55,22 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
         <div className="row flex-grow-1">
           {featuredImage}
           <div className="col-12 col-md px-3 py-3 py-md-0 box">
-            <div className="d-flex justify-content-between align-content-start flex-nowrap w-100 enrollment-mode-container">
+            <div className="align-content-start d-flex enrollment-mode-container w-100">
+              {courseRunStatusDetail !== null &&
+              courseRunStatusDetail.active ? (
+                  <span className="badge badge-in-progress mr-2">
+                  In Progress
+                  </span>
+                ) : null}
+            </div>
+            <div className="d-flex justify-content-between align-content-start flex-nowrap w-100 enrollment-mode-container flex-wrap pb-1">
               <h2 className="my-0 mr-3">{course.title}</h2>
             </div>
             <div className="detail pt-1">
               {course.readable_id.split("+")[1] || course.readable_id}
-              {startDateDescription !== null && startDateDescription.active ? (
-                <span> | Starts - {startDateDescription.datestr}</span>
-              ) : (
-                <span>
-                  {startDateDescription === null ? null : (
-                    <span>
-                      <strong>Active</strong> from{" "}
-                      {startDateDescription.datestr}
-                    </span>
-                  )}
-                </span>
-              )}
+              {courseRunStatusDetail !== null
+                ? courseRunStatusMessageText
+                : null}
               <div className="enrollment-extra-links d-flex">
                 {courseDetailsPage ? (
                   <a href={courseDetailsPage}>Course details</a>
@@ -70,7 +81,32 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
           </div>
         </div>
         <div className="row flex-grow-1 pt-3">
-          <div className="col pl-0 pr-0">{null}</div>
+          <div className="col pl-0 pr-0">
+            <div className="upgrade-item-description detail d-md-flex flex-column px-4 justify-content-between pb-3">
+              <div className=" w-100 ">
+                <strong>Enroll today</strong> for free, and start learning from
+                MIT faculty. Courses are always free until you want to get a
+                certificate.
+              </div>
+              <div className="enrollment-extra-links d-flex d-md-flex justify-content-center w-100">
+                <div className="pr-4 my-auto">
+                  {financialAssistanceForm ? (
+                    <a href={financialAssistanceForm}>Financial assistance?</a>
+                  ) : null}
+                </div>
+                <div className="my-auto">
+                  <form method="get" action={courseDetailsPage}>
+                    <button
+                      type="submit"
+                      className="btn btn-primary btn-gradient-red"
+                    >
+                      Enroll
+                    </button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     )

--- a/frontend/public/src/flow/courseTypes.js
+++ b/frontend/public/src/flow/courseTypes.js
@@ -39,23 +39,38 @@ export type Certificate = {
   uuid: string
 }
 
+export type CourseRunGrade = {
+  grade:         number,
+  letter_grade:  string,
+  passed:        boolean,
+  set_by_admin:  boolean,
+  grade_percent: number,
+}
+
 export type RunEnrollment = {
   run: CourseRunDetail,
   id: number,
   edx_emails_subscription: ?string,
   enrollment_mode: string,
   certificate: ?Certificate,
+  grades: Array<CourseRunGrade>,
 }
 
 export type CourseDetailWithRuns = CourseDetail & {
   courseruns: Array<BaseCourseRun>
 }
 
+export type ProgramEnrollments = {
+  electives: Array<number>,
+  required: Array<number>,
+}
+
 export type Program = {
   id: number,
   title: string,
   readable_id: string,
-  courses: Array<CourseDetailWithRuns>
+  courses: Array<CourseDetailWithRuns>,
+  requirements: ?ProgramEnrollments,
 }
 
 export type ProgramEnrollment = {

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -6,7 +6,11 @@ import { isNil } from "ramda"
 import { notNil, parseDateString, formatPrettyDateTimeAmPmTz } from "./util"
 
 import type Moment from "moment"
-import type { CourseRunDetail, CourseRun } from "../flow/courseTypes"
+import type {
+  CourseRunDetail,
+  CourseRun,
+  RunEnrollment
+} from "../flow/courseTypes"
 import type { CurrentUser } from "../flow/authTypes"
 
 export const isLinkableCourseRun = (
@@ -44,14 +48,17 @@ export const courseRunStatusMessage = (run: CourseRun) => {
         return (
           <span>
             {" "}
-            | <b>Ended</b> - {formatPrettyDateTimeAmPmTz(dateString)}
+            | <strong>Ended</strong> - {formatPrettyDateTimeAmPmTz(dateString)}
           </span>
         )
       } else {
         return (
           <span>
             {" "}
-            |<strong> Active</strong> - {startDateDescription.datestr}
+            |<strong className="active-enrollment-text">
+              {" "}
+              Active
+            </strong> from {startDateDescription.datestr}
           </span>
         )
       }
@@ -59,7 +66,8 @@ export const courseRunStatusMessage = (run: CourseRun) => {
       return (
         <span>
           {" "}
-          | <b>Starts</b> - {startDateDescription.datestr}
+          | <strong className="text-dark">Starts</strong>{" "}
+          {startDateDescription.datestr}
         </span>
       )
     }
@@ -83,4 +91,16 @@ export const generateStartDateText = (run: CourseRunDetail) => {
 
 export const isFinancialAssistanceAvailable = (run: CourseRunDetail) => {
   return run.page ? !!run.page.financial_assistance_form_url : false
+}
+
+export const enrollmentHasPassingGrade = (enrollment: RunEnrollment) => {
+  if (enrollment.grades && enrollment.grades.length > 0) {
+    for (let i = 0; i < enrollment.grades.length; i++) {
+      if (enrollment.grades[i].passed) {
+        return true
+      }
+    }
+  }
+
+  return false
 }

--- a/static/images/done.svg
+++ b/static/images/done.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="12px" height="10px" viewBox="0 0 12 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>4A8B5ADF-C7CE-4657-AD03-32FF608FF4E1</title>
+    <g id="Q3-2022" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="MITx---Dashboard---Program-Details-Pane" transform="translate(-934.000000, -381.000000)" fill="#FFFFFF">
+            <g id="Group-23" transform="translate(701.000000, 0.000000)">
+                <g id="Group-22" transform="translate(30.000000, 182.000000)">
+                    <g id="Group-19" transform="translate(0.000000, 24.400000)">
+                        <g id="basic-/-done" transform="translate(203.000000, 175.357355)">
+                            <path d="M4.77297056,7.42462993 L3.71231067,8.48528981 L0,4.77297914 L1.06066015,3.7123189 L4.77297056,7.42462993 Z M10.0762689,0 L11.1369288,1.06066042 L4.77297056,7.42462993 L3.71230781,6.36396074 L10.0762689,0 Z"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1190 
Fixes #1193 (the code doesn't work in that way anymore so that issue is moot)

#### What's this PR do?

This PR adds grouping of courses in the program drawer according to the program's set requirements. It also resets some of the styling attributes for the enrolled item cards and program drawer to better match the InVision design here: https://projects.invisionapp.com/d/main?origin=v7#/console/21535972/468431707/preview?scrollOffset=0 

To summarize, this:
* Changes the program drawer to display a "Program overview" that consists of a total course count, not enrolled count, and passed course count
* Groups the available courses in the program by their status as an elective or a requirement in the course
* Updates the item cards in the program drawer to display an Enroll message when the user isn't enrolled in the course
* Adds tags (back) to the cards (on both the regular dashboard and in the program drawer):
   * "In progress" for courses whose start date is before now
   * "Enrolled in certificate track" for courses where the learner has a verified enrollment
   * "Course passed" for courses that the learner has a passing grade for 
* Updates the upsell message (either enroll or get certificate) to be formatted in a stacked manner _only if the card is displayed in the program drawer_

This PR also adds a serializer for grades, some helper functions to mark courses in a program as requirements or electives, and updates the `create_courseware` command to support that same tagging.  

#### How should this be manually tested?

Automated tests should pass.

Testing the `create_courseware` management command: See the documentation for details. 
* The `--required` and `--elective` flags are new and will flag the course appropriately within the program. 
* The command will now error if you swap the readable ID and title fields.
* It will also ignore `--required` and `--elective` if the course you're creating won't be live. (Having a not-live course in the requirements tree causes Django Admin to have issues.) 

Testing the program drawer: 
* You will need to either turn the feature flag for the program UI on or use the `?enable_programs` flag on the URI to see the program drawer.
* The tags should display accordingly for the status of the course.
* Opening the program drawer should present a UI that looks like the InVision layout in desktop mode.
* The program drawer should span the width of the screen on a mobile device (< 1024px horizontally). 
* The program drawer should list the total number of courses in the program, the number you've passed, and the number you've not enrolled in.
* The program drawer should list all live courses that are represented in the program's requirements tree. (In other words, it _will not_ display a course that isn't an elective or a requirement.) 
* The program drawer should group the courses by their status (elective or requirement). The groupings should show a count of programs in that particular status.
* The program drawer should show the standard EnrolledItemCard for courses that you have an enrollment in, and the ProgramCourseInfoCard for ones that you don't. 
* You should see upsell messaging for courses that you're not enrolled in.
   * The Enroll button on the enrollment specific upsell message should take you to the course details page. 
   * The Financial Aid? link on the enrollment specific upsell message should take you to the configured finaid form for the course (this may be the program's form, and will depend on how you have that set up)
* Other functionality should function as per usual.

Accessibility: The Program Drawer should gain focus when opened and the individual cards should be read in order while using a screen reader. (We are reusing elements here that worked OK for accessibility so the page should work as expected using accessible means.) 

#### Screenshots (if appropriate)
My Courses dashboard (with new tags):
![image](https://user-images.githubusercontent.com/945611/200673381-82c459bb-b2e7-4693-9ed8-f821bfadc966.png)

Program Drawer (open): 
![image](https://user-images.githubusercontent.com/945611/200673463-b8a67b26-183e-4ee0-b2e1-e9172cb2d6f5.png)

Program Drawer (open, phone):
![image](https://user-images.githubusercontent.com/945611/200674080-35f2e39e-bb27-49eb-9a52-097ff59ef9f4.png)

Program Drawer (open, tablet):
![image](https://user-images.githubusercontent.com/945611/200673633-653e8696-2862-4bae-8489-186f537e09d5.png)

