### PR TITLE
1206 dashboard course detail and view certificate links are too close together

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -388,7 +388,9 @@ export class EnrolledItemCard extends React.Component<
               {courseRunStatusMessageText}
               <div className="enrollment-extra-links d-flex">
                 {pageLocation ? (
-                  <a className="pr-4" href={pageLocation.page_url}>Course details</a>
+                  <a className="pr-4" href={pageLocation.page_url}>
+                    Course details
+                  </a>
                 ) : null}
                 {enrollment.certificate ? (
                   <a
@@ -479,7 +481,9 @@ export class EnrolledItemCard extends React.Component<
                   {enrollment.program.courses.length > 1 ? "s" : null}
                 </a>
                 {pageLocation ? (
-                  <a className="pr-2" href={pageLocation.page_url}>Course details</a>
+                  <a className="pr-2" href={pageLocation.page_url}>
+                    Course details
+                  </a>
                 ) : null}
                 {enrollment.certificate ? (
                   <a

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -298,7 +298,7 @@ export class EnrolledItemCard extends React.Component<
               </p>
             </div>
             <div className="enrollment-extra-links d-flex d-md-flex justify-content-end col-auto pr-0">
-              <div className="pr-2 my-auto">{financialAssistanceLink}</div>
+              <div className="pr-4 my-auto">{financialAssistanceLink}</div>
               <div className="my-auto">
                 <GetCertificateButton productId={enrollment.run.products[0].id} />
               </div>

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -388,7 +388,7 @@ export class EnrolledItemCard extends React.Component<
               {courseRunStatusMessageText}
               <div className="enrollment-extra-links d-flex">
                 {pageLocation ? (
-                  <a href={pageLocation.page_url}>Course details</a>
+                  <a className="pr-4" href={pageLocation.page_url}>Course details</a>
                 ) : null}
                 {enrollment.certificate ? (
                   <a
@@ -466,13 +466,13 @@ export class EnrolledItemCard extends React.Component<
               {courseId}
               {startDateDescription === null}
               {courseRunStatusMessageText}
-              <div className="enrollment-extra-links d-flex">
+              <div className="enrollment-extra-links d-flex pr-2">
                 <span className="program-course-count">
                   {enrollment.program.courses.length} course
                   {enrollment.program.courses.length > 1 ? "s" : null}
                 </span>
                 {pageLocation ? (
-                  <a href={pageLocation.page_url}>Course details</a>
+                  <a className="pr-4" href={pageLocation.page_url}>Course details</a>
                 ) : null}
                 {enrollment.certificate ? (
                   <a

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -298,7 +298,7 @@ export class EnrolledItemCard extends React.Component<
               </p>
             </div>
             <div className="enrollment-extra-links d-flex d-md-flex justify-content-end col-auto pr-0">
-              <div className="pr-4 my-auto">{financialAssistanceLink}</div>
+              <div className="pr-2 my-auto">{financialAssistanceLink}</div>
               <div className="my-auto">
                 <GetCertificateButton productId={enrollment.run.products[0].id} />
               </div>
@@ -388,7 +388,7 @@ export class EnrolledItemCard extends React.Component<
               {courseRunStatusMessageText}
               <div className="enrollment-extra-links d-flex">
                 {pageLocation ? (
-                  <a className="pr-4" href={pageLocation.page_url}>
+                  <a className="pr-2" href={pageLocation.page_url}>
                     Course details
                   </a>
                 ) : null}

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -467,12 +467,19 @@ export class EnrolledItemCard extends React.Component<
               {startDateDescription === null}
               {courseRunStatusMessageText}
               <div className="enrollment-extra-links d-flex pr-2">
-                <span className="program-course-count">
+                <a
+                  className="program-course-count pr-2"
+                  rel="noopener noreferrer"
+                  href="#program_enrollment_drawer"
+                  aria-flowto="program_enrollment_drawer"
+                  aria-haspopup="dialog"
+                  onClick={() => this.toggleProgramInfo()}
+                >
                   {enrollment.program.courses.length} course
                   {enrollment.program.courses.length > 1 ? "s" : null}
-                </span>
+                </a>
                 {pageLocation ? (
-                  <a className="pr-4" href={pageLocation.page_url}>Course details</a>
+                  <a className="pr-2" href={pageLocation.page_url}>Course details</a>
                 ) : null}
                 {enrollment.certificate ? (
                   <a


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1206

#### What's this PR do?
Adds some spacing to the links in the course card (shown in the mock-up linked in the issue).  Also makes the "course(s)" link on the program card into a link instead (shown in the mock-up linked in the issue).

#### How should this be manually tested?

- Enroll your user into a program which has a few courses as requirements.  
- Create the CMS pages for the program and courses, along with a certificate page for the program.  
- Create a certificate for your user for one of the courses and the program.  
- Create a program run enrollment and course run enrollment for your user, making sure each enrollment is "verified".
- View the course enrollment and program enrollment cards on the user's dashboard.  Ensure that the links are spaced correctly and that the "Course(s)" link on the program card opens the program course drawer when clicked.

#### Screenshots (if appropriate)
![Screen Shot 2022-11-15 at 9 37 18](https://user-images.githubusercontent.com/8311573/201946460-6729acf4-3000-47eb-af9d-2e9e225a9a60.png)
![Screen Shot 2022-11-15 at 9 33 54](https://user-images.githubusercontent.com/8311573/201946466-340f65f4-406d-46aa-a72f-75ac59086474.png)
![Screen Shot 2022-11-15 at 9 33 45](https://user-images.githubusercontent.com/8311573/201946468-1cad2b23-6ff8-4535-9db4-3a01925a8808.png)
![Screen Shot 2022-11-15 at 9 37 57](https://user-images.githubusercontent.com/8311573/201946610-39a49d7e-f2d5-40f1-a778-ed02a5ab017b.png)


