### PR TITLE
1207 accessibility more dates popup on course pages lacks keyboard controls

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -48,20 +48,19 @@
               </div>
               {% if course_runs|length > 1 %}
                 <strong class="more-dates">
-                  <span tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="click" onkeydown="{ $('span.dates-tooltip').popover('show'); event.preventDefault(); }" onClick="{ $('span.dates-tooltip').popover('show'); event.preventDefault(); }" 
-                  data-toggle="popover" data-placement="auto" title="More dates available" data-html="true"
+                  <button class="dates-tooltip" id="datesPopover" data-trigger="click" data-toggle="popover" data-placement="auto" title="More dates available" data-html="true"
                     data-content="
                       <div>
                         <p>Click below to enroll in one of these dates</p>
                       </div>
                       {% for course_run in course_runs %}
                           <div>
-                            <span role='button' taborder='0' class='date-link' id='{{ course_run.courseware_id }}' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</span>
+                            <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
                           </div>
                       {% endfor %}
                     ">
                     More Dates
-                  </a>
+                  </button>
                 </strong>
               {% endif %}
             </div>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -48,15 +48,15 @@
               </div>
               {% if course_runs|length > 1 %}
                 <strong class="more-dates">
-                  <a href="#" role="button" class="dates-tooltip" id="datesPopover" data-trigger="click"
-                    data-toggle="popover" data-placement="auto" title="More dates available" data-html="true"
+                  <span tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="click" onkeydown="{ $('span.dates-tooltip').popover('show'); event.preventDefault(); }" onClick="{ $('span.dates-tooltip').popover('show'); event.preventDefault(); }" 
+                  data-toggle="popover" data-placement="auto" title="More dates available" data-html="true"
                     data-content="
                       <div>
                         <p>Click below to enroll in one of these dates</p>
                       </div>
                       {% for course_run in course_runs %}
                           <div>
-                            <button class='date-link' id='{{ course_run.courseware_id }}' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
+                            <span role='button' taborder='0' class='date-link' id='{{ course_run.courseware_id }}' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</span>
                           </div>
                       {% endfor %}
                     ">

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -48,7 +48,7 @@
               </div>
               {% if course_runs|length > 1 %}
                 <strong class="more-dates">
-                  <span tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="focus" onClick="event.preventDefault();"
+                  <a href="#" role="button" class="dates-tooltip" id="datesPopover" data-trigger="click"
                     data-toggle="popover" data-placement="auto" title="More dates available" data-html="true"
                     data-content="
                       <div>
@@ -56,12 +56,12 @@
                       </div>
                       {% for course_run in course_runs %}
                           <div>
-                            <span class='date-link' id='{{ course_run.courseware_id }}' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</span>
+                            <button class='date-link' id='{{ course_run.courseware_id }}' onClick='event.preventDefault();'>Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
                           </div>
                       {% endfor %}
                     ">
                     More Dates
-                  </span>
+                  </a>
                 </strong>
               {% endif %}
             </div>

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -240,6 +240,7 @@
         font-size: 12px;
 
         .dates-tooltip {
+          font-weight: bolder;
           color: $link-blue !important;
           text-decoration: underline;
           background-color: transparent;

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -242,7 +242,8 @@
         .dates-tooltip {
           color: $link-blue !important;
           text-decoration: underline;
-          cursor: pointer;
+          background-color: transparent;
+          border: none;
         }
       }
 
@@ -478,5 +479,6 @@
 .date-link {
   color: $link-blue !important;
   text-decoration: underline;
-  cursor: pointer;
+  background-color: transparent;
+  border: none;
 }

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -10,5 +10,5 @@ $(".dates-tooltip").popover({
     '<div class="arrow"></div>' +
     '<div class="popover-header py-2 px-0 mx-5"></div>' +
     '<div class="popover-body"></div>' +
-    "</div>"
+    '</div>'
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -5,6 +5,7 @@ import "video.js"
 import "videojs-youtube/dist/Youtube"
 import $ from "jquery"
 $(".dates-tooltip").popover({
+  sanitize: false,
   template:
     '<div class="popover" role="tooltip">' +
     '<div class="arrow"></div>' +
@@ -15,4 +16,8 @@ $(".dates-tooltip").popover({
 $(".dates-tooltip").on("shown.bs.popover", () => {
   $(".date-link").attr("tabindex", 0)
   $(".date-link").first().focus()
+  $(".date-link").on("click", () => {
+    $(".dates-tooltip").popover('hide')
+    $(".dates-tooltip").focus()
+  })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -11,13 +11,15 @@ $(".dates-tooltip").popover({
     '<div class="arrow"></div>' +
     '<div class="popover-header py-2 px-0 mx-5"></div>' +
     '<div class="popover-body"></div>' +
-    '</div>'
+    "</div>"
 })
 $(".dates-tooltip").on("shown.bs.popover", () => {
   $(".date-link").attr("tabindex", 0)
-  $(".date-link").first().focus()
+  $(".date-link")
+    .first()
+    .focus()
   $(".date-link").on("click", () => {
-    $(".dates-tooltip").popover('hide')
+    $(".dates-tooltip").popover("hide")
     $(".dates-tooltip").focus()
   })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -12,3 +12,7 @@ $(".dates-tooltip").popover({
     '<div class="popover-body"></div>' +
     '</div>'
 })
+$(".dates-tooltip").on("shown.bs.popover", () => {
+  $(".date-link").attr("tabindex", 0)
+  $(".date-link").first().focus()
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1207

#### What's this PR do?
Ensures that a keyboard only user and users using a screen reader are able to access the "More dates" popover and select different dates to enroll in.

#### How should this be manually tested?

1. Pull down this branch
2. Navigate to a course page which has multiple course runs that start on different dates.
3. Enable a screen reader.
4. Use the 'tab' button in order to navigate to "More Dates".
5. Click the enter key on the "More Dates" button and ensure that the popover is shown. 
6. Tab through the popover options and ensure each option can be navigated to using the 'tab' button and that date is read by the screen reader.
7. Press the 'enter' button on one of the dates.  Ensure that the date selected is updated on the course page and the focus goes back to the 'More Dates' button.


#### Screenshots (if appropriate)
![Screen Shot 2022-11-21 at 13 40 44](https://user-images.githubusercontent.com/8311573/203135241-703add2d-1431-4e19-8be7-0cb72528ffc1.png)
![Screen Shot 2022-11-21 at 13 40 38](https://user-images.githubusercontent.com/8311573/203135242-70a7993b-1893-402b-aab8-e8af0db4ef57.png)

