### PR TITLE
Updates program drawer to handle empty requirements trees; adds function to check for invalid trees

### DIFF
--- a/app.json
+++ b/app.json
@@ -91,6 +91,14 @@
       "description": "'hours' value for the 'generate-course-certificate' scheduled task (defaults to midnight)",
       "required": false
     },
+    "CRON_ORPHAN_CHECK_DAYS": {
+      "description": "'day_of_week' value for 'check-for-program-orphans' scheduled task (default will run once a day).",
+      "required": false
+    },
+    "CRON_ORPHAN_CHECK_HOURS": {
+      "description": "'hours' value for 'check-for-program-orphans' scheduled task (default will run at 3 AM).",
+      "required": false
+    },
     "CRON_PROCESS_REFUND_REQUESTS_MINUTES": {
       "description": "minute value for scheduled task to process refund requests",
       "required": false

--- a/courses/management/commands/check_program_requirements.py
+++ b/courses/management/commands/check_program_requirements.py
@@ -1,0 +1,98 @@
+"""
+Checks programs for a valid requirements tree. A valid tree is one that:
+a) exists
+b) has all the courses in the program accounted for as either an elective
+   or a required course
+
+This won't fix the issue for you - do that via Django Admin - but it will tell
+you if there are any.
+"""
+
+import io
+import logging
+
+from django.core.management import BaseCommand
+from django.db.models import Q
+
+from courses.api import check_program_for_orphans
+from courses.models import Program
+
+
+class Command(BaseCommand):
+    """
+    Checks program(s) for valid requirements trees
+    """
+
+    help = "Checks program(s) for valid requirements trees"
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--program",
+            action="append",
+            help="Program to check.",
+            nargs="*",
+        )
+
+        parser.add_argument(
+            "--live", action="store_true", help="Check only live programs."
+        )
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+        if kwargs["program"] is not None and len(kwargs["program"]) > 0:
+            numeric_ids = []
+            readable_ids = []
+
+            [
+                readable_ids.append(id[0])
+                if not id[0].isnumeric()
+                else numeric_ids.append(id[0])
+                for id in kwargs["program"]
+            ]
+
+            programs_qset = Program.objects.filter(
+                Q(id__in=numeric_ids) | Q(readable_id__in=readable_ids)
+            )
+        else:
+            programs_qset = Program.objects
+
+        if kwargs["live"]:
+            programs_qset = programs_qset.filter(live=True)
+
+        logger = logging.getLogger("courses.api")
+
+        log_capture = io.StringIO()
+        handler = logging.StreamHandler(log_capture)
+
+        logger.addHandler(handler)
+
+        for program in programs_qset.all():
+            orphans = check_program_for_orphans(program)
+
+            if len(orphans) > 0:
+                if "no requirements tree" in log_capture.getvalue():
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Program {program.readable_id} has no requirements tree!"
+                        )
+                    )
+
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Program {program.readable_id} has {len(orphans)} orphaned course{'s' if len(orphans) > 1 else ''}:"
+                    )
+                )
+
+                [
+                    self.stdout.write(
+                        self.style.WARNING(f"{orphan.title} - {orphan.readable_id}")
+                    )
+                    for orphan in orphans
+                ]
+            else:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Program {program.readable_id} has a complete requirements tree"
+                    )
+                )
+
+            self.stdout.write("\n")

--- a/docs/source/commands/check_program_requirements.rst
+++ b/docs/source/commands/check_program_requirements.rst
@@ -1,0 +1,22 @@
+``check_program_requirements``
+==============================
+
+Checks programs for a valid requirements tree. A program has a valid requirements tree if it:
+
+1. Exists
+2. Has nodes for all courses assigned to the program
+
+If the tree does not fit this criteria, an error message is printed to the screen. (This uses the ``check_program_for_orphans`` API call, but it suppresses its error logging so it won't clog up the error log.)
+
+By default, this will check all programs in the system. Specify individual programs to check with ``--program`` (multiple times if needed) or check only live programs with ``--live``. Note that if you specify both of these together they will be combined: if you specify a check for a specific program that isn't live and then also specify ``--live``, it won't return anything for that program.
+
+Syntax
+------
+
+``check_program_requirements [--program <readable or numeric id>] [--live]``
+
+Options
+-------
+
+* ``--program <readable or numeric id>`` - Check this specific program. Can be either the readable ID of the program (e.g. ``program-v1:MITx+DEDP``) or the numeric ID, and can be specified multiple times to check multiple programs.
+* ``--live`` - Check only live programs.

--- a/docs/source/commands/index.rst
+++ b/docs/source/commands/index.rst
@@ -5,11 +5,13 @@ MITx Online Commands
    :maxdepth: 2
    :caption: Contents:
 
+   check_program_requirements
    configure_instance
    create_courseware
    create_courseware_page
    create_product
    create_user
+   generate_discount_code
 
 
 Indices and tables

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -463,7 +463,7 @@ export class EnrolledItemCard extends React.Component<
     return (
       <div
         className="enrolled-item container card mb-4 rounded-0 pb-0 pt-md-3"
-        key={enrollment.program.id}
+        key={`enrolled-program-card-id-${enrollment.program.id}`}
       >
         <div className="row flex-grow-1">
           <div className="col-12 col-md-auto px-0 px-md-3">

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -71,6 +71,49 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
     return passedFlags
   }
 
+  renderCourseCards() {
+    const { enrollment } = this.props
+
+    return (
+      <React.Fragment
+        key={`drawer-course-list-${enrollment.program.readable_id}`}
+      >
+        <div className="row enrolled-items" id="program_enrolled_items">
+          <h6>REQUIRED ({enrollment.program.requirements.required.length})</h6>
+
+          {enrollment.program.courses.map(courseEnrollment =>
+            this.isRequired(courseEnrollment)
+              ? this.renderCourseInfoCard(courseEnrollment)
+              : null
+          )}
+        </div>
+        <div className="row enrolled-items" id="program_unenrolled_items">
+          <h6>OPTIONAL ({enrollment.program.requirements.electives.length})</h6>
+
+          {enrollment.program.courses.map(courseEnrollment => {
+            return this.isElective(courseEnrollment)
+              ? this.renderCourseInfoCard(courseEnrollment)
+              : null
+          })}
+        </div>
+      </React.Fragment>
+    )
+  }
+
+  renderFlatCourseCards() {
+    const { enrollment } = this.props
+
+    return (
+      <div className="row enrolled-items" id="program_enrolled_items">
+        <h6>COURSES ({enrollment.program.courses.length})</h6>
+
+        {enrollment.program.courses.map(courseEnrollment =>
+          this.renderCourseInfoCard(courseEnrollment)
+        )}
+      </div>
+    )
+  }
+
   render() {
     const { isHidden, enrollment, showDrawer } = this.props
 
@@ -135,28 +178,9 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
                 ) : null}
               </p>
             </div>
-            <div className="row enrolled-items" id="program_enrolled_items">
-              <h6>
-                REQUIRED ({enrollment.program.requirements.required.length})
-              </h6>
-
-              {enrollment.program.courses.map(courseEnrollment =>
-                this.isRequired(courseEnrollment)
-                  ? this.renderCourseInfoCard(courseEnrollment)
-                  : null
-              )}
-            </div>
-            <div className="row enrolled-items" id="program_unenrolled_items">
-              <h6>
-                OPTIONAL ({enrollment.program.requirements.electives.length})
-              </h6>
-
-              {enrollment.program.courses.map(courseEnrollment => {
-                return this.isElective(courseEnrollment)
-                  ? this.renderCourseInfoCard(courseEnrollment)
-                  : null
-              })}
-            </div>
+            {enrollment.program.requirements.length === 0
+              ? this.renderFlatCourseCards()
+              : this.renderCourseCards()}
           </div>
         </div>
       </>

--- a/main/settings.py
+++ b/main/settings.py
@@ -7,8 +7,8 @@ import os
 import platform
 from datetime import timedelta
 from urllib.parse import urljoin, urlparse
-import cssutils
 
+import cssutils
 import dj_database_url
 from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
@@ -20,11 +20,9 @@ from mitol.common.envs import (
     get_string,
     import_settings_modules,
 )
-
-from mitol.payment_gateway.constants import MITOL_PAYMENT_GATEWAY_CYBERSOURCE
 from mitol.google_sheets.settings.google_sheets import *
 from mitol.google_sheets_refunds.settings.google_sheets_refunds import *
-
+from mitol.payment_gateway.constants import MITOL_PAYMENT_GATEWAY_CYBERSOURCE
 from redbeat import RedBeatScheduler
 
 from main.celery_utils import OffsettingSchedule
@@ -790,6 +788,17 @@ CRON_COURSE_CERTIFICATES_DAYS = get_string(
     default="*",
     description="'day_of_week' value for 'generate-course-certificate' scheduled task (default will run once a day).",
 )
+CRON_ORPHAN_CHECK_HOURS = get_string(
+    name="CRON_ORPHAN_CHECK_HOURS",
+    default="3",
+    description="'hours' value for 'check-for-program-orphans' scheduled task (default will run at 3 AM).",
+)
+CRON_ORPHAN_CHECK_DAYS = get_string(
+    name="CRON_ORPHAN_CHECK_DAYS",
+    default="*",
+    description="'day_of_week' value for 'check-for-program-orphans' scheduled task (default will run once a day).",
+)
+
 CERTIFICATE_CREATION_DELAY_IN_HOURS = get_int(
     name="CERTIFICATE_CREATION_DELAY_IN_HOURS",
     default=24,
@@ -844,6 +853,16 @@ CELERY_BEAT_SCHEDULE = {
             minute=0,
             hour=CRON_COURSE_CERTIFICATES_HOURS,
             day_of_week=CRON_COURSE_CERTIFICATES_DAYS,
+            day_of_month="*",
+            month_of_year="*",
+        ),
+    },
+    "check-for-program-orphans": {
+        "task": "courses.tasks.check_for_program_orphans",
+        "schedule": crontab(
+            minute=0,
+            hour=CRON_ORPHAN_CHECK_HOURS,
+            day_of_week=CRON_ORPHAN_CHECK_DAYS,
             day_of_month="*",
             month_of_year="*",
         ),


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots - no real UI changes so no mobile
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1242

#### What's this PR do?

Four things:
1. Updates the Program Drawer to flatten the list of courses if there's no requirements tree. This was throwing an error otherwise as it was assuming there was something there; not having a requirements tree is an error condition but it should have been handling it gracefully.
2. Adds a `check_program_for_orphans` function that checks for a) the requirement tree's existence, and 2) course membership within the tree. 
3. Adds a management command, `check_program_requirements`, to scan programs for potentially problematic requirements trees.
4. Adds a scheduled Celery task to do the tree check automatically (defaults to daily at 3AM). 

#### How should this be manually tested?

1. Create a program with a course, a course run, and a course run enrollment for your test learner.
2. In the database, manually remove all rows from `courses_programrequirement` that belong to the program. (The Django admin stuff and the management command will make you a requirements tree. You may be able to skip this step; the tree will be empty, but the error condition was a program that didn't have a requirements tree at all.) 
3. Go to the program drawer and attempt to open the drawer for that program. It should work. 
6. Run `check_program_for_orphans` in a Django shell or a Jupyter notebook against the program. It should return your orphaned courses, and should log an appropriate error message.
7. Run `check_program_requirements` management command. It should list out the program(s) that have orphaned courses, and should display a message for programs that have no requirements tree at all. 
8. Either wait for the scheduled task to run or manually queue `check_for_program_orphans` to be run, and observe the output. The scheduled task should log error messages if it finds inconsistencies in the program requirements. 

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/945611/205355051-2ca1ba24-e310-4e34-bde8-177ff8f4b896.png)
