### PR TITLE
Fixes the URL in the partner school email

### DIFF
--- a/courses/mail_api.py
+++ b/courses/mail_api.py
@@ -82,11 +82,7 @@ def send_partner_school_sharing_message(learner_record):
                 learner_record.partner_school.email,
                 {
                     "learner_record": learner_record,
-                    "record_link": SITE_BASE_URL
-                    + reverse(
-                        "shared_learner_record_from_uuid",
-                        kwargs={"uuid": learner_record.share_uuid},
-                    ),
+                    "record_link": f"{SITE_BASE_URL}/records/shared/{learner_record.share_uuid}",
                 },
             )
     except Exception:  # pylint: disable=broad-except

--- a/courses/mail_api_test.py
+++ b/courses/mail_api_test.py
@@ -79,9 +79,7 @@ def test_send_enrollment_failure_message(user, mocker, is_program):
 def test_send_partner_school_sharing_message(mocker):
     """Test that the partner school message goes to the right spot"""
     record = LearnerProgramRecordShareFactory()
-    record_link = SITE_BASE_URL + reverse(
-        "shared_learner_record_from_uuid", kwargs={"uuid": record.share_uuid}
-    )
+    record_link = f"{SITE_BASE_URL}/records/shared/{record.share_uuid}"
 
     patched_get_message_sender = mocker.patch("courses.mail_api.get_message_sender")
     mock_sender = patched_get_message_sender.return_value.__enter__.return_value


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1247 

#### What's this PR do?

Fixes the URL that gets put into the partner school sharing email so it goes to the right place.

#### How should this be manually tested?

Send a partner school sharing email (see #1247 for details). The link should go to the right URL, and not to DRF.
