### PR TITLE
Adds "reference_number" to the searchable fields in order admins

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -187,7 +187,12 @@ class OrderTransactionInline(admin.TabularInline):
 class BaseOrderAdmin(FSMTransitionMixin, TimestampedModelAdmin):
     """Base admin for Order"""
 
-    search_fields = ["id", "purchaser__email", "purchaser__username"]
+    search_fields = [
+        "id",
+        "purchaser__email",
+        "purchaser__username",
+        "reference_number",
+    ]
     list_display = ["id", "state", "get_purchaser", "total_price_paid"]
     list_fields = ["state"]
     list_filter = ["state"]
@@ -245,7 +250,12 @@ class FulfilledOrderAdmin(TimestampedModelAdmin):
     """Admin for FulfilledOrder"""
 
     readonly_fields = ["reference_number"]
-    search_fields = ["id", "purchaser__email", "purchaser__username"]
+    search_fields = [
+        "id",
+        "purchaser__email",
+        "purchaser__username",
+        "reference_number",
+    ]
     list_display = ["id", "state", "get_purchaser", "total_price_paid"]
     list_fields = ["state"]
     list_filter = ["state"]


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

n/a

#### What's this PR do?

Adds the reference number field to the searchable fields in `BaseOrderAdmin` and `FulfilledOrderAdmin` (which doesn't subclass `BaseOrderAdmin`). This should make it less annoying to try to find orders based on the reference number. 

#### How should this be manually tested?

In an instance that has orders:
1. Navigate to Django Admin
2. Test that you can search by the reference number