### PR TITLE
feat: management command for creating, revoking program certificates

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -988,3 +988,34 @@ def generate_multiple_programs_certificate(user, programs):
         result = generate_program_certificate(user, program)
         results.append(result)
     return results
+
+
+def manage_program_certificate_access(user, program, revoke_state):
+    """
+    Revokes/Un-Revokes a program certificate.
+
+    Args:
+        user (User): a Django user.
+        program (Program): A Program model object.
+        revoke_state (bool): A flag representing True(Revoke), False(Un-Revoke)
+
+    Returns:
+        bool: A boolean representing the revoke/unrevoke success
+    """
+
+    try:
+        program_certificate = ProgramCertificate.all_objects.get(
+            user=user, program=program
+        )
+    except ProgramCertificate.DoesNotExist:
+        log.warning(
+            "Program certificate for user: %s and program: %s does not exist.",
+            user.username,
+            program.readable_id,
+        )
+        return False
+
+    program_certificate.is_revoked = revoke_state
+    program_certificate.save()
+
+    return True

--- a/courses/api.py
+++ b/courses/api.py
@@ -917,7 +917,7 @@ def has_earned_program_cert(user, program):
     return _has_earned(root)
 
 
-def generate_program_certificate(user, program):
+def generate_program_certificate(user, program, force_create=False):
     """
     Create a program certificate if the user has a course certificate
     for each course in the program. Also, It will create the
@@ -926,6 +926,8 @@ def generate_program_certificate(user, program):
     Args:
         user (User): a Django user.
         program (programs.models.Program): program where the user is enrolled.
+        force_create (bool): Default False, ignores the requirement of passing
+                            the courses for the program certificate if True
 
     Returns:
         (ProgramCertificate or None, bool): A tuple containing a
@@ -941,7 +943,7 @@ def generate_program_certificate(user, program):
         )
         return existing_cert_queryset.first(), False
 
-    if not has_earned_program_cert(user, program):
+    if not force_create and not has_earned_program_cert(user, program):
         return None, False
 
     program_cert = ProgramCertificate.objects.create(user=user, program=program)

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -46,9 +46,11 @@ class Command(BaseCommand):
             help="The id, email or username of the enrolled User",
             required=True,
         )
-        group = parser.add_mutually_exclusive_group()
-        group.add_argument(
-            "--program", type=str, help="The 'readable_id' value for a Program"
+        parser.add_argument(
+            "--program",
+            type=str,
+            help="The id, email or username of the enrolled User",
+            required=True,
         )
         parser.add_argument(
             "--revoke", dest="revoke", action="store_true", required=False
@@ -87,20 +89,12 @@ class Command(BaseCommand):
                 "The command needs a valid action e.g. --revoke, --unrevoke, --create."
             )
 
-        # A user is needed for revoke/un-revoke and certificate creation
-        if not user:
-            raise CommandError("The command needs a valid user.")
-
         try:
             user = fetch_user(user)
         except User.DoesNotExist:
             raise CommandError(
                 "Could not find a user with <username or email>={}.".format(user)
             )
-
-        # A program is needed for revoke/un-revoke and certificate creation
-        if not program:
-            raise CommandError("The command needs a valid program.")
 
         # Unable to obtain a program object based on the provided program readable id
         try:
@@ -133,7 +127,7 @@ class Command(BaseCommand):
         # Handle the creation of the program certificate.
         elif create:
 
-            # if -f or --force argument is provided, we'll forcefully genrate the program certificate
+            # If -f or --force argument is provided, we'll forcefully generate the program certificate
             certificate, created_cert = generate_program_certificate(
                 user=user, program=program, force_create=force_create
             )

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -5,15 +5,15 @@ Check the usages of this command below:
 
 **Certificate Creation**
 
-2. Generate Pogram certificate for a user
+1. Generate Pogram certificate for a user
 ./manage.py manage_program_certificates —-create -—program=<program_readable_id> -—user=<username or email>
 
 **Revoke/Un-revoke Certificates**
 
-3. Revoke a certificate for a user
+2. Revoke a certificate for a user
 ./mange.py manage_program_certificates -—revoke -—user=<username or email> -—program=<program_readable_id>
 
-4. Un-Revoke a certificate for a user
+3. Un-Revoke a certificate for a user
 ./mange.py manage_program_certificates -—unrevoke —-program=<program_readable_id> -—user=<username or email>
 
 """

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -1,0 +1,144 @@
+"""
+Management command to revoke, un revoke or create a certificate for a program for the given User.
+
+Check the usages of this command below:
+
+**Certificate Creation**
+
+2. Generate Pogram certificate for a user
+./manage.py manage_program_certificates —-create -—program=<program_readable_id> -—user=<username or email>
+
+**Revoke/Un-revoke Certificates**
+
+3. Revoke a certificate for a user
+./mange.py manage_program_certificates -—revoke -—user=<username or email> -—program=<program_readable_id>
+
+4. Un-Revoke a certificate for a user
+./mange.py manage_program_certificates -—unrevoke —-program=<program_readable_id> -—user=<username or email>
+
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from users.api import fetch_user
+from courses.api import manage_program_certificate_access, generate_program_certificate
+from courses.models import Program
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Invoke with:
+
+        python manage.py manage_program_certificates
+    """
+
+    help = (
+        "Revoke, un revoke or create a certificate for a program for the given User "
+        "or Users when no user is provided"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="The id, email or username of the enrolled User",
+            required=True,
+        )
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--program", type=str, help="The 'readable_id' value for a Program"
+        )
+        parser.add_argument(
+            "--revoke", dest="revoke", action="store_true", required=False
+        )
+        parser.add_argument(
+            "--unrevoke", dest="unrevoke", action="store_true", required=False
+        )
+        parser.add_argument(
+            "--create", dest="create", action="store_true", required=False
+        )
+
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # pylint: disable=too-many-locals
+        """Handle command execution"""
+
+        revoke = options.get("revoke")
+        unrevoke = options.get("unrevoke")
+        create = options.get("create")
+        program = options.get("program")
+
+        if not (revoke or unrevoke) and not create:
+            raise CommandError(
+                "The command needs a valid action e.g. --revoke, --unrevoke, --create."
+            )
+        try:
+            user = fetch_user(options["user"]) if options["user"] else None
+        except User.DoesNotExist:
+            user = None
+
+        # A program is needed for revoke/un-revoke and certificate creation
+        if not program:
+            raise CommandError("The command needs a valid program.")
+
+        # Unable to obtain a program object based on the provided courseware id
+        try:
+            program = Program.objects.get(readable_id=program)
+        except Program.DoesNotExist:
+            raise CommandError(
+                "Could not find program with readable_id={}.".format(program)
+            )
+
+        # Handle revoke/un-revoke of a certificate
+        if revoke or unrevoke:
+            if not user:
+                raise CommandError("Revoke/Un-revoke operation needs a valid user.")
+
+            revoke_status = manage_program_certificate_access(
+                user=user,
+                program=program,
+                revoke_state=True if revoke else False,
+            )
+
+            if revoke_status:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "Certificate for {} has been {}".format(
+                            "program: {}".format(program),
+                            "revoked." if revoke else "un-revoked.",
+                        )
+                    )
+                )
+            else:
+                self.stdout.write(self.style.WARNING("No changes made."))
+
+        # Handle the creation of the certificates.
+        # Also check if the certificate creation was requested with grade override. (Generally useful when we want to
+        # create a certificate for a user while overriding the grade value)
+        elif create:
+
+            # While overriding grade we force create the certificate
+            certificate, created_cert = generate_program_certificate(
+                user=user,
+                program=program,
+            )
+
+            if certificate and created_cert:
+                cert_status = "created"
+            elif certificate and not created_cert:
+                cert_status = "already exists"
+            else:
+                cert_status = "ignored, certificates for requied courses are missing"
+
+            result_summary = "Certificate: {}".format(cert_status)
+
+            result = "Processed user {} ({}) in program {}. Result - {}".format(
+                user.username,
+                user.email,
+                program.readable_id,
+                result_summary,
+            )
+
+            self.stdout.write(self.style.SUCCESS(result))

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
         user = options.get("user")
         force_create = options.get("force", False)
 
-        if not (revoke or unrevoke) and not create and not user:
+        if not (revoke or unrevoke) and not create:
             raise CommandError(
                 "The command needs a valid action e.g. --revoke, --unrevoke, --create."
             )

--- a/courses/management/commands/test_manage_program_certificate.py
+++ b/courses/management/commands/test_manage_program_certificate.py
@@ -1,0 +1,126 @@
+"""Tests for Certificates management command"""
+
+import pytest
+from courses.management.commands import manage_program_certificates
+from courses.models import ProgramCertificate
+from django.core.management.base import CommandError
+from users.factories import UserFactory
+from courses.factories import (
+    CourseFactory,
+    CourseRunFactory,
+    CourseRunGradeFactory,
+    CourseRunCertificateFactory,
+    ProgramFactory,
+    ProgramCertificateFactory,
+    ProgramRequirementFactory,
+)
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def edx_grade_json(user):
+    return {
+        "passed": True,
+        "course_id": "test_course_id",
+        "username": user.username,
+        "percent": 0.5,
+    }
+
+
+def test_certificate_management_no_argument():
+    """Test that command throws error when no input is provided"""
+
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle()
+    assert (
+        str(command_error.value)
+        == "The command needs a valid action e.g. --revoke, --unrevoke, --create."
+    )
+
+
+def test_certificate_management_invalid_program():
+    """Test that certificate management command throws proper error when no valid program is supplied"""
+
+    test_user = UserFactory.create()
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle(
+            user=test_user.username, create=True
+        )
+    assert str(command_error.value) == "The command needs a valid program."
+
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle(
+            user=test_user.username, create=True, program="test"
+        )
+    assert str(command_error.value) == "Could not find program with readable_id=test."
+
+
+@pytest.mark.parametrize(
+    "username, revoke, unrevoke",
+    [
+        (None, True, None),
+        ("test", True, None),
+        (None, None, True),
+        ("test", None, True),
+    ],
+)
+def test_certificate_management_revoke_unrevoke_invalid_args(
+    username, revoke, unrevoke
+):
+    """Test that the command throws proper error when revoke, un-revoke operations are not given proper arguments"""
+    program = ProgramFactory.create()
+
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle(
+            user=username,
+            revoke=revoke,
+            unrevoke=unrevoke,
+            program=program.readable_id,
+        )
+    assert str(command_error.value) == "Revoke/Un-revoke operation needs a valid user."
+
+
+@pytest.mark.parametrize(
+    "revoke, unrevoke",
+    [
+        (True, None),
+        (None, True),
+    ],
+)
+def test_certificate_management_revoke_unrevoke_success(user, revoke, unrevoke):
+    """Test that certificate revoke, un-revoke work as expected and manage the certificate access properly"""
+    program = ProgramFactory.create()
+    certificate = ProgramCertificateFactory(
+        program=program, user=user, is_revoked=False if revoke else True
+    )
+    manage_program_certificates.Command().handle(
+        revoke=revoke,
+        unrevoke=unrevoke,
+        program=program.readable_id,
+        user=user.username,
+    )
+    certificate.refresh_from_db()
+    assert certificate.is_revoked is (True if revoke else False)
+    assert certificate.is_revoked is (False if unrevoke else True)
+
+
+def test_certificate_management_create(user):
+    """Test that create operation for certificate management command creates the certificates for a single user
+    when a user is provided"""
+    program = ProgramFactory.create()
+    course = CourseFactory.create(program=program)
+    ProgramRequirementFactory.add_root(program)
+    program.add_requirement(course)
+    course_run = CourseRunFactory.create(course=course)
+    CourseRunGradeFactory.create(course_run=course_run, user=user, passed=True, grade=1)
+    CourseRunCertificateFactory.create(user=user, course_run=course_run)
+    manage_program_certificates.Command().handle(
+        create=True, program=program.readable_id, user=user.username
+    )
+
+    generated_certificates = ProgramCertificate.objects.filter(
+        user=user, program=program
+    )
+
+    assert generated_certificates.count() == 1

--- a/courses/management/commands/test_manage_program_certificate.py
+++ b/courses/management/commands/test_manage_program_certificate.py
@@ -51,7 +51,9 @@ def test_program_certificate_management_invalid_program():
         manage_program_certificates.Command().handle(
             user=test_user.username, create=True
         )
-    assert str(command_error.value) == "Could not find program with readable_id={}.".format(None)
+    assert str(
+        command_error.value
+    ) == "Could not find program with readable_id={}.".format(None)
 
     with pytest.raises(CommandError) as command_error:
         manage_program_certificates.Command().handle(

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -8,7 +8,7 @@ from django.test.client import Client
 from rest_framework.test import APIClient
 
 from users.factories import UserFactory
-from courses.factories import ProgramFactory
+from courses.factories import CourseFactory, ProgramFactory, ProgramRequirementFactory
 
 
 @pytest.fixture
@@ -79,6 +79,14 @@ def mock_context(mocker, user):
 def program():
     """Program object fixture"""
     return ProgramFactory.create()
+
+
+@pytest.fixture()
+def program_with_requirements():
+    """Program with requirement root object fixture"""
+    program = ProgramFactory.create()
+    ProgramRequirementFactory.add_root(program)
+    return program
 
 
 @pytest.fixture


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1041 

#### What's this PR do?
- Management command to manually revoke, un revokes, or create a certificate for a program for the given User.

#### How should this be manually tested?
- Checkout to the branch
- Program certificate will only be created if the user has earned certifications of all required courses for a given program
- Following operations can be performed

1. Generate a Program certificate for a user
`./manage.py manage_program_certificates --create --program <program_readable_id> --user <username or email>`

2. Forcefully Generate a Program certificate for a user using `-f` or `--force`
`./manage.py manage_program_certificates --create --program <program_readable_id> --user <username or email> -f`

**Revoke/Un-revoke Program Certificates**

3. Revoke a program certificate for a user
`./mange.py manage_program_certificates --revoke --program <program_readable_id> --user <username or email>`

4. Un-Revoke a program certificate for a user
`./mange.py manage_program_certificates --unrevoke --program <program_readable_id> --user <username or email>`
