### PR TITLE
1253: dashboard courses and programs tabs aren't screen reader accessible

### DIFF
--- a/frontend/public/scss/dashboard.scss
+++ b/frontend/public/scss/dashboard.scss
@@ -17,6 +17,18 @@ $enrolled-passed-bg: #3E775D;
 $enrolled-passed-fg: #ffffff;
 
 .enrolled-items {
+  .hide-element {
+    // hidden elements for screenreaders only
+    border: 0;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px; 
+  } 
   .card {
     display: flex;
 
@@ -197,7 +209,7 @@ $enrolled-passed-fg: #ffffff;
   }
 }
 
-.dashboard h1 {
+.dashboard .tabs {
   margin-bottom: 38px;
   font-size: 38px;
 

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -385,11 +385,11 @@ export class EnrolledItemCard extends React.Component<
                 toggle={this.toggleMenuVisibility.bind(this)}
                 id={`enrollmentDropdown-${enrollment.id}`}
               >
-                <DropdownToggle className="d-inline-flex unstyled dot-menu">
+                <DropdownToggle className="d-inline-flex unstyled dot-menu" aria-label={menuTitle}>
                   <span
                     className="material-icons"
-                    aria-label={menuTitle}
                     title={menuTitle}
+                    aria-hidden="true"
                   >
                     more_vert
                   </span>

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -385,7 +385,10 @@ export class EnrolledItemCard extends React.Component<
                 toggle={this.toggleMenuVisibility.bind(this)}
                 id={`enrollmentDropdown-${enrollment.id}`}
               >
-                <DropdownToggle className="d-inline-flex unstyled dot-menu" aria-label={menuTitle}>
+                <DropdownToggle
+                  className="d-inline-flex unstyled dot-menu"
+                  aria-label={menuTitle}
+                >
                   <span
                     className="material-icons"
                     title={menuTitle}

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -141,7 +141,13 @@ export class DashboardPage extends React.Component<
                 </>
               )}
             </nav>
-            <div id="enrollment-items" className="enrolled-items" aria-live="polite">{this.renderCurrentTab()}</div>
+            <div
+              id="enrollment-items"
+              className="enrolled-items"
+              aria-live="polite"
+            >
+              {this.renderCurrentTab()}
+            </div>
 
             <ProgramEnrollmentDrawer
               isHidden={this.state.programDrawerVisibility}

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -85,19 +85,25 @@ export class DashboardPage extends React.Component<
 
     if (this.state.currentTab === DashboardTab.programs) {
       return (
-        <EnrolledProgramList
-          key={"enrolled-programs"}
-          enrollments={programEnrollments}
-          toggleDrawer={this.toggleDrawer.bind(this)}
-        ></EnrolledProgramList>
+        <div>
+          <h1 className="hide-element">Programs</h1>
+          <EnrolledProgramList
+            key={"enrolled-programs"}
+            enrollments={programEnrollments}
+            toggleDrawer={this.toggleDrawer.bind(this)}
+          ></EnrolledProgramList>
+        </div>
       )
     }
 
     return (
-      <EnrolledCourseList
-        key={"enrolled-courses"}
-        enrollments={enrollments}
-      ></EnrolledCourseList>
+      <div>
+        <h1 className="hide-element">My Courses</h1>
+        <EnrolledCourseList
+          key={"enrolled-courses"}
+          enrollments={enrollments}
+        ></EnrolledCourseList>
+      </div>
     )
   }
 
@@ -115,7 +121,7 @@ export class DashboardPage extends React.Component<
       <DocumentTitle title={`${SETTINGS.site_name} | ${DASHBOARD_PAGE_TITLE}`}>
         <div className="std-page-body dashboard container">
           <Loader isLoading={isLoading}>
-            <h1>
+            <nav className="tabs" aria-controls="enrollment-items">
               {!isProgramUIEnabled() ? (
                 <>My Courses</>
               ) : (
@@ -134,8 +140,8 @@ export class DashboardPage extends React.Component<
                   </button>
                 </>
               )}
-            </h1>
-            <div className="enrolled-items">{this.renderCurrentTab()}</div>
+            </nav>
+            <div id="enrollment-items" className="enrolled-items" aria-live="polite">{this.renderCurrentTab()}</div>
 
             <ProgramEnrollmentDrawer
               isHidden={this.state.programDrawerVisibility}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1253

#### What's this PR do?
Makes sure that screen readers are able to clearly communicate that the user has toggled between the "My courses" and "Programs" tab of the dashboard by announcing the respective tab name when either of the navigation options are selected.  

This also fixes an issue with the "three dot" menu on the course card to ensure that the screen reader will only read the menu title and not "more_vert".

#### How should this be manually tested?
1. Have mitxonline up and running with a program and course created, program run and course run created, and your user enrolled in both.
2. Navigate to http://mitxonline.odl.local:8013/dashboard/?enable_programs
3. Turn on your screen reader.
4. Use the tab key to navigate to the "My courses" and "Programs" navigational options.
5. Focus on the "Programs" navigational option and press enter.  Verify that you hear "Programs" first before the screen reader continues reading the rest of the program card. 
6. Bring focus back to the "My courses" navigational option and press enter.  Verify that you hear "My Courses" first before the screen reader continues reading the rest of the course card.
7. Listen for when the screen reader begins reading the menu title and verify that the screen reader does not say "more vert".

#### Any background context you want to provide?
**Helpful links:**
This is where I found the CSS to visually hide elements but ensure that the screen reader announces them: https://www.nomensa.com/blog/how-improve-web-accessibility-hiding-elements

This is where I learned how to have the screen reader announce the course cards and program cards whenever the navigational options are selected: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
