### PR TITLE
Updates program UI to enable unenrollments

### DIFF
--- a/courses/urls.py
+++ b/courses/urls.py
@@ -14,15 +14,15 @@ router.register(
 router.register(
     r"partnerschools", v1.PartnerSchoolViewSet, basename="partner_schools_api"
 )
+router.register(
+    r"program_enrollments",
+    v1.UserProgramEnrollmentsViewSet,
+    basename="user_program_enrollments_api",
+)
+
 urlpatterns = [
     re_path(r"^api/v1/", include(router.urls)),
     re_path(r"^api/", include(router.urls)),
-    re_path(
-        r"^api//v1/program_enrollments",
-        v1.get_user_program_enrollments,
-        name="user-program-enrollments-api",
-    ),
-    re_path(r"^api/program_enrollments", v1.get_user_program_enrollments),
     path("api/records/program/<pk>/share/", v1.get_learner_record_share),
     path("api/records/program/<pk>/revoke/", v1.revoke_learner_record_share),
     path("api/records/program/<pk>/", v1.get_learner_record),

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -330,12 +330,10 @@ class UserProgramEnrollmentsViewSet(viewsets.ViewSet):
         """
 
         program = Program.objects.get(pk=pk)
-        (enrollment, created) = ProgramEnrollment.objects.filter(
-            user=request.user, program=program
-        ).update_or_create(
+        (enrollment, created) = ProgramEnrollment.objects.update_or_create(
             user=request.user,
             program=program,
-            change_status=ENROLL_CHANGE_STATUS_UNENROLLED,
+            defaults={"change_status": ENROLL_CHANGE_STATUS_UNENROLLED},
         )
 
         return self.list(request)

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -255,55 +255,90 @@ class UserEnrollmentsApiViewSet(
             raise NotImplementedError
 
 
-@api_view()
-@permission_classes([IsAuthenticated])
-def get_user_program_enrollments(request):
-    """
-    Returns a unified set of program and course enrollments for the current
-    user.
-    """
+class UserProgramEnrollmentsViewSet(viewsets.ViewSet):
+    permission_classes = [IsAuthenticated]
 
-    courseruns = (
-        CourseRunEnrollment.objects.filter(user=request.user)
-        .select_related("run__course__page")
-        .select_related("run__course__program")
-        .all()
-    )
+    def list(self, request):
+        """
+        Returns a unified set of program and course enrollments for the current
+        user.
+        """
 
-    program_list = {}
-
-    for enrollment in courseruns:
-        if enrollment.run.course.program is not None:
-            if enrollment.run.course.program.id in program_list:
-                program_list[enrollment.run.course.program.id]["enrollments"].append(
-                    enrollment
-                )
-            else:
-                program_list[enrollment.run.course.program.id] = {
-                    "enrollments": [enrollment],
-                    "program": enrollment.run.course.program,
-                    "certificate": get_program_certificate_by_enrollment(enrollment),
-                }
-
-    non_course_programs = (
-        ProgramEnrollment.objects.filter(user=request.user)
-        .exclude(program_id__in=program_list.keys())
-        .select_related("program")
-        .all()
-    )
-
-    program_list = list(program_list.values())
-
-    for enrollment in non_course_programs:
-        program_list.append(
-            {
-                "enrollments": [],
-                "program": enrollment.program,
-                "certificate": get_program_certificate_by_enrollment(enrollment),
-            }
+        courseruns = (
+            CourseRunEnrollment.objects.filter(user=request.user)
+            .select_related("run__course__page")
+            .select_related("run__course__program")
+            .all()
         )
 
-    return Response(UserProgramEnrollmentDetailSerializer(program_list, many=True).data)
+        program_list = {}
+
+        unenrollments = (
+            ProgramEnrollment.objects.filter(
+                user=request.user, change_status=ENROLL_CHANGE_STATUS_UNENROLLED
+            )
+            .values_list("program_id", flat=True)
+            .all()
+        )
+
+        for enrollment in courseruns:
+            if (
+                enrollment.run.course.program is not None
+                and enrollment.run.course.program.id not in unenrollments
+            ):
+                if enrollment.run.course.program.id in program_list:
+                    program_list[enrollment.run.course.program.id][
+                        "enrollments"
+                    ].append(enrollment)
+                else:
+                    program_list[enrollment.run.course.program.id] = {
+                        "enrollments": [enrollment],
+                        "program": enrollment.run.course.program,
+                        "certificate": get_program_certificate_by_enrollment(
+                            enrollment
+                        ),
+                    }
+
+        non_course_programs = (
+            ProgramEnrollment.objects.filter(user=request.user)
+            .exclude(program_id__in=program_list.keys())
+            .exclude(change_status=ENROLL_CHANGE_STATUS_UNENROLLED)
+            .select_related("program")
+            .all()
+        )
+
+        program_list = list(program_list.values())
+
+        for enrollment in non_course_programs:
+            program_list.append(
+                {
+                    "enrollments": [],
+                    "program": enrollment.program,
+                    "certificate": get_program_certificate_by_enrollment(enrollment),
+                }
+            )
+
+        return Response(
+            UserProgramEnrollmentDetailSerializer(program_list, many=True).data
+        )
+
+    def destroy(self, request, pk=None):
+        """
+        Unenroll the user from this program. This is simpler than the corresponding
+        function for CourseRunEnrollments; edX doesn't really know what programs
+        are so there's nothing to process there.
+        """
+
+        program = Program.objects.get(pk=pk)
+        (enrollment, created) = ProgramEnrollment.objects.filter(
+            user=request.user, program=program
+        ).update_or_create(
+            user=request.user,
+            program=program,
+            change_status=ENROLL_CHANGE_STATUS_UNENROLLED,
+        )
+
+        return self.list(request)
 
 
 class PartnerSchoolViewSet(viewsets.ReadOnlyModelViewSet):

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -7,35 +7,36 @@ import operator as op
 import pytest
 from django.db.models import Count, Q
 from django.urls import reverse
-from requests import HTTPError, ConnectionError as RequestsConnectionError
+from requests import ConnectionError as RequestsConnectionError
+from requests import HTTPError
 from rest_framework import status
 
 from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
 from courses.factories import (
+    BlockedCountryFactory,
     CourseFactory,
     CourseRunEnrollmentFactory,
     CourseRunFactory,
     ProgramFactory,
-    BlockedCountryFactory,
 )
 from courses.models import CourseRun, ProgramEnrollment
 from courses.serializers import (
+    CourseRunEnrollmentSerializer,
     CourseRunSerializer,
     CourseSerializer,
     ProgramSerializer,
-    CourseRunEnrollmentSerializer,
 )
 from courses.views.v1 import UserEnrollmentsApiViewSet
 from main import features
 from main.constants import (
     USER_MSG_COOKIE_NAME,
     USER_MSG_TYPE_ENROLL_BLOCKED,
-    USER_MSG_TYPE_ENROLLED,
     USER_MSG_TYPE_ENROLL_FAILED,
+    USER_MSG_TYPE_ENROLLED,
 )
 from main.test_utils import assert_drf_json_equal
-from openedx.exceptions import NoEdxApiAuthError
 from main.utils import encode_json_cookie_value
+from openedx.exceptions import NoEdxApiAuthError
 
 pytestmark = [pytest.mark.django_db]
 
@@ -612,7 +613,7 @@ def test_program_enrollments(
     course_run = CourseRunFactory.create(course=course)
     course_run_enrollment = CourseRunEnrollmentFactory.create(run=course_run, user=user)
 
-    resp = user_drf_client.get(reverse("user-program-enrollments-api"))
+    resp = user_drf_client.get(reverse("user_program_enrollments_api-list"))
 
     assert resp.status_code == status.HTTP_200_OK
 

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -562,10 +562,6 @@ export class EnrolledItemCard extends React.Component<
     const courseRunStatusMessageText = null
     const menuTitle = `Program information for ${enrollment.program.title}`
 
-    const courseId = enrollment.program.readable_id
-
-    // const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
-
     return (
       <div
         className="enrolled-item container card mb-4 rounded-0 pb-0 pt-md-3"

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -38,7 +38,7 @@ import {
 } from "../lib/courseApi"
 import { isSuccessResponse } from "../lib/util"
 
-import type { RunEnrollment, Program } from "../flow/courseTypes"
+import type { RunEnrollment, Program, ProgramEnrollment } from "../flow/courseTypes"
 import type { CurrentUser } from "../flow/authTypes"
 
 type EnrolledItemCardProps = {
@@ -59,6 +59,7 @@ type EnrolledItemCardState = {
   submittingEnrollmentId: number | null,
   emailSettingsModalVisibility: boolean,
   verifiedUnenrollmentModalVisibility: boolean,
+  programUnenrollmentModalVisibility: boolean,
   menuVisibility: boolean
 }
 
@@ -70,6 +71,7 @@ export class EnrolledItemCard extends React.Component<
     submittingEnrollmentId:              null,
     emailSettingsModalVisibility:        false,
     verifiedUnenrollmentModalVisibility: false,
+    programUnenrollmentModalVisibility:  false,
     menuVisibility:                      false
   }
 
@@ -84,6 +86,14 @@ export class EnrolledItemCard extends React.Component<
     const { verifiedUnenrollmentModalVisibility } = this.state
     this.setState({
       verifiedUnenrollmentModalVisibility: !verifiedUnenrollmentModalVisibility
+    })
+  }
+
+  toggleProgramUnenrollmentModalVisibility = () => {
+    const { programUnenrollmentModalVisibility } = this.state
+    console.log("fartin in the wind")
+    this.setState({
+      programUnenrollmentModalVisibility: !programUnenrollmentModalVisibility
     })
   }
 
@@ -258,6 +268,42 @@ export class EnrolledItemCard extends React.Component<
             </a>{" "}
             for assistance.
           </p>
+        </ModalBody>
+      </Modal>
+    )
+  }
+
+  renderProgramUnenrollmentModal(enrollment: ProgramEnrollment) {
+    const { programUnenrollmentModalVisibility } = this.state
+
+    return (
+      <Modal
+        id={`program-unenrollment-${enrollment.program.id}-modal`}
+        className="text-center"
+        isOpen={programUnenrollmentModalVisibility}
+        toggle={() => this.toggleProgramUnenrollmentModalVisibility()}
+      >
+        <ModalHeader
+          toggle={() => this.toggleProgramUnenrollmentModalVisibility()}
+        >
+          Unenroll From {enrollment.program.title}
+        </ModalHeader>
+        <ModalBody>
+          <p>
+            Are you sure you wish to unenroll from {enrollment.program.title}?
+          </p>
+          <Button
+            type="submit"
+            color="success"
+            onClick={() => this.toggleProgramUnenrollmentModalVisibility()}
+          >
+            God Yes
+          </Button>{" "}
+          <Button
+            onClick={() => this.toggleProgramUnenrollmentModalVisibility()}
+          >
+            Hell No
+          </Button>
         </ModalBody>
       </Modal>
     )
@@ -453,6 +499,7 @@ export class EnrolledItemCard extends React.Component<
 
   renderProgramEnrollment() {
     const { enrollment } = this.props
+    const { menuVisibility } = this.state
 
     const title = enrollment.program.title
     const startDateDescription = null
@@ -460,6 +507,10 @@ export class EnrolledItemCard extends React.Component<
     const pageLocation = null
     const courseRunStatusMessageText = null
     const menuTitle = `Program information for ${enrollment.program.title}`
+
+    const courseId = enrollment.program.readable_id
+
+    // const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
 
     return (
       <div
@@ -486,18 +537,37 @@ export class EnrolledItemCard extends React.Component<
                   {title}
                 </a>
               </h2>
-              <a
-                rel="noopener noreferrer"
-                href="#program_enrollment_drawer"
-                aria-flowto="program_enrollment_drawer"
-                aria-haspopup="dialog"
-                className="text-body material-icons"
-                aria-label={menuTitle}
-                title={menuTitle}
-                onClick={this.toggleProgramInfo.bind(this)}
+              <Dropdown
+                isOpen={menuVisibility}
+                toggle={this.toggleMenuVisibility.bind(this)}
+                id={`programEnrollmentDropdown-${enrollment.id}`}
               >
-                more_vert
-              </a>
+                <DropdownToggle
+                  className="d-inline-flex unstyled dot-menu"
+                  aria-label={menuTitle}
+                >
+                  <span
+                    className="material-icons"
+                    title={menuTitle}
+                    aria-hidden="true"
+                  >
+                    more_vert
+                  </span>
+                </DropdownToggle>
+                <DropdownMenu right>
+                  <span id={`unenrollButtonWrapper-${enrollment.id}`}>
+                    <DropdownItem
+                      className="unstyled d-block"
+                      onClick={() =>
+                        this.toggleProgramUnenrollmentModalVisibility()
+                      }
+                    >
+                      Unenroll
+                    </DropdownItem>
+                    {this.renderProgramUnenrollmentModal(enrollment)}
+                  </span>
+                </DropdownMenu>
+              </Dropdown>
             </div>
             <div className="detail pt-1">
               {startDateDescription === null}

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -154,6 +154,8 @@ export class EnrolledItemCard extends React.Component<
   async onProgramUnenrollment(program: Program) {
     const { deactivateProgramEnrollment, addUserNotification } = this.props
 
+    this.toggleProgramUnenrollmentModalVisibility()
+
     let userMessage, messageType
 
     try {
@@ -179,7 +181,6 @@ export class EnrolledItemCard extends React.Component<
     })
     // Scroll to the top of the page to make sure the user sees the message
     window.scrollTo(0, 0)
-    this.toggleProgramUnenrollmentModalVisibility()
   }
 
   async onSubmitEmailSettings(payload: Object) {
@@ -256,8 +257,14 @@ export class EnrolledItemCard extends React.Component<
                     type="checkbox"
                     name="subscribeEmails"
                     checked={values.subscribeEmails}
+                    aria-labelledby={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
                   />{" "}
-                  <label check>Receive course emails</label>
+                  <label
+                    id={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
+                    check
+                  >
+                    Receive course emails
+                  </label>
                 </section>
                 <Button type="submit" color="success">
                   Save Settings
@@ -284,13 +291,17 @@ export class EnrolledItemCard extends React.Component<
         className="text-center"
         isOpen={verifiedUnenrollmentModalVisibility}
         toggle={() => this.toggleVerifiedUnenrollmentModalVisibility()}
+        role="dialog"
+        aria-labelledby={`verified-unenrollment-${enrollment.id}-modal-header`}
+        aria-describedby={`verified-unenrollment-${enrollment.id}-modal-body`}
       >
         <ModalHeader
           toggle={() => this.toggleVerifiedUnenrollmentModalVisibility()}
+          id={`verified-unenrollment-${enrollment.id}-modal-header`}
         >
           Unenroll From {enrollment.run.course_number}
         </ModalHeader>
-        <ModalBody>
+        <ModalBody id={`verified-unenrollment-${enrollment.id}-modal-body`}>
           <p>
             You are enrolled in the certificate track for{" "}
             {enrollment.run.course_number} {enrollment.run.title}. You can't
@@ -318,13 +329,19 @@ export class EnrolledItemCard extends React.Component<
         className="text-center"
         isOpen={programUnenrollmentModalVisibility}
         toggle={() => this.toggleProgramUnenrollmentModalVisibility()}
+        role="dialog"
+        aria-labelledby={`program-unenrollment-${enrollment.program.id}-modal-header`}
+        aria-describedby={`program-unenrollment-${enrollment.program.id}-modal-body`}
       >
         <ModalHeader
+          id={`program-unenrollment-${enrollment.program.id}-modal-header`}
           toggle={() => this.toggleProgramUnenrollmentModalVisibility()}
         >
           Unenroll From {enrollment.program.title}
         </ModalHeader>
-        <ModalBody>
+        <ModalBody
+          id={`program-unenrollment-${enrollment.program.id}-modal-body`}
+        >
           <p>
             Are you sure you wish to unenroll from {enrollment.program.title}?
             You will not be unenrolled from any courses within the program.

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -64,7 +64,9 @@ describe("EnrolledItemCard", () => {
           enrollment={enrollmentCardProps.enrollment}
           currentUser={currentUser}
           deactivateEnrollment={enrollmentCardProps.deactivateEnrollment}
-          deactivateProgramEnrollment={enrollmentCardProps.deactivateProgramEnrollment}
+          deactivateProgramEnrollment={
+            enrollmentCardProps.deactivateProgramEnrollment
+          }
           courseEmailsSubscription={
             enrollmentCardProps.courseEmailsSubscription
           }

--- a/frontend/public/src/components/EnrolledProgramList.js
+++ b/frontend/public/src/components/EnrolledProgramList.js
@@ -17,7 +17,7 @@ export class EnrolledProgramList extends React.Component<EnrolledProgramListProp
 
     return (
       <EnrolledItemCard
-        key={enrollment.id}
+        key={`program-item-${enrollment.program.id}`}
         enrollment={enrollment}
         toggleProgramDrawer={toggleDrawer}
       ></EnrolledItemCard>

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -148,7 +148,9 @@ export const makeCertificate = (): Certificate => ({
   uuid: casual.uuid
 })
 
-export const makeProgramEnrollment = (cert: boolean = false): ProgramEnrollment => ({
+export const makeProgramEnrollment = (
+  cert: boolean = false
+): ProgramEnrollment => ({
   program:     makeProgram(),
   enrollments: makeCourseRunEnrollment(),
   certificate: cert ? makeCertificate() : undefined

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -6,6 +6,7 @@ import { incrementer } from "./util"
 import type { LearnerRecordUser } from "../flow/authTypes"
 
 import type {
+  Certificate,
   CourseRun,
   CourseRunDetail,
   CourseRunEnrollment,
@@ -142,9 +143,15 @@ export const makeProgram = (): Program => ({
   courses:     [makeCourseDetailWithRuns()]
 })
 
-export const makeProgramEnrollment = (): ProgramEnrollment => ({
+export const makeCertificate = (): Certificate => ({
+  link: `/certificate/program/${casual.uuid}`,
+  uuid: casual.uuid
+})
+
+export const makeProgramEnrollment = (cert: boolean = false): ProgramEnrollment => ({
   program:     makeProgram(),
-  enrollments: makeCourseRunEnrollment()
+  enrollments: makeCourseRunEnrollment(),
+  certificate: cert ? makeCertificate() : undefined
 })
 
 export const makeLearnerRecordCertificate = (): LearnerRecordCertificate => ({

--- a/frontend/public/src/flow/courseTypes.js
+++ b/frontend/public/src/flow/courseTypes.js
@@ -109,10 +109,7 @@ export type LearnerRecordGrade = {
   grade_percent: number
 }
 
-export type LearnerRecordCertificate = {
-  uuid: string,
-  link: string
-}
+export type LearnerRecordCertificate = Certficate
 
 export type LearnerRecordCourse = {
   title: string,

--- a/frontend/public/src/lib/queries/enrollment.js
+++ b/frontend/public/src/lib/queries/enrollment.js
@@ -101,6 +101,20 @@ export const deactivateEnrollmentMutation = (enrollmentId: number) => ({
   }
 })
 
+export const deactivateProgramEnrollmentMutation = (programId: number) => ({
+  url:     `/api/program_enrollments/${programId}/`,
+  options: {
+    ...getCsrfOptions(),
+    method: "DELETE"
+  },
+  transform: json => ({
+    program_enrollments: json
+  }),
+  update: {
+    program_enrollments: nextState
+  }
+})
+
 export const courseEmailsSubscriptionMutation = (
   enrollmentId: number,
   emailsSubscription: string = ""


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [ ] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1251.

#### What's this PR do?

Adds the option to unenroll from a program in the program UI. If selected, the learner is unenrolled from the program (creating a specific enrollment record for the program with change status set to "unenrolled" if necessary), but _does not_ affect the enrollment of any individual courses. This also updates the `program_enrollments` API to respect program unenrollments when calculating the learner's program enrollments. As an added bonus, this also fixes the accessibility on all the modals in the `EnrolledItemCard.js` so that the contents of each modal actually get read by the screen reader (this was not the case previously, afaik). 

#### How should this be manually tested?

1. Ensure your learner account is enrolled in some programs, either implicitly (via an enrollment in a course in a program) or explicitly (with a generated program enrollment record). 
2. View the dashboard and switch to the Programs tab. You should see a list of the programs in which the learner is enrolled. 
3. Activate the hamburger/three dots menu on the right side of any of the program item cards. You should now get a menu. (Prior to this, the menu would open the program drawer; it shouldn't do that any longer.
4. The only menu option is Unenroll. Select it.
5. A dialog should pop up asking you to confirm the unenrollment. Select Unenroll.
6. The dialog should clear and you should get a notification saying your enrollment was successful, and the list should update to reflect your changes.
7. Repeat step 4 but click Cancel instead. The dialog should close.

Testing accessibility: With the screen reader (VoiceOver/etc.) turned on, you should be able to navigate to the More Info menu, open it, and select the Unenroll option. The screen reader should read the title of the dialog and also the explanation text inside. You should be able to navigate to the buttons and activate them. 

Similarly, you can test the _course_ unenroll and email options; they should work in the same way. Notably, the course email options should read the label of the checkbox, and the verified course unenrollment error dialog should read the explanation text within. 

#### Screenshots (if appropriate)

![Screen Shot 2022-12-12 at 1 24 37 PM](https://user-images.githubusercontent.com/945611/207135848-8583f6a3-2aff-4533-9970-4790f706bdcd.png)

![image](https://user-images.githubusercontent.com/945611/207135802-9a22182c-0ce5-41c1-bf8e-72a4c7f29f7a.png)

Mobile:

![image](https://user-images.githubusercontent.com/945611/207136020-b0f977d4-7350-42e3-8d04-6794d0b97848.png)


![image](https://user-images.githubusercontent.com/945611/207135942-8da94858-3027-4e71-b8ce-d5df1845cf3b.png)
