### PR TITLE
Program drawer remove not enrolled

### DIFF
--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -160,10 +160,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
             <div className="row chrome" id="program_enrollment_subtite">
               <p>
                 Program overview: {enrollment.program.courses.length} courses |{" "}
-                {passedCourses} passed |{" "}
-                {enrollment.program.courses.length -
-                  enrollment.enrollments.length}{" "}
-                not enrolled
+                {passedCourses} passed
                 {areLearnerRecordsEnabled() ? (
                   <>
                     <br />


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots

#### What are the relevant tickets?
Fix #1259

#### What's this PR do?
Remove the not enrolled course count which sometimes shows negative numbers

#### How should this be manually tested?
Go to the dashboard and check out the program drawer
<img width="554" alt="Screen Shot 2022-12-13 at 10 43 03 AM" src="https://user-images.githubusercontent.com/7574259/207379154-a27aa003-2859-4071-97c9-1e3ab83e26c5.png">


