### PR TITLE
1252: dashboard course should not be in progress and ended at the same time

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -370,12 +370,6 @@ export class EnrolledItemCard extends React.Component<
                       Enrolled in certificate track
                     </span>
                   ) : null}
-                  {startDateDescription !== null &&
-                  startDateDescription.active ? (
-                      <span className="badge badge-in-progress mr-2">
-                      In Progress
-                      </span>
-                    ) : null}
                 </div>
 
                 <h2 className="my-0 mr-3">{title}</h2>

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -148,8 +148,22 @@ describe("EnrolledItemCard", () => {
     assert.isTrue(detailText.startsWith(" | Active"))
   })
 
-  it("Course detail shows `Starts` when start date in future", async () => {
+  it("Course detail shows `Starts` when start date and end date are in the future", async () => {
     enrollmentCardProps.enrollment.run.start_date = moment().add(7, "d")
+    enrollmentCardProps.enrollment.run.end_date = moment().add(14, "d")
+    const inner = await renderedCard()
+    const detail = inner.find(".enrolled-item").find(".detail")
+    assert.isTrue(detail.exists())
+    const detailText = detail
+      .find("span")
+      .at(0)
+      .text()
+    assert.isTrue(detailText.startsWith(" | Starts"))
+  })
+
+  it("Course detail shows `Starts` when start date is in the future and end date is null", async () => {
+    enrollmentCardProps.enrollment.run.start_date = moment().add(7, "d")
+    enrollmentCardProps.enrollment.run.end_date = null
     const inner = await renderedCard()
     const detail = inner.find(".enrolled-item").find(".detail")
     assert.isTrue(detail.exists())

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -49,7 +49,15 @@ export const courseRunStatusMessage = (run: CourseRun) => {
   const startDateDescription = generateStartDateText(run)
   if (startDateDescription !== null) {
     if (startDateDescription.active) {
-      if (moment(run.end_date).isBefore(moment())) {
+      return (
+        <span>
+          {" "}
+          |<strong className="active-enrollment-text"> Active</strong> from{" "}
+          {startDateDescription.datestr}
+        </span>
+      )
+    } else {
+      if (run.end_date !== null && moment(run.end_date).isBefore(moment())) {
         const dateString = parseDateString(run.end_date)
         return (
           <span>
@@ -61,21 +69,11 @@ export const courseRunStatusMessage = (run: CourseRun) => {
         return (
           <span>
             {" "}
-            |<strong className="active-enrollment-text">
-              {" "}
-              Active
-            </strong> from {startDateDescription.datestr}
+            | <strong className="text-dark">Starts</strong>{" "}
+            {startDateDescription.datestr}
           </span>
         )
       }
-    } else {
-      return (
-        <span>
-          {" "}
-          | <strong className="text-dark">Starts</strong>{" "}
-          {startDateDescription.datestr}
-        </span>
-      )
     }
   } else {
     return null
@@ -87,9 +85,16 @@ export const generateStartDateText = (run: CourseRunDetail) => {
     const now = moment()
     const startDate = parseDateString(run.start_date)
     const formattedStartDate = formatPrettyDateTimeAmPmTz(startDate)
-    return now.isBefore(startDate)
-      ? { active: false, datestr: formattedStartDate }
-      : { active: true, datestr: formattedStartDate }
+    if (run.end_date) {
+      const endDate = parseDateString(run.end_date)
+      return now.isAfter(startDate) && now.isBefore(endDate)
+        ? { active: true, datestr: formattedStartDate }
+        : { active: false, datestr: formattedStartDate }
+    } else {
+      return now.isAfter(startDate)
+        ? { active: true, datestr: formattedStartDate }
+        : { active: false, datestr: formattedStartDate }
+    }
   }
 
   return null

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -107,7 +107,14 @@ describe("Course API", () => {
         future,
         null,
         "run is not in progress",
-        { active: true, datestr: "" }
+        { active: false, datestr: "" }
+      ],
+      [
+        exampleUrl,
+        past,
+        past,
+        "run is not in progress",
+        { active: false, datestr: "" }
       ],
       [exampleUrl, null, null, "run has no start date", null]
     ].forEach(([coursewareUrl, startDate, endDate, desc, expLinkable]) => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1252

#### What's this PR do?
Removes the "In Progress" badge from the course card on the dashboard.  Cleans up some of the logic regarding whether a a course run is before the start date, in progress, or ended.

#### How should this be manually tested?

1. Have mitxonline up and running with an administrator user.
2. Create a course and associated course run which has a start date in the future.
3. Enroll your user into the course run.
4. Visit http://mitxonline.odl.local:8013/dashboard/ and ensure that the course card description shows "Starts"
5. Modify the course run from step 2 to have a start date that is before the current time.
6. Visit http://mitxonline.odl.local:8013/dashboard/ and ensure that the course card description shows "Active"
7. Modify the course run from step 2 to have an end date that is before the current time.
8. Visit http://mitxonline.odl.local:8013/dashboard/ and ensure that the course card description shows "Ended"
9. Modify the course run from step 2 to not have an end date.
10. Visit http://mitxonline.odl.local:8013/dashboard/ and ensure that the course card description shows "Active"


#### Screenshots (if appropriate)

![Screen Shot 2022-12-13 at 11 00 31](https://user-images.githubusercontent.com/8311573/207382654-c8409acb-8f47-4706-b8ac-5b43f8bed55e.png)
![Screen Shot 2022-12-13 at 11 00 15](https://user-images.githubusercontent.com/8311573/207382657-7dd24066-3038-4769-ae2a-d96eb781ec15.png)
![Screen Shot 2022-12-13 at 10 55 40](https://user-images.githubusercontent.com/8311573/207382658-e7098adb-3527-4c65-9092-d5d87190b11c.png)
![Screen Shot 2022-12-13 at 11 02 15](https://user-images.githubusercontent.com/8311573/207382979-9d53439f-ece1-4c68-b05c-4a8ffa518fde.png)
![Screen Shot 2022-12-13 at 11 01 58](https://user-images.githubusercontent.com/8311573/207382983-df3bcdc9-c939-4277-8df5-746b25a081d8.png)
![Screen Shot 2022-12-13 at 11 01 31](https://user-images.githubusercontent.com/8311573/207382984-e3a7d9b6-1456-4f25-93e1-98eaa5d245c5.png)

