### PR TITLE
Updates courseware URL generation in import_courseware command

### DIFF
--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -180,7 +180,7 @@ class Command(BaseCommand):
                     is_self_paced=edx_course.is_self_paced(),
                     courseware_url_path=parse.urljoin(
                         settings.OPENEDX_API_BASE_URL,
-                        f"/courses/{edx_course.course_id}",
+                        f"/courses/{edx_course.course_id}/home",
                     ),
                 )
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1280

#### What's this PR do?

Changes the generated URL for `courseware_url` to include `/home` when importing a course run from edX, so the learner will be taken into the course rather than to the about page on edX. 

#### How should this be manually tested?

Import a course run - the instructions from https://github.com/mitodl/mitxonline/pull/1256 or the [documentation for the command](https://mitodl.github.io/mitxonline/commands/import_courserun.html) would be helpful here. The resulting course run in MITx Online should have a URL that ends in `/home` and activating it should take you into the course.
