### PR TITLE
Fixed program info card to render course details link properly

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -1,10 +1,8 @@
 """CMS app serializers"""
-from django.templatetags.static import static
-from rest_framework import serializers
 import bleach
 from django.contrib.contenttypes.models import ContentType
-
-from django.contrib.contenttypes.models import ContentType
+from django.templatetags.static import static
+from rest_framework import serializers
 
 from cms import models
 from cms.api import get_wagtail_img_src
@@ -22,6 +20,7 @@ class CoursePageSerializer(serializers.ModelSerializer):
     description = serializers.SerializerMethodField()
     current_price = serializers.SerializerMethodField()
     instructors = serializers.SerializerMethodField()
+    live = serializers.SerializerMethodField()
 
     def get_feature_image_src(self, instance):
         """Serializes the source of the feature_image"""
@@ -116,6 +115,9 @@ class CoursePageSerializer(serializers.ModelSerializer):
 
         return returnable_members
 
+    def get_live(self, instance):
+        return instance.live
+
     class Meta:
         model = models.CoursePage
         fields = [
@@ -125,4 +127,5 @@ class CoursePageSerializer(serializers.ModelSerializer):
             "description",
             "current_price",
             "instructors",
+            "live",
         ]

--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -1,18 +1,19 @@
 """
 Tests for cms serializers
 """
-from cms.models import FlexiblePricingRequestForm
+import bleach
 import pytest
+from django.test.client import RequestFactory
+
 from cms.factories import (
     CoursePageFactory,
     FlexiblePricingFormFactory,
     ProgramPageFactory,
 )
+from cms.models import FlexiblePricingRequestForm
 from cms.serializers import CoursePageSerializer
 from courses.factories import CourseFactory, ProgramFactory
 from main.test_utils import assert_drf_json_equal
-from django.test.client import RequestFactory
-import bleach
 
 pytestmark = [pytest.mark.django_db]
 
@@ -53,6 +54,7 @@ def test_serialize_course_page(
             "instructors": [],
             "current_price": None,
             "description": bleach.clean(course_page.description, tags=[], strip=True),
+            "live": True,
         },
     )
     patched_get_wagtail_src.assert_called_once_with(course_page.feature_image)
@@ -92,6 +94,7 @@ def test_serialize_course_page_with_flex_price_with_program_fk_and_parent(
             "instructors": [],
             "current_price": None,
             "description": bleach.clean(course_page.description, tags=[], strip=True),
+            "live": True,
         },
     )
 
@@ -130,6 +133,7 @@ def test_serialize_course_page_with_flex_price_with_program_fk_no_parent(
             "instructors": [],
             "current_price": None,
             "description": bleach.clean(course_page.description, tags=[], strip=True),
+            "live": True,
         },
     )
 
@@ -168,6 +172,7 @@ def test_serialize_course_page_with_flex_price_form_as_program_child(
             "instructors": [],
             "current_price": None,
             "description": bleach.clean(course_page.description, tags=[], strip=True),
+            "live": True,
         },
     )
 
@@ -204,5 +209,6 @@ def test_serialize_course_page_with_flex_price_form_as_child_no_program(
             "instructors": [],
             "current_price": None,
             "description": bleach.clean(course_page.description, tags=[], strip=True),
+            "live": True,
         },
     )

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -229,6 +229,7 @@ def test_serialize_course_with_page_fields(
             "instructors": [],
             "current_price": None,
             "description": bleach.clean(course_page.description, tags=[], strip=True),
+            "live": True,
         },
     )
     patched_get_wagtail_src.assert_called_once_with(course_page.feature_image)

--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -27,10 +27,10 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
           course.courseruns[0]
         )
       }
+    }
 
-      if (course.courseruns[0].page) {
-        courseDetailsPage = course.courseruns[0].page.page_url
-      }
+    if (course.page) {
+      courseDetailsPage = course.page.page_url
     }
 
     if (course.financial_assistance_form_url) {

--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -29,7 +29,7 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
       }
     }
 
-    if (course.page) {
+    if (course.page && course.page.live) {
       courseDetailsPage = course.page.page_url
     }
 

--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -80,34 +80,38 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
             </div>
           </div>
         </div>
-        <div className="row flex-grow-1 pt-3">
-          <div className="col pl-0 pr-0">
-            <div className="upgrade-item-description detail d-md-flex flex-column px-4 justify-content-between pb-3">
-              <div className=" w-100 ">
-                <strong>Enroll today</strong> for free, and start learning from
-                MIT faculty. Courses are always free until you want to get a
-                certificate.
-              </div>
-              <div className="enrollment-extra-links d-flex d-md-flex justify-content-center w-100">
-                <div className="pr-4 my-auto">
-                  {financialAssistanceForm ? (
-                    <a href={financialAssistanceForm}>Financial assistance?</a>
-                  ) : null}
+        {courseDetailsPage ? (
+          <div className="row flex-grow-1 pt-3">
+            <div className="col pl-0 pr-0">
+              <div className="upgrade-item-description detail d-md-flex flex-column px-4 justify-content-between pb-3">
+                <div className=" w-100 ">
+                  <strong>Enroll today</strong> for free, and start learning
+                  from MIT faculty. Courses are always free until you want to
+                  get a certificate.
                 </div>
-                <div className="my-auto">
-                  <form method="get" action={courseDetailsPage}>
-                    <button
-                      type="submit"
-                      className="btn btn-primary btn-gradient-red"
-                    >
-                      Enroll
-                    </button>
-                  </form>
+                <div className="enrollment-extra-links d-flex d-md-flex justify-content-center w-100">
+                  <div className="pr-4 my-auto">
+                    {financialAssistanceForm ? (
+                      <a href={financialAssistanceForm}>
+                        Financial assistance?
+                      </a>
+                    ) : null}
+                  </div>
+                  <div className="my-auto">
+                    <form method="get" action={courseDetailsPage}>
+                      <button
+                        type="submit"
+                        className="btn btn-primary btn-gradient-red"
+                      >
+                        Enroll
+                      </button>
+                    </form>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
+        ) : null}
       </div>
     )
   }

--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -80,9 +80,9 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
             </div>
           </div>
         </div>
-        {courseDetailsPage ? (
-          <div className="row flex-grow-1 pt-3">
-            <div className="col pl-0 pr-0">
+        <div className="row flex-grow-1 pt-3">
+          <div className="col pl-0 pr-0">
+            {courseDetailsPage ? (
               <div className="upgrade-item-description detail d-md-flex flex-column px-4 justify-content-between pb-3">
                 <div className=" w-100 ">
                   <strong>Enroll today</strong> for free, and start learning
@@ -109,9 +109,9 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
                   </div>
                 </div>
               </div>
-            </div>
+            ) : null}
           </div>
-        ) : null}
+        </div>
       </div>
     )
   }

--- a/frontend/public/src/flow/cmsTypes.js
+++ b/frontend/public/src/flow/cmsTypes.js
@@ -1,4 +1,5 @@
 export type CoursePage = {
   featured_image_src: string,
-  page_url: string
+  page_url: string,
+  live: boolean,
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1288 

#### What's this PR do?

Fixes the Program Info Card (used in the program drawer to display course info when there's no enrollment) to look for the course details page in the course, rather than in the course run, which should fix the rendering issue.

#### How should this be manually tested?

To test, you will need a program that has several courses in it. Your test learner needs either an explicit enrollment in the program or enrollment in one of the courses. The courses should have CMS pages attached to them - to fully test, at least one _should not_ have a CMS page. 

Open the program drawer for the program. All courses that have a CMS page should also have a Course Details link, and that link should go to the CMS page, regardless of the learner's enrollment in the course. Courses that do _not_ have a CMS page should not display the Course Details link.
