### PR TITLE
Fixes the course model to round the grade (fixes a flaky test)

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -4,6 +4,9 @@ Course models
 import logging
 import operator as op
 import uuid
+from decimal import ROUND_HALF_EVEN
+from decimal import Context as DecimalContext
+from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
@@ -1110,7 +1113,11 @@ class CourseRunGrade(TimestampedModel, AuditableModel, ValidateOnSaveMixin):
     @property
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
-        return self.grade * 100 if self.grade is not None else None
+        return (
+            Decimal(self.grade * 100, DecimalContext(prec=2, rounding=ROUND_HALF_EVEN))
+            if self.grade is not None
+            else None
+        )
 
     @property
     def is_certificate_eligible(self):


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

n/a

#### What's this PR do?

Updates `grade_percent` to return a Decimal that's rounded half even to 2 places rather than the default. This was causing a test to fail randomly. 

#### How should this be manually tested?

The test that fails is `courses/serializers_test.py::test_serialize_course_run_enrollments_with_grades` and the problem is that the grade is stored as a decimal and the grade calculation (which then uses a `Decimal` object and divides it) ends up adding precision where it's not really needed. (So, grade is .78 and then it gets multiplied by 100 and due to floating point math ends up being 77.99999 or something.) 
