### PR TITLE
Update course message if already enrolled

### DIFF
--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -23,7 +23,10 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
 
     if (course.courseruns) {
       for (let i = 0; i < enrollment.enrollments.length; i++) {
-        if (enrollment.enrollments[i].run.course.readable_id === course.readable_id) {
+        if (
+          enrollment.enrollments[i].run.course.readable_id ===
+          course.readable_id
+        ) {
           found = enrollment.enrollments[i]
         }
       }

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -22,13 +22,12 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
     let found = undefined
 
     if (course.courseruns) {
-      for (let i = 0; i < course.courseruns.length; i++) {
-        found = enrollment.enrollments.find(
-          elem => elem.run.id === course.courseruns[i].id
-        )
+      for (let i = 0; i < enrollment.enrollments.length; i++) {
+        if (enrollment.enrollments[i].run.course.readable_id === course.readable_id) {
+          found = enrollment.enrollments[i]
+        }
       }
     }
-
     if (found === undefined) {
       return (
         <ProgramCourseInfoCard


### PR DESCRIPTION

<img width="839" alt="Screen Shot 2022-12-20 at 10 15 49 AM" src="https://user-images.githubusercontent.com/7574259/208700880-887902a3-a610-461e-8f3b-4407303d0165.png">
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots


#### What are the relevant tickets?
Fix #1294

#### What's this PR do?

Update course message in the program drawer if already enrolled. Updates the logic that decides which course card to show.
#### How should this be manually tested?
Go to the student dashboard, open the program drawer and make sure that courses that the user is already enrolled do not show a button to enroll

