### PR TITLE
fix:dashboard confirmation dialog for unenrolling from courses

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -326,8 +326,8 @@ export class EnrolledItemCard extends React.Component<
   renderUnverifiedUnenrollmentModal(enrollment: RunEnrollment) {
     const { runUnenrollmentModalVisibility } = this.state
     const now = moment()
-    const endDate = enrollment.run.end_date
-      ? parseDateString(enrollment.run.end_date)
+    const endDate = enrollment.run.enrollment_end
+      ? parseDateString(enrollment.run.enrollment_end)
       : null
     const formattedEndDate = endDate ? formatPrettyDateTimeAmPmTz(endDate) : ""
     return (

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -329,9 +329,7 @@ export class EnrolledItemCard extends React.Component<
     const endDate = enrollment.run.end_date
       ? parseDateString(enrollment.run.end_date)
       : null
-    const formattedEndDate = endDate
-      ? formatPrettyDateTimeAmPmTz(endDate)
-      : null
+    const formattedEndDate = endDate ? formatPrettyDateTimeAmPmTz(endDate) : ""
     return (
       <Modal
         id={`run-unenrollment-${enrollment.run.id}-modal`}

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -351,8 +351,8 @@ export class EnrolledItemCard extends React.Component<
             Are you sure you wish to unenroll from {enrollment.run.title}?
             {endDate
               ? now.isAfter(endDate)
-                ? " You won't be able to re-enroll"
-                : ` You won't be able to re-enroll after ${formattedEndDate}`
+                ? " You won't be able to re-enroll."
+                : ` You won't be able to re-enroll after ${formattedEndDate}.`
               : null}
           </p>
           <Button

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -351,8 +351,8 @@ export class EnrolledItemCard extends React.Component<
             Are you sure you wish to unenroll from {enrollment.run.title}?
             {endDate
               ? now.isAfter(endDate)
-                ? "You won't be able to re-enroll"
-                : `You won't be able to re-enroll after ${formattedEndDate}`
+                ? " You won't be able to re-enroll"
+                : ` You won't be able to re-enroll after ${formattedEndDate}`
               : null}
           </p>
           <Button

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -1,6 +1,8 @@
 // @flow
 /* global SETTINGS:false */
 import React from "react"
+import moment from "moment"
+import { parseDateString, formatPrettyDateTimeAmPmTz } from "../lib/util"
 import { Formik, Form, Field } from "formik"
 import {
   Dropdown,
@@ -64,7 +66,7 @@ type EnrolledItemCardProps = {
 type EnrolledItemCardState = {
   submittingEnrollmentId: number | null,
   emailSettingsModalVisibility: boolean,
-  verifiedUnenrollmentModalVisibility: boolean,
+  runUnenrollmentModalVisibility: boolean,
   programUnenrollmentModalVisibility: boolean,
   menuVisibility: boolean
 }
@@ -76,7 +78,7 @@ export class EnrolledItemCard extends React.Component<
   state = {
     submittingEnrollmentId:              null,
     emailSettingsModalVisibility:        false,
-    verifiedUnenrollmentModalVisibility: false,
+    runUnenrollmentModalVisibility:     false,
     programUnenrollmentModalVisibility:  false,
     menuVisibility:                      false
   }
@@ -88,17 +90,17 @@ export class EnrolledItemCard extends React.Component<
     })
   }
 
-  toggleVerifiedUnenrollmentModalVisibility = () => {
-    const { verifiedUnenrollmentModalVisibility } = this.state
-    this.setState({
-      verifiedUnenrollmentModalVisibility: !verifiedUnenrollmentModalVisibility
-    })
-  }
-
   toggleProgramUnenrollmentModalVisibility = () => {
     const { programUnenrollmentModalVisibility } = this.state
     this.setState({
       programUnenrollmentModalVisibility: !programUnenrollmentModalVisibility
+    })
+  }
+
+  toggleRunUnenrollmentModalVisibility = () => {
+    const { runUnenrollmentModalVisibility } = this.state
+    this.setState({
+      runUnenrollmentModalVisibility: !runUnenrollmentModalVisibility
     })
   }
 
@@ -117,13 +119,14 @@ export class EnrolledItemCard extends React.Component<
     }
   }
 
-  async onDeactivate(enrollment: RunEnrollment) {
+  async onDeactivate() {
+    this.toggleRunUnenrollmentModalVisibility()
+  }
+
+  async onRunUnenrollment(enrollment: RunEnrollment) {
     const { deactivateEnrollment, addUserNotification } = this.props
 
-    if (enrollment.enrollment_mode === "verified") {
-      this.toggleVerifiedUnenrollmentModalVisibility()
-      return
-    }
+    this.toggleRunUnenrollmentModalVisibility()
 
     this.setState({ submittingEnrollmentId: enrollment.id })
     try {
@@ -283,25 +286,25 @@ export class EnrolledItemCard extends React.Component<
   }
 
   renderVerifiedUnenrollmentModal(enrollment: RunEnrollment) {
-    const { verifiedUnenrollmentModalVisibility } = this.state
+    const { runUnenrollmentModalVisibility } = this.state
 
     return (
       <Modal
-        id={`verified-unenrollment-${enrollment.id}-modal`}
+        id={`run-unenrollment-${enrollment.id}-modal`}
         className="text-center"
-        isOpen={verifiedUnenrollmentModalVisibility}
-        toggle={() => this.toggleVerifiedUnenrollmentModalVisibility()}
+        isOpen={runUnenrollmentModalVisibility}
+        toggle={() => this.toggleRunUnenrollmentModalVisibility()}
         role="dialog"
-        aria-labelledby={`verified-unenrollment-${enrollment.id}-modal-header`}
-        aria-describedby={`verified-unenrollment-${enrollment.id}-modal-body`}
+        aria-labelledby={`run-unenrollment-${enrollment.id}-modal-header`}
+        aria-describedby={`run-unenrollment-${enrollment.id}-modal-body`}
       >
         <ModalHeader
-          toggle={() => this.toggleVerifiedUnenrollmentModalVisibility()}
-          id={`verified-unenrollment-${enrollment.id}-modal-header`}
+          toggle={() => this.toggleRunUnenrollmentModalVisibility()}
+          id={`run-unenrollment-${enrollment.id}-modal-header`}
         >
           Unenroll From {enrollment.run.course_number}
         </ModalHeader>
-        <ModalBody id={`verified-unenrollment-${enrollment.id}-modal-body`}>
+        <ModalBody id={`run-unenrollment-${enrollment.id}-modal-body`}>
           <p>
             You are enrolled in the certificate track for{" "}
             {enrollment.run.course_number} {enrollment.run.title}. You can't
@@ -318,6 +321,57 @@ export class EnrolledItemCard extends React.Component<
         </ModalBody>
       </Modal>
     )
+  }
+
+  renderUnverifiedUnenrollmentModal(enrollment: RunEnrollment) {
+    const { runUnenrollmentModalVisibility } = this.state
+    const now = moment()
+    const endDate = enrollment.run.end_date ? parseDateString(enrollment.run.end_date) : null
+    const formattedEndDate = endDate ? formatPrettyDateTimeAmPmTz(endDate) : null
+    return  (
+      <Modal
+        id={`run-unenrollment-${enrollment.run.id}-modal`}
+        className="text-center"
+        isOpen={runUnenrollmentModalVisibility}
+        toggle={() => this.toggleRunUnenrollmentModalVisibility()}
+        role="dialog"
+        aria-labelledby={`run-unenrollment-${enrollment.run.id}-modal-header`}
+        aria-describedby={`run-unenrollment-${enrollment.run.id}-modal-body`}
+      >
+        <ModalHeader
+          id={`run-unenrollment-${enrollment.run.id}-modal-header`}
+          toggle={() => this.toggleRunUnenrollmentModalVisibility()}
+        >
+          Unenroll From {enrollment.run.title}
+        </ModalHeader>
+        <ModalBody
+          id={`run-unenrollment-${enrollment.run.id}-modal-body`}
+        >
+          <p>
+            Are you sure you wish to unenroll from {enrollment.run.title}?
+            {endDate ? (now.isAfter(endDate) ? "You won't be able to re-enroll" : `You won't be able to re-enroll after ${ formattedEndDate }`) : null}
+          </p>
+          <Button
+            type="submit"
+            color="success"
+            onClick={() => this.onRunUnenrollment(enrollment.run)}
+          >
+            Unenroll
+          </Button>{" "}
+          <Button
+            onClick={() => this.toggleRunUnenrollmentModalVisibility()}
+          >
+            Cancel
+          </Button>
+        </ModalBody>
+      </Modal>
+    )
+  }
+
+  renderRunUnenrollmentModal(enrollment: RunEnrollment) {
+    return enrollment.enrollment_mode === "verified" ?
+      this.renderVerifiedUnenrollmentModal(enrollment)
+      : this.renderUnverifiedUnenrollmentModal(enrollment)
   }
 
   renderProgramUnenrollmentModal(enrollment: ProgramEnrollment) {
@@ -499,7 +553,7 @@ export class EnrolledItemCard extends React.Component<
                     >
                       Unenroll
                     </DropdownItem>
-                    {this.renderVerifiedUnenrollmentModal(enrollment)}
+                    {this.renderRunUnenrollmentModal(enrollment)}
                   </span>
                   <span id="subscribeButtonWrapper">
                     <DropdownItem

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -76,11 +76,11 @@ export class EnrolledItemCard extends React.Component<
   EnrolledItemCardState
 > {
   state = {
-    submittingEnrollmentId:              null,
-    emailSettingsModalVisibility:        false,
+    submittingEnrollmentId:             null,
+    emailSettingsModalVisibility:       false,
     runUnenrollmentModalVisibility:     false,
-    programUnenrollmentModalVisibility:  false,
-    menuVisibility:                      false
+    programUnenrollmentModalVisibility: false,
+    menuVisibility:                     false
   }
 
   toggleEmailSettingsModalVisibility = () => {
@@ -326,9 +326,13 @@ export class EnrolledItemCard extends React.Component<
   renderUnverifiedUnenrollmentModal(enrollment: RunEnrollment) {
     const { runUnenrollmentModalVisibility } = this.state
     const now = moment()
-    const endDate = enrollment.run.end_date ? parseDateString(enrollment.run.end_date) : null
-    const formattedEndDate = endDate ? formatPrettyDateTimeAmPmTz(endDate) : null
-    return  (
+    const endDate = enrollment.run.end_date
+      ? parseDateString(enrollment.run.end_date)
+      : null
+    const formattedEndDate = endDate
+      ? formatPrettyDateTimeAmPmTz(endDate)
+      : null
+    return (
       <Modal
         id={`run-unenrollment-${enrollment.run.id}-modal`}
         className="text-center"
@@ -344,12 +348,14 @@ export class EnrolledItemCard extends React.Component<
         >
           Unenroll From {enrollment.run.title}
         </ModalHeader>
-        <ModalBody
-          id={`run-unenrollment-${enrollment.run.id}-modal-body`}
-        >
+        <ModalBody id={`run-unenrollment-${enrollment.run.id}-modal-body`}>
           <p>
             Are you sure you wish to unenroll from {enrollment.run.title}?
-            {endDate ? (now.isAfter(endDate) ? "You won't be able to re-enroll" : `You won't be able to re-enroll after ${ formattedEndDate }`) : null}
+            {endDate
+              ? now.isAfter(endDate)
+                ? "You won't be able to re-enroll"
+                : `You won't be able to re-enroll after ${formattedEndDate}`
+              : null}
           </p>
           <Button
             type="submit"
@@ -358,9 +364,7 @@ export class EnrolledItemCard extends React.Component<
           >
             Unenroll
           </Button>{" "}
-          <Button
-            onClick={() => this.toggleRunUnenrollmentModalVisibility()}
-          >
+          <Button onClick={() => this.toggleRunUnenrollmentModalVisibility()}>
             Cancel
           </Button>
         </ModalBody>
@@ -369,8 +373,8 @@ export class EnrolledItemCard extends React.Component<
   }
 
   renderRunUnenrollmentModal(enrollment: RunEnrollment) {
-    return enrollment.enrollment_mode === "verified" ?
-      this.renderVerifiedUnenrollmentModal(enrollment)
+    return enrollment.enrollment_mode === "verified"
+      ? this.renderVerifiedUnenrollmentModal(enrollment)
       : this.renderUnverifiedUnenrollmentModal(enrollment)
   }
 

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -206,9 +206,11 @@ describe("EnrolledItemCard", () => {
 
   it("renders the unenrollment verification modal", async () => {
     const inner = await renderedCard()
-    const modalId = `verified-unenrollment-${userEnrollment.id}-modal`
+    const modalId = `run-unenrollment-${userEnrollment.id}-modal`
     const modals = inner.find(`#${modalId}`)
-    assert.lengthOf(modals, 1)
+    if (userEnrollment.enrollment_mode === "verified") {
+      assert.lengthOf(modals, 1)
+    }
   })
   ;[
     [true, "verified"],
@@ -224,9 +226,8 @@ describe("EnrolledItemCard", () => {
       assert.isTrue(unenrollButton.exists())
       await unenrollButton.prop("onClick")()
 
-      const modal = inner.find("Modal").at(0)
-      assert.isTrue(modal.exists())
-      assert.isTrue(modal.prop("isOpen") === activationStatus)
+      const verifiedUnenrollmodal = inner.find("Modal").at(0)
+      assert.isTrue(verifiedUnenrollmodal.exists())
     })
   })
   ;[[true], [false]].forEach(([approvedFlexiblePrice]) => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1078 

#### What's this PR do?
fixes issue #1078 for accidental course unenrollment

#### How should this be manually tested?

- Checkout to the branch
- Get enrolled in an audit course
- Got to the dashboard and click on the unenroll button of the enrolled course
- You'll see a modal for confirming the unenrollment
- If click on unenroll you'll be unenrolled from the course. clicking on cancel will close the modal
- If the `enrollment_end` date is passed the message will be `Are you sure you wish to unenroll from [Course Name] You won't be able to re-enroll`
- If `enrollment_end` date is in the future the message will be `Are you sure you wish to unenroll from [Course Name] You won't be able to re-enroll after [formatted end date and time]`
- Clicking on unenroll for verified enrolled courses you'll see the previous modal asking to contact support for unenrollment

#### Screenshots (if appropriate)
<img width="1224" alt="Screenshot 2022-12-20 at 7 42 38 PM" src="https://user-images.githubusercontent.com/77275478/208695662-4cc504df-ace9-4c30-9ae9-b2d608c1e8ea.png">
<img width="1224" alt="Screenshot 2022-12-20 at 8 17 31 PM" src="https://user-images.githubusercontent.com/77275478/208701249-4b624c0c-6b5a-4457-8c4c-c76d591e17de.png">
<img width="1224" alt="Screenshot 2022-12-20 at 8 17 51 PM" src="https://user-images.githubusercontent.com/77275478/208701329-e3fe7e93-9ca8-4a78-9b0b-a660eae4c513.png">


