### PR TITLE
fix: don't show programs tab if user isn't enrolled in a program

### DIFF
--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -118,14 +118,14 @@ export class DashboardPage extends React.Component<
     }`
     const programEnrollmentsLength = programEnrollments
       ? programEnrollments.length
-      : -1
+      : 0
 
     return (
       <DocumentTitle title={`${SETTINGS.site_name} | ${DASHBOARD_PAGE_TITLE}`}>
         <div className="std-page-body dashboard container">
           <Loader isLoading={isLoading}>
             <nav className="tabs" aria-controls="enrollment-items">
-              {!isProgramUIEnabled() || !programEnrollmentsLength > 0 ? (
+              {!isProgramUIEnabled() || programEnrollmentsLength <= 0 ? (
                 <>My Courses</>
               ) : (
                 <>

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -108,7 +108,7 @@ export class DashboardPage extends React.Component<
   }
 
   render() {
-    const { isLoading } = this.props
+    const { isLoading, programEnrollments } = this.props
 
     const myCourseClasses = `dash-tab${
       this.state.currentTab === DashboardTab.courses ? " active" : ""
@@ -116,13 +116,16 @@ export class DashboardPage extends React.Component<
     const programsClasses = `dash-tab${
       this.state.currentTab === DashboardTab.programs ? " active" : ""
     }`
+    const programEnrollmentsLength = programEnrollments
+      ? programEnrollments.length
+      : -1
 
     return (
       <DocumentTitle title={`${SETTINGS.site_name} | ${DASHBOARD_PAGE_TITLE}`}>
         <div className="std-page-body dashboard container">
           <Loader isLoading={isLoading}>
             <nav className="tabs" aria-controls="enrollment-items">
-              {!isProgramUIEnabled() ? (
+              {!isProgramUIEnabled() || !programEnrollmentsLength > 0 ? (
                 <>My Courses</>
               ) : (
                 <>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1293 

#### What's this PR do?
Don't show the programs tab if a user is not enrolled in any program by visiting this URL https://rc.mitxonline.mit.edu/dashboard/?enable_programs

#### How should this be manually tested?

- Checkout to this branch
- Unenroll from all programs if enrolled and check you should not see the programs tab on the dashboard `$local_host/dashboard/?enable_programs`

#### Screenshots (if appropriate)
Before:
<img width="1759" alt="Screenshot 2022-12-20 at 10 13 10 PM" src="https://user-images.githubusercontent.com/77275478/208727633-06ca104d-e2a2-4761-bebd-62d07255a511.png">

After:
<img width="1759" alt="Screenshot 2022-12-20 at 10 12 50 PM" src="https://user-images.githubusercontent.com/77275478/208727715-f90f54d8-bde9-401b-ad4d-1d4778df9202.png">


