### PR TITLE
fix: Fix courseware URL in command

### DIFF
--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -180,7 +180,7 @@ class Command(BaseCommand):
                     is_self_paced=edx_course.is_self_paced(),
                     courseware_url_path=parse.urljoin(
                         settings.OPENEDX_API_BASE_URL,
-                        f"/courses/{edx_course.course_id}/home",
+                        f"/courses/{edx_course.course_id}/course",
                     ),
                 )
 


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
Fix for https://github.com/mitodl/mitxonline/pull/1295 (Please take a look at the comments in this PR)

#### What's this PR do?
Actually, fixes a value in courseware path generation that we missed in https://github.com/mitodl/mitxonline/pull/1295

#### How should this be manually tested?
Same steps as mentioned in https://github.com/mitodl/mitxonline/pull/1295

