### PR TITLE
Fixes import_courserun to handle courses that exist already

### DIFF
--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -151,13 +151,14 @@ class Command(BaseCommand):
             course_readable_id = edx_course.course_id.removesuffix(f"+{courserun_tag}")
 
             try:
-                (course, created) = Course.objects.filter(
-                    readable_id=course_readable_id
-                ).get_or_create(
-                    program=program,
-                    title=edx_course.name,
+                (course, created) = Course.objects.get_or_create(
                     readable_id=course_readable_id,
-                    live=kwargs["live"],
+                    defaults={
+                        "program": program,
+                        "title": edx_course.name,
+                        "readable_id": course_readable_id,
+                        "live": kwargs["live"],
+                    },
                 )
 
                 if created:


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1306 

#### What's this PR do?

Updates the call to `get_or_create` so that single courseruns create the underlying course successfully. If you tried to import a course run for a course that existed, this would fail because the call to `get_or_create` to retrieve the course was malformed.

#### How should this be manually tested?

Create a new course run for an existing course in edX, then import using `import_courserun --courserun`. The command should complete successfully.

Create an entirely new course in edX, then import using `import_courserun --courserun`. The command should complete successfully. 

#### Any background context you want to provide?

Noticed this reviewing #1305 