### PR TITLE
Updates manage_certificates to handle revoked certificates better

### DIFF
--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -182,21 +182,10 @@ class Command(BaseCommand):
                     )
 
                 # While overriding grade we force create the certificate
-                try:
-                    (
-                        _,
-                        created_cert,
-                        deleted_cert,
-                    ) = process_course_run_grade_certificate(
-                        course_run_grade=course_run_grade,
-                        should_force_create=is_grade_override,
-                    )
-                except IntegrityError:
-                    log.warn(
-                        f"IntegrityError caught processing certificate for {course_run.courseware_id} for user {user} - certificate was likely already revoked."
-                    )
-                    created_cert = False
-                    deleted_cert = False
+                (_, created_cert, deleted_cert,) = process_course_run_grade_certificate(
+                    course_run_grade=course_run_grade,
+                    should_force_create=is_grade_override,
+                )
 
                 if created_grade:
                     grade_status = "created"

--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -25,8 +25,6 @@ Check the usages of this command below:
 
 """
 
-import logging
-
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 
@@ -42,8 +40,6 @@ from openedx.api import get_edx_grades_with_users
 from users.api import fetch_user
 
 User = get_user_model()
-
-log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):

--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -29,7 +29,6 @@ import logging
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
-from django.db import IntegrityError
 
 from courses.api import (
     ensure_course_run_grade,

--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -25,20 +25,26 @@ Check the usages of this command below:
 
 """
 
-from django.core.management.base import BaseCommand, CommandError
-from users.api import fetch_user
-from courses.api import (
-    manage_course_run_certificate_access,
-    ensure_course_run_grade,
-    process_course_run_grade_certificate,
-    override_user_grade,
-)
-from courses.utils import is_grade_valid
-from courses.models import CourseRun, CourseRunGrade
-from openedx.api import get_edx_grades_with_users
+import logging
+
 from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError
+
+from courses.api import (
+    ensure_course_run_grade,
+    manage_course_run_certificate_access,
+    override_user_grade,
+    process_course_run_grade_certificate,
+)
+from courses.models import CourseRun
+from courses.utils import is_grade_valid
+from openedx.api import get_edx_grades_with_users
+from users.api import fetch_user
 
 User = get_user_model()
+
+log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -176,10 +182,19 @@ class Command(BaseCommand):
                     )
 
                 # While overriding grade we force create the certificate
-                _, created_cert, deleted_cert = process_course_run_grade_certificate(
-                    course_run_grade=course_run_grade,
-                    should_force_create=is_grade_override,
-                )
+                try:
+                    (
+                        _,
+                        created_cert,
+                        deleted_cert,
+                    ) = process_course_run_grade_certificate(
+                        course_run_grade=course_run_grade,
+                        should_force_create=is_grade_override,
+                    )
+                except IntegrityError:
+                    log.warn(
+                        f"IntegrityError caught processing certificate for {course_run.courseware_id} for user {user} - certificate was likely already revoked."
+                    )
 
                 if created_grade:
                     grade_status = "created"

--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -195,6 +195,8 @@ class Command(BaseCommand):
                     log.warn(
                         f"IntegrityError caught processing certificate for {course_run.courseware_id} for user {user} - certificate was likely already revoked."
                     )
+                    created_cert = False
+                    deleted_cert = False
 
                 if created_grade:
                     grade_status = "created"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [ ] Changes have been manually tested _see below)

#### What are the relevant tickets?

Closes #1319 

#### What's this PR do?

Updates the `manage_certificates` command to wrap batched certificate generation in a try/except, so if there's an existing revoked certificate, it'll just skip over those instead of failing.

#### How should this be manually tested?

Automated tests should work.

1. Create a certificate for a learner.
2. Revoke that certificate (either through `manage_certificates` or through Django Admin). 
3. Run `manage_certificates` to generate certificates for the course run in question. If your error logging is set low enough, you should see a log message when it tries to make a certificate for the revoked learner, but it shouldn't fail. 

#### Any background context you want to provide?

To test this fully, you'll need to have grades in edX that can be synced. 