### PR TITLE
fix: dashboard confirmation dialog for unenrolling from courses 404 enrollment not found

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -332,21 +332,21 @@ export class EnrolledItemCard extends React.Component<
     const formattedEndDate = endDate ? formatPrettyDateTimeAmPmTz(endDate) : ""
     return (
       <Modal
-        id={`run-unenrollment-${enrollment.run.id}-modal`}
+        id={`run-unenrollment-${enrollment.id}-modal`}
         className="text-center"
         isOpen={runUnenrollmentModalVisibility}
         toggle={() => this.toggleRunUnenrollmentModalVisibility()}
         role="dialog"
-        aria-labelledby={`run-unenrollment-${enrollment.run.id}-modal-header`}
-        aria-describedby={`run-unenrollment-${enrollment.run.id}-modal-body`}
+        aria-labelledby={`run-unenrollment-${enrollment.id}-modal-header`}
+        aria-describedby={`run-unenrollment-${enrollment.id}-modal-body`}
       >
         <ModalHeader
-          id={`run-unenrollment-${enrollment.run.id}-modal-header`}
+          id={`run-unenrollment-${enrollment.id}-modal-header`}
           toggle={() => this.toggleRunUnenrollmentModalVisibility()}
         >
           Unenroll From {enrollment.run.title}
         </ModalHeader>
-        <ModalBody id={`run-unenrollment-${enrollment.run.id}-modal-body`}>
+        <ModalBody id={`run-unenrollment-${enrollment.id}-modal-body`}>
           <p>
             Are you sure you wish to unenroll from {enrollment.run.title}?
             {endDate
@@ -358,7 +358,7 @@ export class EnrolledItemCard extends React.Component<
           <Button
             type="submit"
             color="success"
-            onClick={() => this.onRunUnenrollment(enrollment.run)}
+            onClick={() => this.onRunUnenrollment(enrollment)}
           >
             Unenroll
           </Button>{" "}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1301 

#### What's this PR do?
Follow up PR for above PR to resolve the `404 enrollment not found` issue

#### How should this be manually tested?

- Checkout to the branch
- Get enrolled in an audit course
- Go to the dashboard and click on the unenroll button of the enrolled course
- You'll see a modal for confirming the unenrollment
- If you click on unenroll you'll be unenrolled from the course. clicking on cancel will close the modal
- If the `enrollment_end` date is passed the message will be `Are you sure you wish to unenroll from [Course Name] You won't be able to re-enroll`
- If the `enrollment_end` date is in the future the message will be `Are you sure you wish to unenroll from [Course Name] You won't be able to re-enroll after [formatted end date and time]`
- Clicking on unenroll for verified enrolled courses you'll see the previous modal asking to contact support for unenrollment

#### Screenshots (if appropriate)
<img width="1792" alt="Screenshot 2023-01-05" src="https://user-images.githubusercontent.com/77275478/210853646-0a655a06-7254-4677-952f-8043124cdda2.png">

<img width="1792" alt="Screenshot 2023-01-05" src="https://user-images.githubusercontent.com/77275478/210853675-ea12635a-362c-4aab-95f9-aed25083fb21.png">
