### PR TITLE
1326: decimal grades on the learner record

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -1118,7 +1118,7 @@ class CourseRunGrade(TimestampedModel, AuditableModel, ValidateOnSaveMixin):
     @property
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
-        TWOPLACES = Decimal(10) ** -2
+        TWOPLACES = Decimal(10)
         return (
             Decimal(self.grade * 100).quantize(TWOPLACES)
             if self.grade is not None

--- a/courses/models.py
+++ b/courses/models.py
@@ -4,7 +4,7 @@ Course models
 import logging
 import operator as op
 import uuid
-from decimal import ROUND_HALF_EVEN
+from decimal import ROUND_HALF_EVEN, getcontext
 from decimal import Context as DecimalContext
 from decimal import Decimal
 
@@ -1118,11 +1118,9 @@ class CourseRunGrade(TimestampedModel, AuditableModel, ValidateOnSaveMixin):
     @property
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
-        return (
-            Decimal(self.grade * 100, DecimalContext(prec=2, rounding=ROUND_HALF_EVEN))
-            if self.grade is not None
-            else None
-        )
+        getcontext().prec = 2
+        getcontext().rounding = ROUND_HALF_EVEN
+        return Decimal(100) * Decimal(self.grade) if self.grade is not None else None
 
     @property
     def is_certificate_eligible(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -1118,9 +1118,12 @@ class CourseRunGrade(TimestampedModel, AuditableModel, ValidateOnSaveMixin):
     @property
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
-        getcontext().prec = 2
-        getcontext().rounding = ROUND_HALF_EVEN
-        return Decimal(100) * Decimal(self.grade) if self.grade is not None else None
+        TWOPLACES = Decimal(10) ** -2
+        return (
+            Decimal(self.grade * 100).quantize(TWOPLACES)
+            if self.grade is not None
+            else None
+        )
 
     @property
     def is_certificate_eligible(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -1119,7 +1119,7 @@ class CourseRunGrade(TimestampedModel, AuditableModel, ValidateOnSaveMixin):
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
         return (
-            Decimal(self.grade * 100).quantize(Decimal(10))
+            Decimal(self.grade * 100).quantize(Decimal(1))
             if self.grade is not None
             else None
         )

--- a/courses/models.py
+++ b/courses/models.py
@@ -1118,9 +1118,8 @@ class CourseRunGrade(TimestampedModel, AuditableModel, ValidateOnSaveMixin):
     @property
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
-        TWOPLACES = Decimal(10)
         return (
-            Decimal(self.grade * 100).quantize(TWOPLACES)
+            Decimal(self.grade * 100).quantize(Decimal(10))
             if self.grade is not None
             else None
         )

--- a/courses/models.py
+++ b/courses/models.py
@@ -1119,7 +1119,7 @@ class CourseRunGrade(TimestampedModel, AuditableModel, ValidateOnSaveMixin):
     def grade_percent(self):
         """Returns the grade field value as a number out of 100 (or None if the value is None)"""
         return (
-            Decimal(self.grade * 100).quantize(Decimal(1))
+            Decimal(self.grade * 100).quantize(exp=Decimal(1), rounding=ROUND_HALF_EVEN)
             if self.grade is not None
             else None
         )

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -760,6 +760,7 @@ class LearnerRecordSerializer(serializers.BaseSerializer):
                 .order_by("-grade")
                 .first()
             )
+            grade.grade = round(grade.grade, 2)
 
             if grade is not None:
                 fmt_course["grade"] = CourseRunGradeSerializer(grade).data

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -546,7 +546,7 @@ def test_learner_record_serializer(mock_context):
             CourseRunGradeFactory.create(
                 course_run=course_run,
                 user=user,
-                grade=(0.3333333 * grade_multiplier_to_test_ordering),
+                grade=(0.313133 * grade_multiplier_to_test_ordering),
             )
         )
         grade_multiplier_to_test_ordering += 1
@@ -554,142 +554,104 @@ def test_learner_record_serializer(mock_context):
     serialized_data = LearnerRecordSerializer(
         instance=program, context=mock_context
     ).data
-    assert serialized_data == {
-        "partner_schools": [],
-        "program": {
-            "courses": [
-                {
-                    "certificate": None,
-                    "grade": {
-                        "grade": round(grades[0].grade, 2),
-                        "grade_percent": Decimal(round(grades[0].grade_percent)),
-                        "letter_grade": grades[0].letter_grade,
-                        "passed": grades[0].passed,
-                        "set_by_admin": grades[0].set_by_admin,
-                    },
-                    "id": courses[0].id,
-                    "readable_id": courses[0].readable_id,
-                    "reqtype": "Required",
-                    "title": courses[0].title,
-                },
-                {
-                    "certificate": None,
-                    "grade": {
-                        "grade": round(grades[1].grade, 2),
-                        "grade_percent": Decimal(round(grades[1].grade_percent)),
-                        "letter_grade": grades[1].letter_grade,
-                        "passed": grades[1].passed,
-                        "set_by_admin": grades[1].set_by_admin,
-                    },
-                    "id": courses[1].id,
-                    "readable_id": courses[1].readable_id,
-                    "reqtype": "Required",
-                    "title": courses[1].title,
-                },
-                {
-                    "certificate": None,
-                    "grade": {
-                        "grade": round(grades[2].grade, 2),
-                        "grade_percent": Decimal(round(grades[2].grade_percent)),
-                        "letter_grade": grades[2].letter_grade,
-                        "passed": grades[2].passed,
-                        "set_by_admin": grades[2].set_by_admin,
-                    },
-                    "id": courses[2].id,
-                    "readable_id": courses[2].readable_id,
-                    "reqtype": "Required",
-                    "title": courses[2].title,
-                },
-            ],
-            "readable_id": program.readable_id,
-            "requirements": [
+    program_requirements_payload = [
+        {
+            "children": [
                 {
                     "children": [
                         {
-                            "children": [
-                                {
-                                    "data": {
-                                        "course": courses[0].id,
-                                        "node_type": "course",
-                                        "operator": None,
-                                        "operator_value": None,
-                                        "program": program.id,
-                                        "title": "",
-                                    },
-                                    "id": program.get_requirements_root()
-                                    .get_children()
-                                    .first()
-                                    .get_children()
-                                    .filter(course=courses[0].id)
-                                    .first()
-                                    .id,
-                                },
-                                {
-                                    "data": {
-                                        "course": courses[1].id,
-                                        "node_type": "course",
-                                        "operator": None,
-                                        "operator_value": None,
-                                        "program": program.id,
-                                        "title": "",
-                                    },
-                                    "id": program.get_requirements_root()
-                                    .get_children()
-                                    .first()
-                                    .get_children()
-                                    .filter(course=courses[1].id)
-                                    .first()
-                                    .id,
-                                },
-                                {
-                                    "data": {
-                                        "course": courses[2].id,
-                                        "node_type": "course",
-                                        "operator": None,
-                                        "operator_value": None,
-                                        "program": program.id,
-                                        "title": "",
-                                    },
-                                    "id": program.get_requirements_root()
-                                    .get_children()
-                                    .first()
-                                    .get_children()
-                                    .filter(course=courses[2].id)
-                                    .first()
-                                    .id,
-                                },
-                            ],
                             "data": {
-                                "course": None,
-                                "node_type": "operator",
-                                "operator": "all_of",
+                                "course": courses[0].id,
+                                "node_type": "course",
+                                "operator": None,
                                 "operator_value": None,
                                 "program": program.id,
-                                "title": "Required",
+                                "title": "",
                             },
                             "id": program.get_requirements_root()
                             .get_children()
                             .first()
+                            .get_children()
+                            .filter(course=courses[0].id)
+                            .first()
                             .id,
-                        }
+                        },
+                        {
+                            "data": {
+                                "course": courses[1].id,
+                                "node_type": "course",
+                                "operator": None,
+                                "operator_value": None,
+                                "program": program.id,
+                                "title": "",
+                            },
+                            "id": program.get_requirements_root()
+                            .get_children()
+                            .first()
+                            .get_children()
+                            .filter(course=courses[1].id)
+                            .first()
+                            .id,
+                        },
+                        {
+                            "data": {
+                                "course": courses[2].id,
+                                "node_type": "course",
+                                "operator": None,
+                                "operator_value": None,
+                                "program": program.id,
+                                "title": "",
+                            },
+                            "id": program.get_requirements_root()
+                            .get_children()
+                            .first()
+                            .get_children()
+                            .filter(course=courses[2].id)
+                            .first()
+                            .id,
+                        },
                     ],
                     "data": {
                         "course": None,
-                        "node_type": "program_root",
-                        "operator": None,
+                        "node_type": "operator",
+                        "operator": "all_of",
                         "operator_value": None,
                         "program": program.id,
-                        "title": "",
+                        "title": "Required",
                     },
-                    "id": root.id,
+                    "id": program.get_requirements_root().get_children().first().id,
                 }
             ],
-            "title": program.title,
-        },
-        "sharing": [],
-        "user": {
-            "email": user.email,
-            "name": user.name,
-            "username": user.username,
-        },
+            "data": {
+                "course": None,
+                "node_type": "program_root",
+                "operator": None,
+                "operator_value": None,
+                "program": program.id,
+                "title": "",
+            },
+            "id": root.id,
+        }
+    ]
+    user_info_payload = {
+        "email": user.email,
+        "name": user.name,
+        "username": user.username,
     }
+    course_0_payload = {
+        "certificate": None,
+        "grade": {
+            "grade": round(grades[0].grade, 2),
+            "grade_percent": Decimal(grades[0].grade_percent),
+            "letter_grade": grades[0].letter_grade,
+            "passed": grades[0].passed,
+            "set_by_admin": grades[0].set_by_admin,
+        },
+        "id": courses[0].id,
+        "readable_id": courses[0].readable_id,
+        "reqtype": "Required",
+        "title": courses[0].title,
+    }
+    assert user_info_payload == serialized_data["user"]
+    assert program_requirements_payload == serialized_data["program"]["requirements"]
+    assert course_0_payload in serialized_data["program"]["courses"]

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -3,6 +3,7 @@ Tests for course serializers
 """
 # pylint: disable=unused-argument, redefined-outer-name
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 import bleach
 import factory
@@ -28,6 +29,7 @@ from courses.serializers import (
     CourseRunGradeSerializer,
     CourseRunSerializer,
     CourseSerializer,
+    LearnerRecordSerializer,
     ProgramEnrollmentSerializer,
     ProgramRequirementSerializer,
     ProgramRequirementTreeSerializer,
@@ -507,3 +509,187 @@ def test_program_requirement_deletion():
         root1
     ]  # just the one root node
     assert list(ProgramRequirement.get_tree(parent=root2)) == expected
+
+
+def test_learner_record_serializer(mock_context):
+    """Verify that saving the requirements for one program doesn't affect other programs"""
+
+    program = ProgramFactory.create()
+    courses = CourseFactory.create_batch(3, program=program)
+    root = program.requirements_root
+
+    user = mock_context["request"].user
+
+    # build the same basic tree structure for both
+    required = root.add_child(
+        program=program,
+        node_type=ProgramRequirementNodeType.OPERATOR,
+        title="Required",
+        operator=ProgramRequirement.Operator.ALL_OF,
+    )
+    course_runs = []
+    grades = []
+    grade_multiplier_to_test_ordering = 1
+    for course in courses:
+        required.add_child(
+            program=program,
+            node_type=ProgramRequirementNodeType.COURSE,
+            course=course,
+        )
+        course_run = CourseRunFactory.create(course=course)
+        course_run_enrollment = CourseRunEnrollmentFactory.create(
+            run=course_run, user=user
+        )
+        course_runs.append(course_run)
+
+        grades.append(
+            CourseRunGradeFactory.create(
+                course_run=course_run,
+                user=user,
+                grade=(0.3333333 * grade_multiplier_to_test_ordering),
+            )
+        )
+        grade_multiplier_to_test_ordering += 1
+
+    serialized_data = LearnerRecordSerializer(
+        instance=program, context=mock_context
+    ).data
+    assert serialized_data == {
+        "partner_schools": [],
+        "program": {
+            "courses": [
+                {
+                    "certificate": None,
+                    "grade": {
+                        "grade": round(grades[0].grade, 2),
+                        "grade_percent": Decimal(round(grades[0].grade_percent)),
+                        "letter_grade": grades[0].letter_grade,
+                        "passed": grades[0].passed,
+                        "set_by_admin": grades[0].set_by_admin,
+                    },
+                    "id": courses[0].id,
+                    "readable_id": courses[0].readable_id,
+                    "reqtype": "Required",
+                    "title": courses[0].title,
+                },
+                {
+                    "certificate": None,
+                    "grade": {
+                        "grade": round(grades[1].grade, 2),
+                        "grade_percent": Decimal(round(grades[1].grade_percent)),
+                        "letter_grade": grades[1].letter_grade,
+                        "passed": grades[1].passed,
+                        "set_by_admin": grades[1].set_by_admin,
+                    },
+                    "id": courses[1].id,
+                    "readable_id": courses[1].readable_id,
+                    "reqtype": "Required",
+                    "title": courses[1].title,
+                },
+                {
+                    "certificate": None,
+                    "grade": {
+                        "grade": round(grades[2].grade, 2),
+                        "grade_percent": Decimal(round(grades[2].grade_percent)),
+                        "letter_grade": grades[2].letter_grade,
+                        "passed": grades[2].passed,
+                        "set_by_admin": grades[2].set_by_admin,
+                    },
+                    "id": courses[2].id,
+                    "readable_id": courses[2].readable_id,
+                    "reqtype": "Required",
+                    "title": courses[2].title,
+                },
+            ],
+            "readable_id": program.readable_id,
+            "requirements": [
+                {
+                    "children": [
+                        {
+                            "children": [
+                                {
+                                    "data": {
+                                        "course": courses[0].id,
+                                        "node_type": "course",
+                                        "operator": None,
+                                        "operator_value": None,
+                                        "program": program.id,
+                                        "title": "",
+                                    },
+                                    "id": program.get_requirements_root()
+                                    .get_children()
+                                    .first()
+                                    .get_children()
+                                    .filter(course=courses[0].id)
+                                    .first()
+                                    .id,
+                                },
+                                {
+                                    "data": {
+                                        "course": courses[1].id,
+                                        "node_type": "course",
+                                        "operator": None,
+                                        "operator_value": None,
+                                        "program": program.id,
+                                        "title": "",
+                                    },
+                                    "id": program.get_requirements_root()
+                                    .get_children()
+                                    .first()
+                                    .get_children()
+                                    .filter(course=courses[1].id)
+                                    .first()
+                                    .id,
+                                },
+                                {
+                                    "data": {
+                                        "course": courses[2].id,
+                                        "node_type": "course",
+                                        "operator": None,
+                                        "operator_value": None,
+                                        "program": program.id,
+                                        "title": "",
+                                    },
+                                    "id": program.get_requirements_root()
+                                    .get_children()
+                                    .first()
+                                    .get_children()
+                                    .filter(course=courses[2].id)
+                                    .first()
+                                    .id,
+                                },
+                            ],
+                            "data": {
+                                "course": None,
+                                "node_type": "operator",
+                                "operator": "all_of",
+                                "operator_value": None,
+                                "program": program.id,
+                                "title": "Required",
+                            },
+                            "id": program.get_requirements_root()
+                            .get_children()
+                            .first()
+                            .id,
+                        }
+                    ],
+                    "data": {
+                        "course": None,
+                        "node_type": "program_root",
+                        "operator": None,
+                        "operator_value": None,
+                        "program": program.id,
+                        "title": "",
+                    },
+                    "id": root.id,
+                }
+            ],
+            "title": program.title,
+        },
+        "sharing": [],
+        "user": {
+            "email": user.email,
+            "name": user.name,
+            "username": user.username,
+        },
+    }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1326

#### What's this PR do?
Sets the grade returned from the `LearnerRecordSerializer` to have only 2 decimal places.  That serializer is used on the program records page (http://mitxonline.odl.local:8013/records/1/)

#### How should this be manually tested?

1. Have `mitxonline` up and running locally.
2. Set `ENABLE_LEARNER_RECORDS=True` in the .env file.
3. Have a user enrolled into a course run for a course that is a requirement of a program.  Create a course run grade for the course run, and set the grade value as a repeating decimal.
4. Create a partner school record through Django Admin.
5. Navigate to the `mitxonline` Dashboard (http://mitxonline.odl.local:8013/dashboard/?enable_programs&enable_lr).
6. Go to the programs tab and open the program drawer by clicking on the program card.
7. Click "view program record" from the drawer.
8. Ensure that the grade shown for the course is only showing 2 decimal places and not the repeating decimal.


#### Screenshots (if appropriate)
![Screenshot 2023-01-09 at 15 35 08](https://user-images.githubusercontent.com/8311573/211405834-f7a7907e-35c5-4242-a3c9-16daad41065b.png)
