### PR TITLE
add the row back for formatting

### DIFF
--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -76,8 +76,7 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
           </div>
         </div>
         <div className="row flex-grow-1 pt-3">
-          <div className="col pl-0 pr-0">
-          </div>
+          <div className="col pl-0 pr-0"></div>
         </div>
       </div>
     )

--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -75,6 +75,10 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
             </div>
           </div>
         </div>
+        <div className="row flex-grow-1 pt-3">
+          <div className="col pl-0 pr-0">
+          </div>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots


#### What are the relevant tickets?
Related to #1314 
add padding for the course info

Before:
<img width="834" alt="Screen Shot 2023-01-09 at 10 06 31 AM" src="https://user-images.githubusercontent.com/7574259/211411949-f325cafc-9f2a-499c-8c2e-f590a19ad18e.png">

After:
<img width="819" alt="Screen Shot 2023-01-09 at 4 30 12 PM" src="https://user-images.githubusercontent.com/7574259/211412110-b7fc7e97-32eb-4971-acee-53e957cb9772.png">

