### PR TITLE
feat: unenroll without a refund

### DIFF
--- a/courses/management/commands/test_unenroll_enrollment.py
+++ b/courses/management/commands/test_unenroll_enrollment.py
@@ -3,6 +3,7 @@
 import pytest
 
 from django.core.management.base import CommandError
+from types import SimpleNamespace
 
 from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
 from courses.factories import (
@@ -15,15 +16,22 @@ from users.factories import UserFactory
 pytestmark = [pytest.mark.django_db]
 
 
+@pytest.fixture()
+def patches(mocker):  # pylint: disable=missing-docstring
+    edx_unenroll = mocker.patch("courses.api.unenroll_edx_course_run")
+    log_exception = mocker.patch("courses.api.log.exception")
+    return SimpleNamespace(
+        edx_unenroll=edx_unenroll,
+        log_exception=log_exception,
+    )
+
+
 def test_unenroll_enrollment_no_argument():
     """Test that command throws error when no input is provided"""
 
     with pytest.raises(CommandError) as command_error:
         unenroll_enrollment.Command().handle()
-    assert (
-        str(command_error.value)
-        == "Could not find a user with <username or email>="
-    )
+    assert str(command_error.value) == "Could not find a user with <username or email>="
 
 
 def test_unenroll_enrollment_invalid_run():
@@ -61,39 +69,53 @@ def test_unenroll_enrollment_invalid_user():
     )
 
 
-def test_unenroll_enrollment(mocker):
+def test_unenroll_enrollment(patches):
     """
     Test that user unenrolled from the course properly
     """
     enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
     assert enrollment.change_status is None
-    with pytest.raises(CommandError) as command_error:
-        unenroll_enrollment.Command().handle(
-            run=enrollment.run.courseware_id,
-            user=enrollment.user.username,
-        )
-    edx_unenroll = mocker.patch("courses.api.unenroll_edx_course_run")
-    edx_unenroll.assert_called_once_with(enrollment)
-    enrollment.refresh_from_db()
-    assert enrollment.change_status == ENROLL_CHANGE_STATUS_UNENROLLED
-
-
-def test_unenroll_enrollment_without_edx(user):
-    """
-    Test that user unenrolled from the course properly
-    """
-    run = CourseRunFactory(user=user)
-    enrollment = CourseRunEnrollmentFactory(
-        user=user,
-        runs=run
+    assert enrollment.active is True
+    assert enrollment.edx_enrolled is True
+    unenroll_enrollment.Command().handle(
+        run=enrollment.run.courseware_id,
+        user=enrollment.user.username,
     )
-    assert enrollment.change_status is None
-    with pytest.raises(CommandError) as command_error:
-        unenroll_enrollment.Command().handle(
-            run=enrollment.run.courseware_id,
-            user=enrollment.user.username,
-            keep_failed_enrollments=True
-        )
-    assert str(command_error.value) is None
+    patches.edx_unenroll.assert_called_once_with(enrollment)
     enrollment.refresh_from_db()
     assert enrollment.change_status == ENROLL_CHANGE_STATUS_UNENROLLED
+    assert enrollment.active is False
+    assert enrollment.edx_enrolled is False
+
+
+def test_unenroll_enrollment_without_edx():
+    """
+    Test that user unenrolled from the course properly without edx
+    """
+    enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
+    assert enrollment.change_status is None
+    assert enrollment.active is True
+    assert enrollment.edx_enrolled is True
+    # User will not be unenrolled
+    # Unenrolling without mocker and keep_failed_enrollments argument
+    unenroll_enrollment.Command().handle(
+        run=enrollment.run.courseware_id,
+        user=enrollment.user.username,
+    )
+    enrollment.refresh_from_db()
+    # Enrollment will remain as it is
+    assert enrollment.change_status is None
+    assert enrollment.active is True
+    assert enrollment.edx_enrolled is True
+    # User will not unenrolled
+    # Unenrolling with keep_failed_enrollments argument
+    unenroll_enrollment.Command().handle(
+        run=enrollment.run.courseware_id,
+        user=enrollment.user.username,
+        keep_failed_enrollments=True,
+    )
+    enrollment.refresh_from_db()
+    assert enrollment.change_status == ENROLL_CHANGE_STATUS_UNENROLLED
+    assert enrollment.active is False
+    # Enrollment will remain edx_enrolled
+    assert enrollment.edx_enrolled is True

--- a/courses/management/commands/test_unenroll_enrollment.py
+++ b/courses/management/commands/test_unenroll_enrollment.py
@@ -1,0 +1,99 @@
+"""Tests for Unenroll Enrollment management command"""
+
+import pytest
+
+from django.core.management.base import CommandError
+
+from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
+from courses.factories import (
+    CourseRunFactory,
+    CourseRunEnrollmentFactory,
+)
+from courses.management.commands import unenroll_enrollment
+from users.factories import UserFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_unenroll_enrollment_no_argument():
+    """Test that command throws error when no input is provided"""
+
+    with pytest.raises(CommandError) as command_error:
+        unenroll_enrollment.Command().handle()
+    assert (
+        str(command_error.value)
+        == "Could not find a user with <username or email>="
+    )
+
+
+def test_unenroll_enrollment_invalid_run():
+    """
+    Test that unenroll_enrollment management command throws proper error when
+    no valid course run is supplied
+    """
+
+    test_user = UserFactory.create()
+    with pytest.raises(CommandError) as command_error:
+        unenroll_enrollment.Command().handle(user=test_user.username)
+    assert str(
+        command_error.value
+    ) == "Could not find course run with courseware_id={}".format(None)
+
+    with pytest.raises(CommandError) as command_error:
+        unenroll_enrollment.Command().handle(user=test_user.username, run="test")
+    assert (
+        str(command_error.value) == "Could not find course run with courseware_id=test"
+    )
+
+
+def test_unenroll_enrollment_invalid_user():
+    """Test that the command throws proper error when user is invalid arguments"""
+    run = CourseRunFactory.create()
+
+    with pytest.raises(CommandError) as command_error:
+        unenroll_enrollment.Command().handle(
+            user="test",
+            run=run.courseware_id,
+        )
+    assert (
+        str(command_error.value)
+        == "Could not find a user with <username or email>=test"
+    )
+
+
+def test_unenroll_enrollment(mocker):
+    """
+    Test that user unenrolled from the course properly
+    """
+    enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
+    assert enrollment.change_status is None
+    with pytest.raises(CommandError) as command_error:
+        unenroll_enrollment.Command().handle(
+            run=enrollment.run.courseware_id,
+            user=enrollment.user.username,
+        )
+    edx_unenroll = mocker.patch("courses.api.unenroll_edx_course_run")
+    edx_unenroll.assert_called_once_with(enrollment)
+    enrollment.refresh_from_db()
+    assert enrollment.change_status == ENROLL_CHANGE_STATUS_UNENROLLED
+
+
+def test_unenroll_enrollment_without_edx(user):
+    """
+    Test that user unenrolled from the course properly
+    """
+    run = CourseRunFactory(user=user)
+    enrollment = CourseRunEnrollmentFactory(
+        user=user,
+        runs=run
+    )
+    assert enrollment.change_status is None
+    with pytest.raises(CommandError) as command_error:
+        unenroll_enrollment.Command().handle(
+            run=enrollment.run.courseware_id,
+            user=enrollment.user.username,
+            keep_failed_enrollments=True
+        )
+    assert str(command_error.value) is None
+    enrollment.refresh_from_db()
+    assert enrollment.change_status == ENROLL_CHANGE_STATUS_UNENROLLED

--- a/courses/management/commands/unenroll_enrollment.py
+++ b/courses/management/commands/unenroll_enrollment.py
@@ -55,12 +55,12 @@ class Command(EnrollmentChangeCommand):
 
     def handle(self, *args, **options):
         """Handle command execution"""
-        user = options.get("user", "")
+        username = options.get("user", "")
         try:
-            user = fetch_user(options.get("user", ""))
+            user = fetch_user(username)
         except User.DoesNotExist:
             raise CommandError(
-                "Could not find a user with <username or email>={}".format(user)
+                "Could not find a user with <username or email>={}".format(username)
             )
         courseware_id = options.get("run")
         course_run = CourseRun.objects.filter(courseware_id=courseware_id).first()

--- a/courses/management/commands/unenroll_enrollment.py
+++ b/courses/management/commands/unenroll_enrollment.py
@@ -78,7 +78,7 @@ class Command(EnrollmentChangeCommand):
         )
 
         if run_enrollment:
-            success_msg = "Unenrolled enrollments for user: {} ({})\nEnrollment affected: {}".format(
+            success_msg = "Unenrolled enrollment for user: {} ({})\nEnrollment affected: {}".format(
                 enrollment.user.username,
                 enrollment.user.email,
                 enrollment_summary(run_enrollment),

--- a/courses/management/commands/unenroll_enrollment.py
+++ b/courses/management/commands/unenroll_enrollment.py
@@ -10,7 +10,7 @@ Check the usages of this command below:
 
 **Keep failed enrollments**
 
-4. Keep failed enrollments
+2. Keep failed enrollments
 ./manage.py unenroll_enrollment -—user=<username or email> -—run=<course_run_courseware_id> -k or --keep-failed-enrollments
 """
 from django.contrib.auth import get_user_model


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1335 #1321 

#### What's this PR do?
Management command to unenroll a user from enrollment

#### How should this be manually tested?

- Checkout to the branch
- Enroll in a course run with edx enrollment
- Test the command with the below options (to test the failed enrollment you can turn off the local edx server)

    **Unenroll enrollment**

    1. Unenroll enrollment for user
    `./manage.py unenroll_enrollment -—user=<username or email> -—run=<course_run_courseware_id>`

    **Keep failed enrollments**

    2. Keep failed enrollments
    `./manage.py unenroll_enrollment -—user=<username or email> -—run=<course_run_courseware_id> -k or --keep-failed-enrollments`