### PR TITLE
Fix: Program courses drawer won't open if program has no elective or required courses

### DIFF
--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -98,6 +98,10 @@ const makeRequirementRootNode = (
   includeRequirements: boolean,
   includeElectives: boolean
 ) => {
+  // @param includeElectives: if true, will define "children" under the requirements operator node as an empty array.
+  // If false, the "children" variable will be undefined.
+  // @param includeRequirements: if true, will define "children" under the electives operator node as an empty array.
+  // If false, the "children" variable will be undefined.
   const requirementsChildrenArray = includeRequirements ? [] : undefined
   const electivesChildrenArray = includeElectives ? [] : undefined
   const result = {

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -108,7 +108,7 @@ const makeRequirementRootNode = (program: Program) => ({
         operator:  "all_of",
         title:     "Required Courses"
       },
-      children: []
+      children: undefined
     },
     {
       id:   genProgramRequirementId.next().value,
@@ -119,7 +119,7 @@ const makeRequirementRootNode = (program: Program) => ({
         operator_value: 1,
         title:          "Elective Courses"
       },
-      children: []
+      children: undefined
     }
   ]
 })
@@ -143,18 +143,17 @@ const makeDEDPSampleRequirementsTree = (
 
   // add courses to the Required Courses node
   if (includeRequirements) {
+    rn.children[0].children = []
     for (let i = 0; i < 3; i++) {
       rn.children[0].children.push(
         makeRequirementCourseNode(courses[i], rn.children[0], shouldBeCompleted)
       )
     }
-  } else {
-    // The children array of the required node is undefined unless there are required courses.
-    rn.children[0].children = undefined
   }
 
   // add base-level electives
   if (includeElectives) {
+    rn.children[1].children = []
     for (let i = 3; i < 5; i++) {
       rn.children[1].children.push(
         makeRequirementCourseNode(courses[i], rn.children[1], shouldBeCompleted)
@@ -185,9 +184,6 @@ const makeDEDPSampleRequirementsTree = (
     }
 
     rn.children[1].children.push(nestedElectiveOp)
-  } else {
-    // The children array of the elective node is undefined unless there are elective courses.
-    rn.children[1].children = undefined
   }
 
   return rn

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -150,8 +150,8 @@ const makeDEDPSampleRequirementsTree = (
   // root nodes have two children - both operators, one for reqs and one for electives
   const rn = makeRequirementRootNode(
     program,
-    includeElectives,
-    includeRequirements
+    includeRequirements,
+    includeElectives
   )
 
   // add courses to the Required Courses node

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -155,9 +155,11 @@ export const extractCoursesFromNode = (
   } else if (node.data.node_type === NODETYPE_OPERATOR) {
     let courseList = []
 
-    node.children.forEach(child => {
-      courseList = courseList.concat(extractCoursesFromNode(child, enrollment))
-    })
+    if (node.children) {
+      node.children.forEach(child => {
+        courseList = courseList.concat(extractCoursesFromNode(child, enrollment))
+      })
+    }
 
     return courseList
   }

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -157,7 +157,9 @@ export const extractCoursesFromNode = (
 
     if (node.children) {
       node.children.forEach(child => {
-        courseList = courseList.concat(extractCoursesFromNode(child, enrollment))
+        courseList = courseList.concat(
+          extractCoursesFromNode(child, enrollment)
+        )
       })
     }
 

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -155,17 +155,13 @@ export const extractCoursesFromNode = (
   } else if (node.data.node_type === NODETYPE_OPERATOR) {
     let courseList = []
 
-    node.children.forEach(child => {
-      courseList = courseList.concat(extractCoursesFromNode(child, enrollment))
-    })
-
-    // if (node.children) {
-    //   node.children.forEach(child => {
-    //     courseList = courseList.concat(
-    //       extractCoursesFromNode(child, enrollment)
-    //     )
-    //   })
-    // }
+    if (node.children) {
+      node.children.forEach(child => {
+        courseList = courseList.concat(
+          extractCoursesFromNode(child, enrollment)
+        )
+      })
+    }
 
     return courseList
   }

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -155,13 +155,17 @@ export const extractCoursesFromNode = (
   } else if (node.data.node_type === NODETYPE_OPERATOR) {
     let courseList = []
 
-    if (node.children) {
-      node.children.forEach(child => {
-        courseList = courseList.concat(
-          extractCoursesFromNode(child, enrollment)
-        )
-      })
-    }
+    node.children.forEach(child => {
+      courseList = courseList.concat(extractCoursesFromNode(child, enrollment))
+    })
+
+    // if (node.children) {
+    //   node.children.forEach(child => {
+    //     courseList = courseList.concat(
+    //       extractCoursesFromNode(child, enrollment)
+    //     )
+    //   })
+    // }
 
     return courseList
   }

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -13,7 +13,9 @@ import moment from "moment"
 import {
   makeCourseRunDetail,
   makeLearnerRecord,
-  makeProgramWithReqTree
+  makeProgramWithReqTree,
+  makeProgramWithOnlyRequirements,
+  makeProgramWithOnlyElectives
 } from "../factories/course"
 import { makeUser } from "../factories/user"
 
@@ -188,6 +190,48 @@ describe("Course API", () => {
       )
 
       assert.equal(requirements.length, 3)
+      assert.equal(electives.length, 4)
+    })
+
+    it("returns a flattened list of courses for the node without any elective courses", () => {
+      // the learner record will generate a requirements tree in the proper
+      // format, so we're just using that factory here
+      const programEnrollment = {
+        program:     makeProgramWithOnlyRequirements(),
+        enrollments: []
+      }
+
+      const requirements = extractCoursesFromNode(
+        programEnrollment.program.req_tree[0].children[0],
+        programEnrollment
+      )
+      const electives = extractCoursesFromNode(
+        programEnrollment.program.req_tree[0].children[1],
+        programEnrollment
+      )
+
+      assert.equal(requirements.length, 3)
+      assert.equal(electives.length, 0)
+    })
+
+    it("returns a flattened list of courses for the node without any required courses", () => {
+      // the learner record will generate a requirements tree in the proper
+      // format, so we're just using that factory here
+      const programEnrollment = {
+        program:     makeProgramWithOnlyElectives(),
+        enrollments: []
+      }
+
+      const requirements = extractCoursesFromNode(
+        programEnrollment.program.req_tree[0].children[0],
+        programEnrollment
+      )
+      const electives = extractCoursesFromNode(
+        programEnrollment.program.req_tree[0].children[1],
+        programEnrollment
+      )
+
+      assert.equal(requirements.length, 0)
       assert.equal(electives.length, 4)
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What's this PR do?
Fixes a bug which was caused when viewing the program's course-drawer for the following configurations:

1. A program which has required courses and no elective courses.
2. A program which has elective courses and no required courses.

#### How should this be manually tested?

1. Enroll your user into a course run for which the corresponding course is a required course in a program.
2. Visit http://mitxonline.odl.local:8013/dashboard/?enable_programs#program_enrollment_drawer
3. Navigate to the "program" tab and then click on the card shown.
4. With this branch running, you should be shown the course associated with the program.  With the current master branch, you should see a blank screen and console errors in the browser.
