### PR TITLE
Only display course number

### DIFF
--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -90,7 +90,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
             ) : null}
           </span>
         </td>
-        <td>{course.readable_id}</td>
+        <td>{course.readable_id.split("+")[1] || course.readable_id}</td>
         <td>{course.grade ? course.grade.grade_percent : ""}</td>
         <td>{course.grade ? course.grade.letter_grade : ""}</td>
         <td className="learner-record-cert-status">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1344

#### What's this PR do?
Changes the Course ID column from displaying the readable course ID to, now, displaying the course number.

#### How should this be manually tested?

1. Enroll a user into a course which is associated with a program.
2. Visit http://mitxonline.odl.local:8013/dashboard/?enable_programs&enable_lr
3. Click the Programs tab
4. Click on the course from step 1.
5. Click on "View program record"
6. Verify the Course ID column displays the course number only.

#### Screenshots (if appropriate)
![Screenshot 2023-01-12 at 13 46 47](https://user-images.githubusercontent.com/8311573/212152876-d0491204-ff90-4fa4-bc33-5ff8c3fb0c9b.png)
