### PR TITLE
feat(import_courserun): add ability to block countries

### DIFF
--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--block_countries",
             type=str,
-            help="Comma separated list of countries to block enrollments.",
+            help="Comma separated list of countries to block enrollments. Both Country Name and ISO code are supported",
             nargs="?",
         )
 

--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -81,11 +81,10 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "--block-country",
-            action="append",
-            default=[],
-            dest="blocked_countries",
-            help="Single or multiple countries to block enrollments.",
+            "--block_countries",
+            type=str,
+            help="Comma separated list of countries to block enrollments.",
+            nargs="?",
         )
 
     def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
@@ -235,7 +234,7 @@ class Command(BaseCommand):
                             )
                         )
 
-                for country_name in kwargs["blocked_countries"]:
+                for country_name in kwargs["block_countries"].split(","):
                     country_code = countries.by_name(country_name)
                     if country_code:
                         BlockedCountry.objects.get_or_create(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1349

#### What's this PR do?

- Adds a new flag `--block_countries` to create `BlockedCountry` objects.
- `--block_countries` is a comma-separated list of country names to block enrollments.

#### How should this be manually tested?

- Make sure that your integration with edX is working fine.
- Create a new course in edX locally.
- Import the course using `import_courserun` command and provide an argument to block countries like `--block_countries='pakistan,united states of america'`. You should see success messages for the blocked countries.
- Visit `/admin/courses/blockedcountry/`. Blocked Country objects should be created.
