### PR TITLE
fix: incorrect output from manage_certificates command when auditing

### DIFF
--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -177,7 +177,11 @@ class Command(BaseCommand):
                     )
 
                 # While overriding grade we force create the certificate
-                (_, created_cert, deleted_cert,) = process_course_run_grade_certificate(
+                (
+                    certificate,
+                    created_cert,
+                    deleted_cert,
+                ) = process_course_run_grade_certificate(
                     course_run_grade=course_run_grade,
                     should_force_create=is_grade_override,
                 )
@@ -199,7 +203,7 @@ class Command(BaseCommand):
                     cert_status = "created"
                 elif deleted_cert:
                     cert_status = "deleted"
-                elif course_run_grade.passed:
+                elif course_run_grade.passed and certificate:
                     cert_status = "already exists"
                 else:
                     cert_status = "ignored"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1328 

#### What's this PR do?
Fix for the incorrect message of the `manage_certificates` command

#### How should this be manually tested?

- Enroll a user into a course run as auditing.
- Create passing grades for that user in edX.
- Run `docker-compose run --rm web ./manage.py manage_certificates --create --run=<COURSE_RUN_ID>`
- The Previous message for the audit user was `Processed user <AUDIT_ENROLLED_USER> in course run <COURSE_RUN_ID>. Result - Grade: already exists (passed: True), Certificate: already exists`
- The new message should be `Processed user <AUDIT_ENROLLED_USER> in course run <COURSE_RUN_ID>. Result - Grade: already exists (passed: True), Certificate: ignored`