### PR TITLE
fix: show only published/live product pages on home page

### DIFF
--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -230,6 +230,21 @@ def test_home_page_featured_products_sorting(mocker):
 
 
 @pytest.mark.django_db
+def test_home_page_featured_products_published_only():
+    """Tests that featured products contain only published products/pages in the HomePage"""
+    home_page = HomePageFactory.create()
+    course_pages = CoursePageFactory.create_batch(2, parent=home_page)
+    unpublished_course_page = CoursePageFactory.create(parent=home_page, live=False)
+
+    for course_page in course_pages + [unpublished_course_page]:
+        HomeProductLink.objects.create(page=home_page, course_product_page=course_page)
+
+    featured_products = home_page.products
+    assert len(featured_products) == 2
+    assert unpublished_course_page not in featured_products
+
+
+@pytest.mark.django_db
 def test_create_courseware_page():
     ensure_home_page_and_site()
     ensure_product_index()

--- a/cms/models.py
+++ b/cms/models.py
@@ -541,7 +541,7 @@ class HomePage(Page):
     def products(self):
         future_data = []
         past_data = []
-        for page in self.featured_products.all():
+        for page in self.featured_products.filter(course_product_page__live=True):
             if page.course_product_page:
                 product_page = page.course_product_page.specific
                 run = product_page.product.first_unexpired_run


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1354

#### What's this PR do?
- Fixes a bug with product listing on the home page, Which shows unpublished courses too, and opening them leads to a 404 page.

#### How should this be manually tested?
- Reproduce the issue with the steps mentioned in https://github.com/mitodl/mitxonline/issues/1354
- Set this branch up, Switch between `published/unpublished` for a course and check that you don't see unpublished pages on Home Page and vice versa.


#### Where should the reviewer start?
Setup a couple of courses with cms pages

#### Screenshots (if appropriate)
**After - Active Products only**
<img width="1551" alt="Screenshot 2023-01-18 at 4 59 50 PM" src="https://user-images.githubusercontent.com/34372316/213166163-fb0cd3f0-e1e3-40a9-aa40-e3d8e269e2c9.png">

**Before - All Products**
<img width="1551" alt="Screenshot 2023-01-18 at 4 49 08 PM" src="https://user-images.githubusercontent.com/34372316/213166153-181980ff-742c-4461-a034-c33727c51add.png">


NOTE: I should be adding some tests for this too. (To be added soon, before i finalize the PR)
