### PR TITLE
fix: Fix admin search for redeemed discounts

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -135,8 +135,19 @@ class UserDiscountAdmin(admin.ModelAdmin):
 @admin.register(DiscountRedemption)
 class DiscountRedemptionAdmin(admin.ModelAdmin):
     model = DiscountRedemption
-    search_fields = ["redemption_date", "redeemed_discount", "redeemed_by"]
-    list_display = ["id", "redemption_date", "redeemed_discount", "redeemed_by"]
+    search_fields = [
+        "redeemed_discount__discount_code",
+        "redeemed_by__email",
+        "redeemed_by__username",
+        "redeemed_order__reference_number",
+    ]
+    list_display = [
+        "id",
+        "redemption_date",
+        "redeemed_discount",
+        "redeemed_by",
+        "redeemed_order",
+    ]
     readonly_fields = (
         "redemption_date",
         "redeemed_discount",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes [Sentry Issue](https://sentry.io/organizations/mit-office-of-digital-learning/issues/3882322266/?project=5864687&referrer=slack)

#### What's this PR do?

- Fixes admin search for Discount Redemptions.
- Adds order info in the list display

#### How should this be manually tested?

- Visit `/admin/ecommerce/discountredemption/`
- Verify that order information is visible.
- Verify that the search is not breaking and is working fine as well.