### PR TITLE
fix: Fix program learner record when there is no grade

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -762,9 +762,9 @@ class LearnerRecordSerializer(serializers.BaseSerializer):
                 .order_by("-grade")
                 .first()
             )
-            grade.grade = round(grade.grade, 2)
 
             if grade is not None:
+                grade.grade = round(grade.grade, 2)
                 fmt_course["grade"] = CourseRunGradeSerializer(grade).data
 
             certificate = (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://sentry.io/organizations/mit-office-of-digital-learning/issues/3885865905/?project=5864687&referrer=slack

#### What's this PR do?
Adds a check to fix an error while setting a grade object attribute.

#### How should this be manually tested?
Testing instructions are taken from the main learner records [PR](https://github.com/mitodl/mitxonline/pull/1237).
- Ensure that you have a learner account enrolled in a program.
- Generate grades and certificates for the learner.
- Using Django Admin, also create some partner school records.
- View the learner's dashboard and open the program drawer. You should see the View Program Record link.
- Now delete the grade for one of the courses. Make sure that the learner records are still fine.
