### PR TITLE
1346 learner record UI improvements

### DIFF
--- a/frontend/public/scss/learner-records.scss
+++ b/frontend/public/scss/learner-records.scss
@@ -34,10 +34,6 @@ div.learner-record {
     padding: 30px;
     margin-top: 1em;
   }
-
-  @media (max-width:960px) {
-    overflow-x: auto;
-  }
   
   h1 {
     font-size: 32px;

--- a/frontend/public/scss/learner-records.scss
+++ b/frontend/public/scss/learner-records.scss
@@ -1,8 +1,3 @@
-div.std-page-body.learner-record.container {
-  padding-left: 0;
-  padding-right: 0;
-}
-
 #learner-record-school-name img {
   width: 245px;
 }
@@ -20,7 +15,7 @@ div.std-page-body.learner-record.container {
 span.badge-learner-completion {
   color: white;
   background-color: #f0ad4e;
-  font-size: 125%;
+  font-size: 14px;
   font-weight: normal;
 }
 
@@ -29,6 +24,25 @@ div.learner-record-user-profile {
 
   span.learner-record-user-name {
     font-size: 150%;
+  }
+}
+
+div.learner-record {
+  @media (min-width:960px) { 
+    border: 1px solid #c2c2c2;
+    border-radius: 8px;
+    padding: 30px;
+    margin-top: 1em;
+  }
+
+  @media (max-width:960px) {
+    overflow-x: auto;
+  }
+  
+  h1 {
+    font-size: 32px;
+    font-weight: 500;
+    line-height: 1.1;
   }
 }
 
@@ -53,6 +67,13 @@ table.learner-record-table {
 div.learner-record-sharing-controls {
   button.btn {
     padding: 8px 10px !important;
+    font-weight: 400;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+    border: none;
+    line-height: 35px;
+    text-align: center;
+    border-radius: 0.25rem;
+    font-size: 15px;
   }
 
   button:not(:first-child) {

--- a/frontend/public/scss/learner-records.scss
+++ b/frontend/public/scss/learner-records.scss
@@ -42,6 +42,7 @@ table.learner-record-table {
 
   td, th {
     padding: 10px;
+    vertical-align: bottom;
   }
 
   thead {

--- a/frontend/public/scss/learner-records.scss
+++ b/frontend/public/scss/learner-records.scss
@@ -44,7 +44,7 @@ div.learner-record {
 
 table.learner-record-table {
   margin-top: .5em;
-  width: 100vw;
+  width: 100%;
 
   tr:first-child {
     width: 45%;
@@ -66,10 +66,12 @@ div.learner-record-sharing-controls {
     font-weight: 400;
     box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
     border: none;
-    line-height: 35px;
     text-align: center;
     border-radius: 0.25rem;
     font-size: 15px;
+    @media (min-width:960px) { 
+      line-height: 35px;
+    }
   }
 
   button:not(:first-child) {

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -473,30 +473,26 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
         {/* Display for mobile screens. */}
         <div className="d-md-none">
           <div className="learner-record">
-            <div className="row">
-              <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
-                <div className="d-flex">
-                  <div className="d-flex flex-column">
-                    <h3 className="learner-record-program-title">
-                      {learnerRecord
-                        ? learnerRecord.program.title
-                        : "MITx Online Program Record"}
-                    </h3>
-                    <p>Program Record</p>
-                  </div>
-                </div>
-                <div>
-                  {!this.isProgramCompleted() ? (
-                    <span className="badge badge-learner-completion badge-partially-completed">
-                      Partially Completed
-                    </span>
-                  ) : null}
-                  {this.isProgramCompleted() ? (
-                    <span className="badge badge-learner-completion badge-completed">
-                      Completed
-                    </span>
-                  ) : null}
-                </div>
+            <div className="m-0 d-flex flex-column">
+              <div>
+                <h3 className="learner-record-program-title">
+                  {learnerRecord
+                    ? learnerRecord.program.title
+                    : "MITx Online Program Record"}
+                </h3>
+                <p>Program Record</p>
+              </div>
+              <div>
+                {!this.isProgramCompleted() ? (
+                  <span className="badge badge-learner-completion badge-partially-completed">
+                    Partially Completed
+                  </span>
+                ) : null}
+                {this.isProgramCompleted() ? (
+                  <span className="badge badge-learner-completion badge-completed">
+                    Completed
+                  </span>
+                ) : null}
               </div>
             </div>
 
@@ -516,34 +512,33 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
         {/* {Display for desktop screens.} */}
         <div className="d-none d-md-block">
           <div className="learner-record">
-            <div className="row">
-              <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
-                <div className="d-flex">
-                  <div className="d-flex flex-column">
-                    <p className="w-50">MITx Online Program Record</p>
-                    <h1 className="flex-grow-1 learner-record-program-title">
-                      {learnerRecord ? learnerRecord.program.title : null}
-                    </h1>
-                  </div>
-                  <div id="learner-record-school-name">
-                    <img
-                      src="/static/images/mitx-online-logo.png"
-                      alt="MITx Online Logo"
-                    />
-                  </div>
+            <div className="flex-column">
+              <div>
+                <div
+                  className="d-flex justify-content-between"
+                  id="learner-record-school-name"
+                >
+                  <p className="w-50">MITx Online Program Record</p>
+                  <img
+                    src="/static/images/mitx-online-logo.png"
+                    alt="MITx Online Logo"
+                  />
                 </div>
-                <div>
-                  {!this.isProgramCompleted() ? (
-                    <span className="badge badge-learner-completion badge-partially-completed">
-                      Partially Completed
-                    </span>
-                  ) : null}
-                  {this.isProgramCompleted() ? (
-                    <span className="badge badge-learner-completion badge-completed">
-                      Completed
-                    </span>
-                  ) : null}
-                </div>
+              </div>
+              <h1 className="flex-grow-1 learner-record-program-title w-50">
+                {learnerRecord ? learnerRecord.program.title : null}
+              </h1>
+              <div>
+                {!this.isProgramCompleted() ? (
+                  <span className="badge badge-learner-completion badge-partially-completed">
+                    Partially Completed
+                  </span>
+                ) : null}
+                {this.isProgramCompleted() ? (
+                  <span className="badge badge-learner-completion badge-completed">
+                    Completed
+                  </span>
+                ) : null}
               </div>
             </div>
 

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -82,7 +82,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
   // Renders program's courses table.
   renderCourseTableRow(course: LearnerRecordCourse) {
     return (
-      <tr key={`learner-record-course-${course.id}`}>
+      <tr scope="row" key={`learner-record-course-${course.id}`}>
         <td className="d-flex">
           <span className="flex-grow-1">{course.title}</span>
           <span className="learner-record-req-badges pr-2">
@@ -549,8 +549,8 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
                 <table className="learner-record-table">
                   <thead>
                     <tr>
-                      <th>Course Name</th>
-                      <th>Course ID</th>
+                      <th scope="col">Course Name</th>
+                      <th scope="col">Course ID</th>
                       <th>
                         Highest
                         <br />

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -32,7 +32,7 @@ import type {
   LearnerRecordCourse
 } from "../../../flow/courseTypes"
 
-import type { CurrentUser } from "../flow/authTypes"
+import type { CurrentUser } from "../../flow/authTypes"
 
 type Props = {
   learnerRecord: LearnerRecord,

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -91,7 +91,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
             ) : null}
           </span>
         </td>
-        <td>{course.readable_id}</td>
+        <td>{course.readable_id.split("+")[1] || course.readable_id}</td>
         <td>{course.grade ? course.grade.grade_percent : ""}</td>
         <td>{course.grade ? course.grade.letter_grade : ""}</td>
         <td className="learner-record-cert-status">
@@ -108,10 +108,13 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
   // Renders program's courses list items.
   renderCourseListItem(course: LearnerRecordCourse) {
     return (
-      <div key={`learner-record-course-${course.id}`} className="list-group-item d-flex flex-column justify-content-between align-items-start">
+      <div
+        key={`learner-record-course-${course.id}`}
+        className="list-group-item d-flex flex-column justify-content-between align-items-start"
+      >
         <div className="d-flex w-100 justify-content-between">
           <h5 className="mb-1">{course.title}</h5>
-          <span className="learner-record-req-badges pr-2">
+          <span className="learner-record-req-badges pl-2">
             {course.reqtype === "Required Courses" ? (
               <span className="badge badge-danger">Core</span>
             ) : null}
@@ -120,38 +123,39 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
             ) : null}
           </span>
         </div>
-        {course.grade ? <p className="mb-1">Grade: {course.grade.grade_percent}</p> : ""}
+        {course.readable_id.split("+")[1] || course.readable_id}
+        {course.grade ? (
+          <p className="mb-1">Grade: {course.grade.grade_percent}</p>
+        ) : (
+          ""
+        )}
+        {course.certificate ? (
+          <span className="badge badge-success">Certificate Earned</span>
+        ) : (
+          <span className="badge badge-secondary">Not Earned</span>
+        )}
       </div>
     )
   }
 
-  // <tr key={`learner-record-course-${course.id}`}>
-  //   <td>{course.readable_id}</td>
-  //   <td>{course.grade ? course.grade.grade_percent : ""}</td>
-  //   <td>{course.grade ? course.grade.letter_grade : ""}</td>
-  //   <td className="learner-record-cert-status">
-  //     {course.certificate ? (
-  //       <span className="badge badge-success">Certificate Earned</span>
-  //     ) : (
-  //       <span className="badge badge-secondary">Not Earned</span>
-  //     )}
-  //   </td>
-  // </tr>
-
   renderLearnerInfo() {
     const { learnerRecord } = this.props
-
-    return learnerRecord && learnerRecord.user ? (
-      <div className="row">
-        <div className="col-12 learner-record-user-profile">
-          <span className="learner-record-user-name">
-            {learnerRecord.user.name}
-          </span>
-          <br />
-          {learnerRecord.user.username} | {learnerRecord.user.email}
+    // Only display the leaner info if the current user is different from the leanerRecord's user
+    // or the visitor is not logged in.
+    return learnerRecord &&
+      learnerRecord.user &&
+      (!this.props.currentUser ||
+        this.props.currentUser.username !== learnerRecord.user.username) ? (
+        <div className="row">
+          <div className="col-12 learner-record-user-profile">
+            <span className="learner-record-user-name">
+              {learnerRecord.user.name}
+            </span>
+            <br />
+            {learnerRecord.user.username} | {learnerRecord.user.email}
+          </div>
         </div>
-      </div>
-    ) : null
+      ) : null
   }
 
   renderSharingLinkDialog(learnerRecord: LearnerRecord) {
@@ -465,24 +469,17 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
       <div>
         {/* Display for mobile screens. */}
         <div className="d-md-none">
-          <hr/>
           <div className="learner-record">
             <div className="row">
               <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
-                <div className="d-flex mb-2">
+                <div className="d-flex">
                   <div className="d-flex flex-column">
-                    <p className="w-50">MITx Online Program Record</p>
-                    <h1 className="flex-grow-1 learner-record-program-title">
-                      {learnerRecord ? learnerRecord.program.title : null}
-                    </h1>
-                  </div>
-                  <div
-                    id="learner-record-school-name"
-                  >
-                    <img
-                      src="/static/images/mitx-online-logo.png"
-                      alt="MITx Online Logo"
-                    />
+                    <h3 className="learner-record-program-title">
+                      {learnerRecord
+                        ? learnerRecord.program.title
+                        : "MITx Online Program Record"}
+                    </h3>
+                    <p>Program Record</p>
                   </div>
                 </div>
                 <div>
@@ -501,8 +498,9 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
             </div>
 
             {this.renderLearnerInfo()}
-
-            <div className="col-12 mt-2 d-flex justify-content-between">
+            <hr />
+            <h4>Courses</h4>
+            <div className="mt-2 d-flex justify-content-between">
               <div className="list-group">
                 {learnerRecord
                   ? learnerRecord.program.courses.map(this.renderCourseListItem)
@@ -517,16 +515,14 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
           <div className="learner-record">
             <div className="row">
               <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
-                <div className="d-flex mb-2">
+                <div className="d-flex">
                   <div className="d-flex flex-column">
                     <p className="w-50">MITx Online Program Record</p>
                     <h1 className="flex-grow-1 learner-record-program-title">
                       {learnerRecord ? learnerRecord.program.title : null}
                     </h1>
                   </div>
-                  <div
-                    id="learner-record-school-name"
-                  >
+                  <div id="learner-record-school-name">
                     <img
                       src="/static/images/mitx-online-logo.png"
                       alt="MITx Online Logo"
@@ -574,7 +570,9 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
                   </thead>
                   <tbody>
                     {learnerRecord
-                      ? learnerRecord.program.courses.map(this.renderCourseTableRow)
+                      ? learnerRecord.program.courses.map(
+                        this.renderCourseTableRow
+                      )
                       : null}
                   </tbody>
                 </table>
@@ -597,7 +595,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
       <DocumentTitle title={`${SETTINGS.site_name} | ${RECORDS_PAGE_TITLE}`}>
         <Loader isLoading={isLoading}>
           <div className="std-page-body container">
-            <div className="d-flex flex-row-reverse">
+            <div className="d-flex flex-row-reverse mb-4">
               {isSharedRecord ? (
                 <div className="d-flex learner-record-sharing-controls mb-2">
                   {!hasSharingEnabled ? (

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -438,7 +438,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
           <div className="std-page-body learner-record container">
             <div className="row">
               <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
-                <div className="d-flex flex-row mb-2 align-items-end">
+                <div className="d-flex mb-2 align-items-end">
                   <p className="w-50">MITx Online Program Record</p>
                   {isSharedRecord ? (
                     <div className="w-50 text-right learner-record-sharing-controls">
@@ -493,7 +493,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
                     </div>
                   ) : null}
                 </div>
-                <div className="d-flex flex-row">
+                <div className="d-flex flex-sm-row flex-column">
                   <h1 className="flex-grow-1 learner-record-program-title">
                     {learnerRecord ? learnerRecord.program.title : null}
                   </h1>
@@ -523,7 +523,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
 
             <div className="row">
               <div className="col-12 d-flex justify-content-between">
-                <table className="learner-record-table">
+                <table className="learner-record-table table-responsive">
                   <thead>
                     <tr>
                       <th>Course Name</th>

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -76,7 +76,8 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
     return parseInt(this.props.match.params.program.length)
   }
 
-  renderCourse(course: LearnerRecordCourse) {
+  // Renders program's courses table.
+  renderCourseTableRow(course: LearnerRecordCourse) {
     return (
       <tr key={`learner-record-course-${course.id}`}>
         <td className="d-flex">
@@ -103,6 +104,39 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
       </tr>
     )
   }
+
+  // Renders program's courses list items.
+  renderCourseListItem(course: LearnerRecordCourse) {
+    return (
+      <div key={`learner-record-course-${course.id}`} className="list-group-item d-flex flex-column justify-content-between align-items-start">
+        <div className="d-flex w-100 justify-content-between">
+          <h5 className="mb-1">{course.title}</h5>
+          <span className="learner-record-req-badges pr-2">
+            {course.reqtype === "Required Courses" ? (
+              <span className="badge badge-danger">Core</span>
+            ) : null}
+            {course.reqtype === "Elective Courses" ? (
+              <span className="badge badge-success">Elective</span>
+            ) : null}
+          </span>
+        </div>
+        {course.grade ? <p className="mb-1">Grade: {course.grade.grade_percent}</p> : ""}
+      </div>
+    )
+  }
+
+  // <tr key={`learner-record-course-${course.id}`}>
+  //   <td>{course.readable_id}</td>
+  //   <td>{course.grade ? course.grade.grade_percent : ""}</td>
+  //   <td>{course.grade ? course.grade.letter_grade : ""}</td>
+  //   <td className="learner-record-cert-status">
+  //     {course.certificate ? (
+  //       <span className="badge badge-success">Certificate Earned</span>
+  //     ) : (
+  //       <span className="badge badge-secondary">Not Earned</span>
+  //     )}
+  //   </td>
+  // </tr>
 
   renderLearnerInfo() {
     const { learnerRecord } = this.props
@@ -425,6 +459,133 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
     )
   }
 
+  // Render the course record table differently based on screen size.
+  renderLearnerRecordTable(learnerRecord) {
+    return (
+      <div>
+        {/* Display for mobile screens. */}
+        <div className="d-md-none">
+          <hr/>
+          <div className="learner-record">
+            <div className="row">
+              <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
+                <div className="d-flex mb-2">
+                  <div className="d-flex flex-column">
+                    <p className="w-50">MITx Online Program Record</p>
+                    <h1 className="flex-grow-1 learner-record-program-title">
+                      {learnerRecord ? learnerRecord.program.title : null}
+                    </h1>
+                  </div>
+                  <div
+                    id="learner-record-school-name"
+                  >
+                    <img
+                      src="/static/images/mitx-online-logo.png"
+                      alt="MITx Online Logo"
+                    />
+                  </div>
+                </div>
+                <div>
+                  {!this.isProgramCompleted() ? (
+                    <span className="badge badge-learner-completion badge-partially-completed">
+                      Partially Completed
+                    </span>
+                  ) : null}
+                  {this.isProgramCompleted() ? (
+                    <span className="badge badge-learner-completion badge-completed">
+                      Completed
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+
+            {this.renderLearnerInfo()}
+
+            <div className="col-12 mt-2 d-flex justify-content-between">
+              <div className="list-group">
+                {learnerRecord
+                  ? learnerRecord.program.courses.map(this.renderCourseListItem)
+                  : null}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* {Display for desktop screens.} */}
+        <div className="d-none d-md-block">
+          <div className="learner-record">
+            <div className="row">
+              <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
+                <div className="d-flex mb-2">
+                  <div className="d-flex flex-column">
+                    <p className="w-50">MITx Online Program Record</p>
+                    <h1 className="flex-grow-1 learner-record-program-title">
+                      {learnerRecord ? learnerRecord.program.title : null}
+                    </h1>
+                  </div>
+                  <div
+                    id="learner-record-school-name"
+                  >
+                    <img
+                      src="/static/images/mitx-online-logo.png"
+                      alt="MITx Online Logo"
+                    />
+                  </div>
+                </div>
+                <div>
+                  {!this.isProgramCompleted() ? (
+                    <span className="badge badge-learner-completion badge-partially-completed">
+                      Partially Completed
+                    </span>
+                  ) : null}
+                  {this.isProgramCompleted() ? (
+                    <span className="badge badge-learner-completion badge-completed">
+                      Completed
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+
+            {this.renderLearnerInfo()}
+
+            <div className="row">
+              <div className="col-12 d-flex justify-content-between">
+                <table className="learner-record-table">
+                  <thead>
+                    <tr>
+                      <th>Course Name</th>
+                      <th>Course ID</th>
+                      <th>
+                        Highest
+                        <br />
+                        Grade
+                        <br />
+                        Earned
+                      </th>
+                      <th>
+                        Letter
+                        <br />
+                        Grade
+                      </th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {learnerRecord
+                      ? learnerRecord.program.courses.map(this.renderCourseTableRow)
+                      : null}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   render() {
     const { learnerRecord, isLoading } = this.props
     const { isRevoking, isEnablingSharing } = this.state
@@ -488,75 +649,10 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
                 </div>
               ) : null}
             </div>
-            <hr className="d-md-none" />
-            <div className="learner-record">
-              <div className="row">
-                <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
-                  <div className="d-flex mb-2">
-                    <div className="d-flex flex-column">
-                      <p className="w-50">MITx Online Program Record</p>
-                      <h1 className="flex-grow-1 learner-record-program-title">
-                        {learnerRecord ? learnerRecord.program.title : null}
-                      </h1>
-                    </div>
-                    <div
-                      className="d-none d-md-block"
-                      id="learner-record-school-name"
-                    >
-                      <img
-                        src="/static/images/mitx-online-logo.png"
-                        alt="MITx Online Logo"
-                      />
-                    </div>
-                  </div>
-                  <div>
-                    {!this.isProgramCompleted() ? (
-                      <span className="badge badge-learner-completion badge-partially-completed">
-                        Partially Completed
-                      </span>
-                    ) : null}
-                    {this.isProgramCompleted() ? (
-                      <span className="badge badge-learner-completion badge-completed">
-                        Completed
-                      </span>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
 
-              {this.renderLearnerInfo()}
-
-              <div className="row">
-                <div className="col-12 d-flex justify-content-between">
-                  <table className="learner-record-table">
-                    <thead>
-                      <tr>
-                        <th>Course Name</th>
-                        <th>Course ID</th>
-                        <th>
-                          Highest
-                          <br />
-                          Grade
-                          <br />
-                          Earned
-                        </th>
-                        <th>
-                          Letter
-                          <br />
-                          Grade
-                        </th>
-                        <th>Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {learnerRecord
-                        ? learnerRecord.program.courses.map(this.renderCourse)
-                        : null}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
+            {learnerRecord
+              ? this.renderLearnerRecordTable(learnerRecord)
+              : null}
 
             {learnerRecord
               ? this.renderPartnerSchoolSharingDialog(learnerRecord)

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -147,7 +147,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
     // or the visitor is not logged in.
     return learnerRecord &&
       learnerRecord.user &&
-      (!this.props.currentUser ||
+      (!this.props.currentUser.is_authenticated ||
         this.props.currentUser.username !== learnerRecord.user.username) ? (
         <div className="row">
           <div className="col-12 learner-record-user-profile">

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -32,7 +32,7 @@ import type {
   LearnerRecordCourse
 } from "../../../flow/courseTypes"
 
-import type { CurrentUser } from "../../flow/authTypes"
+import type { CurrentUser } from "../../../flow/authTypes"
 
 type Props = {
   learnerRecord: LearnerRecord,

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -114,7 +114,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
             {learnerRecord.user.name}
           </span>
           <br />
-          {learnerRecord.user.email} | {learnerRecord.user.username}
+          {learnerRecord.user.username} | {learnerRecord.user.email}
         </div>
       </div>
     ) : null
@@ -435,120 +435,126 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
     return (
       <DocumentTitle title={`${SETTINGS.site_name} | ${RECORDS_PAGE_TITLE}`}>
         <Loader isLoading={isLoading}>
-          <div className="std-page-body learner-record container">
-            <div className="row">
-              <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
-                <div className="d-flex mb-2 align-items-end">
-                  <p className="w-50">MITx Online Program Record</p>
-                  {isSharedRecord ? (
-                    <div className="w-50 text-right learner-record-sharing-controls">
-                      {!hasSharingEnabled ? (
-                        <button
-                          key="togglesharing"
-                          className="btn btn-primary"
-                          type="button"
-                          onClick={() => this.onEnableRecordSharing()}
-                        >
-                          {isEnablingSharing ? (
-                            <>Please Wait...</>
-                          ) : (
-                            <>Allow Record Sharing</>
-                          )}
-                        </button>
-                      ) : null}
-                      {hasSharingEnabled ? (
-                        <>
-                          <button
-                            key="sendlearnerrecord"
-                            className="btn btn-primary"
-                            type="button"
-                            onClick={() =>
-                              this.togglePartnerSchoolSharingDialog()
-                            }
-                          >
-                            Send Learner Record
-                          </button>
-                          <button
-                            key="sharingdialog"
-                            className="btn btn-primary"
-                            type="button"
-                            onClick={() => this.toggleSharingLinkDialog()}
-                          >
-                            Share
-                          </button>
-                          <button
-                            key="revokesharing"
-                            className="btn btn-primary"
-                            type="button"
-                            onClick={() => this.onRevokeSharing()}
-                          >
-                            {isRevoking ? (
-                              <>Revoking Access...</>
-                            ) : (
-                              <>Revoke Sharing</>
-                            )}
-                          </button>
-                        </>
-                      ) : null}
-                    </div>
+          <div className="std-page-body container">
+            <div className="d-flex flex-row-reverse">
+              {isSharedRecord ? (
+                <div className="d-flex learner-record-sharing-controls mb-2">
+                  {!hasSharingEnabled ? (
+                    <button
+                      key="togglesharing"
+                      className="btn btn-primary mdl-button"
+                      type="button"
+                      onClick={() => this.onEnableRecordSharing()}
+                    >
+                      {isEnablingSharing ? (
+                        <>Please Wait...</>
+                      ) : (
+                        <>Allow Record Sharing</>
+                      )}
+                    </button>
+                  ) : null}
+                  {hasSharingEnabled ? (
+                    <>
+                      <button
+                        key="sendlearnerrecord"
+                        className="btn btn-primary"
+                        type="button"
+                        onClick={() => this.togglePartnerSchoolSharingDialog()}
+                      >
+                        Send Learner Record
+                      </button>
+                      <button
+                        key="sharingdialog"
+                        className="btn btn-primary"
+                        type="button"
+                        onClick={() => this.toggleSharingLinkDialog()}
+                      >
+                        Share
+                      </button>
+                      <button
+                        key="revokesharing"
+                        className="btn btn-primary"
+                        type="button"
+                        onClick={() => this.onRevokeSharing()}
+                      >
+                        {isRevoking ? (
+                          <>Revoking Access...</>
+                        ) : (
+                          <>Revoke Sharing</>
+                        )}
+                      </button>
+                    </>
                   ) : null}
                 </div>
-                <div className="d-flex flex-sm-row flex-column">
-                  <h1 className="flex-grow-1 learner-record-program-title">
-                    {learnerRecord ? learnerRecord.program.title : null}
-                  </h1>
-                  <div id="learner-record-school-name">
-                    <img
-                      src="/static/images/mitx-online-logo.png"
-                      alt="MITx Online Logo"
-                    />
+              ) : null}
+            </div>
+            <hr className="d-md-none" />
+            <div className="learner-record">
+              <div className="row">
+                <div className="col-12 d-flex justify-content-between learner-record-header flex-column">
+                  <div className="d-flex mb-2">
+                    <div className="d-flex flex-column">
+                      <p className="w-50">MITx Online Program Record</p>
+                      <h1 className="flex-grow-1 learner-record-program-title">
+                        {learnerRecord ? learnerRecord.program.title : null}
+                      </h1>
+                    </div>
+                    <div
+                      className="d-none d-md-block"
+                      id="learner-record-school-name"
+                    >
+                      <img
+                        src="/static/images/mitx-online-logo.png"
+                        alt="MITx Online Logo"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    {!this.isProgramCompleted() ? (
+                      <span className="badge badge-learner-completion badge-partially-completed">
+                        Partially Completed
+                      </span>
+                    ) : null}
+                    {this.isProgramCompleted() ? (
+                      <span className="badge badge-learner-completion badge-completed">
+                        Completed
+                      </span>
+                    ) : null}
                   </div>
                 </div>
-                <div>
-                  {!this.isProgramCompleted() ? (
-                    <span className="badge badge-learner-completion badge-partially-completed">
-                      Partially Completed
-                    </span>
-                  ) : null}
-                  {this.isProgramCompleted() ? (
-                    <span className="badge badge-learner-completion badge-completed">
-                      Completed
-                    </span>
-                  ) : null}
-                </div>
               </div>
-            </div>
 
-            {this.renderLearnerInfo()}
+              {this.renderLearnerInfo()}
 
-            <div className="row">
-              <div className="col-12 d-flex justify-content-between">
-                <table className="learner-record-table table-responsive">
-                  <thead>
-                    <tr>
-                      <th>Course Name</th>
-                      <th>Course ID</th>
-                      <th>
-                        Highest
-                        <br />
-                        Grade
-                        <br />
-                        Earned
-                      </th>
-                      <th>
-                        Letter
-                        <br />
-                        Grade
-                      </th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {learnerRecord
-                      ? learnerRecord.program.courses.map(this.renderCourse)
-                      : null}
-                  </tbody>
-                </table>
+              <div className="row">
+                <div className="col-12 d-flex justify-content-between">
+                  <table className="learner-record-table">
+                    <thead>
+                      <tr>
+                        <th>Course Name</th>
+                        <th>Course ID</th>
+                        <th>
+                          Highest
+                          <br />
+                          Grade
+                          <br />
+                          Earned
+                        </th>
+                        <th>
+                          Letter
+                          <br />
+                          Grade
+                        </th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {learnerRecord
+                        ? learnerRecord.program.courses.map(this.renderCourse)
+                        : null}
+                    </tbody>
+                  </table>
+                </div>
               </div>
             </div>
 

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -32,6 +32,8 @@ import type {
   LearnerRecordCourse
 } from "../../../flow/courseTypes"
 
+import type { CurrentUser } from "../flow/authTypes"
+
 type Props = {
   learnerRecord: LearnerRecord,
   isSharedRecord: boolean,
@@ -44,7 +46,8 @@ type Props = {
     partnerSchoolId: number | null
   ) => Promise<any>,
   revokeRecordSharing: (programId: number) => Promise<any>,
-  match: any
+  match: any,
+  currentUser: CurrentUser
 }
 
 type State = {
@@ -464,7 +467,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
   }
 
   // Render the course record table differently based on screen size.
-  renderLearnerRecordTable(learnerRecord) {
+  renderLearnerRecordTable(learnerRecord: LearnerRecord) {
     return (
       <div>
         {/* Display for mobile screens. */}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1346

#### What's this PR do?
Makes visual and functional improvements to the leaner record page.

#### How should this be manually tested?
**Configure learner record**
1. Create a couple courses, course runs.  Enroll you user into the courses which will create a course run enrollment and course run grades entry.  Create a Program, Program run, Program run enrollment for your user.  
2. Visit https://rc.mitxonline.mit.edu/dashboard/?enable_programs&enable_lr
3. Click the "My Programs" tab.
4. Click the program card.
5. Click "View program record".
6. Verify that the desktop UI looks clean.
7. Switch to a mobile screen view and verify the UI looks clean.  The MIT logo should disappear and the table should become a list group.
8. Click allow record sharing.
9. Click share.
10. Copy the link.
11. Visit the link when logged in as your current user.
12. Verify that the user information is not displayed.
13. Visit the link when logged in as a different user.
14. Verify that the user information is displayed.
15. View the page with a mobile screen.
16. Log out and visit the link when not logged in.
17. Verify that the user information is displayed.


#### Where should the reviewer start?
1. Configure leaner record
2. Test desktop version
3. Test mobile version
4. Test shared record while logged out.
5. Test shared record while logged in as a different user.

#### Screenshots

<img width="1148" alt="Screenshot 2023-01-21 at 14 07 53" src="https://user-images.githubusercontent.com/8311573/213883799-34723838-8aa7-4bed-8a9c-4a371ffa5f9a.png">
**Desktop view of program record while logged in as associated learner.**



<img width="1147" alt="Screenshot 2023-01-21 at 14 25 48" src="https://user-images.githubusercontent.com/8311573/213883800-27f834a6-28bc-4ccb-bb96-0718bbc8191b.png">
**Desktop view of program record while not logged in as associated learner.**



<img width="403" alt="Screenshot 2023-01-21 at 14 25 42" src="https://user-images.githubusercontent.com/8311573/213883801-47ec736b-e44e-46ac-9fa0-8928b36ee049.png">
**Mobile view of program record while not logged in as associated learner.**
