### PR TITLE
Updates repair_faulty_edx_user to reconnect edX users

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -301,7 +301,7 @@ def repair_faulty_edx_user(user):
         # 409 means we have a username conflict - pass in that case so we can
         # try to create the api auth tokens; re-raise otherwise
 
-        if str(e).contains("code: 409"):
+        if "code: 409" in str(e):
             pass
         else:
             raise Exception from e

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -15,12 +15,13 @@ from oauthlib.common import generate_token
 from requests.exceptions import HTTPError
 from rest_framework import status
 
-from courses.factories import CourseRunFactory, CourseRunEnrollmentFactory
+from courses.factories import CourseRunEnrollmentFactory, CourseRunFactory
 from main.test_utils import MockHttpError, MockResponse
 from openedx.api import (
     ACCESS_TOKEN_HEADER_NAME,
     OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS,
     OPENEDX_REGISTRATION_VALIDATION_PATH,
+    check_username_exists_in_edx,
     create_edx_auth_token,
     create_edx_user,
     create_user,
@@ -29,28 +30,27 @@ from openedx.api import (
     get_valid_edx_api_auth,
     repair_faulty_edx_user,
     repair_faulty_openedx_users,
-    update_edx_user_email,
-    update_edx_user_name,
-    sync_enrollments_with_edx,
     retry_failed_edx_enrollments,
     subscribe_to_edx_course_emails,
+    sync_enrollments_with_edx,
     unsubscribe_from_edx_course_emails,
-    check_username_exists_in_edx,
+    update_edx_user_email,
+    update_edx_user_name,
 )
 from openedx.constants import (
+    EDX_DEFAULT_ENROLLMENT_MODE,
     EDX_ENROLLMENT_AUDIT_MODE,
     OPENEDX_REPAIR_GRACE_PERIOD_MINS,
     PLATFORM_EDX,
-    EDX_DEFAULT_ENROLLMENT_MODE,
 )
 from openedx.exceptions import (
+    EdxApiEmailSettingsErrorException,
     EdxApiEnrollErrorException,
     EdxApiRegistrationValidationException,
     OpenEdxUserCreateError,
+    UnknownEdxApiEmailSettingsException,
     UnknownEdxApiEnrollException,
     UserNameUpdateFailedException,
-    EdxApiEmailSettingsErrorException,
-    UnknownEdxApiEmailSettingsException,
 )
 from openedx.factories import OpenEdxApiAuthFactory, OpenEdxUserFactory
 from openedx.models import OpenEdxApiAuth, OpenEdxUser
@@ -87,7 +87,7 @@ def test_create_user(user, mocker):
 
 
 """
-    Adds a mocked response from the EdX username validation API. 
+    Adds a mocked response from the EdX username validation API.
 
     Args:
        username_exists (boolean): Determines whether the mocked response will indicate a matched EdX username (True), or not (False).
@@ -509,7 +509,7 @@ def test_repair_faulty_edx_user(mocker, user, no_openedx_user, no_edx_auth):
     user.openedx_api_auth = openedx_api_auth
 
     created_user, created_auth_token = repair_faulty_edx_user(user)
-    patched_find_object.assert_called_once()
+    patched_find_object.assert_called()
     assert patched_create_edx_user.called is no_openedx_user
     assert patched_create_edx_auth_token.called is no_edx_auth
     assert created_user is no_openedx_user


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #258 

#### What's this PR do?

Makes some changes to the `repair_faulty_edx_users` API call: 
* If the call to create the user account in edX fails with a 409 specifically, this should ignore that error and continue. (Otherwise, it should re-raise the exception that is generated.)
* After creating the edX auth tokens, it should now check to see if there's an OpenEdxUser record as well, and should create a new one if there isn't one. 

#### How should this be manually tested?

1. Create two users manually (via Django Admin) in both MITx Online and Open edX. 
   * Note that the Open edX account _must_ have a profile for this to work. (Specify anything here; it's enough for it to have the record at all.) If you're testing a failure mode, then don't specify a profile.
   * The Open edX account password doesn't matter. 
   * The usernames and email addresses must match between MITx Online and Open edX. 
   * The users must be active.
2. Run the `repair_missing_courseware_records` management command. It should find the user you created, then try to repair it. It should successfully create auth tokens. 

If you're running the devstack Open edX deployment, it comes with a bunch of accounts set up for various purposes; these are handy to test with as well. (For example, you should be able to make an "edx@example.com" account in mitxonline and it should then connect to the devstack one.)  

#### Any background context you want to provide?

The failure mode here is that the user accounts get created in both systems, but the auth tokens don't get stored. When this happens and the repair command is run, the `repair_faulty_edx_users` API call first tries to re-create the user in edX. edX notices that there's already a user with a matching username and email, so it errors out, and the `repair_faulty_edx_users` call wasn't catching the exception when this happened so the entire process stopped for that user. However, in these cases, we already have users on both sides, so really we just need to make the respective auth tokens and go from there, which is what the changes here do.
