### PR TITLE
Enables learner records.

### DIFF
--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -3,7 +3,6 @@ import React from "react"
 import EnrolledItemCard from "./EnrolledItemCard"
 import ProgramCourseInfoCard from "./ProgramCourseInfoCard"
 import { extractCoursesFromNode } from "../lib/courseApi"
-import { areLearnerRecordsEnabled } from "../lib/util"
 import type {
   ProgramEnrollment,
   CourseDetailWithRuns
@@ -203,18 +202,14 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
             <div className="row chrome" id="program_enrollment_subtite">
               <p>
                 Program overview: {this.renderProgramOverview()}
-                {areLearnerRecordsEnabled() ? (
-                  <>
-                    <br />
-                    <a
-                      href={`/records/${enrollment.program.id}/`}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      View program record
-                    </a>
-                  </>
-                ) : null}
+                <br />
+                <a
+                  href={`/records/${enrollment.program.id}/`}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  View program record
+                </a>
               </p>
             </div>
             {enrolledItemCards}

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -1,5 +1,4 @@
 // @flow
-/* global SETTINGS:false */
 import {
   all,
   complement,
@@ -252,13 +251,4 @@ export const getFlexiblePriceForProduct = (product: Product) => {
   default:
     return Number(product.price)
   }
-}
-
-export const areLearnerRecordsEnabled = () => {
-  const params = new URLSearchParams(document.location.search)
-
-  return (
-    params.get("enable_lr") !== null ||
-    (SETTINGS && SETTINGS.features && SETTINGS.features.enable_learner_records)
-  )
 }

--- a/main/features.py
+++ b/main/features.py
@@ -5,7 +5,6 @@ from django.conf import settings
 
 IGNORE_EDX_FAILURES = "IGNORE_EDX_FAILURES"
 SYNC_ON_DASHBOARD_LOAD = "SYNC_ON_DASHBOARD_LOAD"
-ENABLE_LEARNER_RECORDS = "ENABLE_LEARNER_RECORDS"
 
 
 def is_enabled(name, default=None):

--- a/main/utils.py
+++ b/main/utils.py
@@ -48,11 +48,7 @@ def get_js_settings(request: HttpRequest):
         "sentry_dsn": remove_password_from_url(settings.SENTRY_DSN),
         "support_email": settings.EMAIL_SUPPORT,
         "site_name": settings.SITE_NAME,
-        "features": {
-            "enable_learner_records": features.is_enabled(
-                features.ENABLE_LEARNER_RECORDS
-            ),
-        },
+        "features": {},
     }
 
 

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -35,7 +35,6 @@ def test_get_js_settings(settings, rf):
     settings.VERSION = "4.5.6"
     settings.EMAIL_SUPPORT = "support@text.com"
     settings.RECAPTCHA_SITE_KEY = "fake_key"
-    settings.ENABLE_LEARNER_RECORDS = False
 
     request = rf.get("/")
 
@@ -47,9 +46,7 @@ def test_get_js_settings(settings, rf):
         "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
         "support_email": settings.EMAIL_SUPPORT,
         "site_name": settings.SITE_NAME,
-        "features": {
-            "enable_learner_records": settings.ENABLE_LEARNER_RECORDS,
-        },
+        "features": {},
     }
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1372.

#### What's this PR do?

Removes the `ENABLE_LEARNER_RECORDS` flag, so the records are available by default.

#### How should this be manually tested?

Go to the dashboard. You should be able to see your learner record from the program drawer without having to append anything to the URL.

