### PR TITLE
feat: Sync courseware title with CMS page title

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -757,6 +757,7 @@ class ProductPage(Page):
             courseware_object = getattr(self, "program")
         courseware_object.title = self.title
         courseware_object.save()
+
         return super().save(clean=clean, user=user, log_action=log_action, **kwargs)
 
     def _get_child_page_of_type(self, cls):

--- a/cms/models.py
+++ b/cms/models.py
@@ -750,8 +750,6 @@ class ProductPage(Page):
         """
         Updates related courseware object title.
         """
-        super().save(clean=clean, user=user, log_action=log_action, **kwargs)
-
         courseware_object = None
         if self.is_course_page:
             courseware_object = getattr(self, "course")
@@ -759,6 +757,7 @@ class ProductPage(Page):
             courseware_object = getattr(self, "program")
         courseware_object.title = self.title
         courseware_object.save()
+        return super().save(clean=clean, user=user, log_action=log_action, **kwargs)
 
     def _get_child_page_of_type(self, cls):
         """Gets the first child page of the given type if it exists"""

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -543,7 +543,7 @@ def test_certificate_for_program_page():
 
 @pytest.mark.parametrize("test_course", [True, False])
 def test_courseware_title_synced_with_product_page_title(test_course):
-    """Tests that Courseware title is synced with the Course Page title"""
+    """Tests that Courseware title is synced with the Course Page title from CMS"""
     product_page = CoursePageFactory() if test_course else ProgramPageFactory()
     updated_title = "Updated Courseware Page Title"
     product_page.title = updated_title

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -539,3 +539,20 @@ def test_certificate_for_program_page():
         assert signatory.value.title_2 == "Title_2"
         assert signatory.value.organization == "Organization"
         assert signatory.value.signature_image.title == "Image"
+
+
+@pytest.mark.parametrize("test_course", [True, False])
+def test_courseware_title_synced_with_product_page_title(test_course):
+    """Tests that Courseware title is synced with the Course Page title"""
+    product_page = CoursePageFactory() if test_course else ProgramPageFactory()
+    updated_title = "Updated Courseware Page Title"
+    product_page.title = updated_title
+    product_page.save()
+
+    courseware = (
+        getattr(product_page, "course")
+        if test_course
+        else getattr(product_page, "program")
+    )
+
+    assert courseware.title == updated_title

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.contrib.admin.decorators import display
 from django.db import models
 from django.forms import TextInput
+from django.urls import reverse
 from mitol.common.admin import TimestampedModelAdmin
 
 from courses.forms import ProgramAdminForm
@@ -67,6 +68,32 @@ class CourseAdmin(admin.ModelAdmin):
     formfield_overrides = {
         models.CharField: {"widget": TextInput(attrs={"size": "80"})}
     }
+
+    def get_readonly_fields(self, request, obj=None):
+        """
+        Adds `title` as readonly field while editing an existing object.
+        """
+        if obj:
+            return self.readonly_fields + ("title",)
+        return self.readonly_fields
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        """
+        Adds help text for `title` field while editing an existing object.
+        """
+        if obj:
+            product_page_edit_url = (
+                f"{reverse('wagtailadmin_home')}/pages/{obj.page.id}/edit"
+            )
+            product_page_edit_url = (
+                f"<a href={product_page_edit_url} target='_blank'>CMS Product Page</a>"
+            )
+            help_texts = {
+                "title": f"You can update the course title using {product_page_edit_url}."
+            }
+            kwargs.update({"help_texts": help_texts})
+
+        return super().get_form(request, obj=obj, change=change, **kwargs)
 
 
 class CourseRunAdmin(TimestampedModelAdmin):

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -73,7 +73,7 @@ class CourseAdmin(admin.ModelAdmin):
         """
         Adds `title` as readonly field while editing an existing object.
         """
-        if obj:
+        if obj and hasattr(obj, "page"):
             return self.readonly_fields + ("title",)
         return self.readonly_fields
 
@@ -81,7 +81,7 @@ class CourseAdmin(admin.ModelAdmin):
         """
         Adds help text for `title` field while editing an existing object.
         """
-        if obj:
+        if obj and hasattr(obj, "page"):
             product_page_edit_url = (
                 f"{reverse('wagtailadmin_home')}/pages/{obj.page.id}/edit"
             )

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -85,11 +85,11 @@ class CourseAdmin(admin.ModelAdmin):
             product_page_edit_url = (
                 f"{reverse('wagtailadmin_home')}/pages/{obj.page.id}/edit"
             )
-            product_page_edit_url = (
+            product_page_edit_link = (
                 f"<a href={product_page_edit_url} target='_blank'>CMS Product Page</a>"
             )
             help_texts = {
-                "title": f"You can update the course title using {product_page_edit_url}."
+                "title": f"You can update the course title using {product_page_edit_link}."
             }
             kwargs.update({"help_texts": help_texts})
 

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -73,7 +73,7 @@ class CourseAdmin(admin.ModelAdmin):
         """
         Adds `title` as readonly field while editing an existing object.
         """
-        if obj and hasattr(obj, "page"):
+        if getattr(obj, "page", None):
             return self.readonly_fields + ("title",)
         return self.readonly_fields
 
@@ -81,7 +81,7 @@ class CourseAdmin(admin.ModelAdmin):
         """
         Adds help text for `title` field while editing an existing object.
         """
-        if obj and hasattr(obj, "page"):
+        if getattr(obj, "page", None):
             product_page_edit_url = (
                 f"{reverse('wagtailadmin_home')}/pages/{obj.page.id}/edit"
             )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1365

#### What's this PR do?
Syncs courseware title with CMS Product page title.

#### How should this be manually tested?

- Update CMS Product page i.e. CoursePage or ProgramPage
- Verify that the title is synced with the Courseware object title either by visiting Django Admin or through the APIs.
