### PR TITLE
Fixes sizing on program course badge, list keys, font size styling

### DIFF
--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -43,14 +43,11 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
     }
 
     return (
-      <div
-        className="enrolled-item container card mb-4 rounded-0 pb-0 pt-md-3"
-        key={course.readable_id}
-      >
+      <div className="enrolled-item container card mb-4 rounded-0 pb-0 pt-md-3">
         <div className="row flex-grow-1">
           {featuredImage}
           <div className="col-12 col-md px-3 py-3 py-md-0 box">
-            <div className="align-content-start d-flex enrollment-mode-container w-100">
+            <div className="align-content-start enrollment-mode-container w-100">
               {courseRunStatusDetail !== null &&
               courseRunStatusDetail.active ? (
                   <span className="badge badge-in-progress mr-2">

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -41,7 +41,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
 
     return (
       <EnrolledItemCard
-        key={found.readable_id}
+        key={found.run.course.readable_id}
         enrollment={found}
         isProgramCard={true}
       ></EnrolledItemCard>
@@ -52,9 +52,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
     const { enrollment } = this.props
 
     return (
-      <React.Fragment
-        key={`drawer-course-list-${enrollment.program.readable_id}`}
-      >
+      <React.Fragment>
         {enrollment.program.req_tree[0].children.map(node => {
           const interiorCourses = extractCoursesFromNode(node, enrollment)
 

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -126,7 +126,7 @@ export class DashboardPage extends React.Component<
             <nav className="tabs" aria-controls="enrollment-items">
               {programEnrollmentsLength === 0 ? (
                 <>
-                  <strong style={{ "font-size": "75%" }}>My Courses</strong>
+                  <strong style={{ fontSize: "75%" }}>My Courses</strong>
                 </>
               ) : (
                 <>


### PR DESCRIPTION
Fix the badge sizing.  Remove unnecessary keys.  Fix key for found enrollments.  Fix font size error.

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1377

#### What's this PR do?
Resolves a few issues:

1. The "In Progress" badge shown on course cards in the program drawer were not sized uniformly.
2. An error was showing on the program drawer page for items of a list not having unique keys.  This was caused by the key value being set to a value which was undefined.
3. There was an error showing 

#### How should this be manually tested?

1. Have a program, program run, and program run enrollment for the user.  
2. Create two courses and add them as requirements in the program.  
3. Create a course run for each course that has a start date before now and an end date after now.  
4. Enroll your user into one of the course runs.
5. Navigate to http://mitxonline.odl.local:8013/dashboard/ and click "My Programs"
6. Click on the program shown.
7. Verify that the "In Progress" badge is shown for the course which you are not currently enrolled in.  Verify that the badge's size remains uniform as you resize the page.  I was not able to recreate the issue locally, only in RC when enrolled in the Testing Program and not enrolled in the Test Course.
8. Verify that there are no errors or warnings shown in the developer console of your browser.  You can trigger these errors when not using this branch.

The console warnings this PR resolves are:
`Warning: Unsupported style property font-size. Did you mean fontSize?` when viewing the dashboard.
`Warning: Each child in a list should have a unique "key" prop.` when viewing the program drawer.

#### Screenshots (if appropriate)
![Screenshot 2023-01-26 at 10 35 42](https://user-images.githubusercontent.com/8311573/214878861-658cdb9e-d8a1-437f-9df4-8f03269c7083.png)
![Screenshot 2023-01-26 at 10 35 50](https://user-images.githubusercontent.com/8311573/214878865-c8528173-b876-475f-9bc4-b1a254675310.png)
