### PR TITLE
Updates enrollments to regenerate auth tokens if they're invalid

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -248,14 +248,18 @@ def create_run_enrollments(
 
     try:
         enroll_in_edx_course_runs(
-            user, runs, mode=mode, force_enrollment=force_enrollment
+            user,
+            runs,
+            mode=mode,
+            force_enrollment=force_enrollment,
+            regen_auth_tokens=False,
         )
     except (
-        EdxApiEnrollErrorException,
         UnknownEdxApiEnrollException,
         NoEdxApiAuthError,
-        HTTPError,
         RequestsConnectionError,
+        EdxApiEnrollErrorException,
+        HTTPError,
     ):
         log.exception(
             "edX enrollment failure for user: %s, runs: %s",

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -20,6 +20,7 @@ from courses.api import (
     deactivate_run_enrollment,
     defer_enrollment,
     generate_course_run_certificates,
+    generate_program_certificate,
     get_user_enrollments,
     get_user_relevant_course_run,
     manage_course_run_certificate_access,
@@ -28,7 +29,6 @@ from courses.api import (
     process_course_run_grade_certificate,
     sync_course_mode,
     sync_course_runs,
-    generate_program_certificate,
 )
 from courses.constants import (
     ENROLL_CHANGE_STATUS_DEFERRED,
@@ -40,9 +40,9 @@ from courses.factories import (
     CourseRunEnrollmentFactory,
     CourseRunFactory,
     CourseRunGradeFactory,
-    ProgramFactory,
     ProgramCertificateFactory,
     ProgramEnrollmentFactory,
+    ProgramFactory,
     ProgramRequirementFactory,
 )
 
@@ -322,7 +322,11 @@ def test_create_run_enrollments(
         user, runs, mode=enrollment_mode, force_enrollment=False
     )
     patched_edx_enroll.assert_called_once_with(
-        user, runs, mode=enrollment_mode, force_enrollment=False
+        user,
+        runs,
+        mode=enrollment_mode,
+        force_enrollment=False,
+        regen_auth_tokens=False,
     )
 
     with django_capture_on_commit_callbacks(execute=True):
@@ -407,7 +411,11 @@ def test_create_run_enrollments_api_fail(mocker, user, exception_cls):
         keep_failed_enrollments=True,
     )
     patched_edx_enroll.assert_called_once_with(
-        user, [run], mode=EDX_DEFAULT_ENROLLMENT_MODE, force_enrollment=False
+        user,
+        [run],
+        mode=EDX_DEFAULT_ENROLLMENT_MODE,
+        force_enrollment=False,
+        regen_auth_tokens=False,
     )
     patched_log_exception.assert_called_once()
     patched_send_enrollment_email.assert_not_called()
@@ -453,7 +461,11 @@ def test_create_run_enrollments_enroll_api_fail(
         keep_failed_enrollments=keep_failed_enrollments,
     )
     patched_edx_enroll.assert_called_once_with(
-        user, runs, mode=EDX_DEFAULT_ENROLLMENT_MODE, force_enrollment=False
+        user,
+        runs,
+        mode=EDX_DEFAULT_ENROLLMENT_MODE,
+        force_enrollment=False,
+        regen_auth_tokens=False,
     )
     patched_log_exception.assert_called_once()
     patched_send_enrollment_email.assert_not_called()
@@ -490,7 +502,11 @@ def test_create_run_enrollments_creation_fail(mocker, user):
         runs,
     )
     patched_edx_enroll.assert_called_once_with(
-        user, runs, mode=EDX_DEFAULT_ENROLLMENT_MODE, force_enrollment=False
+        user,
+        runs,
+        mode=EDX_DEFAULT_ENROLLMENT_MODE,
+        force_enrollment=False,
+        regen_auth_tokens=False,
     )
     patched_log_exception.assert_called_once()
     patched_mail_api.send_course_run_enrollment_email.assert_not_called()
@@ -1150,7 +1166,11 @@ def test_create_run_enrollments_upgrade(mocker, user):
         mode=EDX_ENROLLMENT_AUDIT_MODE,
     )
     patched_edx_enroll.assert_called_once_with(
-        user, [test_course_run], mode=EDX_ENROLLMENT_AUDIT_MODE, force_enrollment=False
+        user,
+        [test_course_run],
+        mode=EDX_ENROLLMENT_AUDIT_MODE,
+        force_enrollment=False,
+        regen_auth_tokens=False,
     )
 
     patched_send_enrollment_email.assert_called_once()
@@ -1174,6 +1194,7 @@ def test_create_run_enrollments_upgrade(mocker, user):
         [test_course_run],
         mode=EDX_ENROLLMENT_VERIFIED_MODE,
         force_enrollment=False,
+        regen_auth_tokens=False,
     )
 
     assert edx_request_success is False

--- a/docs/source/commands/regenerate_edx_auth_tokens.rst
+++ b/docs/source/commands/regenerate_edx_auth_tokens.rst
@@ -1,0 +1,16 @@
+``regenerate_edx_auth_tokens``
+==================
+
+Regenerates the authentication tokens for a specified learner. In essence, deletes the ``OpenEdxApiAuth`` record and then makes a call to edX to generate a new refresh and access token.
+
+If the user doesn't have an ``OpenEdxUser`` record either, then this command is not appropriate. Use ``repair_missing_courseware_records`` instead. This will also not do anything with enrollments or grades. The main usecase is if the learner's ``OpenEdxApiAuth`` record gets deleted for some reason, or if their refresh tokens on the edX side are revoked.
+
+Syntax
+------
+
+``regenerate_edx_auth_tokens <username>``
+
+Options
+-------
+
+* ``username`` - the learner's ID, username, or email address.

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -45,6 +45,7 @@ from openedx.exceptions import (
     UserNameUpdateFailedException,
 )
 from openedx.models import OpenEdxApiAuth, OpenEdxUser
+from openedx.tasks import regenerate_openedx_auth_tokens
 from openedx.utils import SyncResult, edx_url
 from users.api import fetch_user
 
@@ -526,10 +527,16 @@ def get_edx_grades_with_users(course_run, user=None):
 
 
 def enroll_in_edx_course_runs(
-    user, course_runs, *, mode=EDX_DEFAULT_ENROLLMENT_MODE, force_enrollment=False
+    user,
+    course_runs,
+    *,
+    mode=EDX_DEFAULT_ENROLLMENT_MODE,
+    force_enrollment=False,
+    regen_auth_tokens=True,
 ):
     """
-    Enrolls a user in edx course runs
+    Enrolls a user in edx course runs. If the user doesn't have a valid
+    set of API credentials, this will try to regenerate them.
 
     Args:
         user (users.models.User): The user to enroll
@@ -537,6 +544,7 @@ def enroll_in_edx_course_runs(
         mode (str): The course mode to enroll the user with
         force_enrollment (bool): If True, Enforces Enrollment after the enrollment end date
                                     has been passed or upgrade_deadline is ended
+        regen_auth_token (bool): Regenerate the auth tokens if the learner's are invalid
 
     Returns:
         list of edx_api.enrollments.models.Enrollment:
@@ -546,11 +554,49 @@ def enroll_in_edx_course_runs(
         EdxApiEnrollErrorException: Raised if the underlying edX API HTTP request fails
         UnknownEdxApiEnrollException: Raised if an unknown error was encountered during the edX API request
     """
-    edx_client = get_edx_api_client(user)
     username = None
     if force_enrollment:
         edx_client = get_edx_api_service_client()
         username = user.username
+    else:
+        try:
+            edx_client = get_edx_api_client(user)
+        except (HTTPError, NoEdxApiAuthError) as exc:
+            log.exception(
+                "enroll_in_edx_course_runs got exception getting API client: %s %s",
+                type(exc),
+                exc,
+            )
+
+            if regen_auth_tokens and (
+                "Bad Request" in str(exc) or type(exc) == NoEdxApiAuthError
+            ):
+                if OpenEdxApiAuth.objects.filter(user=user).count():
+                    OpenEdxApiAuth.objects.filter(user=user).delete()
+                    user.refresh_from_db()
+
+                try:
+                    log.exception(
+                        "enroll_in_edx_course_runs: creating new auth tokens for %s",
+                        user,
+                    )
+                    create_edx_auth_token(user)
+                    user.refresh_from_db()
+                    edx_client = get_edx_api_client(user)
+                except Exception as auth_exc:
+                    log.exception(
+                        "enroll_in_edx_course_runs: got exception creating new auth token: %s",
+                        auth_exc,
+                    )
+                    raise auth_exc
+            elif not regen_auth_tokens and (
+                "Bad Request" in str(exc) or type(exc) == NoEdxApiAuthError
+            ):
+                regenerate_openedx_auth_tokens.delay(user.id)
+                raise exc
+            else:
+                raise exc
+
     results = []
     for course_run in course_runs:
         try:

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -536,7 +536,7 @@ def enroll_in_edx_course_runs(
 ):
     """
     Enrolls a user in edx course runs. If the user doesn't have a valid
-    set of API credentials, this will try to regenerate them.
+    set of API credentials, this will try to regenerate them (unless told not to).
 
     Args:
         user (users.models.User): The user to enroll

--- a/openedx/management/commands/regenerate_edx_auth_tokens.py
+++ b/openedx/management/commands/regenerate_edx_auth_tokens.py
@@ -1,0 +1,69 @@
+"""
+Clears and regenerates the OAuth tokens for the specified learner.
+"""
+from argparse import RawTextHelpFormatter
+
+from django.core.management import BaseCommand
+
+from openedx.api import create_edx_auth_token
+from openedx.constants import PLATFORM_EDX
+from openedx.models import OpenEdxApiAuth
+from users.api import fetch_users
+
+
+class Command(BaseCommand):
+    """
+    Clears and regenerates the OAuth tokens for the specified learner.
+    """
+
+    help = "Clears and regenerates the OAuth tokens for the specified learner."
+
+    def create_parser(self, prog_name, subcommand):  # pylint: disable=arguments-differ
+        """
+        create parser to add new line in help text.
+        """
+        parser = super().create_parser(prog_name, subcommand)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "username",
+            action="store",
+            help="The ID, username or email address to reset.",
+        )
+
+    def handle(self, *args, **kwargs):
+        self.stdout.write(f"Looking for {kwargs['username']}...")
+
+        user = fetch_users([kwargs["username"]])
+
+        if user is None or user.count() == 0:
+            self.stderr.write(
+                self.style.ERROR(f"Could not find user {kwargs['username']}.")
+            )
+        elif user.count() > 1:
+            self.stderr.write(self.style.ERROR(f"Ambiguous ID {kwargs['username']}."))
+        else:
+            user = user.get()
+
+            if user.openedx_users.filter(platform=PLATFORM_EDX).count() == 0:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"No OpenEdxUser for {user.username}. Run repair instead."
+                    )
+                )
+                return
+
+            self.stdout.write(
+                f"Regenerating Open edX auth tokens for {user.username}..."
+            )
+
+            OpenEdxApiAuth.objects.filter(user=user).delete()
+            create_edx_auth_token(user)
+
+            new_tokens = OpenEdxApiAuth.objects.filter(user=user).get()
+
+            self.stdout.write(
+                f"Done! New refresh token {new_tokens.refresh_token} and new access token {new_tokens.access_token} creatd."
+            )

--- a/openedx/management/commands/retry_edx_enrollment.py
+++ b/openedx/management/commands/retry_edx_enrollment.py
@@ -4,10 +4,9 @@ Management command to retry edX enrollment for a user's course run enrollments
 from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
 
+from courses.models import CourseRunEnrollment
 from openedx.api import enroll_in_edx_course_runs
 from users.api import fetch_users
-
-from courses.models import CourseRunEnrollment
 
 User = get_user_model()
 
@@ -69,7 +68,7 @@ class Command(BaseCommand):
             try:
                 enroll_in_edx_course_runs(user, [course_run])
             except Exception as exc:  # pylint: disable=broad-except
-                self.stderr.write(self.style.ERROR(str(exc)))
+                self.stderr.write(self.style.ERROR(f"{str(exc)}"))
             else:
                 enrollment.edx_enrolled = True
                 enrollment.edx_emails_subscription = True

--- a/openedx/tasks.py
+++ b/openedx/tasks.py
@@ -37,6 +37,14 @@ def repair_faulty_openedx_users():
 
 
 @app.task(acks_late=True)
+def regenerate_openedx_auth_tokens(user_id):
+    """Calls the API method to repair A faulty Open edX user"""
+    user = User.objects.get(id=user_id)
+    api.create_edx_auth_token(user)
+    return user.email
+
+
+@app.task(acks_late=True)
 def change_edx_user_email_async(user_id):
     """
     Task to change edX user email in the background to avoid database level locks


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1395 

#### What's this PR do?

Makes the system regenerate the learner's authentication tokens when enrollment fails because they're invalid. This also adds a command to manually force the tokens to be regenerated. 

Enrollments will fail if the user's auth tokens (i.e., their `OpenEdxApiAuth` record) is in one of these states:
1. Nonexistent.
2. In place, but the access token has expired and the refresh token has been revoked in edX. 

In these cases, the code will take the following actions:
* If the learner themselves is enrolling in a course, the regeneration function will be queued for asynchronous execution. The enrollment will still fail but the system should fix the issue in the background. (Ideally, the system is also set to store enrollments when they fail and the enrollment will be tried again later - at that point it will succeed.) The action is queued so the system remains responsive to the learner. 
* If a task or a management command is running to perform enrollments, the regeneration function will happen immediately. (In a task or management command, the extra time it takes to generate the auth tokens again is acceptable.) 

In addition, there's a new `regenerate_edx_auth_token` management command that will clear the `OpenEdxApiAuth` record for the learner and create new tokens for them, regardless of the state of their existing tokens. 

#### How should this be manually tested?

Front-end enrollments:

1. Ensure you have a learner that's set up correctly (i.e. can get into Open edX successfully, enrollments otherwise work, etc.) and at least one course that is set up properly on both MITx Online and edX. 
2. Revoke and expire the learner's refresh and access tokens in edX. 
   1. I've found it's easiest to pull the learner's `OpenEdxApiAuth` record so you can search in edX by that. 
   2. Link to refresh tokens: http://localhost:18000/admin/oauth2_provider/refreshtoken/
   3. Link to access tokens: http://localhost:18000/admin/oauth2_provider/accesstoken/
   4. The refresh token will need a revoke date/time set, and the access token needs its expiration date/time reset to now. (Using the Today/Now links works.) 
3. Expire the `OpenEdxApiAuth` record in MITx Online. (Again, using the Today/Now links works.) 
4. As the learner, attempt to enroll in a course. If you have `IGNORE_EDX_FAILURES` set to True, you should get a success message; otherwise, you should get an error. In either case, you should see the task be queued and processed in the Celery logs and the user should have a new set of tokens.  

Management command enrollments:

1. Generate an enrollment record for the learner in a courserun. You can also use an existing enrollment. In either case, the `Edx enrolled` flag needs to be set to False.
2. Perform steps 2 and 3 from above again.
3. Run the `retry_edx_enrollment` command.
4. The command should succeed - it should create a new set of tokens for the user, and the enrollment should be processed successfully. 

Scheduled task:

The scheduled task is `openedx.tasks.retry_failed_edx_enrollments`. After performing the first two steps from the management command test, you can either adjust the schedule to make the task run or queue it manually to test. You should have the same outcome as the management command test.
