### PR TITLE
1366: Fix and tests for undefined program course nodes

### DIFF
--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -300,6 +300,27 @@ export const makeProgramWithOnlyElectives = (): Program => {
   return program
 }
 
+export const makeProgramWithNoElectivesOrRequirements = (): Program => {
+  const program = makeProgram()
+
+  // for the reqtree stuff to work, the program needs 6 more courses
+  for (let i = 0; i < 6; i++) {
+    program.courses.push(makeCourseDetailWithRuns())
+  }
+
+  program.req_tree = [
+    makeDEDPSampleRequirementsTree(
+      program,
+      program.courses,
+      false,
+      false,
+      false
+    )
+  ]
+
+  return program
+}
+
 export const makeCertificate = (): Certificate => ({
   link: `/certificate/program/${casual.uuid}`,
   uuid: casual.uuid

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -155,29 +155,30 @@ export const extractCoursesFromNode = (
   // Processes the node, and returns the courses that are within it. If there
   // are nested operators, this will walk them but it won't group the courses
   // based on them.
+  if (typeof node !== "undefined") {
+    if (node.data.node_type === NODETYPE_COURSE) {
+      const retCourse = enrollment.program.courses.find(
+        elem => elem.id === node.data.course
+      )
 
-  if (node.data.node_type === NODETYPE_COURSE) {
-    const retCourse = enrollment.program.courses.find(
-      elem => elem.id === node.data.course
-    )
+      if (retCourse) {
+        return [retCourse]
+      }
 
-    if (retCourse) {
-      return [retCourse]
+      return []
+    } else if (node.data.node_type === NODETYPE_OPERATOR) {
+      let courseList = []
+
+      if (node.children) {
+        node.children.forEach(child => {
+          courseList = courseList.concat(
+            extractCoursesFromNode(child, enrollment)
+          )
+        })
+      }
+
+      return courseList
     }
-
-    return []
-  } else if (node.data.node_type === NODETYPE_OPERATOR) {
-    let courseList = []
-
-    if (node.children) {
-      node.children.forEach(child => {
-        courseList = courseList.concat(
-          extractCoursesFromNode(child, enrollment)
-        )
-      })
-    }
-
-    return courseList
   }
 
   return []

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -15,7 +15,9 @@ import {
   makeLearnerRecord,
   makeProgramWithReqTree,
   makeProgramWithOnlyRequirements,
-  makeProgramWithOnlyElectives
+  makeProgramWithOnlyElectives,
+  makeProgramWithNoElectivesOrRequirements,
+  makeProgram
 } from "../factories/course"
 import { makeUser } from "../factories/user"
 
@@ -233,6 +235,43 @@ describe("Course API", () => {
 
       assert.equal(requirements.length, 0)
       assert.equal(electives.length, 4)
+    })
+
+    it("returns a flattened list of courses for the node without any required courses or elective courses", () => {
+      // the learner record will generate a requirements tree in the proper
+      // format, so we're just using that factory here
+      const programEnrollment = {
+        program:     makeProgramWithNoElectivesOrRequirements(),
+        enrollments: []
+      }
+
+      const requirements = extractCoursesFromNode(
+        programEnrollment.program.req_tree[0].children[0],
+        programEnrollment
+      )
+      const electives = extractCoursesFromNode(
+        programEnrollment.program.req_tree[0].children[1],
+        programEnrollment
+      )
+
+      assert.equal(requirements.length, 0)
+      assert.equal(electives.length, 0)
+    })
+
+    it("returns a flattened list of courses associated with the program without nodes", () => {
+      // the learner record will generate a requirements tree in the proper
+      // format, so we're just using that factory here
+      const programEnrollment = {
+        program:     makeProgram(),
+        enrollments: []
+      }
+
+      // Pass undefined which can occur when an admin user deletes the requirement or elective sections from the program record.
+      const requirements = extractCoursesFromNode(undefined, programEnrollment)
+      const electives = extractCoursesFromNode(undefined, programEnrollment)
+
+      assert.equal(requirements.length, 0)
+      assert.equal(electives.length, 0)
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
 
#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1366

#### What's this PR do?
Fixes an error when the requirements and, or electives nodes have been removed from a program.  This also adds a test for handling when a program has both a requirements and electives node, but courses defined as requirements or children (which has caused issues in the past).

#### How should this be manually tested?

1. Have mitxonline setup with a program with the elective and requirements sections deleted in Django admin, program run, course associated with the Program, course run, and all required CMS pages. 
2. Enroll your user in the course through the frontend
3. Visit the dashboard (http://mitxonline.odl.local:8013/dashboard/)
4. Click on the "My programs" tab
5. Click on the program card to open the program's course drawer.
6. Verify that the course is shown in the drawer and that no errors are shown in the browser console.
