### PR TITLE
1384: Fix for heading and description height

### DIFF
--- a/frontend/public/scss/course-cards.scss
+++ b/frontend/public/scss/course-cards.scss
@@ -25,7 +25,6 @@
         padding: 15px;
 
         h2 {
-          height: 44px;
           color: #000000;
           font-size: 18px;
           font-weight: 600;
@@ -34,7 +33,6 @@
         }
 
         p {
-          height: 115px;
           color: #333333;
           font-size: 16px;
           font-weight: 400;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1384

#### What's this PR do?
Removes some static definitions for height of `h1` and `p` tags in the course cards shown on the homepage.

#### How should this be manually tested?

1. Configure a course, course run, and associated CMS pages.
2. Modify the CMS course page to have a very long title and description.
3. Visit the mitxonline homepage (http://mitxonline.odl.local:8013/)
4. Ensure that the title and description do not overlap each other when zoomed in on different browsers.
5. Also ensure that the space between the description and the course date (at the bottom of the course card) is not strangely large (as shown in one of the screenshots below).

#### Screenshots (if appropriate)

![Screenshot 2023-02-02 at 14 22 22](https://user-images.githubusercontent.com/8311573/216430170-b142164b-7b1d-493d-8770-6be519c9a0e5.png)
![Screenshot 2023-02-02 at 14 19 51](https://user-images.githubusercontent.com/8311573/216430176-37eba80e-36d3-4177-a01c-bb5ce8886464.png)

Below is the large spacing between description and date.
![Screenshot 2023-02-02 at 14 19 37](https://user-images.githubusercontent.com/8311573/216430180-760be0e4-e1e9-445d-be55-77d1edf89a28.png)
