### PR TITLE
Updates enrollment upsell dialog to immediately create enrollments

### DIFF
--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -431,4 +431,23 @@ describe("ProductDetailEnrollApp", () => {
       }
     })
   })
+
+  it(`shows the enroll button and upsell message, and generates an enrollment when the button is clicked`, async () => {
+    courseRun["products"] = [
+      {
+        id:                     1,
+        price:                  10,
+        product_flexible_price: {}
+      }
+    ]
+    isWithinEnrollmentPeriodStub.returns(true)
+
+    const { inner } = await renderPage()
+
+    const enrollBtn = inner.find(".enroll-now").at(0)
+    assert.isTrue(enrollBtn.exists())
+    await enrollBtn.prop("onClick")()
+
+    sinon.assert.calledWith(helper.handleRequestStub, "/enrollments/", "POST")
+  })
 })

--- a/frontend/public/src/lib/queries/enrollment.js
+++ b/frontend/public/src/lib/queries/enrollment.js
@@ -174,3 +174,16 @@ export const revokeLearnerRecordSharingLinkMutation = (programId: number) => ({
     learnerRecord: nextState
   }
 })
+
+export const enrollmentMutation = (runId: number) => ({
+  url:  `/enrollments/`,
+  body: {
+    run:   `${runId}`,
+    isapi: true
+  },
+  options: {
+    ...getCsrfOptions(),
+    method: "POST"
+  },
+  update: {}
+})


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1379

#### What's this PR do?

- Adds some logic to `create_enrollment_view` to respond with an API-esque response
- Updates the frontend logic to proactively hit the `/enrollments/` API when the user clicks Enroll Now
- Redirects the user to the dashboard if they cancel out of the upsell dialog
- Tests for above

#### How should this be manually tested?

Automated tests should pass.

Testing enrollment creation:
1. Attempt to enroll in a course that has a product. You should see the upsell dialog.
2. In a separate tab, open your dashboard. You should see the new course (and you will see the enrollment notification). 

Testing message persistence:
1. Attempt to enroll in a course that has a product. You should see the upsell dialog.
2. Close the dialog by _clicking the X_. You should be redirected to the dashboard, where you should see the enrollment and the notification as per usual. 
