### PR TITLE
fix: Fix flexible pricing generic relations

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -301,8 +301,16 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
     )
     live = models.BooleanField(default=False)
     topics = models.ManyToManyField(CourseTopic, blank=True)
-    flexible_prices = GenericRelation("flexiblepricing.FlexiblePrice")
-    tiers = GenericRelation("flexiblepricing.FlexiblePriceTier")
+    flexible_prices = GenericRelation(
+        "flexiblepricing.FlexiblePrice",
+        object_id_field="courseware_object_id",
+        content_type_field="courseware_content_type"
+    )
+    tiers = GenericRelation(
+        "flexiblepricing.FlexiblePriceTier",
+        object_id_field="courseware_object_id",
+        content_type_field="courseware_content_type"
+    )
 
     class Meta:
         ordering = ("program", "title")

--- a/courses/models.py
+++ b/courses/models.py
@@ -4,9 +4,9 @@ Course models
 import logging
 import operator as op
 import uuid
-from decimal import ROUND_HALF_EVEN, getcontext
+from decimal import ROUND_HALF_EVEN
 from decimal import Context as DecimalContext
-from decimal import Decimal
+from decimal import Decimal, getcontext
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
@@ -304,12 +304,12 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
     flexible_prices = GenericRelation(
         "flexiblepricing.FlexiblePrice",
         object_id_field="courseware_object_id",
-        content_type_field="courseware_content_type"
+        content_type_field="courseware_content_type",
     )
     tiers = GenericRelation(
         "flexiblepricing.FlexiblePriceTier",
         object_id_field="courseware_object_id",
-        content_type_field="courseware_content_type"
+        content_type_field="courseware_content_type",
     )
 
     class Meta:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes [Sentry Issue](https://mit-office-of-digital-learning.sentry.io/issues/3914598815/?project=5864687&referrer=slack)

#### What's this PR do?
Fixes generic relations with FlexiblePrice and FlexiblePriceTier models.

Context:
As mentioned in the [Django docs](https://docs.djangoproject.com/en/4.1/ref/contrib/contenttypes/#django.contrib.contenttypes.fields.GenericRelation), the default field names for the content type and object id are `content_type` and `object_id`. For flexible pricing, we have `courseware_content_type` and `courseware_object_id`. So, We should mention these while creating a generic relation.

#### How should this be manually tested?

- Go to the Django Shell and test that the relations are working fine by doing `course_object.tiers/flexible_prices.all()`
- You can also try to delete a course object from the Django admin.

