### PR TITLE
Log any exception thrown by hubspot task helpers

### DIFF
--- a/hubspot_sync/task_helpers.py
+++ b/hubspot_sync/task_helpers.py
@@ -1,7 +1,13 @@
 """ Task helper functions for ecommerce """
+import logging
+
 from django.conf import settings
 
 from hubspot_sync import tasks
+
+# pylint:disable-bare-except
+
+log = logging.getLogger(__name__)
 
 
 def sync_hubspot_user(user):
@@ -12,7 +18,12 @@ def sync_hubspot_user(user):
         user (User): The user to sync
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN:
-        tasks.sync_contact_with_hubspot.delay(user.id)
+        try:
+            tasks.sync_contact_with_hubspot.delay(user.id)
+        except:
+            log.exception(
+                "Exception calling sync_contact_with_hubspot for user %s", user.username
+            )
 
 
 def sync_hubspot_deal(order):
@@ -24,7 +35,12 @@ def sync_hubspot_deal(order):
         order (Order): The order to sync
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN and order.lines.first() is not None:
-        tasks.sync_deal_with_hubspot.apply_async(args=(order.id,), countdown=10)
+        try:
+            tasks.sync_deal_with_hubspot.apply_async(args=(order.id,), countdown=10)
+        except:
+            log.exception(
+                "Exception calling sync_deal_with_hubspot for order %d", order.id
+            )
 
 
 def sync_hubspot_product(product):
@@ -35,4 +51,9 @@ def sync_hubspot_product(product):
         product (Product): The product to sync
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN:
-        tasks.sync_product_with_hubspot.delay(product.id)
+        try:
+            tasks.sync_product_with_hubspot.delay(product.id)
+        except:
+            log.exception(
+                "Exception calling sync_product_with_hubspot for product %d", product.id
+            )

--- a/hubspot_sync/task_helpers_test.py
+++ b/hubspot_sync/task_helpers_test.py
@@ -1,0 +1,70 @@
+"""Tests for hubspot_sync.task_helpers"""
+import pytest
+
+from ecommerce.factories import ProductFactory
+from hubspot_sync.task_helpers import (
+    sync_hubspot_deal,
+    sync_hubspot_product,
+    sync_hubspot_user,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def mock_exception_log(settings, mocker):
+    """Return a mocked log.exception object"""
+    settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN = "faketoken"
+    return mocker.patch("hubspot_sync.task_helpers.log.exception")
+
+
+@pytest.mark.parametrize("raise_exc", [True, False])
+def test_sync_hubspot_deal(mocker, mock_exception_log, hubspot_order, raise_exc):
+    """sync_hubspot_deal should call tasks.sync_contact_with_hubspot.applY_async and log any exception"""
+    mock_sync = mocker.patch(
+        "hubspot_sync.task_helpers.tasks.sync_deal_with_hubspot.apply_async",
+        side_effect=(ConnectionError if raise_exc else None),
+    )
+    sync_hubspot_deal(hubspot_order)
+    mock_sync.assert_called_once_with(args=(hubspot_order.id,), countdown=10)
+    if raise_exc:
+        mock_exception_log.assert_called_once_with(
+            "Exception calling sync_deal_with_hubspot for order %d", hubspot_order.id
+        )
+    else:
+        mock_exception_log.assert_not_called()
+
+
+@pytest.mark.parametrize("raise_exc", [True, False])
+def test_sync_hubspot_user(mocker, mock_exception_log, user, raise_exc):
+    """sync_hubspot_user should call tasks.sync_contact_with_hubspot.delay and log any exception"""
+    mock_sync = mocker.patch(
+        "hubspot_sync.task_helpers.tasks.sync_contact_with_hubspot.delay",
+        side_effect=(ConnectionError if raise_exc else None),
+    )
+    sync_hubspot_user(user)
+    mock_sync.assert_called_once_with(user.id)
+    if raise_exc:
+        mock_exception_log.assert_called_once_with(
+            "Exception calling sync_contact_with_hubspot for user %s", user.username
+        )
+    else:
+        mock_exception_log.assert_not_called()
+
+
+@pytest.mark.parametrize("raise_exc", [True, False])
+def test_sync_hubspot_product(mocker, mock_exception_log, raise_exc):
+    """sync_hubspot_product should call tasks.sync_product_with_hubspot.delay and log any exception"""
+    mock_sync = mocker.patch(
+        "hubspot_sync.task_helpers.tasks.sync_product_with_hubspot.delay",
+        side_effect=(ConnectionError if raise_exc else None),
+    )
+    product = ProductFactory.build()
+    sync_hubspot_product(product)
+    mock_sync.assert_called_once_with(product.id)
+    if raise_exc:
+        mock_exception_log.assert_called_once_with(
+            "Exception calling sync_product_with_hubspot for product %d", product.id
+        )
+    else:
+        mock_exception_log.assert_not_called()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closed https://github.com/mitodl/mitxonline/issues/1414

#### What's this PR do?
If any kind of exception occurs when a hubspot task helper function calls a celery task, log the exception instead of raising it.

#### How should this be manually tested?
- Set up hubspot integration as described in the README (you can use the same token as RC)
- With all your docker instances running, try this in a shell (assuming you already have 2 `Order` objects):
  ```python
  from hubspot_sync.task_helpers import *
  from ecommerce.models import Order
  for order in Order.objects.all()[:2]:
    sync_hubspot_deal(order)
  ```

- The above should work without errors or log statements.
- Kill your redis instance (`docker kill mitxonline_redis_1`)
- Run the following:
  ```python
  for order in Order.objects.all()[:2]:
    sync_hubspot_deal(order)
  ```

- The above should generate two exception log statements with the message `Exception calling sync_deal_with_hubspot for order <Order.id>`
