### PR TITLE
Adds methods to check pending orders for resolution through CyberSource

### DIFF
--- a/ecommerce/management/commands/check_pending_order.py
+++ b/ecommerce/management/commands/check_pending_order.py
@@ -1,0 +1,138 @@
+"""
+Looks up pending orders in CyberSource, and changes the status of the order if 
+necessary. 
+
+Occasionally, there may be a breakdown of communication between MITx Online and
+CyberSource, and orders that have gone through on the CyberSource end may not
+have their updated status reflected in MITx Online. This command will find those
+orders (or, alternatively, look at the specified order) and then will either 
+fulfill or cancel the order as necessary.
+
+"""
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import BaseCommand
+from mitol.payment_gateway.api import PaymentGateway
+
+from ecommerce.models import PendingOrder
+from main.settings import ECOMMERCE_DEFAULT_PAYMENT_GATEWAY
+
+
+class Command(BaseCommand):
+    """
+    Looks up pending orders in CyberSource, and changes the status of the order if necessary.
+    """
+
+    help = "Looks up pending orders in CyberSource, and changes the status of the order if necessary."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--order",
+            type=str,
+            help="The order ID to look for (mitxonline-prod-1).",
+            required=False,
+        )
+
+        parser.add_argument(
+            "--all", action="store_true", help="Use all pending orders."
+        )
+
+    def handle(self, *args, **kwargs):
+        gateway = PaymentGateway.get_gateway_class(ECOMMERCE_DEFAULT_PAYMENT_GATEWAY)
+
+        if not kwargs["all"] and not kwargs["order"]:
+            self.stderr.write(self.style.ERROR("Please specify an order."))
+            return
+
+        if not kwargs["all"]:
+            pending_orders = PendingOrder.objects.filter(
+                reference_number=kwargs["order"]
+            ).all()
+
+            if len(pending_orders) == 0:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Order {kwargs['order']} couldn't be found - is it Pending?"
+                    )
+                )
+                return
+            elif len(pending_orders) > 1:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Order {kwargs['order']} returned multiple matches ({len(pending_orders)})"
+                    )
+                )
+                return
+        else:
+            pending_orders = PendingOrder.objects.filter(
+                state=PendingOrder.STATE.PENDING
+            ).all()
+
+        refnos = [order.reference_number for order in pending_orders]
+
+        if len(refnos) == 0:
+            self.stdout.write(self.style.ERROR("No orders to consider."))
+            return
+
+        self.stdout.write(f"Looking up {len(refnos)} orders...")
+
+        results = gateway.find_and_get_transactions(refnos)
+
+        if len(results.keys()) == 0:
+            self.stdout.write(
+                self.style.ERROR("No pending orders found in CyberSource.")
+            )
+            return
+
+        for result in results:
+            payload = results[result]
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Found order {result} - state {payload['reason_code']}"
+                )
+            )
+
+            if int(payload["reason_code"]) == 100:
+                try:
+                    order = PendingOrder.objects.filter(
+                        state=PendingOrder.STATE.PENDING,
+                        reference_number=payload["req_reference_number"],
+                    ).get()
+
+                    order.fulfill(payload)
+
+                    self.stdout.write(
+                        self.style.SUCCESS(f"Fulfilled order {order.reference_number}.")
+                    )
+                except Exception as e:
+                    self.stderr.write(
+                        self.style.ERROR(
+                            f"Couldn't process pending order for fulfillment {payload['req_reference_number']}: {str(e)}"
+                        )
+                    )
+            else:
+                try:
+                    order = PendingOrder.objects.filter(
+                        state=PendingOrder.STATE.PENDING,
+                        reference_number=payload["req_reference_number"],
+                    ).get()
+
+                    order.cancel()
+                    order.transactions.create(
+                        transaction_id=payload["transaction_id"],
+                        amount=order.total_price_paid,
+                        data=payload,
+                        reason=f"Cancelled due to processor code {payload['reason_code']}",
+                    )
+                    order.save()
+
+                    self.stdout.write(
+                        self.style.SUCCESS(f"Cancelled order {order.reference_number}.")
+                    )
+                except Exception as e:
+                    self.stderr.write(
+                        self.style.ERROR(
+                            f"Couldn't process pending order for cancellation {payload['req_reference_number']}: {str(e)}"
+                        )
+                    )

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -480,7 +480,7 @@ class Order(TimestampedModel):
         raise NotImplementedError()
 
     def _generate_reference_number(self):
-        return f"{REFERENCE_NUMBER_PREFIX}{settings.ENVIRONMENT}-{737 + self.id}"
+        return f"{REFERENCE_NUMBER_PREFIX}{settings.ENVIRONMENT}-{self.id}"
 
     @property
     def purchased_runs(self):

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -480,7 +480,7 @@ class Order(TimestampedModel):
         raise NotImplementedError()
 
     def _generate_reference_number(self):
-        return f"{REFERENCE_NUMBER_PREFIX}{settings.ENVIRONMENT}-{self.id}"
+        return f"{REFERENCE_NUMBER_PREFIX}{settings.ENVIRONMENT}-{737 + self.id}"
 
     @property
     def purchased_runs(self):

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -32,3 +32,10 @@ def send_order_refund_email(order_id):
     order = Order.objects.get(pk=order_id)
 
     send_ecommerce_refund_message(order)
+
+
+@app.task(acks_late=True)
+def process_pending_order_resolutions():
+    from ecommerce.api import check_pending_orders_for_resolution
+
+    check_pending_orders_for_resolution()


### PR DESCRIPTION
(This depends on https://github.com/mitodl/ol-django/pull/109 so it's in draft mode until that's done.)

#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

Closes #1415

#### What's this PR do?

Adds a management command and a task to find pending orders and check for their resolution through CyberSource.

#### How should this be manually tested?

Automated tests should work.

The easiest way to get an order to be both pending and completed in CyberSource is to go through an order and then cancel it as it's redirecting you back into MITx Online. This will be difficult to do on RC or prod but should be doable on a local instance, because your browser will (probably) complain about the form being submitted to a non-secure endpoint. You will need one of these to test this functionality. 

In addition, you may want to add an offset to the generated reference number in the Orders model. On like 483 in `ecommerce/models.py`:
```python
        return f"{REFERENCE_NUMBER_PREFIX}{settings.ENVIRONMENT}-{<some number> + self.id}"
```

This way you'll be more certain to get an actual unique order ID, especially if you're using the MIT test CyberSource account. 

To test for denied orders, you will need to adjust the code to treat reason code 100 as a failure rather than a success. 

Test the management command by running `check_pending_order --all` or `check_pending_order --order <order ID>`. It should run successfully (the order should be fulfilled).

Schedule the `process_pending_order_resolutions` task. It should run successfully (the order should be fulfilled). 
