### PR TITLE
fix: sync_enrollments command error message and exit

### DIFF
--- a/openedx/management/commands/sync_enrollments.py
+++ b/openedx/management/commands/sync_enrollments.py
@@ -1,6 +1,7 @@
 """
 Management command to sync local enrollment records with edX
 """
+import sys
 from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
 
@@ -27,7 +28,12 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Walk all users who are missing records and repair them"""
-        user = fetch_user(options["user"])
+        try:
+            user = fetch_user(options["user"])
+        except Exception as exc:  # pylint: disable=broad-except
+            self.stderr.write(self.style.ERROR(f"{str(exc)}"))
+            sys.exit(1)
+            
         self.stdout.write(
             f"Syncing enrollments for user '{user.username}' ({user.email})"
         )

--- a/openedx/management/commands/sync_enrollments.py
+++ b/openedx/management/commands/sync_enrollments.py
@@ -30,10 +30,10 @@ class Command(BaseCommand):
         """Walk all users who are missing records and repair them"""
         try:
             user = fetch_user(options["user"])
-        except Exception as exc:
+        except User.DoesNotExist as exc:
             self.stderr.write(self.style.ERROR(f"{str(exc)}"))
             sys.exit(1)
-            
+
         self.stdout.write(
             f"Syncing enrollments for user '{user.username}' ({user.email})"
         )

--- a/openedx/management/commands/sync_enrollments.py
+++ b/openedx/management/commands/sync_enrollments.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         """Walk all users who are missing records and repair them"""
         try:
             user = fetch_user(options["user"])
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             self.stderr.write(self.style.ERROR(f"{str(exc)}"))
             sys.exit(1)
             


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1437

#### What's this PR do?
Outputs an error message and exits the `sync_enrollments` command when the user is not found.

#### How should this be manually tested?

1. Checkout this branch
2. Have mitxonline up and running
3. Run `docker-compose run web ./manage.py sync_enrollments --user <USER_ID>`.  Replace `<USER_ID>` with a value which is not associated with any users in your environment.
4. Verify that `Could not find User with id=<USER_ID> (case-insensitive)` is output to the terminal and the command exits.  No other error messages should be present in the terminal.
