### PR TITLE
Updates the command to include the enrollment mode when retrying enrollments

### DIFF
--- a/openedx/management/commands/retry_edx_enrollment.py
+++ b/openedx/management/commands/retry_edx_enrollment.py
@@ -66,7 +66,9 @@ class Command(BaseCommand):
             user = enrollment.user
             course_run = enrollment.run
             try:
-                enroll_in_edx_course_runs(user, [course_run])
+                enroll_in_edx_course_runs(
+                    user, [course_run], mode=enrollment.enrollment_mode
+                )
             except Exception as exc:  # pylint: disable=broad-except
                 self.stderr.write(self.style.ERROR(f"{str(exc)}"))
             else:


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1439

#### What's this PR do?

Updates the call to `enroll_in_edx_course_runs` to include the enrollment mode when it attempts to retry the enrollment, so the user's current status (as stored by MITx Online) is reflected in edX.

#### How should this be manually tested?

1. Enroll a user in a course in the audit mode.
2. Manually change their enrollment to verified in Django Admin in MITx Online.
3. Run `retry_edx_enrollment` for the user, and specify the `-f` flag to force it.
4. Check the resulting enrollment in edX. It should be verified.
