### PR TITLE
Bump root python image version to 3.9.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6 as base
+FROM python:3.9.16 as base
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip


### PR DESCRIPTION
#### What are the relevant tickets?

n/a

#### What's this PR do?

Bumps the version of the `python` image referenced in the Dockerfile to 3.9.16. I was having some issues with the prior 3.9.6 image not working (across a couple x86 Linux machines); bumping it to 3.9.16 fixed it and probably wouldn't hurt to have this use the current 3.9 release anyway. This only affects local development.

#### How should this be manually tested?

Rebuild your image and run the standard test suites. Tests should all pass and everything should work as expected.
