### PR TITLE
Adding command for manually "refunding" the user's enrollment

### DIFF
--- a/docs/source/commands/refund_fulfilled_order.rst
+++ b/docs/source/commands/refund_fulfilled_order.rst
@@ -1,0 +1,21 @@
+``refund_fulfilled_order``
+==========================
+
+Looks up a fulfilled order in the system, sets it to Refunded, and then adjusts the enrollments accordingly. 
+
+- If --unenroll is specified, the learner will be unenrolled from the course run associated with the order.
+- If --audit is specified, the learner will keep their unenrollments, but they will be set to "audit" instead of "verified".
+
+This does not make any sort of call to CyberSource or any other payment gateway to perform a refund - you're expected to have refunded the learner's money manually already. (At time of writing, PayPal transactions can't be refunded  using the normal means, so they get refunded manually via CyberSource and then  this command comes in to clean up afterwards.)
+
+Syntax
+------
+
+``refund_fulfilled_order <reference number> [--audit] [--unenroll]``
+
+Options
+-------
+
+* ``<reference number>`` - The reference number for the order to refund.
+* ``--audit`` - Change the learner's enrollment status to ``audit``.
+* ``--unenroll`` - Unenroll the learner.

--- a/docs/source/commands/regenerate_edx_auth_tokens.rst
+++ b/docs/source/commands/regenerate_edx_auth_tokens.rst
@@ -1,5 +1,5 @@
 ``regenerate_edx_auth_tokens``
-==================
+==============================
 
 Regenerates the authentication tokens for a specified learner. In essence, deletes the ``OpenEdxApiAuth`` record and then makes a call to edX to generate a new refresh and access token.
 

--- a/ecommerce/management/commands/refund_fulfilled_order.py
+++ b/ecommerce/management/commands/refund_fulfilled_order.py
@@ -1,0 +1,91 @@
+"""
+Looks up a fulfilled order in the system, sets it to Refunded, and then adjusts
+the enrollments accordingly. 
+
+- If --unenroll is specified, the learner will be unenrolled from the course run
+  associated with the order.
+- If --audit is specified, the learner will keep their unenrollments, but they
+  will be set to "audit" instead of "verified".
+
+This does not make any sort of call to CyberSource or any other payment gateway
+to perform a refund - you're expected to have refunded the learner's money
+manually already. (At time of writing, PayPal transactions can't be refunded 
+using the normal means, so they get refunded manually via CyberSource and then 
+this command comes in to clean up afterwards.)
+
+"""
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import BaseCommand
+from django.core.management.base import CommandError
+from django.db.models import Q
+
+from courses.api import deactivate_run_enrollment
+from courses.models import CourseRunEnrollment
+from ecommerce.models import Order
+from openedx.api import enroll_in_edx_course_runs
+
+
+class Command(BaseCommand):
+    """
+    Looks up a fulfilled order in the system, sets it to Refunded, and then adjusts the enrollments accordingly.
+    """
+
+    help = "Looks up a fulfilled order in the system, sets it to Refunded, and then adjusts the enrollments accordingly."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "order", type=str, help="The order reference number to retrieve."
+        )
+        parser.add_argument(
+            "--unenroll",
+            action="store_true",
+            help="Completely unenroll the learner from the course(s).",
+        )
+        parser.add_argument(
+            "--audit",
+            action="store_true",
+            help="Set the learner's enrollments to audit.",
+        )
+
+    def handle(self, *args, **kwargs):
+        if (not "audit" in kwargs or not kwargs["audit"]) and (
+            not "unenroll" in kwargs or not kwargs["unenroll"]
+        ):
+            raise CommandError("Please specify an action to take on the enrollment.")
+
+        try:
+            order = Order.objects.filter(reference_number=kwargs["order"]).get()
+        except:
+            raise CommandError("Couldn't find that order, or the order was ambiguous.")
+
+        order.state = Order.STATE.REFUNDED
+        order.save()
+
+        run_enrollments = (
+            CourseRunEnrollment.objects.filter(user=order.purchaser)
+            .filter(run__in=order.purchased_runs)
+            .all()
+        )
+
+        for enrollment in run_enrollments:
+            if "unenroll" in kwargs and kwargs["unenroll"]:
+                self.stdout.write(
+                    f"Unenrolling {order.purchaser.username} in {enrollment.run}"
+                )
+                deactivate_run_enrollment(enrollment, "refunded", True)
+            else:
+                self.stdout.write(
+                    f"Changing enrollment for {order.purchaser.username} in {enrollment.run} to 'audit'"
+                )
+
+                enrollment.enrollment_mode = "audit"
+                enrollment.save()
+
+                enroll_in_edx_course_runs(
+                    order.purchaser, [enrollment.run], mode="audit"
+                )
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Updated order {order.reference_number}.")
+        )

--- a/ecommerce/management/commands/refund_fulfilled_order.py
+++ b/ecommerce/management/commands/refund_fulfilled_order.py
@@ -55,7 +55,9 @@ class Command(BaseCommand):
             raise CommandError("Please specify an action to take on the enrollment.")
 
         try:
-            order = Order.objects.filter(reference_number=kwargs["order"]).get()
+            order = Order.objects.filter(
+                state=Order.STATE.FULFILLED, reference_number=kwargs["order"]
+            ).get()
         except:
             raise CommandError("Couldn't find that order, or the order was ambiguous.")
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Fixes #1426 

#### What's this PR do?

Adds a new management command, `refund_fulfilled_order`, that will do a "dry refund" of a fulfilled order. That is, this will update the status of the order to "refunded" and will adjust the learner's enrollments, but will not attempt to refund the learner's money via CyberSource. 

#### How should this be manually tested?

1. Complete a transaction in the system.
2. Run `refund_fulfilled_order` using the reference number. Specify each flag separately and check the outcome - if `--audit` is specified, the enrollment should be converted to an audit one, and if `--unenroll` is specified, the enrollment should be unenrolled. 
