### PR TITLE
Updated configure_tiers to work with courses as well as programs

### DIFF
--- a/docs/source/commands/configure_tiers.rst
+++ b/docs/source/commands/configure_tiers.rst
@@ -1,0 +1,93 @@
+``configure_tiers``
+===================
+
+Creates financial assistance tiers and discounts for a course or program.
+
+This operates in two modes: creating tiers for a program and creating tiers for a course.
+
+*In the tables below, <year> represents the current year.*
+
+**Configuring tiers for a course** 
+
+The command will use the readable ID of the course as part of the financial aid discounts. They will default to this:
+
+=========================== ============= ======
+Code                        Type          Amount
+=========================== ============= ======
+<course id>-fa-tier1-<year> percent-off   .75
+<course id>-fa-tier2-<year> percent-off   .50
+<course id>-fa-tier3-<year> percent-off   .25
+<course id>-fa-tier4-<year> percent-off   0
+=========================== ============= ======
+
+Note that configuring course tiers requires the course to exist. Use ``create_courseware`` (or any of the other methods) to create the course before you run this command.
+
+**Configuring tiers for a program**
+
+The command will create or reuse a program. By default, the program it will try to use is:
+
+* Data, Econonmics and Development Policy
+* program-v1:MITx+DEDP
+* Abbreviated to DEDP
+
+The default discounts will be:
+
+==================== =========== ======
+Code                 Type        Amount
+==================== =========== ======
+DEDP-fa-tier1-<year> dollars-off 750
+DEDP-fa-tier2-<year> dollars-off 650
+DEDP-fa-tier3-<year> dollars-off 500
+DEDP-fa-tier4-<year> percent-off 0
+==================== =========== ======
+
+Specify changes using ``--program``, ``--program-name``, and/or ``--program-abbrev``. 
+
+**Tiers**
+
+The actual tiers that will be created are:
+
+========= ========================
+Threshold Discount
+========= ========================
+$0        <abbrev>-fa-tier1-<year>
+$25,000   <abbrev>-fa-tier2-<year>
+$50,000   <abbrev>-fa-tier3-<year>
+$75,000   <abbrev>-fa-tier4-<year>
+========= ========================
+
+These can be overridden by providing a CSV file. The CSV file should have the following fields and should not have a header row::
+
+  threshold amount,discount type,discount amount
+
+If you specify tier information, you must provide all the tiers you want to create - the specified information will override the default. In addition, you must supply a zero income tier. This is a requirement and the command will quit if you don't have one set up, as that tier is used as the starting point for financial assistance. (In other words, learners will see errors if there's not a zero-income threshold tier set up.)
+
+**Reuse**
+
+The command will try to reuse any discounts and tiers that match ones the command would have created, so you can safely run this for a course or program that may have already had financial assistance tiers set up.
+
+Syntax
+------
+
+Configuring tiers for a program:
+``configure_tiers [--program <readable id>] [--program-name <name of the program>] [--program-abbrev <program abbreviation>] [--tier-info <tier info CSV>]``
+
+Configuring tiers for a course:
+``configure_tiers [--course <readable id>] [--tier-info <tier info CSV>]``
+
+Options
+-------
+
+Program options:
+
+* ``--program <readable id>`` - Program ID to use or create. Defaults to ``program-v1:MITx+DEDP``.
+* ``--program-name <name of the program>`` - Name of the new program. Defaults to ``Data, Economics and Development Policy``.
+* ``--program-abbrev <abbreviation>`` - Abbreviation to use for tiers and discounts. Defaults to ``DEDP``. 
+
+Course options:
+
+* ``--course <readable id>`` - Course ID to use. This won't create a course; use ``create_courseware`` for that. 
+
+Common options:
+
+* ``--tier-info <csv file>`` - Tier info in CSV format.

--- a/docs/source/commands/index.rst
+++ b/docs/source/commands/index.rst
@@ -7,6 +7,7 @@ MITx Online Commands
 
    check_program_requirements
    configure_instance
+   configure_tiers
    create_courseware
    create_courseware_page
    create_product

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "MITx Online"
-copyright = "2021, OL Engineering"
+copyright = "2023, OL Engineering"
 author = "OL Engineering"
 
 

--- a/flexiblepricing/management/commands/configure_tiers_test.py
+++ b/flexiblepricing/management/commands/configure_tiers_test.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from factory import fuzzy
 
+from courses.factories import CourseFactory
 from courses.models import Program
 from ecommerce.constants import PAYMENT_TYPE_FINANCIAL_ASSISTANCE
 from ecommerce.factories import DiscountFactory
@@ -25,11 +26,11 @@ FAKE = faker.Factory.create()
     "with_existing_records, as_dedp",
     [[False, True], [False, False], [True, True], [True, False]],
 )
-def test_tier_setup(with_existing_records, as_dedp):
+def test_program_tier_setup(with_existing_records, as_dedp):
     """
-    Runs the setup command and then makes sure the result is correct.
+    Runs the configure command for a program and makes sure everything gets created.
     This tests specifically a setup where there's no existing DEDP records.
-    If as_dedp is specified, this will provide
+    If as_dedp is specified, this will use DEDP-specific values.
     """
     this_year = date.today().year
     content_type = ContentType.objects.filter(
@@ -102,6 +103,70 @@ def test_tier_setup(with_existing_records, as_dedp):
         existing_program.refresh_from_db()
 
         assert program == existing_program
+        assert (
+            existing_discount.expiration_date is not None
+            and existing_discount.expiration_date
+            < datetime.now(tz=pytz.timezone(settings.TIME_ZONE))
+        )
+        assert existing_tier.current is False
+
+
+@pytest.mark.parametrize(
+    "with_existing_records",
+    [True, False],
+)
+def test_course_tier_setup(with_existing_records):
+    """
+    Runs the setup command for a course and makes sure the tiers are set up.
+    """
+    this_year = date.today().year
+    content_type = ContentType.objects.filter(
+        app_label="courses", model="course"
+    ).first()
+    course = CourseFactory.create()
+
+    if with_existing_records:
+        existing_discount = DiscountFactory.create(
+            discount_code=f"{course.readable_id}-fa-tier1-1999",
+            payment_type=PAYMENT_TYPE_FINANCIAL_ASSISTANCE,
+        )
+        existing_tier = FlexiblePriceTier(
+            courseware_content_type=content_type,
+            courseware_object_id=course.id,
+            current=True,
+            income_threshold_usd=fuzzy.FuzzyInteger(0, 500).fuzz(),
+            discount=existing_discount,
+        )
+        existing_tier.save()
+
+    output = StringIO()
+    call_command(
+        "configure_tiers",
+        course=course.readable_id,
+        stdout=output,
+    )
+
+    discounts_qset = Discount.objects.filter(
+        discount_code__startswith=f"{course.readable_id}-fa-tier",
+        discount_code__endswith=this_year,
+    )
+
+    assert discounts_qset.count() == 4
+
+    assert (
+        FlexiblePriceTier.objects.filter(
+            current=True,
+            discount__in=discounts_qset.all(),
+            courseware_object_id=course.id,
+            courseware_content_type=content_type,
+        ).count()
+        == 4
+    )
+
+    if with_existing_records:
+        existing_discount.refresh_from_db()
+        existing_tier.refresh_from_db()
+
         assert (
             existing_discount.expiration_date is not None
             and existing_discount.expiration_date


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1434

#### What's this PR do?

Updates the `configure_tiers` command so that it can be used for individual courses as well as programs. We've had a few instances where courses that don't belong to programs needed financial assistance tiers, so this needed a bit of updating to be able to handle that. 

#### How should this be manually tested?

Automated tests should pass.

1. Create a course. (For testing, I used the `create_courseware` command: `create_courseware --live --create-run 1T2023 --start 2023-01-01 --end 2023-01-1 course course-v1:TIMxT+12.345x "Test Course for Tiers"`
2. Run the `configure_tiers` command, specifying the course: `configure_tiers --course course-v1:TIMxT+12.345x`
3. Check that everything ran successfully.
4. Re-run `configure_tiers` for a program and make sure that also works properly. 

Optionally, run tests with `--tier-info` and a CSV in the proper format to test that.

There is additionally documentation in the `docs` folder for this command now that probably should be proofed.

#### Background Info

It's probably worth noting that the default tier discounts for courses and programs are different: courses use percent-off discounts across the board where programs have dollars-off ones. 