### PR TITLE
Fixing a call to `set_rollback` that was incorrect; adding a test

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -442,9 +442,10 @@ def refund_order(*, order_id: int = None, reference_number: str = None, **kwargs
                 )
                 # PaymentGateway didn't raise an exception and instead gave a Response but the response status was not
                 # success so we manually rollback the transaction in this case.
-                transaction.set_rollback()
-                # Just return here if the refund failed, no matter if unenroll was requested or not
-                return False
+                transaction.rollback()
+                raise Exception(
+                    f"Payment gateway returned an error: {response.message}"
+                )
 
         except RefundDuplicateException:
             # Duplicate refund error during the API call will be treated as success, we just log it


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1432

#### What's this PR do?

Corrects a call to `set_rollback`; sets it to just roll back the transaction when a refund attempt is processed and the payment gateway returns an error. Raises an exception in this case as well, rather than just returning false. 

#### How should this be manually tested?

Automated tests should pass.

You would have to mock out the payment gateway API to return an error (as this hits a CyberSource API to do its job) but if you have a transaction that has an error and was returning `Error: set_rollback() missing 1 required positional argument: 'rollback'`, it shouldn't do that anymore. 

#### Any background context you want to provide?

There are transactions on prod that have this - they're regular credit card transactions, not PayPal ones, so not sure what the actual error is (because the syntax error ends up taking precedence). 