### PR TITLE
Moves Highest Level of Education field up

### DIFF
--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -416,6 +416,31 @@ export const ProfileFields = () => (
 export const AddlProfileFields = ({ values }: AddlProfileFieldsProps) => (
   <React.Fragment>
     <div className="form-group">
+      <div className="row">
+        <div className="col">
+          <label
+            htmlFor="user_profile.highest_education"
+            className="font-weight-bold"
+          >
+            Highest Level of Education
+          </label>
+          <Field
+            component="select"
+            name="user_profile.highest_education"
+            id="user_profile.highest_education"
+            className="form-control"
+          >
+            <option value="">-----</option>
+            {HIGHEST_EDUCATION_CHOICES.map((level, i) => (
+              <option key={i} value={level}>
+                {level}
+              </option>
+            ))}
+          </Field>
+        </div>
+      </div>
+    </div>
+    <div className="form-group">
       <label htmlFor="user_profile.type_multi" className="font-weight-bold">
         Are you a:
       </label>
@@ -633,31 +658,6 @@ export const AddlProfileFields = ({ values }: AddlProfileFieldsProps) => (
               >
                 <option value="">-----</option>
                 {EMPLOYMENT_LEVEL.map((level, i) => (
-                  <option key={i} value={level}>
-                    {level}
-                  </option>
-                ))}
-              </Field>
-            </div>
-          </div>
-        </div>
-        <div className="form-group">
-          <div className="row">
-            <div className="col">
-              <label
-                htmlFor="user_profile.highest_education"
-                className="font-weight-bold"
-              >
-                Highest Level of Education
-              </label>
-              <Field
-                component="select"
-                name="user_profile.highest_education"
-                id="user_profile.highest_education"
-                className="form-control"
-              >
-                <option value="">-----</option>
-                {HIGHEST_EDUCATION_CHOICES.map((level, i) => (
                   <option key={i} value={level}>
                     {level}
                   </option>

--- a/frontend/public/src/containers/pages/profile/EditProfilePage.js
+++ b/frontend/public/src/containers/pages/profile/EditProfilePage.js
@@ -9,7 +9,6 @@ import { connectRequest, mutateAsync, requestAsync } from "redux-query"
 import { createStructuredSelector } from "reselect"
 
 import users, { currentUserSelector } from "../../../lib/queries/users"
-import { routes } from "../../../lib/urls"
 import queries from "../../../lib/queries"
 import EditProfileForm from "../../../components/forms/EditProfileForm"
 
@@ -39,7 +38,7 @@ type Props = {|
 
 export class EditProfilePage extends React.Component<Props> {
   async onSubmit(profileData: User, { setSubmitting, setErrors }: Object) {
-    const { editProfile, history } = this.props
+    const { editProfile } = this.props
 
     try {
       const {
@@ -51,7 +50,7 @@ export class EditProfilePage extends React.Component<Props> {
           email: errors[0]
         })
       } else {
-        history.push(routes.profile)
+        window.location.reload()
       }
     } finally {
       setSubmitting(false)

--- a/frontend/public/src/containers/pages/profile/EditProfilePage_test.js
+++ b/frontend/public/src/containers/pages/profile/EditProfilePage_test.js
@@ -75,7 +75,6 @@ describe("EditProfilePage", () => {
         assert.isNull(helper.currentLocation)
         sinon.assert.calledOnce(setErrors)
       } else {
-        assert.equal(helper.currentLocation.pathname, "/profile/")
         sinon.assert.notCalled(setErrors)
       }
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1457

#### What's this PR do?

Two things:
* Moves the Highest Level of Education field above the "Are you a..." field in the extended profile fields (and thus moves it up out of the conditionally-displayed fields)
* In the edit profile form's onSubmit handler, changes the page refresh method to use window.location.refresh rather than pushing a new browser history entry. (This should prevent people from hitting back and getting the profile page over and over again, and also makes it so that the feature flag keeps working if you specify it in the URL.) 

#### How should this be manually tested?

These fields are hidden behind a feature flag; you'll either need to set `FEATURE_ENABLE_ADDL_PROFILE_FIELDS` or append `?enable_addl_profile_fields` to the URL.

1. Load the Profile page.
2. You should see the Highest Level of Education field below the Gender and Year of Birth fields.
3. Selecting Professional should have no effect on the Highest Level of Education field. 
4. If you're using the URL flag, saving should not clear the flag.

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/945611/222766546-e58c5b30-7582-4d0d-b7fd-4b8b919cc564.png)
