### PR TITLE
Changes refund_order to let exceptions bubble up, removes duplicate as a successful state

### DIFF
--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -177,12 +177,18 @@ def test_order_refund_success(mocker, order_state, unenroll, fulfilled_transacti
         "mitol.payment_gateway.api.PaymentGateway.start_refund",
         return_value=sample_response,
     )
-    refund_success = refund_order(
-        order_id=fulfilled_transaction.order.id, unenroll=unenroll
-    )
 
     if order_state == ProcessorResponse.STATE_DUPLICATE:
-        assert f"Duplicate refund request for order_id {fulfilled_transaction.order.id}"
+        with pytest.raises(Exception) as e:
+            refund_success = refund_order(
+                order_id=fulfilled_transaction.order.id, unenroll=unenroll
+            )
+
+        return
+    else:
+        refund_success = refund_order(
+            order_id=fulfilled_transaction.order.id, unenroll=unenroll
+        )
 
     # There should be two transaction objects (One for payment and other for refund)
     assert (

--- a/ecommerce/constants.py
+++ b/ecommerce/constants.py
@@ -79,7 +79,6 @@ CYBERSOURCE_CARD_TYPES = {
 
 REFUND_SUCCESS_STATES = [
     ProcessorResponse.STATE_ACCEPTED,
-    ProcessorResponse.STATE_DUPLICATE,
     ProcessorResponse.STATE_PENDING,
 ]
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
 
#### What are the relevant tickets?

Closes #1461

#### What's this PR do?

Changes the behavior of `refund_order` to prevent it from trying to catch exceptions that happen during the refund process. 

Changes the list of refund success states to remove duplicate as as successful state.

#### How should this be manually tested?

While this is really meant to be run from within the Google sheets processing code, you can call `refund_order` from a Django shell if you'd rather not set all that up. 

1. Complete a transaction in the system.
2. Refund your transaction. 
3. Attempt to process the refund transaction again. An exception should be raised - CyberSource won't let you refund a transaction twice. 
4. If you do have Google Sheets integration set up, you should see an error message in the refunds sheet. 

#### Any background context you want to provide?

I think we regarded "duplicate" as a success state to allow the Google automation the ability to re-process rows that were completed. (In other words, if it processed row 12 successfully in a prior run, when it processes row 12 in a future run it should not report errors just because it's already been done.) However, in practice, we keep track of what rows have been processed so instead I feel like it's better that we see that an error has occurred - it won't re-process rows (unless you do some finagling to force that to happen). 