### PR TITLE
1455: Adds templatetag for noindex in non-prod

### DIFF
--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -1,5 +1,5 @@
 {% load static hijack_tags js_interop %}
-{% load wagtailcore_tags startswith %}
+{% load wagtailcore_tags startswith noindex_meta %}
 {% load render_bundle from webpack_loader %}
 <!DOCTYPE html>
 <html lang="en">
@@ -18,6 +18,7 @@
       media="none" onload="if(media!='all') media='all'">
     {% js_settings %}
     {% render_bundle 'style' %}
+    {% noindex_meta %}
     <title>{% block title %}{% endblock %}</title>
     <meta name="google-site-verification" content="{{ domain_verification_tag }}" />
     <meta name="description" content="{% block description %}{% endblock %}">

--- a/main/templatetags/noindex_meta.py
+++ b/main/templatetags/noindex_meta.py
@@ -12,5 +12,5 @@ def noindex_meta():
     return (
         mark_safe("""<meta name="robots" content="noindex">""")
         if settings.ENVIRONMENT not in ("production", "prod")
-        else None
+        else ""
     )

--- a/main/templatetags/noindex_meta.py
+++ b/main/templatetags/noindex_meta.py
@@ -1,0 +1,16 @@
+"""Blocks search engine indexing for non-production environments."""
+from django import template
+from django.utils.safestring import mark_safe
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag()
+def noindex_meta():
+    """Adds in noindex for non-production environments."""
+    return (
+        mark_safe("""<meta name="robots" content="noindex">""")
+        if settings.ENVIRONMENT not in ("production", "prod")
+        else None
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1455

#### What's this PR do?
Blocks search engines from indexing `mitxonline` pages in non-production environments using a `<meta>` tag with the `noindex` value described here: https://developers.google.com/search/docs/crawling-indexing/block-indexing.  

The `<meta>` tag is included in the header of each `mitxonline` page if the value of the `MITX_ONLINE_ENVIRONMENT` environment variable does not equal 'prod' or 'production'.  The default value for this environment variable is 'dev'

#### How should this be manually tested?
1. Pull down this branch.
2. If `MITX_ONLINE_ENVIRONMENT` has not been added to your `.env` file, then start `mitxonline`.  Otherwise, set `MITX_ONLINE_ENVIRONMENT` equal to `dev` in your `.env`.
3. Visit any page in your local instance of `mitxonline` and view the page source.  Ensure that you see `<meta name="robots" content="noindex">` in the header of the page when `MITX_ONLINE_ENVIRONMENT` equal to `dev`.
4. Stop `mitxonline`.  Set `MITX_ONLINE_ENVIRONMENT` equal to `prod` in your `.env` file.
5. Start `mitxonline`
6. Visit any page and view the source code.  Ensure that you do not see `<meta name="robots" content="noindex">` in the header of the page when `MITX_ONLINE_ENVIRONMENT` is equal to `prod`.


#### Any background context you want to provide?
When this change is deployed to QA or Production, we can also test this functionality using the steps described here: https://developers.google.com/search/docs/crawling-indexing/block-indexing#debugging-noindex-issues
