### PR TITLE
Adds friendlier error message when State is unset

### DIFF
--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -56,8 +56,11 @@ export const legalAddressValidation = yup.object().shape({
       .string()
       .label("State")
       .when("country", {
-        is:        value => value === "US" || value === "CA",
-        then:      yup.string().required(),
+        is:   value => value === "US" || value === "CA",
+        then: yup
+          .string()
+          .required("State is a required field")
+          .typeError("State is a required field"),
         otherwise: yup.string().nullable()
       })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

https://github.com/mitodl/hq/issues/886

#### What's this PR do?

Adds a `typeError` to the validation for the State field that says "State is a required field" rather than the default yup error (which is very programmery). 

#### How should this be manually tested?

1. Log in with an account that either doesn't have a country/state set or has one set to a country that doesn't have states (so not US or Canada)
2. Set the country to US or Canada
3. Open the State field, but don't select anything. Instead, click to a different field.
4. Validation should run and you should see the "State is a required field" error message.

#### Screenshots (if appropriate)

https://share.cleanshot.com/167R3ykMmtl8vrKPS5lt
