### PR TITLE
Declining an order clears discounts associated with the order

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -670,8 +670,17 @@ class PendingOrder(FulfillableOrder, Order):
 
     @transition(field="state", source=Order.STATE.PENDING, target=Order.STATE.DECLINED)
     def decline(self):
-        """Decline this order"""
-        pass
+        """
+        Decline this order. This additionally clears the discount redemptions
+        for the order so the discounts can be reused.
+        """
+        for redemption in self.discounts.all():
+            redemption.delete()
+
+        self.state = Order.STATE.DECLINED
+        self.save()
+
+        return self
 
     @transition(field="state", source=Order.STATE.PENDING, target=Order.STATE.ERRORED)
     def error(self):


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1467 

#### What's this PR do?

Adds some code to remove discount redemptions when a pending order is declined. 

#### How should this be manually tested?

1. Start an order that has a discount attached to it and progress into the CyberSource part of it. (Don't complete the order). 
2. From a Django shell, load the order and call `decline` on it.
3. The order should change status to Declined, and the discount redemptions should be cleared for the order.
