### PR TITLE
977: allow enrollment in archived courses

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -73,10 +73,7 @@ def get_user_relevant_course_run_qset(
     Returns a QuerySet of relevant course runs
     """
     now = now or now_in_utc()
-    run_qset = (
-        course.courseruns.exclude(start_date=None)
-        .exclude(enrollment_start=None)
-    )
+    run_qset = course.courseruns.exclude(start_date=None).exclude(enrollment_start=None)
     if user and user.is_authenticated:
         user_enrollments = Count(
             "enrollments",

--- a/courses/api.py
+++ b/courses/api.py
@@ -76,7 +76,6 @@ def get_user_relevant_course_run_qset(
     run_qset = (
         course.courseruns.exclude(start_date=None)
         .exclude(enrollment_start=None)
-        .filter(Q(end_date=None) | Q(end_date__gt=now))
     )
     if user and user.is_authenticated:
         user_enrollments = Count(

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -111,9 +111,9 @@ def courses_api_logs(mocker):
 
 
 @pytest.mark.parametrize("is_enrolled", [True, False])
-def test_get_user_relevant_course_run(user, dates, course, is_enrolled):
+def test_get_user_relevant_course_run(client, user, dates, course, is_enrolled):
     """
-    get_user_relevant_course_run should return an enrolled run if the end date isn't in the past, or the soonest course
+    get_user_relevant_course_run should return an enrolled run or the soonest course
     run that does not have a past enrollment end date.
     """
     # One run in the near future, one run in progress with an expired enrollment period, and one run in the far future.
@@ -142,9 +142,9 @@ def test_get_user_relevant_course_run(user, dates, course, is_enrolled):
 
 def test_get_user_relevant_course_run_invalid_dates(user, dates, course):
     """
-    get_user_relevant_course_run should ignore course runs with any of the following properties:
+    get_user_relevant_course_run should ignore course runs with any of the following properties when the user is not enrolled:
     1) No start date or enrollment start date
-    2) An end date in the past
+    2) An enrollment end date in the past
 
     """
     CourseRunFactory.create_batch(
@@ -193,8 +193,8 @@ def test_get_user_relevant_course_run_ignore_enrolled(user, dates, course):
         run=course_runs[1], user=user, edx_enrolled=False, active=True
     )
     returned_run = get_user_relevant_course_run(course=course, user=user)
-    # Returned course run should be the one with the unexpired enrollment period
-    assert returned_run == course_runs[2]
+    # Returned course run should be the one the user is enrolled in that is active in edx
+    assert returned_run == course_runs[0]
 
 
 def test_get_user_enrollments(user):

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -37,13 +37,10 @@ export const isLinkableCourseRun = (
 
 export const isWithinEnrollmentPeriod = (run: CourseRunDetail): boolean => {
   const enrollStart = run.enrollment_start ? moment(run.enrollment_start) : null
-  const enrollEnd = run.enrollment_end ? moment(run.enrollment_end) : null
   const now = moment()
-  return (
-    !!enrollStart &&
-    now.isAfter(enrollStart) &&
-    (isNil(enrollEnd) || now.isBefore(enrollEnd))
-  )
+  const result = !!enrollStart && now.isAfter(enrollStart)
+  console.log("CP", result)
+  return true
 }
 
 export const courseRunStatusMessage = (run: CourseRun) => {

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -37,10 +37,13 @@ export const isLinkableCourseRun = (
 
 export const isWithinEnrollmentPeriod = (run: CourseRunDetail): boolean => {
   const enrollStart = run.enrollment_start ? moment(run.enrollment_start) : null
+  const enrollEnd = run.enrollment_end ? moment(run.enrollment_end) : null
   const now = moment()
-  const result = !!enrollStart && now.isAfter(enrollStart)
-  console.log("CP", result)
-  return true
+  return (
+    !!enrollStart &&
+    now.isAfter(enrollStart) &&
+    (isNil(enrollEnd) || now.isBefore(enrollEnd))
+  )
 }
 
 export const courseRunStatusMessage = (run: CourseRun) => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/977

#### What's this PR do?
Enables the "Enroll now" button to be displayed on a course page in mitxonline when that course meets the following requirements:
- Has an end date in the past
- Has no enrollment end date, or an enrollment end date in the future.
- Has an upgrade deadline in the past

Since the course's upgrade deadline is in the past, the course certificate related pricing and upsell card functionality are not shown to the user.  The user is only able to enroll in the course with the `audit` mode.

#### How should this be manually tested?

1. Create a course and associated course run.  The course run should meet the requirements stated in the section above.
2. View the course page within `mitxonline` and verify that you can view the "Enroll now" button and are able to enroll in the course.
3. Ensure that you do not see any certificate or pricing related functionality associated with this course enrollment.

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)
