### PR TITLE
Allows verified learners the ability to unenroll; adjusts flow for refunds

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -277,7 +277,11 @@ def create_run_enrollments(
             enrollment, created = CourseRunEnrollment.all_objects.get_or_create(
                 user=user,
                 run=run,
-                defaults=dict(edx_enrolled=edx_request_success, enrollment_mode=mode),
+                defaults=dict(
+                    change_status=None,
+                    edx_enrolled=edx_request_success,
+                    enrollment_mode=mode,
+                ),
             )
 
             if run.course.program is not None:

--- a/courses/models.py
+++ b/courses/models.py
@@ -990,6 +990,17 @@ class CourseRunEnrollment(EnrollmentModel):
         """
         return cls.objects.filter(user=user, run__course__program=program)
 
+    def deactivate_and_save(self, change_status, no_user=False):
+        """
+        For course run enrollments, we need to clear any PaidCourseRun records
+        for this enrollment (if any) so they can re-enroll later.
+        """
+        from courses.tasks import clear_unenrolled_paid_course_run
+
+        clear_unenrolled_paid_course_run.delay(self.id)
+
+        return super().deactivate_and_save(change_status, no_user)
+
     def to_dict(self):
         return {**super().to_dict(), "text_id": self.run.courseware_id}
 

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -11,11 +11,15 @@ from courses.factories import (
     CourseRunGradeFactory,
     LearnerProgramRecordShareFactory,
 )
+from courses.models import CourseRunEnrollment, PaidCourseRun
 from courses.tasks import (
+    clear_unenrolled_paid_course_run,
     generate_course_certificates,
     send_partner_school_email,
     subscribe_edx_course_emails,
 )
+from ecommerce.factories import OrderFactory
+from ecommerce.models import Order
 from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
 
 pytestmark = pytest.mark.django_db
@@ -56,3 +60,22 @@ def test_send_partner_school_email(mocker):
     )
     send_partner_school_email.delay(record.share_uuid)
     send_partner_school_sharing_message.assert_called_once()
+
+
+def test_clear_unenrolled_paid_course_runs(user):
+    """Test generating a paid course run, then clearing the enrollment"""
+
+    course_run = CourseRunFactory.create()
+    enrollment = CourseRunEnrollment.objects.create(user=user, run=course_run)
+    order = OrderFactory.create(purchaser=user, state=Order.STATE.FULFILLED)
+
+    PaidCourseRun.objects.create(user=user, course_run=course_run, order=order)
+
+    clear_unenrolled_paid_course_run(enrollment.id)
+
+    assert (
+        PaidCourseRun.objects.filter(
+            user=user, course_run=course_run, order=order
+        ).count()
+        == 0
+    )

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -177,8 +177,8 @@ def test_order_refund_success(mocker, order_state, unenroll, fulfilled_transacti
         message="",
         response_code="",
     )
-    unenroll_task_mock = mocker.patch(
-        "ecommerce.tasks.perform_unenrollment_from_order.delay"
+    downgrade_task_mock = mocker.patch(
+        "ecommerce.tasks.perform_downgrade_from_order.delay"
     )
 
     mocker.patch(
@@ -217,9 +217,9 @@ def test_order_refund_success(mocker, order_state, unenroll, fulfilled_transacti
 
     # Unenrollment task should only run if unenrollment was requested
     if unenroll:
-        unenroll_task_mock.assert_called_once_with(fulfilled_transaction.order.id)
+        downgrade_task_mock.assert_called_once_with(fulfilled_transaction.order.id)
     else:
-        assert not unenroll_task_mock.called
+        assert not downgrade_task_mock.called
 
     # Refund transaction object should have appropriate data
     refund_transaction = Transaction.objects.filter(
@@ -248,8 +248,8 @@ def test_order_refund_success_with_ref_num(mocker, unenroll, fulfilled_transacti
         message="",
         response_code="",
     )
-    unenroll_task_mock = mocker.patch(
-        "ecommerce.tasks.perform_unenrollment_from_order.delay"
+    downgrade_task_mock = mocker.patch(
+        "ecommerce.tasks.perform_downgrade_from_order.delay"
     )
 
     mocker.patch(
@@ -278,9 +278,9 @@ def test_order_refund_success_with_ref_num(mocker, unenroll, fulfilled_transacti
 
     # Unenrollment task should only run if unenrollment was requested
     if unenroll:
-        unenroll_task_mock.assert_called_once_with(fulfilled_transaction.order.id)
+        downgrade_task_mock.assert_called_once_with(fulfilled_transaction.order.id)
     else:
-        assert not unenroll_task_mock.called
+        assert not downgrade_task_mock.called
 
     # Refund transaction object should have appropriate data
     refund_transaction = Transaction.objects.filter(
@@ -301,8 +301,8 @@ def test_order_refund_failure(mocker, fulfilled_transaction):
         "mitol.payment_gateway.api.PaymentGateway.start_refund",
         side_effect=ApiException(),
     )
-    unenroll_task_mock = mocker.patch(
-        "ecommerce.tasks.perform_unenrollment_from_order.delay"
+    downgrade_task_mock = mocker.patch(
+        "ecommerce.tasks.perform_downgrade_from_order.delay"
     )
 
     with pytest.raises(ApiException):
@@ -316,7 +316,7 @@ def test_order_refund_failure(mocker, fulfilled_transaction):
         == 0
     )
     # Unenrollment task should not run when API fails
-    assert not unenroll_task_mock.called
+    assert not downgrade_task_mock.called
 
 
 def test_order_refund_failure_no_exception(mocker, fulfilled_transaction):
@@ -330,8 +330,8 @@ def test_order_refund_failure_no_exception(mocker, fulfilled_transaction):
         "mitol.payment_gateway.api.PaymentGateway.start_refund",
         returns=error_return,
     )
-    unenroll_task_mock = mocker.patch(
-        "ecommerce.tasks.perform_unenrollment_from_order.delay"
+    downgrade_task_mock = mocker.patch(
+        "ecommerce.tasks.perform_downgrade_from_order.delay"
     )
 
     with pytest.raises(Exception) as exc:
@@ -346,7 +346,7 @@ def test_order_refund_failure_no_exception(mocker, fulfilled_transaction):
         == 0
     )
     # Unenrollment task should not run when API fails
-    assert not unenroll_task_mock.called
+    assert not downgrade_task_mock.called
 
 
 def test_unenrollment_unenrolls_learner(mocker, user):

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -24,6 +24,19 @@ def perform_unenrollment_from_order(order_id):
     unenroll_learner_from_order(order_id)
 
 
+@app.task(acks_late=True)
+def perform_downgrade_from_order(order_id):
+    """
+    Task to perform enrollment downgrade from courses against a specific order
+
+    Args:
+       order_id (int): Id of the order
+    """
+    from ecommerce.api import downgrade_learner_from_order
+
+    downgrade_learner_from_order(order_id)
+
+
 @app.task
 def send_order_refund_email(order_id):
     from ecommerce.mail_api import send_ecommerce_refund_message

--- a/ecommerce/tasks_test.py
+++ b/ecommerce/tasks_test.py
@@ -1,9 +1,12 @@
 import pytest
 import reversion
 
-from ecommerce.serializers_test import create_order_receipt
 from ecommerce.factories import ProductFactory
-from ecommerce.tasks import perform_unenrollment_from_order
+from ecommerce.serializers_test import create_order_receipt
+from ecommerce.tasks import (
+    perform_downgrade_from_order,
+    perform_unenrollment_from_order,
+)
 
 
 @pytest.fixture()
@@ -65,3 +68,14 @@ def test_delayed_unenrollment_unenrolls_user(mocker, user):
     unenroll_learner_mock = mocker.patch("ecommerce.api.unenroll_learner_from_order")
     perform_unenrollment_from_order.delay(order_id=1)
     unenroll_learner_mock.assert_called()
+
+
+@pytest.mark.django_db
+def test_delayed_downgrade_user(mocker, user):
+    """
+    Test that unenroll task properly calls the unenrollment functionality against an order
+    """
+
+    downgrade_learner_mock = mocker.patch("ecommerce.api.downgrade_learner_from_order")
+    perform_downgrade_from_order.delay(order_id=1)
+    downgrade_learner_mock.assert_called()

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -286,45 +286,7 @@ export class EnrolledItemCard extends React.Component<
     )
   }
 
-  renderVerifiedUnenrollmentModal(enrollment: RunEnrollment) {
-    const { runUnenrollmentModalVisibility } = this.state
-
-    return (
-      <Modal
-        id={`run-unenrollment-${enrollment.id}-modal`}
-        className="text-center"
-        isOpen={runUnenrollmentModalVisibility}
-        toggle={() => this.toggleRunUnenrollmentModalVisibility()}
-        role="dialog"
-        aria-labelledby={`run-unenrollment-${enrollment.id}-modal-header`}
-        aria-describedby={`run-unenrollment-${enrollment.id}-modal-body`}
-      >
-        <ModalHeader
-          toggle={() => this.toggleRunUnenrollmentModalVisibility()}
-          id={`run-unenrollment-${enrollment.id}-modal-header`}
-        >
-          Unenroll From {enrollment.run.course_number}
-        </ModalHeader>
-        <ModalBody id={`run-unenrollment-${enrollment.id}-modal-body`}>
-          <p>
-            You are enrolled in the certificate track for{" "}
-            {enrollment.run.course_number} {enrollment.run.title}. You can't
-            unenroll from this course from My Courses.
-          </p>
-
-          <p>
-            To unenroll, please{" "}
-            <a href="https://mitxonline.zendesk.com/hc/en-us/requests/new">
-              contact customer support
-            </a>{" "}
-            for assistance.
-          </p>
-        </ModalBody>
-      </Modal>
-    )
-  }
-
-  renderUnverifiedUnenrollmentModal(enrollment: RunEnrollment) {
+  renderRunUnenrollmentModal(enrollment: RunEnrollment) {
     const { runUnenrollmentModalVisibility } = this.state
     const now = moment()
     const endDate = enrollment.run.enrollment_end
@@ -356,6 +318,17 @@ export class EnrolledItemCard extends React.Component<
                 : ` You won't be able to re-enroll after ${formattedEndDate}.`
               : null}
           </p>
+          {enrollment.enrollment_mode === "verified" ? (
+            <p>
+              You are enrolled in the certificate track for this course. If you
+              wish to request a refund for your payment for this course (if
+              any), please{" "}
+              <a href="https://mitxonline.zendesk.com/hc/en-us/requests/new">
+                contact customer support
+              </a>{" "}
+              for assistance.
+            </p>
+          ) : null}
           <Button
             type="submit"
             color="success"
@@ -369,12 +342,6 @@ export class EnrolledItemCard extends React.Component<
         </ModalBody>
       </Modal>
     )
-  }
-
-  renderRunUnenrollmentModal(enrollment: RunEnrollment) {
-    return enrollment.enrollment_mode === "verified"
-      ? this.renderVerifiedUnenrollmentModal(enrollment)
-      : this.renderUnverifiedUnenrollmentModal(enrollment)
   }
 
   renderProgramUnenrollmentModal(enrollment: ProgramEnrollment) {

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -281,7 +281,7 @@ describe("EnrolledItemCard", () => {
   })
   ;[
     [true, "verified"],
-    [false, "audit"]
+    [true, "audit"]
   ].forEach(([activationStatus, enrollmentType]) => {
     it(`${shouldIf(
       activationStatus


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots (but no mobile since it's just copy changes)
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1466 

#### What's this PR do?

- If the learner's payment is refunded, we now bump the enrollment to audit instead of completely unenrolling them.
- Learners can now unenroll from certficate track (verified) enrollments at will (but this won't result in a refund).

Learners unenrolling from the certificate track will unenroll from the entire course, _and_ this will clear their `PaidCourseRecord` entry for the course so they can enroll again. (The checkout process checks the `PaidCourseRecord` table for an existing purchase of the course to prevent duplicate purchases.)

#### How should this be manually tested?

Testing unenrollments:
1. Enroll in and upgrade your enrollment for a course. 
2. From the Dashboard, select Unenroll from the menu.
3. You should get a dialog asking you to confirm. The dialog should note that unenrolling will not refund your money. 
4. Continuing through the dialog should unenroll you from the course. 
5. You should be able to re-buy into the course. 

Testing refunds:
For this to work, you'll need to have REST API credentials for your CyberSource integration set up. 
1. Enroll in a course and upgrade the enrollment.
2. Refund the transaction. You can do this either in a Django shell by calling `ecommerce.api.refund_order` or you can process a row in the Google sheet if you have that integration set up. 
3. The refund should be successful and the enrollment should be converted to an `audit` enrollment.
4. The dashboard should reflect the change.

#### Screenshots (if appropriate)

The text in the unenroll confirmation dialog was amended a bit to include refund text:
![image](https://user-images.githubusercontent.com/945611/223855194-f14d9337-61c5-4476-8496-b8509a2914df.png)
