### PR TITLE
1473: duplicate enrollment emails

### DIFF
--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -147,7 +147,7 @@ export class ProductDetailEnrollApp extends React.Component<
               {needFinancialAssistanceLink}
             </div>
           </div>
-          <div className="cancel-link">{this.getEnrollmentForm(run)}</div>
+          <div className="cancel-link">{this.getEnrollmentForm()}</div>
           <div className="faq-link">
             <a
               href="https://mitxonline.zendesk.com/hc/en-us"

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -161,12 +161,9 @@ export class ProductDetailEnrollApp extends React.Component<
       </Modal>
     ) : null
   }
-  getEnrollmentForm(run: EnrollmentFlaggedCourseRun) {
-    const csrfToken = getCookie("csrftoken")
+  getEnrollmentForm() {
     return (
-      <form action="/enrollments/" method="post">
-        <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
-        <input type="hidden" name="run" value={run ? run.id : ""} />
+      <form>
         <button type="submit" className="btn enroll-now enroll-now-free">
           No thanks, I'll take the free version without a certificate
         </button>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1473

#### What's this PR do?
Removes a duplicate call to the `/enrollment/` API when a user enrolls in a course run.

#### How should this be manually tested?
1. Have a course run and associated product configured in mitxonline.
2. Open the network tab of your browser in order to view the API calls being made.
3. From the course page, click the "Enroll now" button.  This should trigger a call to the `/enrollment/` API.
4. The upsell modal should then be displayed asking if you would like to pay for the course or continue with the free enrollment.
5. Click on the free enrollment option of the modal.  This should **not** trigger a call to the `/enrollment/` API.
6. You should only receive a single email regarding your enrollment in the course.
