### PR TITLE
fix: Fix program admin to add a new program

### DIFF
--- a/courses/forms.py
+++ b/courses/forms.py
@@ -220,7 +220,15 @@ class ProgramAdminForm(ModelForm):
     def save(self, commit=True):
         """Save requirements"""
         program = super().save(commit=commit)
+        transaction.on_commit(self.save_requirements)
+        return program
+
+    def save_requirements(self):
+        """
+        Save related program requirements.
+        """
         with transaction.atomic():
+            program = self.instance
             root = program.get_requirements_root(for_update=True)
 
             if root is None:
@@ -238,8 +246,6 @@ class ProgramAdminForm(ModelForm):
             )
             serializer.is_valid(raise_exception=True)
             serializer.save()
-
-        return program
 
     class Meta:
         model = Program


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://mit-office-of-digital-learning.sentry.io/issues/3777726522/events/?project=5864687&referrer=issue-stream
https://github.com/mitodl/mitxonline/issues/1224

#### What's this PR do?
Fixes program creation from Django Admin.

The program admin was throwing 500 when we try to create a new program. The new program instance was not saved as the model admin does not commit the object while saving the form and we were trying to create program requirements. Stacktrace is attached
<img width="1447" alt="Screen Shot 2023-03-10 at 3 08 52 PM" src="https://user-images.githubusercontent.com/52656433/224288707-edffa0c0-2e62-47cd-81fe-88227ec6d3e1.png">


#### How should this be manually tested?

- Visit /admin/courses/program/
- Add a new program with some requirements
- Program should be created

#### Any background context you want to provide?
`ModelAdmin` has a `save_form` method which saves the form to get the unsaved new program instance. It sets `commit=False`. So, when we try to create requirements, It raised an exception that the related object `program` is unsaved.
