### PR TITLE
feat: sync certificate_available_date with edX

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -582,6 +582,14 @@ def sync_course_runs(runs):
             run.enrollment_start = course_detail.enrollment_start
             run.enrollment_end = course_detail.enrollment_end
             run.is_self_paced = course_detail.is_self_paced()
+            # Only sync the date if it's set in edX, Otherwise set it to course's end date
+            if course_detail.certificate_available_date:
+                run.certificate_available_date = (
+                    course_detail.certificate_available_date
+                )
+            else:
+                run.certificate_available_date = course_detail.end
+
             try:
                 run.save()
                 success_count += 1

--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ drf-extensions==0.7.1
 django-reversion==4.0.1
 django-storages==1.11.1
 djoser==2.1.0
-git+https://github.com/mitodl/edx-api-client@arslan/1340-certificate-available-date#egg=edx-api-client
+edx-api-client==1.7.0
 hubspot-api-client==6.1.0
 ipython
 mitol-django-common~=2.7.0

--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ drf-extensions==0.7.1
 django-reversion==4.0.1
 django-storages==1.11.1
 djoser==2.1.0
-edx-api-client==1.6.0
+git+https://github.com/mitodl/edx-api-client@arslan/1340-certificate-available-date#egg=edx-api-client
 hubspot-api-client==6.1.0
 ipython
 mitol-django-common~=2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -197,7 +197,7 @@ draftjs-exporter==2.1.7
     # via wagtail
 drf-extensions==0.7.1
     # via -r requirements.in
-edx-api-client @ git+https://github.com/mitodl/edx-api-client@arslan/1340-certificate-available-date
+edx-api-client==1.7.0
     # via -r requirements.in
 edx-opaque-keys==2.2.2
     # via mitol-django-openedx

--- a/requirements.txt
+++ b/requirements.txt
@@ -197,7 +197,7 @@ draftjs-exporter==2.1.7
     # via wagtail
 drf-extensions==0.7.1
     # via -r requirements.in
-edx-api-client==1.6.0
+edx-api-client @ git+https://github.com/mitodl/edx-api-client@arslan/1340-certificate-available-date
     # via -r requirements.in
 edx-opaque-keys==2.2.2
     # via mitol-django-openedx


### PR DESCRIPTION
**NOTE** 🚧 This has a counterpart in edx-api-client, That should be tested/reviewed along with this PR https://github.com/mitodl/edx-api-client/pull/98

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1340 

#### What's this PR do?
- Syncs `certificate_available_date` with edX from within course details sync

#### How should this be manually tested?
- Setup a course(s) in edX and MITxOnline (edX should be on upstream `master` https://github.com/openedx/edx-platform that contains at least https://github.com/openedx/edx-platform/commit/0ff7c5b13f28cb5a8784d5a39d8a63347810e9c7)
- Enable `certificate display behavior` in edX by adding a waffle switch `certificates.auto_certificate_generation`, you should see `certificate_available_date` field in edX studio in the `Set date` section, now set a date here
- Open the shell in MITxOnline, and do the following:
```
from courses.tasks import sync_courseruns_data
sync_courseruns_data()
```
This should sync `certificate_available_date` from edX for that course run, also check:
- If the `Certificate display behavior` is not turned on in edX, or the `certificate available_date` is not set, the sync process should set the `certificate_available_date` in MITxOnline to course run's end date.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/34372316/224320413-77205b39-f269-462a-97c4-c8041f633789.png">


<img width="812" alt="image" src="https://user-images.githubusercontent.com/34372316/224320675-e97b6fbb-ffe9-4b46-a1c3-a6d944c683ae.png">
