### PR TITLE
fix: retry_failed_edx_enrollments should check for existing enrollments (permission fix)

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -539,7 +539,7 @@ def existing_edx_enrollment(user, course_id, mode):
         (edx_api.enrollments.models.Enrollment or None):
             The results of enrollments via the edx API client
     """
-    edx_client = get_edx_api_client(user)
+    edx_client = get_edx_api_service_client()
     edx_enrollments = edx_client.enrollments.get_enrollments(
         course_id=course_id, usernames=[user.username]
     )

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -384,6 +384,7 @@ def test_enroll_in_edx_course_runs(mocker, user):
         side_effect=enroll_return_values
     )
     mocker.patch("openedx.api.get_edx_api_client", return_value=mock_client)
+    mocker.patch("openedx.api.get_edx_api_service_client", return_value=mock_client)
     course_runs = CourseRunFactory.build_batch(2)
     enroll_results = enroll_in_edx_course_runs(user, course_runs)
     mock_client.enrollments.create_student_enrollment.assert_any_call(
@@ -411,6 +412,7 @@ def test_enroll_api_fail(mocker, user):
         side_effect=HTTPError(response=enrollment_response)
     )
     mocker.patch("openedx.api.get_edx_api_client", return_value=mock_client)
+    mocker.patch("openedx.api.get_edx_api_service_client", return_value=mock_client)
     course_run = CourseRunFactory.build()
 
     with pytest.raises(EdxApiEnrollErrorException):


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1445 #1458

#### What's this PR do?

- Fixes permission error on checking the enrollment `code: 403, content: {"developer_message":"You do not have permission to perform this action."}`

#### How should this be manually tested?
1. Add the mitxonline user's course enrollment record in edx and mitxonline, but the mitxonline record has to be `Edx enrolled` equal to `false`.  
2. Add edx course mode expiry before any call to `retry_failed_edx_enrollments()`.
3. Validate that no more `EdxApiEnrollErrorException` exception is raised for this case after this PR
4. And `Edx enrolled` will be changed to `true`