### PR TITLE
Course page 500 error for expired course runs and flex price

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -905,8 +905,12 @@ class CoursePage(ProductPage):
         Returns:
             None, or a tuple of the original price and the discount to apply
         """
-        if is_courseware_flexible_price_approved(self.product, request.user):
-            ecommerce_product = self.product.active_products.first()
+        ecommerce_product = self.product.active_products
+        if (
+            is_courseware_flexible_price_approved(self.product, request.user)
+            and ecommerce_product
+        ):
+            ecommerce_product = ecommerce_product.first()
 
             discount = determine_courseware_flexible_price_discount(
                 ecommerce_product, request.user

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -571,12 +571,12 @@ def test_get_current_finaid_with_flex_price_for_expired_course_run(mocker):
     rf = RequestFactory()
     request = rf.get("/")
     request.user = UserFactory.create()
-    discount = DiscountFactory.create()
-    mocker.patch(
-        "flexiblepricing.api.is_courseware_flexible_price_approved", return_value=True
+    patched_flexible_price_approved = mocker.patch(
+        "flexiblepricing.api.is_courseware_flexible_price_approved"
     )
-    mocker.patch(
-        "flexiblepricing.api.determine_courseware_flexible_price_discount",
-        return_value=discount,
+    patched_flexible_price_discount = mocker.patch(
+        "flexiblepricing.api.determine_courseware_flexible_price_discount"
     )
     assert course_run.course.page.get_current_finaid(request) is None
+    patched_flexible_price_discount.assert_not_called()
+    patched_flexible_price_approved.assert_not_called()

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1,6 +1,7 @@
 """Tests for Wagtail models"""
 import json
 from urllib.parse import quote_plus
+from datetime import timedelta
 
 import factory
 import pytest
@@ -10,6 +11,7 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.test.client import RequestFactory
 from django.urls import resolve
 from mitol.common.factories import UserFactory
+from mitol.common.utils.datetime import now_in_utc
 
 from cms.constants import CMS_EDITORS_GROUP_NAME
 from cms.factories import (
@@ -34,7 +36,7 @@ from courses.factories import (
 )
 from courses.models import CourseRun, limit_to_certificate_pages
 from ecommerce.constants import DISCOUNT_TYPE_FIXED_PRICE
-from ecommerce.factories import ProductFactory
+from ecommerce.factories import DiscountFactory, ProductFactory
 from flexiblepricing.api import determine_courseware_flexible_price_discount
 from flexiblepricing.constants import FlexiblePriceStatus
 from flexiblepricing.factories import FlexiblePriceFactory, FlexiblePriceTierFactory
@@ -556,3 +558,25 @@ def test_courseware_title_synced_with_product_page_title(test_course):
     )
 
     assert courseware.title == updated_title
+
+
+def test_get_current_finaid_with_flex_price_for_expired_course_run(mocker):
+    """
+    Tests that get_current_finaid returns None for a user approved for
+    financial aid on a course with only expired course runs.
+    """
+    now = now_in_utc()
+    course_run = CourseRunFactory.create(enrollment_end=now - timedelta(days=10))
+    ProductFactory.create(purchasable_object=course_run)
+    rf = RequestFactory()
+    request = rf.get("/")
+    request.user = UserFactory.create()
+    discount = DiscountFactory.create()
+    mocker.patch(
+        "flexiblepricing.api.is_courseware_flexible_price_approved", return_value=True
+    )
+    mocker.patch(
+        "flexiblepricing.api.determine_courseware_flexible_price_discount",
+        return_value=discount,
+    )
+    assert course_run.course.page.get_current_finaid(request) is None

--- a/courses/models.py
+++ b/courses/models.py
@@ -325,7 +325,9 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
         """
         relevant_run = self.first_unexpired_run
 
-        return relevant_run.products.filter(is_active=True).all()
+        return (
+            relevant_run.products.filter(is_active=True).all() if relevant_run else None
+        )
 
     @property
     def is_catalog_visible(self):

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -6,6 +6,7 @@ import factory
 import pytest
 from django.core.exceptions import ValidationError
 from mitol.common.utils.datetime import now_in_utc
+from ecommerce.factories import ProductFactory
 from wagtail.core.models import Page
 
 from cms.factories import (
@@ -961,3 +962,12 @@ def test_certificate_choice_limits():
     assert program_certificate_page.id in choices["page_id__in"]
 
     assert len(choices["page_id__in"]) != Page.objects.count()
+
+
+def test_active_products_for_expired_course_run():
+    """No products should be returned if there are no active course runs for the course."""
+    now = now_in_utc()
+    course_run = CourseRunFactory.create(enrollment_end=now - timedelta(days=10))
+    ProductFactory.create(purchasable_object=course_run)
+
+    assert course_run.course.active_products is None


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1483

#### What's this PR do?
Resolves an error that is thrown when a user visits a course page and meets the following requirements:

1. The associated course has no active course runs.
2. The user has an approved flexible price request for the associated course

#### How should this be manually tested?

1. Create a course, a course run with an enrollment end date in the past, course CMS page, flexible pricing page, product, discounts, flexible price tiers, and approved flexible pricing request for your user.
2. Visit the course page and ensure that no errors are thrown.
3. To ensure that you have everything configured correctly, I would recommend recreating the error using the main branch of mitxonline.

