### PR TITLE
Adjust discount redemption checks to only consider orders in Fulfilled state for validity

### DIFF
--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -567,7 +567,7 @@ def test_check_and_process_pending_orders_for_resolution(mocker, test_type):
 
 
 @pytest.mark.parametrize("peruser", [True, False])
-def test_duplicate_redemption_check(caplog, peruser):
+def test_duplicate_redemption_check(peruser):
     """
     Tests the check for multiple discount redemptions. Set peruser to test a
     one-time-per-user discount.
@@ -575,7 +575,7 @@ def test_duplicate_redemption_check(caplog, peruser):
 
     def make_stuff(user, discount):
         """Helper function to DRY out the rest of the test"""
-        order = OrderFactory.create(purchaser=user)
+        order = OrderFactory.create(purchaser=user, state=Order.STATE.FULFILLED)
         redemption = DiscountRedemptionFactory.create(
             redeemed_by=user, redeemed_discount=discount, redeemed_order=order
         )

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1,5 +1,6 @@
 """Tests for Ecommerce api"""
 
+import logging
 import random
 import uuid
 from datetime import datetime
@@ -16,13 +17,17 @@ from reversion.models import Version
 from courses.factories import CourseRunEnrollmentFactory
 from ecommerce.api import (
     check_and_process_pending_orders_for_resolution,
+    check_for_duplicate_discount_redemptions,
     process_cybersource_payment_response,
     refund_order,
     unenroll_learner_from_order,
 )
 from ecommerce.constants import TRANSACTION_TYPE_PAYMENT, TRANSACTION_TYPE_REFUND
 from ecommerce.factories import (
+    DiscountRedemptionFactory,
     LineFactory,
+    OneTimeDiscountFactory,
+    OneTimePerUserDiscountFactory,
     OrderFactory,
     ProductFactory,
     TransactionFactory,
@@ -559,3 +564,38 @@ def test_check_and_process_pending_orders_for_resolution(mocker, test_type):
         order.refresh_from_db()
         assert order.state == Order.STATE.FULFILLED
         assert (fulfilled, cancelled, errored) == (1, 0, 0)
+
+
+@pytest.mark.parametrize("peruser", [True, False])
+def test_duplicate_redemption_check(caplog, peruser):
+    """
+    Tests the check for multiple discount redemptions. Set peruser to test a
+    one-time-per-user discount.
+    """
+
+    def make_stuff(user, discount):
+        """Helper function to DRY out the rest of the test"""
+        order = OrderFactory.create(purchaser=user)
+        redemption = DiscountRedemptionFactory.create(
+            redeemed_by=user, redeemed_discount=discount, redeemed_order=order
+        )
+
+        return (order, redemption)
+
+    discount = (
+        OneTimePerUserDiscountFactory.create()
+        if peruser
+        else OneTimeDiscountFactory.create()
+    )
+
+    user = UserFactory.create()
+    first_redemption = make_stuff(user, discount)
+
+    if not peruser:
+        user = UserFactory.create()
+
+    second_redemption = make_stuff(user, discount)
+
+    seen_ids = check_for_duplicate_discount_redemptions()
+
+    assert discount.id in seen_ids

--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -13,6 +13,7 @@ from ecommerce.constants import (
     REDEMPTION_TYPE_ONE_TIME_PER_USER,
     REDEMPTION_TYPE_UNLIMITED,
 )
+from main.utils import now_datetime_with_tz
 from users.factories import UserFactory
 
 FAKE = faker.Factory.create()
@@ -132,6 +133,7 @@ class DiscountRedemptionFactory(DjangoModelFactory):
     redeemed_by = SubFactory(UserFactory)
     redeemed_discount = SubFactory(DiscountFactory)
     redeemed_order = SubFactory(OrderFactory)
+    redemption_date = now_datetime_with_tz()
 
     class Meta:
         model = models.DiscountRedemption

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -535,39 +535,6 @@ class FulfillableOrder:
             amount=self.total_price_paid,
         )
 
-        # If the order has discounts, those discounts are one-time use, and they
-        # have been redeemed more than once, emit a log error so we're aware of
-        # it. (Discounts are only consumed by fulfilled orders, so there's the
-        # potential that the discount can be used by two orders if neither were
-        # fulfilled at the time.)
-
-        if self.discounts.count() > 0:
-            for redemption in self.discounts.all():
-                if (
-                    redemption.redeemed_discount.discount_type
-                    == REDEMPTION_TYPE_ONE_TIME
-                    and redemption.redeemed_discount.order_redemptions.filter(
-                        redeemed_order__state=Order.STATE.FULFILLED
-                    ).count()
-                    > 1
-                ):
-                    log.error(
-                        f"Warning: discount code {redemption.redeemed_discount.discount_code} is a one-time discount that's been redeemed more than once"
-                    )
-
-                if (
-                    redemption.redeemed_discount.discount_type
-                    == REDEMPTION_TYPE_ONE_TIME_PER_USER
-                    and redemption.redeemed_discount.order_redemptions.filter(
-                        redeemed_order__state=Order.STATE.FULFILLED,
-                        redeemed_by=self.purchaser,
-                    ).count()
-                    > 1
-                ):
-                    log.error(
-                        f"Warning: discount code {redemption.redeemed_discount.discount_code} is a one-time per-user discount that's been redeemed more than once"
-                    )
-
     def create_paid_courseruns(self):
         for run in self.purchased_runs:
             PaidCourseRun.objects.get_or_create(

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -82,7 +82,7 @@ def basket():
 
 def perform_discount_redemption(user, discount):
     """Redeems a discount."""
-    order = Order(purchaser=user, total_price_paid=10)
+    order = Order(purchaser=user, state=Order.STATE.FULFILLED, total_price_paid=10)
     order.save()
 
     redemption = DiscountRedemption(

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -52,3 +52,10 @@ def process_pending_order_resolutions():
     from ecommerce.api import check_and_process_pending_orders_for_resolution
 
     check_and_process_pending_orders_for_resolution()
+
+
+@app.task(acks_late=True)
+def perform_check_for_duplicate_discount_redemptions():
+    from ecommerce.api import check_for_duplicate_discount_redemptions
+
+    check_for_duplicate_discount_redemptions()

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -427,6 +427,9 @@ class CheckoutApiViewSet(ViewSet):
                 raise ObjectDoesNotExist()
 
             if not discount.check_validity(request.user):
+                log.error(
+                    f"Discount code {request.data['discount']} has already been redeemed"
+                )
                 raise ObjectDoesNotExist()
         except ObjectDoesNotExist:
             return Response(

--- a/main/utils.py
+++ b/main/utils.py
@@ -1,5 +1,6 @@
 """mitx_online utilities"""
 import json
+from datetime import datetime
 from decimal import Decimal
 from enum import Flag, auto
 from typing import Set, Tuple, TypeVar, Union
@@ -191,3 +192,9 @@ def parse_supplied_date(datearg):
 def format_decimal(amount: Decimal):
     """Return a Decimal as a formatted string with 2 decimal places"""
     return f"{amount:0.2f}"
+
+
+def now_datetime_with_tz():
+    """Return now with the configured timezone."""
+
+    return datetime.now(tz=pytz.timezone(settings.TIME_ZONE))


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1485 

#### What's this PR do?

Updates the discount validity check to only consider the discount to be consumed if the redemption is for a Fulfilled order. Previously, this would consider all discount redemptions to have consumed the discount, so if the learner's payment attempt fails or never completes (iow, the state remains Pending or changes to Declined or Canceled or Refunded), the learner couldn't reuse their code.

There is an edge case where a one-time code can be redeemed more than once successfully. The learner(s) would have to have entered the code and started the checkout process at the same time (as once any order hits Fulfilled the code would be consumed and the system would error). There's a check for this that's present in the ecommerce API and a task defined but it's not set up to run on a scheduled basis in this PR. (I don't expect this to be a common case - it only applies to one-time and one-time-per-user discounts and for this to be a problem the code would have either had to been provided to more than one person accidentally or the learner would have had to pay for the course twice.) 

#### How should this be manually tested?

1. Generate a one-time or one-time-per-user code 
2. Attempt to purchase a course, using the code. Do not complete the CyberSource portion of the workflow - either abandon the cart there or hit Cancel or force-deny the order through a Django shell. 
3. Check to make sure there's a discount redemption for the order and that the order isn't in Fulfilled state.
4. Attempt to purchase a course again using the code. You should be allowed to do so.
5. Complete the purchase normally.
6. Check to make sure there's a redemption and that the order is in Fulfilled state.
7. Attempt again to use the code - you should see the normal "Discount code is invalid" message.

To test the duplicate submission check:

In two separate browser sessions (or one session and an Incognito window or something), create a cart with a course in it and apply the same one-time (or one-time-per-user) discount to each cart. Click "Place your order" on both carts. Once both sessions are in CyberSource, complete each order. (Timing is somewhat important - if you complete one order with the code, when you go to continue through to CyberSource in the other you'll get an error message saying your code's invalid because it re-checks when it converts your basket to an order.) You should be able to complete the ordering process for both, and you should be able to see in Django Admin or equivalent that the discount has been redeemed twice. 

Then, open a Django shell and run:
```
from ecommerce.api import check_for_duplicate_discount_redemptions
check_for_duplicate_discount_redemptions()
```
This should emit some error logs, which should be reflected in Sentry (if you have that set up). 

