### PR TITLE
Resolve local enrollments found without matching edx enrollment

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -526,7 +526,7 @@ def get_edx_grades_with_users(course_run, user=None):
                 yield edx_grade, user
 
 
-def existing_edx_enrollment(user, course_id, mode):
+def existing_edx_enrollment(user, course_id, mode, is_active=True):
     """
     Returns enrollment object if user is already enrolled in edx course run.
 
@@ -534,6 +534,7 @@ def existing_edx_enrollment(user, course_id, mode):
         user (users.models.User): The user to enroll
         courseware_id : The course runs to enroll in
         mode (str): The course mode to enroll the user with
+        is_active (boolean): Whether the expected course run enrollment is active.
 
     Returns:
         (edx_api.enrollments.models.Enrollment or None):
@@ -544,7 +545,7 @@ def existing_edx_enrollment(user, course_id, mode):
         course_id=course_id, usernames=[user.username]
     )
     for enrollment in edx_enrollments:
-        if enrollment.mode == mode:
+        if enrollment.mode == mode and enrollment.is_active == is_active:
             return enrollment
     return None
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/934
https://github.com/mitodl/hq/issues/498

#### What's this PR do?
Adds logic to match the `is_active` value when checking Edx for existing course enrollments.  Previously, we would assume that an enrollment already exists in Edx even if the `is_active` value for that Edx enrollment was `False`.  This meant that we would not send a `POST` request to Edx to update the existing enrollment which lead to user's having an active enrollment in mitxonline and an inactive enrollment in Edx.

#### How should this be manually tested?
- Have both mitxonline and devstack running locally.
- Have a course configured in mitxonline (using the quick start commands).
- Ensure that you have followed the instructions here: https://github.com/mitodl/mitxonline/blob/main/docs/source/configuration/open_edx.rst
- Enroll in a course, then unenroll from the course.
- Verify that the enrollment records in both mitxonline and Edx are both inactive.
- Re-enroll into the same course.
- Verify that the enrollment records in both mitxonline and Edx are both active.
- Visit the course in Edx by clicking on the course title shown on the course page in mitxonline.
- Verify that Edx shows that you are enrolled.  You should not see any buttons that would enroll you into the course.
- I would also perform a negative test with the current main branch of mitxonline.  After re-enrolling in the course, verify that the mitxonline course run enrollment record is active and the enrollment record in Edx is inactive.
