### PR TITLE
Removing unnecessary alt texts from images

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -62,7 +62,7 @@
                     </div>
                     <span class="institute-text">Massachusetts Institute of Technology</span>
                     <div class="institute-logo">
-                        <img src="{% static 'images/certificates/certificate-logo.png' %}" alt="MIT">
+                        <img src="{% static 'images/certificates/certificate-logo.png' %}" alt="">
                     </div>
                     <span class="certify-text">This is to certify that</span>
                     <span class="certify-name">{{ learner_name }}</span>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -31,7 +31,7 @@
               >
               </video-js>
               {% else %}
-              <img src="{% feature_img_src page.feature_image %}" alt="{{ page.title }}">
+              <img src="{% feature_img_src page.feature_image %}" alt="">
               {% endif %}
             </div>
           </div>
@@ -91,7 +91,7 @@
                   </a>
                 </strong>
               </div>
-            </div>  
+            </div>
             {% endif %}
             {% if not finaid_price and page.price %}
             <div class="stat-col small">
@@ -105,7 +105,7 @@
                   {% endif %}
                 </strong>
               </div>
-            </div>  
+            </div>
             {% endif %}
           </div>
         </div>

--- a/frontend/public/src/components/CartItemCard.js
+++ b/frontend/public/src/components/CartItemCard.js
@@ -48,7 +48,7 @@ export class CartItemCard extends React.Component<Props> {
     const startDateDescription = generateStartDateText(purchasableObject)
     const courseImage =
       course !== undefined && course.page !== null ? (
-        <img src={course.page.feature_image_src} alt={course.title} />
+        <img src={course.page.feature_image_src} alt="" />
       ) : null
     const cardKey = `cartsummarycard_${product.id}`
 

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -467,10 +467,7 @@ export class EnrolledItemCard extends React.Component<
           {enrollment.run.course.feature_image_src && (
             <div className="col-12 col-md-auto px-0 px-md-3">
               <div className="img-container">
-                <img
-                  src={enrollment.run.course.feature_image_src}
-                  alt=""
-                />
+                <img src={enrollment.run.course.feature_image_src} alt="" />
               </div>
             </div>
           )}
@@ -479,10 +476,7 @@ export class EnrolledItemCard extends React.Component<
             enrollment.run.page.feature_image_src && (
             <div className="col-12 col-md-auto px-0 px-md-3">
               <div className="img-container">
-                <img
-                  src={enrollment.run.page.feature_image_src}
-                  alt=""
-                />
+                <img src={enrollment.run.page.feature_image_src} alt="" />
               </div>
             </div>
           )}

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -469,7 +469,7 @@ export class EnrolledItemCard extends React.Component<
               <div className="img-container">
                 <img
                   src={enrollment.run.course.feature_image_src}
-                  alt="Preview image"
+                  alt=""
                 />
               </div>
             </div>
@@ -481,7 +481,7 @@ export class EnrolledItemCard extends React.Component<
               <div className="img-container">
                 <img
                   src={enrollment.run.page.feature_image_src}
-                  alt="Preview image"
+                  alt=""
                 />
               </div>
             </div>
@@ -603,7 +603,7 @@ export class EnrolledItemCard extends React.Component<
         <div className="row flex-grow-1">
           <div className="col-12 col-md-auto px-0 px-md-3">
             <div className="img-container">
-              <img src="/static/images/mit-dome.png" alt="Preview image" />
+              <img src="/static/images/mit-dome.png" alt="" />
             </div>
           </div>
 

--- a/frontend/public/src/components/ProgramCourseInfoCard.js
+++ b/frontend/public/src/components/ProgramCourseInfoCard.js
@@ -36,7 +36,7 @@ export class ProgramCourseInfoCard extends React.Component<ProgramCourseInfoCard
       featuredImage = (
         <div className="col-12 col-md-auto px-0 px-md-3">
           <div className="img-container">
-            <img src={course.feature_image_src} alt="Preview image" />
+            <img src={course.feature_image_src} alt="" />
           </div>
         </div>
       )


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested

#### What are the relevant tickets?

Closes mitodl/hq#653
Closes mitodl/hq#659

#### What's this PR do?

Removes the alt text from the course images in these locations:
- Course detail page (was course title)
- Cart page (was course title)
- Dashboard (was "Preview image")

It does not remove the alt text from the featured item cards on the homepage as they were already an empty string.

Removes the alt text from the MIT logo on the certificate page. 

#### How should this be manually tested?

Load any of the pages in question: course detail page, cart, dashboard, or certificate. The affected images should have an empty string as the alt text and screen readers should not attempt to describe the image.
