### PR TITLE
703: accessibility improvements for dashboard and program drawer

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -672,6 +672,7 @@ export class EnrolledItemCard extends React.Component<
                   href="#program_enrollment_drawer"
                   aria-flowto="program_enrollment_drawer"
                   aria-haspopup="dialog"
+                  aria-label="Program's courses"
                   onClick={() => this.toggleProgramInfo()}
                 >
                   {courseCount} course

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -221,7 +221,10 @@ export class DashboardPage extends React.Component<
 
     return (
       <DocumentTitle title={`${SETTINGS.site_name} | ${DASHBOARD_PAGE_TITLE}`}>
-        <div className="std-page-body dashboard container">
+        <div
+          className="std-page-body dashboard container"
+          aria-hidden={this.state.programDrawerVisibility}
+        >
           <Loader isLoading={isLoading}>
             <nav className="tabs" aria-controls="enrollment-items">
               {programEnrollmentsLength === 0 ? (


### PR DESCRIPTION

#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/703

#### What's this PR do?

1. Link to the program drawer on the dashboard, program tab, program card should read "Program's courses" through a screen reader instead of "2 courses".  
2. Tab navigation should be trapped to the program drawer when it's displayed.  
3. When opening the program drawer, screen readers should pronounce the program title.  Some readers will pronounce a description which would be "X courses, Y passed" where X and Y are the number of courses and those passed, respectively.   In order to verify this, you may need to view the "accessibility" tab in the Google Chrome developer tools.
4. The first element of focus in the program drawer should be the "X" close button in the top left.

#### How should this be manually tested?

1. Have mitxonline up and running with a course and associated program.  Enroll your user into the course.
2. Navigate to http://mitxonline.odl.local:8013/dashboard/?enable_programs&enable_lr#program_enrollment_drawer
3. Verify the statements under "What's this PR do?", above.

I tested this using Chrome and Voiceover.

