### PR TITLE
1104: Perform validation on year of birth field during registration

### DIFF
--- a/frontend/public/src/components/forms/RegisterDetailsForm.js
+++ b/frontend/public/src/components/forms/RegisterDetailsForm.js
@@ -27,7 +27,7 @@ const INITIAL_VALUES = {
     state:      ""
   },
   user_profile: {
-    year_of_birth: "",
+    year_of_birth: ""
   }
 }
 

--- a/frontend/public/src/components/forms/RegisterDetailsForm.js
+++ b/frontend/public/src/components/forms/RegisterDetailsForm.js
@@ -25,6 +25,9 @@ const INITIAL_VALUES = {
     last_name:  "",
     country:    "",
     state:      ""
+  },
+  user_profile: {
+    year_of_birth: "",
   }
 }
 
@@ -35,6 +38,8 @@ const RegisterDetailsForm = ({ onSubmit, countries }: Props) => (
       .concat(newAccountValidation)
       .concat(profileValidation)}
     initialValues={INITIAL_VALUES}
+    validateOnChange={false}
+    validateOnBlur={false}
     render={({ isSubmitting, setFieldValue, setFieldTouched, values }) => (
       <Form>
         <LegalAddressFields

--- a/frontend/public/src/components/forms/RegisterDetailsForm_test.js
+++ b/frontend/public/src/components/forms/RegisterDetailsForm_test.js
@@ -74,7 +74,7 @@ describe("RegisterDetailsForm", () => {
 
       const input = wrapper.find(`input[name="${name}"]`)
       input.simulate("change", { persist: () => {}, target: { name, value } })
-      input.simulate("blur")
+      wrapper.simulate("submit")
       await wait()
       wrapper.update()
       assert.deepEqual(
@@ -137,7 +137,7 @@ describe("RegisterDetailsForm", () => {
             persist: () => {},
             target:  { name: fieldName, value: value }
           })
-          field.simulate("blur")
+          wrapper.simulate("submit")
           await wait()
           wrapper.update()
           assert.deepEqual(
@@ -178,7 +178,7 @@ describe("RegisterDetailsForm", () => {
             persist: () => {},
             target:  { name: fieldName, value: value }
           })
-          field.simulate("blur")
+          wrapper.simulate("submit")
           await wait()
           wrapper.update()
           assert.deepEqual(

--- a/frontend/public/src/components/forms/RegisterDetailsForm_test.js
+++ b/frontend/public/src/components/forms/RegisterDetailsForm_test.js
@@ -65,8 +65,7 @@ describe("RegisterDetailsForm", () => {
     ],
     ["username", "ábc-dèf-123", ""],
     ["legal_address.first_name", "", "First Name is a required field"],
-    ["legal_address.last_name", "", "Last Name is a required field"],
-    ["user_profile.year_of_birth", "", "Year of Birth is a required field"]
+    ["legal_address.last_name", "", "Last Name is a required field"]
   ].forEach(([name, value, errorMessage]) => {
     it(`validates the field name=${name}, value=${JSON.stringify(
       value

--- a/frontend/public/src/components/forms/RegisterDetailsForm_test.js
+++ b/frontend/public/src/components/forms/RegisterDetailsForm_test.js
@@ -65,7 +65,8 @@ describe("RegisterDetailsForm", () => {
     ],
     ["username", "ábc-dèf-123", ""],
     ["legal_address.first_name", "", "First Name is a required field"],
-    ["legal_address.last_name", "", "Last Name is a required field"]
+    ["legal_address.last_name", "", "Last Name is a required field"],
+    ["user_profile.year_of_birth", "", "Year of Birth is a required field"]
   ].forEach(([name, value, errorMessage]) => {
     it(`validates the field name=${name}, value=${JSON.stringify(
       value
@@ -73,6 +74,26 @@ describe("RegisterDetailsForm", () => {
       const wrapper = renderForm()
 
       const input = wrapper.find(`input[name="${name}"]`)
+      input.simulate("change", { persist: () => {}, target: { name, value } })
+      wrapper.simulate("submit")
+      await wait()
+      wrapper.update()
+      assert.deepEqual(
+        findFormikErrorByName(wrapper, name).text(),
+        errorMessage
+      )
+    })
+  })
+  ;[
+    ["legal_address.country", "", "Country is a required field"],
+    ["user_profile.year_of_birth", "", "Year of Birth is a required field"]
+  ].forEach(([name, value, errorMessage]) => {
+    it(`validates the field name=${name}, value=${JSON.stringify(
+      value
+    )} and expects error=${JSON.stringify(errorMessage)}`, async () => {
+      const wrapper = renderForm()
+
+      const input = wrapper.find(`select[name="${name}"]`)
       input.simulate("change", { persist: () => {}, target: { name, value } })
       wrapper.simulate("submit")
       await wait()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1104

#### What's this PR do?
Updates the registration form to:

1. Display an error message if the user does not input a year of birth.
2. Perform validations only when the user submits the form.  Not when the user tabs between fields.

#### How should this be manually tested?

- Start the registration process within mitxonline.
- Press tab to move through the registration form.  Verify that no error messages are displayed.  Error messages should only display after you hit the submit button.
- When asked for your year of birth, enter nothing.  Hitting submit on the form should then present the error message "Year of Birth is a required field".
