### PR TITLE
1508: screen readers should not pronounce * ("star") for labels

### DIFF
--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -19,14 +19,16 @@
             <form action="{% pageurl page %}" method="POST">
               {% csrf_token %}
               <div class="form-group">
-                <label for="your_income" id="your_income_label">Yearly Income{%if form.fields.your_income.required %}<span class="required">*</span>{% endif %}</label>
+                <label for="your_income" id="your_income_label">Yearly Income</label>
+                {%if form.fields.your_income.required %}<span class="required">*</span>{% endif %}
                 <input type="number" name="your_income" step="any" class="form-control {%if form.your_income.errors %}errored{% endif %}" id="your_income" aria-describedby="your_incomeError">
                 {% for error in form.your_income.errors %}
                   <div class="form-error" id="your_incomeError" role="alert">{{error}}</div>
                 {% endfor %}
               </div>
               <div class="form-group">
-                <label for="income_currency">Income Currency{%if form.fields.income_currency.required %}<span class="required">*</span>{% endif %}</label>
+                <label for="income_currency">Income Currency</label>
+                {%if form.fields.income_currency.required %}<span class="required">*</span>{% endif %}
                 <span class="income_currency_label">The currency you’re paid in.</span>
                 <select name="income_currency" id="income_currency" class="form-control {%if form.income_currency.errors %}errored{% endif %}">
                   <option value="">Choose</option>
@@ -39,8 +41,8 @@
                 {% endfor %}
               </div>
               <div class="form-group">
-                <input id="" type="checkbox" required="required" />
-                <span class="financial-assist-testify">I testify that the income I reported is true and accurate. I am aware that I may be asked to verify the reported income with documentation.</span>
+                <input id="" type="checkbox" required="required" aria-describedby="financial-assist-testify"/>
+                <span id="financial-assist-testify" class="financial-assist-testify">I testify that the income I reported is true and accurate. I am aware that I may be asked to verify the reported income with documentation.</span>
               </div>
               <div class="row submit-row no-gutters justify-content-center">
                 <button type="submit" class="btn btn-primary btn-gradient-red large">Submit request</button>

--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -21,7 +21,7 @@
               <div class="form-group">
                 <label for="your_income" id="your_income_label">Yearly Income</label>
                 {%if form.fields.your_income.required %}<span class="required">*</span>{% endif %}
-                <input type="number" name="your_income" step="any" class="form-control {%if form.your_income.errors %}errored{% endif %}" id="your_income" aria-describedby="your_incomeError">
+                <input type="number" name="your_income" step="any" class="form-control {%if form.your_income.errors %}errored{% endif %}" id="your_income" aria-describedby="your_incomeError" required>
                 {% for error in form.your_income.errors %}
                   <div class="form-error" id="your_incomeError" role="alert">{{error}}</div>
                 {% endfor %}
@@ -29,8 +29,8 @@
               <div class="form-group">
                 <label for="income_currency">Income Currency</label>
                 {%if form.fields.income_currency.required %}<span class="required">*</span>{% endif %}
-                <span class="income_currency_label">The currency you’re paid in.</span>
-                <select name="income_currency" id="income_currency" class="form-control {%if form.income_currency.errors %}errored{% endif %}">
+                <span class="income_currency_label" id="income-currency-subtitle">The currency you’re paid in.</span>
+                <select name="income_currency" id="income_currency" class="form-control {%if form.income_currency.errors %}errored{% endif %}" aria-describedby="income-currency-subtitle" required>
                   <option value="">Choose</option>
                   {% for choice in form.fields.income_currency.choices %}
                     <option value="{{ choice.0 }}">{{ choice.1 }}</option>
@@ -41,7 +41,7 @@
                 {% endfor %}
               </div>
               <div class="form-group">
-                <input id="" type="checkbox" required="required" aria-describedby="financial-assist-testify"/>
+                <input id="" type="checkbox" required aria-label="financial assistance attestation" aria-describedby="financial-assist-testify"/>
                 <span id="financial-assist-testify" class="financial-assist-testify">I testify that the income I reported is true and accurate. I am aware that I may be asked to verify the reported income with documentation.</span>
               </div>
               <div class="row submit-row no-gutters justify-content-center">

--- a/frontend/public/scss/auth.scss
+++ b/frontend/public/scss/auth.scss
@@ -198,10 +198,10 @@
       color: $label-subtitle;
       font-size: 14px;
     }
+  }
 
-    .required {
-      color: $brand-button-bg;
-    }
+  .required {
+    color: $brand-button-bg;
   }
 
   .label-secondary {

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -389,6 +389,10 @@
 
   .modal-content {
     padding: 5px 12px;
+    
+    .required {
+      color: $brand-button-bg;
+    }
   }
 
   .modal-header {

--- a/frontend/public/src/components/forms/ChangeEmailForm.js
+++ b/frontend/public/src/components/forms/ChangeEmailForm.js
@@ -43,9 +43,8 @@ const ChangeEmailForm = ({ onSubmit, user }: Props) => (
         <section className="email-section">
           <h4>Change Email</h4>
           <div className="form-group">
-            <label htmlFor="email">
-              Email<span className="required">*</span>
-            </label>
+            <label htmlFor="email">Email</label>
+            <span className="required">*</span>
             <Field
               name="email"
               id="email"
@@ -70,6 +69,7 @@ const ChangeEmailForm = ({ onSubmit, user }: Props) => (
               className="form-control"
               component={PasswordInput}
               aria-describedby="confirmPasswordError"
+              aria-label="Confirm Password"
             />
             <ErrorMessage
               name="confirmPassword"

--- a/frontend/public/src/components/forms/ChangePasswordForm.js
+++ b/frontend/public/src/components/forms/ChangePasswordForm.js
@@ -31,9 +31,8 @@ const ChangePasswordForm = ({ onSubmit }: Props) => (
         <section className="email-section">
           <h4>Change Password</h4>
           <div className="form-group">
-            <label htmlFor="oldPassword">
-              Old Password<span className="required">*</span>
-            </label>
+            <label htmlFor="oldPassword">Old Password</label>
+            <span className="required">*</span>
             <Field
               name="oldPassword"
               id="oldPassword"
@@ -48,9 +47,8 @@ const ChangePasswordForm = ({ onSubmit }: Props) => (
             />
           </div>
           <div className="form-group">
-            <label htmlFor="newPassword">
-              New Password<span className="required">*</span>
-            </label>
+            <label htmlFor="newPassword">New Password</label>
+            <span className="required">*</span>
             <Field
               name="newPassword"
               id="newPassword"
@@ -65,9 +63,8 @@ const ChangePasswordForm = ({ onSubmit }: Props) => (
             />
           </div>
           <div className="form-group">
-            <label htmlFor="confirmPassword">
-              Confirm Password<span className="required">*</span>
-            </label>
+            <label htmlFor="confirmPassword">Confirm Password</label>
+            <span className="required">*</span>
             <Field
               name="confirmPassword"
               id="confirmPassword"

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -168,6 +168,37 @@ const findStates = (country: string, countries: Array<Country>) => {
     : null
 }
 
+const renderYearOfBirthField = () => {
+  return (
+    <div>
+      <label htmlFor="user_profile.year_of_birth" className="font-weight-bold">
+        Year of Birth
+      </label>
+      <span className="required">*</span>
+      <Field
+        component="select"
+        name="user_profile.year_of_birth"
+        id="user_profile.year_of_birth"
+        className="form-control"
+        aria-describedby="user_profile.year_of_birth_error"
+        required
+      >
+        <option value="f">-----</option>
+        {reverse(range(seedYear - 120, seedYear - 13)).map((year, i) => (
+          <option key={i} value={year}>
+            {year}
+          </option>
+        ))}
+      </Field>
+      <ErrorMessage
+        name="user_profile.year_of_birth"
+        id="user_profile.year_of_birth_error"
+        component={FormError}
+      />
+    </div>
+  )
+}
+
 export const LegalAddressFields = ({
   countries,
   isNewAccount,
@@ -179,7 +210,9 @@ export const LegalAddressFields = ({
         <div className="col-auto font-weight-bold">
           First Name<span className="required">*</span>
         </div>
-        <div className="col-auto subtitle">Name that will appear on emails</div>
+        <div id="first-name-subtitle" className="col-auto subtitle">
+          Name that will appear on emails
+        </div>
       </label>
       <Field
         type="text"
@@ -187,18 +220,17 @@ export const LegalAddressFields = ({
         id="legal_address.first_name"
         className="form-control"
         autoComplete="given-name"
-        aria-describedby="legal_address.first_name_error"
+        aria-describedby="first-name-subtitle"
+        aria-label="First Name"
+        required
       />
-      <ErrorMessage
-        name="legal_address.first_name"
-        id="legal_address.first_name_error"
-        component={FormError}
-      />
+      <ErrorMessage name="legal_address.first_name" component={FormError} />
     </div>
     <div className="form-group">
       <label htmlFor="legal_address.last_name" className="font-weight-bold">
-        Last Name<span className="required">*</span>
+        Last Name
       </label>
+      <span className="required">*</span>
       <Field
         type="text"
         name="legal_address.last_name"
@@ -206,6 +238,7 @@ export const LegalAddressFields = ({
         className="form-control"
         autoComplete="family-name"
         aria-describedby="legal_address.last_name_error"
+        required
       />
       <ErrorMessage
         name="legal_address.last_name"
@@ -218,7 +251,7 @@ export const LegalAddressFields = ({
         <div className="col-auto font-weight-bold">
           Full Name<span className="required">*</span>
         </div>
-        <div className="col-auto subtitle">
+        <div id="full-name-subtitle" className="col-auto subtitle">
           Name that will appear on your certificate
         </div>
       </label>
@@ -228,9 +261,11 @@ export const LegalAddressFields = ({
         id="name"
         className="form-control"
         autoComplete="name"
-        aria-describedby="nameError"
+        aria-describedby="full-name-subtitle"
+        aria-label="Full Name"
+        required
       />
-      <ErrorMessage name="name" id="nameError" component={FormError} />
+      <ErrorMessage name="name" component={FormError} />
     </div>
     {isNewAccount ? (
       <React.Fragment>
@@ -239,7 +274,8 @@ export const LegalAddressFields = ({
             <div className="col-auto font-weight-bold">
               Public Username<span className="required">*</span>
             </div>
-            <div className="col-auto subtitle">
+            <span className="required">*</span>
+            <div id="username-subtitle" className="col-auto subtitle">
               Name that will identify you in courses
             </div>
           </label>
@@ -249,31 +285,27 @@ export const LegalAddressFields = ({
             className="form-control"
             autoComplete="username"
             id="username"
-            aria-describedby="usernameError"
+            aria-describedby="username-subtitle"
+            aria-label="Public Username"
+            required
           />
-          <ErrorMessage
-            name="username"
-            id="usernameError"
-            component={FormError}
-          />
+          <ErrorMessage name="username" component={FormError} />
         </div>
         <div className="form-group">
           <label htmlFor="password" className="font-weight-bold">
-            Password<span className="required">*</span>
+            Password
           </label>
+          <span className="required">*</span>
           <Field
             type="password"
             name="password"
             id="password"
-            aria-describedby="passwordError"
+            aria-describedby="password-subtitle"
             className="form-control"
+            required
           />
-          <ErrorMessage
-            name="password"
-            id="passwordError"
-            component={FormError}
-          />
-          <div className="label-secondary">
+          <ErrorMessage name="password" component={FormError} />
+          <div id="password-subtitle" className="label-secondary">
             Passwords must contain at least 8 characters and at least 1 number
             and 1 letter.
           </div>
@@ -282,8 +314,9 @@ export const LegalAddressFields = ({
     ) : null}
     <div className="form-group">
       <label htmlFor="legal_address.country" className="font-weight-bold">
-        Country<span className="required">*</span>
+        Country
       </label>
+      <span className="required">*</span>
       <Field
         component="select"
         name="legal_address.country"
@@ -291,6 +324,7 @@ export const LegalAddressFields = ({
         className="form-control"
         autoComplete="country"
         aria-describedby="legal_address.country_error"
+        required
       >
         <option value="">-----</option>
         {countries
@@ -311,8 +345,9 @@ export const LegalAddressFields = ({
     {findStates(values.legal_address.country, countries) ? (
       <div className="form-group">
         <label htmlFor="legal_address.state" className="font-weight-bold">
-          State<span className="required">*</span>
+          State
         </label>
+        <span className="required">*</span>
         <Field
           component="select"
           name="legal_address.state"
@@ -320,6 +355,7 @@ export const LegalAddressFields = ({
           className="form-control"
           autoComplete="state"
           aria-describedby="legal_address.state_error"
+          required
         >
           <option value="">-----</option>
           {findStates(values.legal_address.country, countries)
@@ -340,33 +376,7 @@ export const LegalAddressFields = ({
       </div>
     ) : null}
     {isNewAccount ? (
-      <div className="form-group">
-        <label
-          htmlFor="user_profile.year_of_birth"
-          className="font-weight-bold"
-        >
-          Year of Birth<span className="required">*</span>
-        </label>
-        <Field
-          component="select"
-          name="user_profile.year_of_birth"
-          id="user_profile.year_of_birth"
-          className="form-control"
-          aria-describedby="user_profile.year_of_birth_error"
-        >
-          <option value="f">-----</option>
-          {reverse(range(seedYear - 120, seedYear - 13)).map((year, i) => (
-            <option key={i} value={year}>
-              {year}
-            </option>
-          ))}
-        </Field>
-        <ErrorMessage
-          name="user_profile.year_of_birth"
-          id="user_profile.year_of_birth_error"
-          component={FormError}
-        />
-      </div>
+      <div className="form-group">{renderYearOfBirthField()}</div>
     ) : null}
   </React.Fragment>
 )
@@ -400,33 +410,7 @@ export const ProfileFields = () => (
             component={FormError}
           />
         </div>
-        <div className="col">
-          <label
-            htmlFor="user_profile.year_of_birth"
-            className="font-weight-bold"
-          >
-            Year of Birth<span className="required">*</span>
-          </label>
-          <Field
-            component="select"
-            name="user_profile.year_of_birth"
-            id="user_profile.year_of_birth"
-            className="form-control"
-            aria-describedby="user_profile.year_of_birth_error"
-          >
-            <option value="">-----</option>
-            {reverse(range(seedYear - 120, seedYear - 13)).map((year, i) => (
-              <option key={i} value={year}>
-                {year}
-              </option>
-            ))}
-          </Field>
-          <ErrorMessage
-            name="user_profile.year_of_birth"
-            id="user_profile.year_of_birth_error"
-            component={FormError}
-          />
-        </div>
+        <div className="col">{renderYearOfBirthField()}</div>
       </div>
     </div>
   </React.Fragment>

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -274,7 +274,6 @@ export const LegalAddressFields = ({
             <div className="col-auto font-weight-bold">
               Public Username<span className="required">*</span>
             </div>
-            <span className="required">*</span>
             <div id="username-subtitle" className="col-auto subtitle">
               Name that will identify you in courses
             </div>

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -428,8 +428,9 @@ export const AddlProfileFields = ({
             htmlFor="user_profile.highest_education"
             className="font-weight-bold"
           >
-            Highest Level of Education{requireAddlFields ? "*" : ""}
+            Highest Level of Education
           </label>
+          {requireAddlFields ? <span className="required">*</span> : ""}
           <Field
             component="select"
             name="user_profile.highest_education"
@@ -453,8 +454,9 @@ export const AddlProfileFields = ({
     </div>
     <div className="form-group">
       <label htmlFor="user_profile.type_multi" className="font-weight-bold">
-        Are you a{requireAddlFields ? "*" : ""}
+        Are you a
       </label>
+      {requireAddlFields ? <span className="required">*</span> : ""}
       <div className="row">
         <div className="col-6">
           <div className="form-check">


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1508
https://github.com/mitodl/mitxonline/issues/1511

#### What's this PR do?

1. Updates the profile page, financial assistance form, additional details modal (shown when clicking on enrolled course title), change email form, change password form, register form; to not pronounce "star" when screen readers read the label for required fields.  
2. Required fields on the forms referenced in 1 are marked so that the screen reader will now pronounce "required".
3. Required fields on the forms referenced in 1 are set so the browser will no longer allow the form to be submitted if these fields are empty.
4. Refactors the year of birth field within `ProfileFormFields.js` to be reused in multiple places.
5. For the flexible price form, this PR uses the testify statement next to the checkbox for the `aria-describedby` reference so that users are informed what the checkbox is agreeing to.  This PR also adds "Financial assistance attestation" as the `aria-label`.
6. Makes sure the "*" are red on the additional details modal shown when a user clicks on the course title for an enrolled course.
7. For fields on the profile and financial assistance forms which have an associated subtitle/help text shown, this subtitle text is used for the `aria-describedby` in order to provide the description to screen reader users.  This replaces the error message for each respective field which was previously used for `aria-describedby`.

#### How should this be manually tested?

1. Have mitxonline up and running locally.  Prime it with enough data that you are able to access forms such as the financial assistance form and additional details modal form.  This can be accomplished with the quick start commands.
2. Visit the forms listed in 1 under "What's this PR do". 
3. Using a screen reader verify each item under "What's this PR do".
4. Verify that the "*" on the additional details modal are red as described in 6 under "What's this PR do".
5. Verify that all of the fields are displayed properly, along with the required "*" shown next to the labels.

**I tested this with Voiceover.  It's best to test this using a well regarded screen reader..**