### PR TITLE
fix: management command for deferring users with course mode

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -475,6 +475,7 @@ def defer_enrollment(
         user,
         [to_run],
         keep_failed_enrollments=keep_failed_enrollments,
+        mode=from_enrollment.enrollment_mode,
     )
     from_enrollment = deactivate_run_enrollment(
         from_enrollment,

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -688,6 +688,7 @@ def test_defer_enrollment(mocker, course, keep_failed_enrollments):
         existing_enrollment.user,
         [target_run],
         keep_failed_enrollments=keep_failed_enrollments,
+        mode=existing_enrollment.enrollment_mode,
     )
     patched_deactivate_enrollments.assert_called_once_with(
         existing_enrollment,

--- a/courses/management/utils.py
+++ b/courses/management/utils.py
@@ -22,12 +22,12 @@ def enrollment_summary(enrollment):
         str: A string representation of an enrollment
     """
     if isinstance(enrollment, ProgramEnrollment):
-        return "<ProgramEnrollment: id={}, program={}>".format(
-            enrollment.id, enrollment.program.text_id
+        return "<ProgramEnrollment: id={}, program={}, mode={}>".format(
+            enrollment.id, enrollment.program.text_id, enrollment.enrollment_mode
         )
     else:
-        return "<CourseRunEnrollment: id={}, run={}>".format(
-            enrollment.id, enrollment.run.text_id
+        return "<CourseRunEnrollment: id={}, run={}, mode={}>".format(
+            enrollment.id, enrollment.run.text_id, enrollment.enrollment_mode
         )
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
#1487 

#### What's this PR do?
This PR is a minor fix as per this [comment](https://github.com/mitodl/mitxonline/issues/1487#issuecomment-1478561939)

#### How should this be manually tested?
- Local MITxOnline and edX should be running
- Enroll in any course run in any mode
- The course in which you enrolled must have another unexpired course run
- Run this command
    `defer_enrollment --user <USER_EMAIL> --from-run <CURRENT_COURSE_RUN_ID> --to-run <UPCOMMING_COURSE_RUN_ID>`
- `--from-run` should be the Course Run Id in which you are already enrolled
- `--to-run` should be the Course Run Id in which you want to enroll
- Both course run Ids should be of the same Course