### PR TITLE
Reworks extra fields form to compress things so the modal fits above the fold on smaller viewports

### DIFF
--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -559,7 +559,7 @@ export const AddlProfileFields = ({
       <React.Fragment>
         <Field
           type="hidden"
-          name="user_profile.type_is_professional"
+          name="user_profile.addl_fields_flag"
           value={true}
         />
         <div className="form-group">
@@ -579,86 +579,104 @@ export const AddlProfileFields = ({
             component={FormError}
           />
         </div>
-        <div className="form-group">
-          <label htmlFor="user_profile.job_title" className="font-weight-bold">
-            Job Title
-          </label>
-          <Field
-            type="text"
-            name="user_profile.job_title"
-            id="user_profile.job_title"
-            aria-describedby="user_profile.job_title_error"
-            className="form-control"
-          />
-          <ErrorMessage
-            name="user_profile.job_title"
-            id="user_profile.job_title_error"
-            component={FormError}
-          />
+        <div className="row">
+          <div className="col">
+            <div className="form-group">
+              <label
+                htmlFor="user_profile.job_title"
+                className="font-weight-bold"
+              >
+                Job Title
+              </label>
+              <Field
+                type="text"
+                name="user_profile.job_title"
+                id="user_profile.job_title"
+                aria-describedby="user_profile.job_title_error"
+                className="form-control"
+              />
+              <ErrorMessage
+                name="user_profile.job_title"
+                id="user_profile.job_title_error"
+                component={FormError}
+              />
+            </div>
+          </div>
+          <div className="col">
+            <div className="form-group">
+              <label
+                htmlFor="user_profile.company_size"
+                className="font-weight-bold"
+              >
+                Company Size
+              </label>
+              <Field
+                component="select"
+                name="user_profile.company_size"
+                id="user_profile.company_size"
+                className="form-control"
+              >
+                <option value="">-----</option>
+                {EMPLOYMENT_SIZE.map(([value, label], i) => (
+                  <option key={i} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </Field>
+            </div>
+          </div>
         </div>
-        <div className="form-group">
-          <label htmlFor="user_profile.industry" className="font-weight-bold">
-            Industry
-          </label>
-          <Field
-            component="select"
-            name="user_profile.industry"
-            id="user_profile.industry"
-            className="form-control"
-          >
-            <option value="">-----</option>
-            {EMPLOYMENT_INDUSTRY.map((industry, i) => (
-              <option key={i} value={industry}>
-                {industry}
-              </option>
-            ))}
-          </Field>
+        <div className="row">
+          <div className="col">
+            <div className="form-group">
+              <label
+                htmlFor="user_profile.industry"
+                className="font-weight-bold"
+              >
+                Industry
+              </label>
+              <Field
+                component="select"
+                name="user_profile.industry"
+                id="user_profile.industry"
+                className="form-control"
+              >
+                <option value="">-----</option>
+                {EMPLOYMENT_INDUSTRY.map((industry, i) => (
+                  <option key={i} value={industry}>
+                    {industry}
+                  </option>
+                ))}
+              </Field>
+            </div>
+          </div>
+          <div className="col">
+            <div className="form-group">
+              <label
+                htmlFor="user_profile.job_function"
+                className="font-weight-bold"
+              >
+                Job Function
+              </label>
+              <Field
+                component="select"
+                name="user_profile.job_function"
+                id="user_profile.job_function"
+                className="form-control"
+              >
+                <option value="">-----</option>
+                {EMPLOYMENT_FUNCTION.map((jobFunction, i) => (
+                  <option key={i} value={jobFunction}>
+                    {jobFunction}
+                  </option>
+                ))}
+              </Field>
+            </div>
+          </div>
         </div>
-        <div className="form-group">
-          <label
-            htmlFor="user_profile.job_function"
-            className="font-weight-bold"
-          >
-            Job Function
-          </label>
-          <Field
-            component="select"
-            name="user_profile.job_function"
-            id="user_profile.job_function"
-            className="form-control"
-          >
-            <option value="">-----</option>
-            {EMPLOYMENT_FUNCTION.map((jobFunction, i) => (
-              <option key={i} value={jobFunction}>
-                {jobFunction}
-              </option>
-            ))}
-          </Field>
-        </div>
-        <div className="form-group">
-          <label
-            htmlFor="user_profile.company_size"
-            className="font-weight-bold"
-          >
-            Company Size
-          </label>
-          <Field
-            component="select"
-            name="user_profile.company_size"
-            id="user_profile.company_size"
-            className="form-control"
-          >
-            <option value="">-----</option>
-            {EMPLOYMENT_SIZE.map(([value, label], i) => (
-              <option key={i} value={value}>
-                {label}
-              </option>
-            ))}
-          </Field>
-        </div>
-        <div className="form-group">
-          <div className="row">
-            <div className="col">
+        <div className="row">
+          <div className="col">
+            <div className="form-group">
               <label
                 htmlFor="user_profile.years_experience"
                 className="font-weight-bold"
@@ -679,7 +697,9 @@ export const AddlProfileFields = ({
                 ))}
               </Field>
             </div>
-            <div className="col">
+          </div>
+          <div className="col">
+            <div className="form-group">
               <label
                 htmlFor="user_profile.leadership_level"
                 className="font-weight-bold"


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

mitodl/hq#1128

#### What's this PR do?

Compresses the professional demographic fields down so they take up less space, allowing the additional fields modal to fit above the fold on smaller viewports, and reduces the need for scrolling to view the form and submit button.

#### How should this be manually tested?

Using a user that does not have the additional fields flag set and is enrolled in a course, attempt to navigate into the course. You should see the Provide More Info modal. Selecting Professional from the "Are you a" choices should show the additional professional demographic fields (Company, Job Title, etc.), and the bottom of the modal including the submit button should be viewable if your window is greater than about 850 pixels tall. 

#### Any background context you want to provide?

We can try migrating the fields to the right of the modal as even with these changes the modal will still extend past the edge of the screen on a 720p-class display, but that seems like we'd potentially end up with a vertical scroll, which doesn't feel great. 

Since the form fields are a shared component, this change will affect the signup and profile pages as well. Screenshots are provided here.

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/945611/229151192-d794f8a5-fb00-4706-b37e-7556626f2a86.png)

![image](https://user-images.githubusercontent.com/945611/229151406-753fcf8a-4b61-466f-9345-41fc949f3326.png)

![image](https://user-images.githubusercontent.com/945611/229153552-f4fca32d-0f9c-4279-92af-4bf7d994ec69.png)

![image](https://user-images.githubusercontent.com/945611/229154352-dceca739-b3ec-492b-8a28-71d1bddc8084.png)

