### PR TITLE
Add aria-label to apply button

### DIFF
--- a/frontend/public/src/components/forms/ApplyCouponForm.js
+++ b/frontend/public/src/components/forms/ApplyCouponForm.js
@@ -47,6 +47,7 @@ const ApplyCouponForm = ({ onSubmit, couponCode, discounts }: Props) => (
                 <button
                   className="btn btn-primary btn-red btn-halfsize mx-2 highlight font-weight-normal"
                   type="submit"
+                  aria-label="Apply coupon"
                 >
                   Apply
                 </button>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1509

#### What's this PR do?
Using a screen reader on the http://mitxonline.odl.local:8013/cart/ page, if you focus on the "Apply" button, you should hear "Apply discount" instead of "Apply".

#### How should this be manually tested?

1. Login to mitxonline.
2. Begin enrollment into a product-based course.
3. At the http://mitxonline.odl.local:8013/cart/ page, verify that screen reader will pronounce "Apply discount" when focusing on the "Apply" button.

