### PR TITLE
123: remove use of aria-hidden and aria-live on dashboard

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -509,11 +509,7 @@ export class EnrolledItemCard extends React.Component<
                   className="d-inline-flex unstyled dot-menu"
                   aria-label={menuTitle}
                 >
-                  <span
-                    className="material-icons"
-                    title={menuTitle}
-                    aria-hidden="true"
-                  >
+                  <span className="material-icons" title={menuTitle}>
                     more_vert
                   </span>
                 </DropdownToggle>
@@ -633,11 +629,7 @@ export class EnrolledItemCard extends React.Component<
                   className="d-inline-flex unstyled dot-menu"
                   aria-label={menuTitle}
                 >
-                  <span
-                    className="material-icons"
-                    title={menuTitle}
-                    aria-hidden="true"
-                  >
+                  <span className="material-icons" title={menuTitle}>
                     more_vert
                   </span>
                 </DropdownToggle>

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -221,10 +221,7 @@ export class DashboardPage extends React.Component<
 
     return (
       <DocumentTitle title={`${SETTINGS.site_name} | ${DASHBOARD_PAGE_TITLE}`}>
-        <div
-          className="std-page-body dashboard container"
-          aria-hidden={this.state.programDrawerVisibility}
-        >
+        <div className="std-page-body dashboard container">
           <Loader isLoading={isLoading}>
             <nav className="tabs" aria-controls="enrollment-items">
               {programEnrollmentsLength === 0 ? (
@@ -248,11 +245,7 @@ export class DashboardPage extends React.Component<
                 </>
               )}
             </nav>
-            <div
-              id="enrollment-items"
-              className="enrolled-items"
-              aria-live="polite"
-            >
+            <div id="enrollment-items" className="enrolled-items">
               {this.renderCurrentTab()}
             </div>
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.mit.edu/mitxonline/mitxonline-issues/issues/123
https://github.com/mitodl/hq/issues/703

#### What's this PR do?
1. When using a screen reader, visiting either the course or program tab on the dashboard should not read all of the records in the list.  
2. Visiting the program drawer should announce that "you are currently inside of a dialog" and not "you are currently inside of a group"

It's helpful to compare RC with this branch running locally in order to understand the differences.
