### PR TITLE
Order History Page table makeover

### DIFF
--- a/frontend/public/scss/layout.scss
+++ b/frontend/public/scss/layout.scss
@@ -26,6 +26,7 @@
 @import "receipt";
 @import "certificates/certificate";
 @import "learner-records";
+@import "order-history";
 
 body {
   font-family: "Montserrat", "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/frontend/public/scss/order-history.scss
+++ b/frontend/public/scss/order-history.scss
@@ -1,0 +1,9 @@
+table.order-history-table {
+  margin-top: .5em;
+  width: 100%;
+
+  td, th {
+    padding: 15px;
+    vertical-align: bottom;
+  }
+}

--- a/frontend/public/src/containers/pages/checkout/OrderHistory.js
+++ b/frontend/public/src/containers/pages/checkout/OrderHistory.js
@@ -85,7 +85,7 @@ export class OrderHistory extends React.Component<Props> {
         <td>
           <a
             className="link-text"
-            aria-label={`View order details for ${orderTitle}`}
+            aria-label={`View order details for ${order.titles}`}
             onClick={() => this.renderOrderReceipt(order.id)}
             href="#"
             role="link"

--- a/frontend/public/src/containers/pages/checkout/OrderHistory.js
+++ b/frontend/public/src/containers/pages/checkout/OrderHistory.js
@@ -75,6 +75,34 @@ export class OrderHistory extends React.Component<Props> {
       parseDateString(order.created_on)
     )
     return (
+      <tr scope="row" key={`ordercard_${order.id}`}>
+        <td className="d-flex">
+          <span className="flex-grow-1">{orderTitle}</span>
+        </td>
+        <td>{orderDate}</td>
+        <td>{formatLocalePrice(parseFloat(order.total_price_paid))}</td>
+        <td>{order.reference_number}</td>
+        <td>
+          <a
+            className="link-text"
+            onClick={() => this.renderOrderReceipt(order.id)}
+            href="#"
+            role="link"
+          >
+            View
+          </a>
+        </td>
+      </tr>
+    )
+  }
+
+  renderMobileOrderCard(order: Object) {
+    const orderTitle =
+      order.titles.length > 0 ? order.titles.join("<br />") : <em>No Items</em>
+    const orderDate = formatPrettyDateTimeAmPmTz(
+      parseDateString(order.created_on)
+    )
+    return (
       <div
         className="row d-flex p-3 my-0 bg-light"
         key={`ordercard_${order.id}`}
@@ -132,9 +160,9 @@ export class OrderHistory extends React.Component<Props> {
   render() {
     const { orderHistory, isLoading } = this.props
     const columns = ORDER_HISTORY_COLUMN_TITLES.map((value: string) => (
-      <div key={value} className="col">
+      <th key={value} scope="col">
         <strong>{value}</strong>
-      </div>
+      </th>
     ))
     return (
       <DocumentTitle
@@ -147,21 +175,54 @@ export class OrderHistory extends React.Component<Props> {
                 <h1 className="flex-grow-1">Order History</h1>
               </div>
             </div>
-
-            <div className="row d-flex p-3 mt-4 bg-light border-bottom border-2 border-dark">
-              {columns}
-            </div>
-            {orderHistory && orderHistory.results.length > 0
-              ? orderHistory.results.map(this.renderOrderCard.bind(this))
-              : null}
-            <div className="row d-flex p-3 mb-4 bg-light border-top border-2 border-dark">
-              <div className="col">
-                Page {this.offset + 1} of{" "}
-                {orderHistory ? Math.ceil(orderHistory.count / 10) : 0} |{" "}
-                {orderHistory ? orderHistory.count : "0"} orders total
+            <div className="d-md-none">
+              <div className="row d-flex p-3 mt-4 bg-light border-bottom border-2 border-dark">
+                {ORDER_HISTORY_COLUMN_TITLES.map((value: string) => (
+                  <div key={value} className="col">
+                    <strong>{value}</strong>
+                  </div>
+                ))}
               </div>
-              <div className="col text-end" />
-              {this.renderPaginationPrevious()} | {this.renderPaginationNext()}
+              {orderHistory && orderHistory.results.length > 0
+                ? orderHistory.results.map(
+                  this.renderMobileOrderCard.bind(this)
+                )
+                : null}
+            </div>
+            <div className="d-none d-md-block">
+              <div className="row">
+                <div className="col-12 d-flex bg-light justify-content-between">
+                  <table title="Order History" className="order-history-table">
+                    <thead className="border-bottom border-2 border-dark">
+                      <tr>{columns}</tr>
+                    </thead>
+                    <tbody>
+                      {orderHistory && orderHistory.results.length > 0
+                        ? orderHistory.results.map(
+                          this.renderOrderCard.bind(this)
+                        )
+                        : null}
+                      <tr className="border-top border-2 border-dark">
+                        <td>
+                          Page {this.offset + 1} of{" "}
+                          {orderHistory
+                            ? Math.ceil(orderHistory.count / 10)
+                            : 0}{" "}
+                          | {orderHistory ? orderHistory.count : "0"} orders
+                          total
+                        </td>
+                        <td />
+                        <td />
+                        <td />
+                        <td className=" col text-right">
+                          {this.renderPaginationPrevious()} |{" "}
+                          {this.renderPaginationNext()}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
             </div>
           </div>
         </Loader>

--- a/frontend/public/src/containers/pages/checkout/OrderHistory.js
+++ b/frontend/public/src/containers/pages/checkout/OrderHistory.js
@@ -85,6 +85,7 @@ export class OrderHistory extends React.Component<Props> {
         <td>
           <a
             className="link-text"
+            aria-label={`View order details for ${orderTitle}`}
             onClick={() => this.renderOrderReceipt(order.id)}
             href="#"
             role="link"
@@ -214,7 +215,7 @@ export class OrderHistory extends React.Component<Props> {
                         <td />
                         <td />
                         <td />
-                        <td className=" col text-right">
+                        <td className="col text-right">
                           {this.renderPaginationPrevious()} |{" "}
                           {this.renderPaginationNext()}
                         </td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
#### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/718

#### What's this PR do?
Updates the order history page to display a proper table so that screen readers work.

#### How should this be manually tested?
Go to orders history page. Make sure it looks good. Then use a screed reader to go over the order history structure.

<img width="1239" alt="Screen Shot 2023-04-06 at 12 34 16 PM" src="https://user-images.githubusercontent.com/7574259/230442724-3feb901b-c955-4a4e-9764-6da4063e10c4.png">
