### PR TITLE
1538 users are still able to log in using a retired email account

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -221,11 +221,13 @@ class LoginEmailSerializer(SocialAuthSerializer):
         self._save_next(validated_data)
 
         try:
-            user=User.objects.get(
+            user = (
+                User.objects.get(
                     social_auth__uid=validated_data.get("email"),
                     social_auth__provider=EmailAuth.name,
                     is_active=True,
                 ),
+            )
             result = super()._authenticate(SocialAuthState.FLOW_LOGIN)
         except (RequireRegistrationException, User.DoesNotExist):
             result = SocialAuthState(

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -221,6 +221,13 @@ class LoginEmailSerializer(SocialAuthSerializer):
         self._save_next(validated_data)
 
         try:
+            user = (
+                User.objects.get(
+                    social_auth__uid=validated_data.get("email"),
+                    social_auth__provider=EmailAuth.name,
+                    is_active=True,
+                ),
+            )
             result = super()._authenticate(SocialAuthState.FLOW_LOGIN)
         except RequireRegistrationException:
             result = SocialAuthState(

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -221,15 +221,13 @@ class LoginEmailSerializer(SocialAuthSerializer):
         self._save_next(validated_data)
 
         try:
-            user = (
-                User.objects.get(
+            user=User.objects.get(
                     social_auth__uid=validated_data.get("email"),
                     social_auth__provider=EmailAuth.name,
                     is_active=True,
                 ),
-            )
             result = super()._authenticate(SocialAuthState.FLOW_LOGIN)
-        except RequireRegistrationException:
+        except (RequireRegistrationException, User.DoesNotExist):
             result = SocialAuthState(
                 SocialAuthState.STATE_REGISTER_REQUIRED,
                 field_errors={"email": "Couldn't find your account"},

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -73,7 +73,7 @@ def assert_api_call(
         "field_errors": {},
         "redirect_url": None,
         "extra_data": {},
-        "state": None,
+        "state": "error",
         "provider": EmailAuth.name,
         "flow": None,
         "partial_token": any_instance_of(str),
@@ -408,11 +408,13 @@ class AuthStateMachine(RuleBasedStateMachine):
             },
             {
                 "flow": auth_state["flow"],
-                "redirect_url": NEXT_URL,
-                "partial_token": None,
-                "state": SocialAuthState.STATE_SUCCESS,
+                "redirect_url": None,
+                "state": SocialAuthState.STATE_ERROR,
+                "field_errors": {
+                    "password": "Unable to login with that email and password combination"
+                },
             },
-            expect_authenticated=True,
+            expect_authenticated=False,
         )
 
     @rule(
@@ -569,12 +571,12 @@ def test_login_email_error(client, mocker):
     )
     assert response.json() == {
         "errors": [],
-        "field_errors": {},
+        "field_errors": {"email": "Couldn't find your account"},
         "flow": SocialAuthState.FLOW_LOGIN,
         "provider": EmailAuth.name,
         "redirect_url": None,
         "partial_token": None,
-        "state": SocialAuthState.STATE_ERROR,
+        "state": SocialAuthState.STATE_REGISTER_REQUIRED,
         "extra_data": {},
     }
     assert response.status_code == status.HTTP_200_OK

--- a/frontend/public/src/components/forms/EmailForm.js
+++ b/frontend/public/src/components/forms/EmailForm.js
@@ -3,9 +3,8 @@ import React from "react"
 
 import { Formik, Field, Form, ErrorMessage } from "formik"
 
-import FormError from "./elements/FormError"
-
 import { EmailInput } from "./elements/inputs"
+import FormError from "./elements/FormError"
 
 type EmailFormProps = {
   onSubmit: Function,
@@ -35,7 +34,15 @@ const EmailForm = ({ onSubmit, children }: EmailFormProps) => (
             aria-describedby="emailError"
             required
           />
+<<<<<<< Updated upstream
           <ErrorMessage name="email" id="emailError" component={FormError} />
+=======
+          <ErrorMessage
+            name="email"
+            id="emailError"
+            component={FormError}
+          />
+>>>>>>> Stashed changes
         </div>
         {children && <div className="form-group">{children}</div>}
         <div className="row submit-row no-gutters justify-content-end">

--- a/frontend/public/src/components/forms/EmailForm.js
+++ b/frontend/public/src/components/forms/EmailForm.js
@@ -34,15 +34,11 @@ const EmailForm = ({ onSubmit, children }: EmailFormProps) => (
             aria-describedby="emailError"
             required
           />
-<<<<<<< Updated upstream
-          <ErrorMessage name="email" id="emailError" component={FormError} />
-=======
           <ErrorMessage
             name="email"
             id="emailError"
             component={FormError}
           />
->>>>>>> Stashed changes
         </div>
         {children && <div className="form-group">{children}</div>}
         <div className="row submit-row no-gutters justify-content-end">

--- a/frontend/public/src/components/forms/EmailForm.js
+++ b/frontend/public/src/components/forms/EmailForm.js
@@ -1,7 +1,9 @@
 // @flow
 import React from "react"
 
-import { Formik, Field, Form } from "formik"
+import { Formik, Field, Form, ErrorMessage } from "formik"
+
+import FormError from "./elements/FormError"
 
 import { EmailInput } from "./elements/inputs"
 
@@ -33,6 +35,7 @@ const EmailForm = ({ onSubmit, children }: EmailFormProps) => (
             aria-describedby="emailError"
             required
           />
+          <ErrorMessage name="email" id="emailError" component={FormError} />
         </div>
         {children && <div className="form-group">{children}</div>}
         <div className="row submit-row no-gutters justify-content-end">

--- a/frontend/public/src/components/forms/EmailForm.js
+++ b/frontend/public/src/components/forms/EmailForm.js
@@ -34,11 +34,7 @@ const EmailForm = ({ onSubmit, children }: EmailFormProps) => (
             aria-describedby="emailError"
             required
           />
-          <ErrorMessage
-            name="email"
-            id="emailError"
-            component={FormError}
-          />
+          <ErrorMessage name="email" id="emailError" component={FormError} />
         </div>
         {children && <div className="form-group">{children}</div>}
         <div className="row submit-row no-gutters justify-content-end">

--- a/frontend/public/src/components/forms/LoginPasswordForm.js
+++ b/frontend/public/src/components/forms/LoginPasswordForm.js
@@ -1,11 +1,12 @@
 // @flow
 import React from "react"
 
-import { Formik, Field, Form } from "formik"
+import { Formik, Field, Form, ErrorMessage } from "formik"
 import { Link } from "react-router-dom"
 
 import { PasswordInput } from "./elements/inputs"
 import { routes } from "../../lib/urls"
+import FormError from "./elements/FormError"
 
 type LoginPasswordFormProps = {
   onSubmit: Function
@@ -29,6 +30,11 @@ const LoginPasswordForm = ({ onSubmit }: LoginPasswordFormProps) => (
             autoComplete="current-password"
             aria-describedby="passwordError"
             required
+          />
+          <ErrorMessage
+            name="password"
+            id="passwordError"
+            component={FormError}
           />
         </div>
         <div className="form-group">

--- a/main/settings.py
+++ b/main/settings.py
@@ -388,8 +388,6 @@ SOCIAL_AUTH_PIPELINE = (
     # "authentication.pipeline.compliance.verify_exports_compliance",
     # Create the record that associates the social account with the user.
     "social_core.pipeline.social_auth.associate_user",
-    # activate the user
-    "authentication.pipeline.user.activate_user",
     # create the user's edx user and auth
     "authentication.pipeline.user.create_openedx_user",
     # Populate the extra_data field in the social record with the values

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -189,6 +189,7 @@ class UserSerializer(serializers.ModelSerializer):
     legal_address = LegalAddressSerializer(allow_null=True)
     user_profile = UserProfileSerializer(allow_null=True, required=False)
     grants = serializers.SerializerMethodField(read_only=True, required=False)
+    is_active = serializers.BooleanField(default=True)
 
     def validate_email(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
@@ -336,6 +337,7 @@ class UserSerializer(serializers.ModelSerializer):
             "created_on",
             "updated_on",
             "grants",
+            "is_active",
         )
         read_only_fields = (
             "username",

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -337,7 +337,7 @@ class UserSerializer(serializers.ModelSerializer):
             "created_on",
             "updated_on",
             "grants",
-            "is_active"
+            "is_active",
         )
         read_only_fields = (
             "username",

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -189,7 +189,7 @@ class UserSerializer(serializers.ModelSerializer):
     legal_address = LegalAddressSerializer(allow_null=True)
     user_profile = UserProfileSerializer(allow_null=True, required=False)
     grants = serializers.SerializerMethodField(read_only=True, required=False)
-    is_active = serializers.BooleanField()
+    is_active = serializers.BooleanField(default=True)
 
     def validate_email(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -189,7 +189,7 @@ class UserSerializer(serializers.ModelSerializer):
     legal_address = LegalAddressSerializer(allow_null=True)
     user_profile = UserProfileSerializer(allow_null=True, required=False)
     grants = serializers.SerializerMethodField(read_only=True, required=False)
-    is_active = serializers.BooleanField(default=True)
+    is_active = serializers.BooleanField()
 
     def validate_email(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
@@ -337,7 +337,7 @@ class UserSerializer(serializers.ModelSerializer):
             "created_on",
             "updated_on",
             "grants",
-            "is_active",
+            "is_active"
         )
         read_only_fields = (
             "username",

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -110,6 +110,7 @@ def test_create_user_serializer(settings, valid_address_dict):
 
     assert serializer.is_valid()
     user = serializer.save()
+    assert user.is_active is True
 
 
 def test_update_email_change_request_existing_email(user):
@@ -305,6 +306,7 @@ def test_user_create_required_fields_post(valid_address_dict, settings):
     assert str(serializer.errors["username"][0]) == "This field is required."
 
 
+@pytest.mark.django_db
 def test_user_create_required_fields_not_post(valid_address_dict):
     """
     If UserSerializer is given no request in the context, or that request is not a POST,

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -72,6 +72,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, show_enrollment_code
             "is_superuser": False,
             "grants": [],
             "user_profile": None,
+            "is_active": False,
         }
         # patched_unused_coupon_api.assert_not_called()
     elif not is_anonymous and show_enrollment_codes:
@@ -111,6 +112,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, show_enrollment_code
             "is_staff": user.is_staff,
             "is_superuser": user.is_superuser,
             "grants": list(user.get_all_permissions()),
+            "is_active": True,
         }
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1538
https://github.com/mitodl/mitxonline/issues/1536

#### What's this PR do?

1. User records that have `is_active = False` should not allow the user to login.
2. For the password and email login screens, if a valid user record matching the email is not found or their password does not match the user record, an error message should be displayed to the user.

#### How should this be manually tested?
1. Go through the registration process for a new user.
3. Once the user is created, go through Django admin and set `is_active = False`.  Logout with that user.
4. Attempt to log back in with that user.  The email login screen should present an error that the user was not found.
5. Through Django admin and set `is_active = True`
6. Attempt to log back in with that user but stop once you reach the password login screen.
7. Through Django admin and set `is_active = False`
8. Enter the password for the user and attempt to login.  The password login screen should present an error that the password did not match the user.
9. Through Django admin and set `is_active = True`
10. Login with the user in order to create an active session.
11. Execute `python manage.py retire_users -u <USER_EMAIL>`
12. Refresh the page where the user is logged in - you should be redirected to the login page.
13. Attempt to login with the user again.  The email login screen should present an error that the user cannot be found.
14. Verify that you can register a new user with the same email address you used in step 1.
