### PR TITLE
fix: remove codecov because it's gone from PyPI, the codecov action would do it anyway

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 black
 bpython
-codecov
 ddt
 django-debug-toolbar
 factory-boy==3.2.0


### PR DESCRIPTION

#### Pre-Flight checklist

#### What are the relevant tickets?
None, The package is gone from PyPI, and we should remove it.
More info on [this slack thread](https://mitodl.slack.com/archives/G3A5RSFDJ/p1681318942371839) and the following conversation.

#### What's this PR do?
- Removed the codecov package from `test_requirements.txt`

#### How should this be manually tested?
Make sure the CI checks pass.
