### PR TITLE
1541: Add back the username is taken error message in the registration form

### DIFF
--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -274,6 +274,7 @@ export const LegalAddressFields = ({
             pattern={usernameFieldRegex}
             title={usernameFieldErrorMessage}
           />
+          <ErrorMessage name="username" component={FormError} />
         </div>
         <div className="form-group">
           <label htmlFor="password" className="font-weight-bold">


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1541

#### What's this PR do?
Brings back the react component to display error messages from the serializer for the username field in the registration form.

#### How should this be manually tested?
Begin the registration process.  When asked to enter a username, enter a username that matches an existing user.  Submit the form and verify that an error message is shown indicating you need to pick another username.
