### PR TITLE
1549: Fixes program record with null nodes and no children with tests

### DIFF
--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -190,7 +190,6 @@ export const walkNodes = (
 ) => {
   // Processes the node. if the node is an operator, roll through each child
   // node and recurse. If the node is a course, check if it's completed.
-  console.log(node)
   if (node) {
     if (node.data.node_type === NODETYPE_OPERATOR) {
       let completedCount = 0

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -184,24 +184,31 @@ export const extractCoursesFromNode = (
   return []
 }
 
-const walkNodes = (node: ProgramRequirement, learnerRecord: LearnerRecord) => {
+export const walkNodes = (
+  node: ProgramRequirement,
+  learnerRecord: LearnerRecord
+) => {
   // Processes the node. if the node is an operator, roll through each child
   // node and recurse. If the node is a course, check if it's completed.
+  console.log(node)
+  if (node) {
+    if (node.data.node_type === NODETYPE_OPERATOR) {
+      let completedCount = 0
 
-  if (node.data.node_type === NODETYPE_OPERATOR) {
-    let completedCount = 0
+      if (node.children) {
+        node.children.forEach(child => {
+          completedCount += walkNodes(child, learnerRecord)
+        })
+      }
 
-    node.children.forEach(child => {
-      completedCount += walkNodes(child, learnerRecord)
-    })
-
-    if (node.data.operator === NODEOPER_ALL) {
-      return completedCount === node.children.length ? 1 : 0
-    } else {
-      return completedCount >= parseInt(node.data.operator_value) ? 1 : 0
+      if (node.data.operator === NODEOPER_ALL) {
+        return completedCount === node.children.length ? 1 : 0
+      } else {
+        return completedCount >= parseInt(node.data.operator_value) ? 1 : 0
+      }
+    } else if (node.data.node_type === NODETYPE_COURSE) {
+      return isNodeCompleted(node.data, learnerRecord) ? 1 : 0
     }
-  } else if (node.data.node_type === NODETYPE_COURSE) {
-    return isNodeCompleted(node.data, learnerRecord) ? 1 : 0
   }
 
   return false

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -5,7 +5,8 @@ import {
   generateStartDateText,
   isFinancialAssistanceAvailable,
   learnerProgramIsCompleted,
-  extractCoursesFromNode
+  extractCoursesFromNode,
+  walkNodes
 } from "./courseApi"
 import { assert } from "chai"
 import moment from "moment"
@@ -272,6 +273,32 @@ describe("Course API", () => {
 
       assert.equal(requirements.length, 0)
       assert.equal(electives.length, 0)
+    })
+  })
+
+  describe("walkNodes", () => {
+    [
+      [
+        {
+          data: {
+            node_type:      "operator",
+            operator:       "min_number_of",
+            operator_value: "1",
+            program:        2,
+            course:         null,
+            title:          "Elective Courses"
+          },
+          id: 13
+        },
+        false
+      ],
+      [undefined, false]
+    ].forEach(([node, expResult]) => {
+      it(`returns ${String(expResult)}`, () => {
+        const learnerRecord = makeLearnerRecord(false)
+        const result = walkNodes(node, learnerRecord)
+        assert.equal(result, expResult)
+      })
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1549

#### What's this PR do?
Fixes a bug that would cause the program record page to be blank if the program didn't have any elective or required courses, or if either of those sections were absent.

#### How should this be manually tested?

1. Create a program that has 1 or more required courses, but does not have any elective courses.
2. Enroll your user into the program.
3. From the program drawer, open the program record page.
4. Verify that the program record page displays correctly.
5. Remove the elective courses section from the program record within Django Admin.  Save the program record.
6. Verify that the program record page displays correctly.

#### Any background context you want to provide?
I made the `walkNodes()` method public in order to make testing easier.  Not best practice, but also makes things easier for future developers to update and test.
