### PR TITLE
Update requests package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ amqp==5.0.9
     # via kombu
 anyascii==0.2.0
     # via wagtail
+appnope==0.1.3
+    # via ipython
 asgiref==3.3.4
     # via
     #   django
@@ -49,7 +51,7 @@ certifi==2021.5.30
     #   sentry-sdk
 cffi==1.14.5
     # via cryptography
-chardet==4.0.0
+charset-normalizer==3.1.0
     # via requests
 click==8.0.1
     # via
@@ -390,7 +392,7 @@ redis==3.5.3
     #   -r requirements.in
     #   celery-redbeat
     #   django-redis
-requests==2.25.1
+requests==2.28.2
     # via
     #   -r requirements.in
     #   coreapi


### PR DESCRIPTION
Also gets rid of the chardet dependency.

#### Pre-Flight checklist

#### What's this PR do?
Updates the `requests` package.  This removed the dependency on the `chardet` package which is out of date (https://github.com/mitodl/mitxonline/pull/993).  

#### How should this be manually tested?
Tests should pass.  All uses of request should continue to function as expected - this can be tested by creating a user and ensuring the `openedx.models.OpenEdxApiAuth` record is created and matching the associated record in edx.  When in RC, additional verifications such as recaptcha and refunding orders can be easily tested.
