### PR TITLE
1294: Update "right" and "left" to "end" and "start"

### DIFF
--- a/frontend/public/src/components/OrderSummaryCard.js
+++ b/frontend/public/src/components/OrderSummaryCard.js
@@ -53,7 +53,7 @@ export class OrderSummaryCard extends React.Component<Props> {
               </em>{" "}
               )
             </div>
-            <div className="ml-auto text-primary text-right">
+            <div className="ml-auto text-primary text-end">
               {discountAmountText}
             </div>
           </div>
@@ -76,9 +76,7 @@ export class OrderSummaryCard extends React.Component<Props> {
             <div className="flex-grow-1">
               <Badge className="bg-danger">Refund applied</Badge>
             </div>
-            <div className="ml-auto text-primary text-right">
-              {refundAmount}
-            </div>
+            <div className="ml-auto text-primary text-end">{refundAmount}</div>
           </div>
         </div>
       </div>

--- a/frontend/public/src/components/UserMenu.js
+++ b/frontend/public/src/components/UserMenu.js
@@ -17,7 +17,7 @@ const desktopMenuContainerProps = {
 }
 
 const desktopUListProps = {
-  className: "dropdown-menu dropdown-menu-right"
+  className: "dropdown-menu dropdown-menu-end"
 }
 
 const overlayListItemProps = {

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -176,7 +176,7 @@ export class ProductDetailEnrollApp extends React.Component<
             <div className="flex-grow-1 align-self-end">
               Learn online and get a certificate
             </div>
-            <div className="text-right align-self-end">
+            <div className="text-end align-self-end">
               {formatLocalePrice(getFlexiblePriceForProduct(product))}
             </div>
           </div>

--- a/frontend/public/src/containers/ProductDetailEnrollApp_test.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp_test.js
@@ -298,7 +298,7 @@ describe("ProductDetailEnrollApp", () => {
 
       assert.equal(
         inner
-          .find(".text-right")
+          .find(".text-end")
           .at(0)
           .text(),
         "$9.00"
@@ -338,7 +338,7 @@ describe("ProductDetailEnrollApp", () => {
 
       assert.equal(
         inner
-          .find(".text-right")
+          .find(".text-end")
           .at(0)
           .text()
           .at(1),
@@ -380,7 +380,7 @@ describe("ProductDetailEnrollApp", () => {
 
       assert.equal(
         inner
-          .find(".text-right")
+          .find(".text-end")
           .at(0)
           .text()
           .at(1),

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -71,7 +71,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
             <Badge color="danger">Enrolled in free course</Badge>
             <h2>Get a certificate</h2>
           </div>
-          <div className="text-right align-self-end">
+          <div className="text-end align-self-end">
             <h2>{formatLocalePrice(getFlexiblePriceForProduct(product))}</h2>
           </div>
         </div>

--- a/frontend/public/src/containers/pages/checkout/CartPage.js
+++ b/frontend/public/src/containers/pages/checkout/CartPage.js
@@ -168,7 +168,7 @@ export class CartPage extends React.Component<Props, CartState> {
               <div className="col-12 d-flex justify-content-between">
                 <h1 className="flex-grow-1">Checkout</h1>
 
-                <p className="text-right d-md-none">
+                <p className="text-end d-md-none">
                   <a
                     href="https://mitxonline.zendesk.com/hc/en-us"
                     target="_blank"
@@ -193,12 +193,12 @@ export class CartPage extends React.Component<Props, CartState> {
                   You are about to purchase the following:
                 </h4>
               </div>
-              <div className="col-md-4 justify-content-end text-right d-flex">
+              <div className="col-md-4 justify-content-end text-end d-flex">
                 <h4 className="fw-normal">
                   {this.renderFinancialAssistanceOffer()}
                 </h4>
               </div>
-              <div className="col-md-2 justify-content-end text-right d-flex">
+              <div className="col-md-2 justify-content-end text-end d-flex">
                 <h4 className="fw-normal">
                   <a
                     href="https://mitxonline.zendesk.com/hc/en-us"

--- a/frontend/public/src/containers/pages/checkout/OrderHistory.js
+++ b/frontend/public/src/containers/pages/checkout/OrderHistory.js
@@ -160,7 +160,7 @@ export class OrderHistory extends React.Component<Props> {
                 {orderHistory ? Math.ceil(orderHistory.count / 10) : 0} |{" "}
                 {orderHistory ? orderHistory.count : "0"} orders total
               </div>
-              <div className="col text-right" />
+              <div className="col text-end" />
               {this.renderPaginationPrevious()} | {this.renderPaginationNext()}
             </div>
           </div>

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -245,7 +245,7 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
             render={() => (
               <Form className="text-center">
                 <section>
-                  <label htmlFor="partnerSchool" className="text-left">
+                  <label htmlFor="partnerSchool" className="text-start">
                     Select School
                   </label>
                   <Field


### PR DESCRIPTION
Update for Bootstrap v5.

#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1294

#### What's this PR do?
Resolves a bug that would clip the dropdown menu on the right side of the screen when a user's full name was short (2 characters).

#### How should this be manually tested?

1. Update your user's full name to "aa".
2. Click on the dropdown menu in the top right of the screen and ensure it is completely visible and not clipped.


#### Any background context you want to provide?
This also updated "text-right" to "text-end" and "text-left" to "text-start" to comply with Bootstrap 5.
