### PR TITLE
1295: learner menu stops functioning at a particular width range

### DIFF
--- a/frontend/public/scss/top-app-bar.scss
+++ b/frontend/public/scss/top-app-bar.scss
@@ -9,7 +9,7 @@ header.site-header {
     justify-content: space-between;
     padding: 0;
 
-    @include media-breakpoint-down(sm) {
+    @include media-breakpoint-down(md) {
       position: static;
     }
   }
@@ -22,7 +22,7 @@ header.site-header {
 .full-screen-menu {
   display: block;
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(md) {
     display: none;
   }
 
@@ -71,7 +71,7 @@ header.site-header {
 .mobile-menu {
   display: none;
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(md) {
     display: block;
   }
 
@@ -148,14 +148,14 @@ header.site-header {
     line-height: 24px;
     letter-spacing: 0;
 
-    @include media-breakpoint-down(sm) {
+    @include media-breakpoint-down(md) {
       font-size: 18px;
       line-height: 18px;
     }
   }
 
   .logo-link {
-    @include media-breakpoint-down(sm) {
+    @include media-breakpoint-down(md) {
       display: inline-flex;
     }
   }
@@ -165,7 +165,7 @@ header.site-header {
     height: 48px;
     margin: 0 15px;
     background: black;
-    @include media-breakpoint-down(sm) {
+    @include media-breakpoint-down(md) {
       height: 34px;
       margin: 0 8px;
     }

--- a/frontend/public/scss/top-app-bar.scss
+++ b/frontend/public/scss/top-app-bar.scss
@@ -100,13 +100,6 @@ header.site-header {
   display: none;
   margin: 0;
 
-  &.collapsing,
-  &.show {
-    @include media-breakpoint-down(sm) {
-      display: block;
-    }
-  }
-
   @include media-breakpoint-up(md) {
     display: block;
 
@@ -115,24 +108,23 @@ header.site-header {
     }
   }
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(md) {
     position: absolute;
     padding-top: 70px;
     left: 0;
     right: 0;
     bottom: -10px;
-    height: auto !important;
+    top: 50px;
+    height: 100%;
     z-index: 9999;
     background: rgba(0, 0, 0, 0.91);
+
+    &.collapsing,
+    &.show {
+        display: block;
+    }
   }
 
-  @include media-breakpoint-between(sm, md) {
-    top: 66px;
-  }
-
-  @include media-breakpoint-down(sm) {
-    top: 50px;
-  }
 }
 
 .site-logo {

--- a/frontend/public/scss/top-app-bar.scss
+++ b/frontend/public/scss/top-app-bar.scss
@@ -114,14 +114,15 @@ header.site-header {
     left: 0;
     right: 0;
     bottom: -10px;
-    top: 50px;
     height: 100%;
+    top: 50px;
     z-index: 9999;
     background: rgba(0, 0, 0, 0.91);
 
     &.collapsing,
     &.show {
-        display: block;
+      display: block;
+      transition: none;
     }
   }
 

--- a/frontend/public/src/components/TopAppBar.js
+++ b/frontend/public/src/components/TopAppBar.js
@@ -19,7 +19,7 @@ const TopAppBar = ({ currentUser }: Props) => (
   <header className="site-header d-flex d-flex flex-column">
     <NotificationContainer id="notifications-container" />
     <nav
-      className={`order-1 sub-nav navbar navbar-expand-md link-section py-2 px-3 py-sm-3 px-sm-4 ${
+      className={`order-1 sub-nav navbar navbar-expand-md link-section py-2 px-3 py-md-3 px-md-4 ${
         currentUser.is_authenticated ? "nowrap login" : ""
       }`}
     >


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1295

#### What's this PR do?
The hamburger menu was not functional when screens were _medium_ width (https://getbootstrap.com/docs/5.0/layout/breakpoints/#available-breakpoints)

#### How should this be manually tested?

1. Set the width of your browser screen to each of the breakpoints mentioned in the link shared above.  Verify that you can view whichever menu is shown based on the browser screen size.

#### Any background context you want to provide?
This PR removes the css transition that comes with Bootstrap navbars.  Previously, we wouldn't display the animation and would only shown the navbar options after the animation completed.  Removing the animation speeds this up.

There is also some general refactoring to cleanup reused code.
