### PR TITLE
Removes call to forcibly set addl_field_flag from frontend

### DIFF
--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -111,7 +111,7 @@ export class DashboardPage extends React.Component<
     send the learner directly to the page.
     */
 
-    const { currentUser, updateAddlFields } = this.props
+    const { currentUser } = this.props
 
     if (
       !checkFeatureFlag("enable_addl_profile_fields") ||
@@ -126,8 +126,6 @@ export class DashboardPage extends React.Component<
       destinationUrl:             url,
       showAddlProfileFieldsModal: true
     })
-
-    updateAddlFields(currentUser)
   }
 
   async saveProfile(profileData: User, { setSubmitting }: Object) {
@@ -292,10 +290,7 @@ const updateAddlFields = (currentUser: User) => {
     name:          currentUser.name,
     email:         currentUser.email,
     legal_address: currentUser.legal_address,
-    user_profile:  {
-      ...currentUser.user_profile,
-      addl_field_flag: true
-    }
+    user_profile:  currentUser.user_profile
   }
 
   return mutateAsync(users.editProfileMutation(updatedUser))

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -298,6 +298,16 @@ class UserSerializer(serializers.ModelSerializer):
                     address_serializer.save()
 
             if user_profile_data:
+                if user_profile_data.get("highest_education") and (
+                    user_profile_data.get("type_is_student")
+                    or user_profile_data.get("type_is_professional")
+                    or user_profile_data.get("type_is_educator")
+                    or user_profile_data.get("type_is_other")
+                ):
+                    user_profile_data["addl_field_flag"] = True
+                else:
+                    user_profile_data["addl_field_flag"] = False
+
                 try:
                     user_profile_serializer = UserProfileSerializer(
                         instance.user_profile, data=user_profile_data

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -18,7 +18,7 @@ from fixtures.common import (
 from openedx.api import OPENEDX_REGISTRATION_VALIDATION_PATH
 from openedx.exceptions import EdxApiRegistrationValidationException
 from users.factories import UserFactory
-from users.models import ChangeEmailRequest, LegalAddress
+from users.models import HIGHEST_EDUCATION_CHOICES, ChangeEmailRequest, LegalAddress
 from users.serializers import (
     ChangeEmailRequestUpdateSerializer,
     LegalAddressSerializer,
@@ -377,3 +377,34 @@ def test_update_user_serializer_with_profile(
         assert serializer.is_valid()
         serializer.save()
         assert isinstance(user.legal_address, LegalAddress)
+
+
+@pytest.mark.parametrize("test_incomplete_addl_fields", [True, False])
+def test_update_user_serializer_sets_addl_field_flag(
+    settings, user, valid_address_dict, user_profile_dict, test_incomplete_addl_fields
+):
+    """Tests that the UserSerializers works right with a supplied UserProfile"""
+
+    if test_incomplete_addl_fields:
+        user_profile_dict["highest_education"] = HIGHEST_EDUCATION_CHOICES[1][0]
+        user_profile_dict["type_is_student"] = True
+
+    serializer = UserSerializer(
+        instance=user,
+        data={
+            "password": "AgJw0123",
+            "legal_address": valid_address_dict,
+            "user_profile": user_profile_dict,
+        },
+        partial=True,
+    )
+
+    assert serializer.is_valid()
+    serializer.save()
+
+    user.refresh_from_db()
+
+    if test_incomplete_addl_fields:
+        assert user.user_profile.addl_field_flag == True
+    else:
+        assert user.user_profile.addl_field_flag == False


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1513 

#### What's this PR do?

When the additional info dialog pops (when the learner navigates into a course without having provided the additional profile info we've requested), the app sets the `addl_fields_flag` in the user's profile so that we don't ask them again for the information, regardless of whether or not they provide any actual info. This removes that operation - we now want to require the learner to provide data for the Highest Level of Education and identity (Are you a...) fields. In addition, this updates the UserSerializer to set the `addl_fields_flag` on update when the learner has provided data for these two fields. 

#### How should this be manually tested?

Automated tests should pass.

With an account that does not have the additional fields flag set, navigate into a course. You should see the Additional Info dialog. Reviewing the account info in Django Admin should show that the `addl_fields_flag` is not set (previously, it would be set when the dialog is opened). 

In any place that allows you to adjust your profile information, save your profile without specifying Highest Level of Education or Are you a... The `addl_fields_flag` should be unset if you do this. This should remain the case if only one of these fields are set. Conversely, set both of these fields and save the profile - the `addl_fields_flag` should be set in this case. 
