### PR TITLE
1302: Set bg-danger to lighter red

### DIFF
--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -361,7 +361,7 @@
         }
 
         span.bg-danger {
-          background-color: #fae8e8;
+          background-color: #fae8e8 !important;
           color: #b43e3e;
         }
       }

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -68,7 +68,7 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
       <div className="card">
         <div className="row d-flex upsell-header">
           <div className="flex-grow-1 align-self-end">
-            <Badge color="danger">Enrolled in free course</Badge>
+            <Badge className="bg-danger">Enrolled in free course</Badge>
             <h2>Get a certificate</h2>
           </div>
           <div className="text-end align-self-end">


### PR DESCRIPTION
Sets the background color of the upsell card badge to a lighter red color if bg-danger is used.

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1302

#### What's this PR do?
Sets the background color of the danger badge to a lighter red which allows the red text to be seen.

#### How should this be manually tested?

1. Enroll your user into a course for free.
2. Ensure that the course enrollment is synced with edx (or at least `Edx enrolled` is set to `True` for the course run enrollment).
3. Visit the course about page and verify that the "Enrolled in free course" badge is styled in the same way as the attached screenshot.


#### Screenshots
![Screenshot 2023-04-21 at 11 39 26](https://user-images.githubusercontent.com/8311573/233677963-4ffdf879-d4a7-40b0-9c97-77c5e9eb2ab6.png)
