### PR TITLE
1566: align price on upsell card

### DIFF
--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -352,7 +352,6 @@
       div.upsell-header {
         margin-left: 0;
         margin-right: 0;
-        clear: both;
 
         span.badge {
           font-weight: normal;

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -352,6 +352,7 @@
       div.upsell-header {
         margin-left: 0;
         margin-right: 0;
+        clear: both;
 
         span.badge {
           font-weight: normal;

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -69,10 +69,10 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
         <div className="row d-flex upsell-header">
           <div className="flex-grow-1 align-self-end">
             <Badge className="bg-danger">Enrolled in free course</Badge>
-            <h2>Get a certificate</h2>
           </div>
           <div className="text-end align-self-end">
-            <h2>{formatLocalePrice(getFlexiblePriceForProduct(product))}</h2>
+            <h2 className="float-start">Get a certificate</h2>
+            <h2 className="float-end">{formatLocalePrice(getFlexiblePriceForProduct(product))}</h2>
           </div>
         </div>
         <div className="row">

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -72,7 +72,9 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
           </div>
           <div className="text-end align-self-end">
             <h2 className="float-start">Get a certificate</h2>
-            <h2 className="float-end">{formatLocalePrice(getFlexiblePriceForProduct(product))}</h2>
+            <h2 className="float-end">
+              {formatLocalePrice(getFlexiblePriceForProduct(product))}
+            </h2>
           </div>
         </div>
         <div className="row">


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1566

#### What's this PR do?
Puts the "Get a certificate" and "{price}" heading on the same line in the upsell card.

#### How should this be manually tested?
Enroll your user into the free track of a course.  Ensure that the course run enrollment record has "Edx enrolled" equal to true.  View the course about page and verify that the "Get a certificate" and "{price}" headings are on the same line.

#### Screenshots (if appropriate)
![Screenshot 2023-04-24 at 11 44 32](https://user-images.githubusercontent.com/8311573/234048551-ae1aa2a3-dd14-4efc-b521-408eadb767b9.png)
![Screenshot 2023-04-24 at 11 44 24](https://user-images.githubusercontent.com/8311573/234048555-7bb1916f-a316-4596-8ea4-7cf68017e4d8.png)
