### PR TITLE
Update legal address validation to check state validity only if specified

### DIFF
--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -107,6 +107,18 @@ def invalid_address_dict():
         first_name="Test",
         last_name="User",
         country="US",
+        state="XX",
+    )
+
+
+@pytest.fixture
+def address_no_state_dict():
+    """Yields a dict that will deserialize into a US legal address with no state"""
+    return dict(
+        first_name="Test",
+        last_name="User",
+        country="US",
+        state=None,
     )
 
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -112,9 +112,13 @@ class LegalAddressSerializer(serializers.ModelSerializer):
         if not data["country"] in ["US", "CA"]:
             return data
         else:
-            if not "state" in data or (
-                data["country"] in ["US", "CA"]
-                and not pycountry.subdivisions.get(code=data["state"])
+            if (
+                "state" in data
+                and data["state"] is not None
+                and (
+                    data["country"] in ["US", "CA"]
+                    and not pycountry.subdivisions.get(code=data["state"])
+                )
             ):
                 raise serializers.ValidationError({"state": "Invalid state specified"})
 

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.exceptions import ValidationError
 
 from fixtures.common import (
+    address_no_state_dict,
     intl_address_dict,
     invalid_address_dict,
     user_profile_dict,
@@ -65,6 +66,7 @@ def test_validate_required_fields(valid_address_dict, field, value, error):
         [lazy_fixture("valid_address_dict"), None],
         [lazy_fixture("intl_address_dict"), None],
         [lazy_fixture("invalid_address_dict"), "Invalid state specified"],
+        [lazy_fixture("address_no_state_dict"), None],
     ],
 )
 def test_legal_address_validate_state_field(address_type, error):


### PR DESCRIPTION
The additional info dialog doesn't ask for a state if you're in the US or Canada, so if your account doesn't have one specified, that fails and it results in annoying the learner. So, this updates to only check the state if one is sent in the payload. (The front end validation on that field for the forms that have Country and State will require the learner to specify it there.)

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

https://github.com/mitodl/hq/issues/1332

#### What's this PR do?

Updates the state field validation in the serializer to only run if the state is specified. If left blank, it should consider that a valid value.

#### How should this be manually tested?

Automated tests should pass.

1. Create a new account, or identify an existing one to use for this. 
2. Enroll them in a course. 
3. Via Django Admin, change the legal address saved in the account to have country set to `US` or `CA` but clear out anything in the state field. Additionally, ensure the `Addl fields flag` field in the Profile is unset. 
4. From either the course about page or the dashboard, attempt to navigate into the course. You should see the additional info dialog appear.
5. Fill out the form and save. 
6. Check to make sure the data is actually saved. The `Addl fields flag` field should be set according to what data you did provide. 
7. Repeat step 4. You should not see the dialog again. 
