### PR TITLE
Reverts the page title on the additional details page

### DIFF
--- a/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
@@ -81,7 +81,7 @@ export class RegisterAdditionalDetailsPage extends React.Component<Props> {
 
     return (
       <DocumentTitle
-        title={`${SETTINGS.site_name} | ${REGISTER_EXTRA_DETAILS_PAGE_TITLE} but they're in space`}
+        title={`${SETTINGS.site_name} | ${REGISTER_EXTRA_DETAILS_PAGE_TITLE}`}
       >
         <div className="std-page-body container auth-page registration-page">
           <div className="auth-card card-shadow auth-form">


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

n/a

#### What's this PR do?

There was some test stuff added to the `RegisterAdditionalDetailsPage` page title that slipped through checks - this just removes that. 

#### How should this be manually tested?

Either register a new account or go to `/create-account/additional-details/` with an existing account. The page title should be `MITx Online | Register`. 

