### PR TITLE
Updates fields that are sent to edX and adds profile sync

### DIFF
--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -2,7 +2,7 @@
 # pylint: disable=redefined-outer-name
 import itertools
 from datetime import timedelta
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urljoin
 
 import factory
 import pytest
@@ -21,6 +21,7 @@ from openedx.api import (
     ACCESS_TOKEN_HEADER_NAME,
     OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS,
     OPENEDX_REGISTRATION_VALIDATION_PATH,
+    OPENEDX_UPDATE_USER_PATH,
     create_edx_auth_token,
     create_edx_user,
     create_user,
@@ -36,6 +37,7 @@ from openedx.api import (
     unsubscribe_from_edx_course_emails,
     update_edx_user_email,
     update_edx_user_name,
+    update_edx_user_profile,
     validate_username_with_edx,
 )
 from openedx.constants import (
@@ -153,7 +155,7 @@ def test_create_edx_user(user, settings, application, access_token_count):
         "name": user.name,
         "provider": settings.MITX_ONLINE_OAUTH_PROVIDER,
         "access_token": created_access_token.token,
-        "country": "US",
+        "country": user.legal_address.country if user.legal_address else None,
         "honor_code": "True",
     }
     assert (

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -14,6 +14,10 @@ class NoEdxApiAuthError(Exception):
     """The user was expected to have an OpenEdxApiAuth object but does not"""
 
 
+class EdxApiUserUpdateError(Exception):
+    """Exception updating the edX user via API"""
+
+
 class EdxApiEnrollErrorException(Exception):
     """An edX enrollment API call resulted in an error response"""
 

--- a/openedx/management/commands/update_edx_profiles.py
+++ b/openedx/management/commands/update_edx_profiles.py
@@ -1,0 +1,69 @@
+"""
+Management command to sync local profiles with edX
+"""
+import sys
+
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+from openedx.api import update_edx_user_profile
+from users.api import fetch_user
+from users.models import User
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Syncs the user's profile with edX.
+    """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="The id, email, or username of the user to sync.",
+        )
+
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Sync all users in the system (this may take a long time).",
+        )
+
+    def handle(self, *args, **options):
+        if not options["all"] and "user" in options:
+            try:
+                users = [fetch_user(options["user"])]
+            except User.DoesNotExist as exc:
+                self.stderr.write(self.style.ERROR(f"{str(exc)}"))
+                sys.exit(1)
+        elif options["all"]:
+            users = User.objects.all()
+        else:
+            self.stderr.write(
+                self.style.ERROR("Please specify a user or the --all flag.")
+            )
+            sys.exit(1)
+
+        successes = failures = 0
+
+        for user in users:
+            self.stdout.write(f"Updating profile for '{user.username}' ({user.email})")
+
+            try:
+                result = update_edx_user_profile(user)
+                successes += 1
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Sync did not complete successfully for user {user.username}: {e}"
+                    )
+                )
+                failures += 1
+
+        self.stdout.write(self.style.SUCCESS(f"{successes} updated successfully"))
+        if failures > 0:
+            self.stdout.write(self.style.ERROR(f"{failures} failed to update"))

--- a/users/models.py
+++ b/users/models.py
@@ -270,6 +270,15 @@ class LegalAddress(TimestampedModel):
     )  # ISO-3166-1
     state = models.CharField(max_length=255, blank=True, null=True)
 
+    @property
+    def us_state(self):
+        """Returns just the state bit, minus the 'US-' part, only for users in the US."""
+
+        if self.country == "US":
+            return self.state.split("-")[1]
+
+        return None
+
     def __str__(self):
         """Str representation for the legal address"""
         return f"Legal address for {self.user}"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested


#### What are the relevant tickets?

https://github.com/mitodl/hq/issues/1118

#### What's this PR do?

Three things:
- Updates the fields that are sent when a learner's account is created in edX. Prior to this, the code always sent the user's country as "US"; now it sends the code that the learner has specified and the state they're in if they're in the US. 
- Adds an API that allows for this data to be re-sent to edX. This syncs name, country, and state (if in the US) and can be amended to sync other data if we feel the learner profile in edX needs to be more complete.
- Adds a management command to sync a particular user, or all users. 

#### How should this be manually tested?

Initial field sync:
1. Create a new account.
2. Specify a country and (optionally) state (depending on country selection).
3. Verify the account information in the LMS Django Admin. The country and state should be filled correctly.

Re-sync:
1. Make sure you have user accounts in MITx Online that also exist in the LMS. 
2. Furthermore, make sure these accounts have country data in them.
3. Run the `update_edx_profiles` command. Specify either `--user <username>` to sync a single user, or `--all` to sync all of them. 
4. Check the synced accounts in the LMS Django Admin and ensure the data is correct. 
