### PR TITLE
Add AR Argentina

### DIFF
--- a/flexiblepricing/data/country_income_thresholds.csv
+++ b/flexiblepricing/data/country_income_thresholds.csv
@@ -1,6 +1,7 @@
 country,income
 AD,75000
 AG,75000
+AR,50000
 AW,75000
 AU,75000
 AT,75000


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1583


#### What's this PR do?
Adds the income threshold for Argentina which is used to automatically detect financial aid eligibility.

#### How should this be manually tested?

1. Get this branch running locally
2. Follow the instructions in this PR https://github.com/mitodl/mitxonline/pull/590 in order to load currencies.
3. Run `docker-compose run web ./manage.py load_country_income_thresholds flexiblepricing/data/country_income_thresholds.csv`
4. Verify that 'AR' has been added here: http://mitxonline.odl.local:8013/admin/flexiblepricing/countryincomethreshold/
5. login to your local instance of MITx Online.
6. Set your user's country to Argentina.
7. Apply for financial aid for a course and enter the user's income as more than 50000 USD.
8. Verify that the financial request was automatically approved here: http://mitxonline.odl.local:8013/admin/flexiblepricing/flexibleprice/
