### PR TITLE
Throw an error if the user manages to get to the registration screen with the same email

### DIFF
--- a/frontend/public/src/containers/pages/register/RegisterDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterDetailsPage.js
@@ -116,6 +116,17 @@ export class RegisterDetailsPage extends React.Component<Props> {
           // field errors.
           if (field_errors) {
             setErrors(field_errors)
+
+            if (field_errors["email"]) {
+              addUserNotification({
+                "registration-failed-status": {
+                  type:  ALERT_TYPE_DANGER,
+                  props: {
+                    text: field_errors["email"]
+                  }
+                }
+              })
+            }
           }
         }
       })

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -199,7 +199,10 @@ class UserSerializer(serializers.ModelSerializer):
 
     def validate_email(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
-        if User.objects.filter(email__iexact=value.strip().lower()).exists():
+        if (
+            not self.instance
+            and User.objects.filter(email__iexact=value.strip().lower()).exists()
+        ):
             raise serializers.ValidationError(EMAIL_ERROR_MSG)
 
         return {"email": value}

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -46,6 +46,8 @@ OPENEDX_USERNAME_VALIDATION_MSGS_MAP = {
     "It looks like this username is already taken": USERNAME_ALREADY_EXISTS_MSG
 }
 
+EMAIL_ERROR_MSG = "Email address already exists in the system."
+
 
 class UserProfileSerializer(serializers.ModelSerializer):
     """Serializer for profile"""
@@ -197,6 +199,9 @@ class UserSerializer(serializers.ModelSerializer):
 
     def validate_email(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
+        if User.objects.filter(email__iexact=value.strip().lower()).exists():
+            raise serializers.ValidationError(EMAIL_ERROR_MSG)
+
         return {"email": value}
 
     def validate_username(self, value):

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -93,7 +93,8 @@ def test_update_user_serializer(settings, user, valid_address_dict):
 
 @responses.activate
 @pytest.mark.django_db
-def test_create_user_serializer(settings, valid_address_dict):
+@pytest.mark.parametrize("test_case_dup", [True, False])
+def test_create_user_serializer(settings, valid_address_dict, test_case_dup):
     """Test that a UserSerializer can be created properly"""
     responses.add(
         responses.POST,
@@ -113,6 +114,18 @@ def test_create_user_serializer(settings, valid_address_dict):
     assert serializer.is_valid()
     user = serializer.save()
     assert user.is_active is True
+
+    if test_case_dup:
+        serializer = UserSerializer(
+            data={
+                "username": "fakename",
+                "email": "FAKE@FAKE.EDU",
+                "password": "fake",
+                "legal_address": valid_address_dict,
+            }
+        )
+
+        assert not serializer.is_valid()
 
 
 def test_update_email_change_request_existing_email(user):


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

https://github.com/mitodl/mitxonline/issues/1580

#### What's this PR do?

Updates the UserSerializer to throw a validation error if the email address isn't actually unique. While there was a database constraint on this, that considers case differences as unique. So, the email validation function has been expanded to do a case insensitive search for the email address, and to also strip whitespace before doing the check. 

This also adds some code to the RegisterDetailsPage component to display an email error using the standard user notification system (since we don't expose the email field on the form). 

#### How should this be manually tested?

1. Open two separate browsers or browser sessions (incognito, etc.)
2. Navigate to the Create Account page in each.
3. Supply an email address in one in all lowercase.
4. Supply the same email address in the other one, but in all caps. 
5. When the verification emails come through for each, navigate to the create account page in each browser. You will need to have the details page open in both before continuing - do not fill the form out yet. 
6. Fill out the details form in one browser and complete the signup process. This should be successful.
7. Fill out the details form in the other browser. This should fail with an error message. 

In addition, editing the profile and changing the email address of an existing account should be successful. 