### PR TITLE
Fixes us_state to return None if there's no state; adds a test for that

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -274,7 +274,7 @@ class LegalAddress(TimestampedModel):
     def us_state(self):
         """Returns just the state bit, minus the 'US-' part, only for users in the US."""
 
-        if self.country == "US":
+        if self.country == "US" and self.state is not None:
             return self.state.split("-")[1]
 
         return None

--- a/users/models_test.py
+++ b/users/models_test.py
@@ -153,3 +153,33 @@ def test_user_coppa(should_pass):
         user.user_profile.year_of_birth = datetime.now().year - random.randint(0, 12)
 
     assert user.is_coppa_compliant() == should_pass
+
+
+def test_legal_address_us_state():
+    """
+    Tests to make sure the us_state property is working properly.
+
+    This should be:
+    - the state code alone if the user's country is US and the state is specified
+    - None if the state is not specified or if the country is not US
+    """
+
+    user = UserFactory.create()
+    legal_address = user.legal_address
+
+    legal_address.country = "US"
+    legal_address.state = "US-MA"
+    legal_address.save()
+
+    assert legal_address.us_state == "MA"
+
+    legal_address.country = "US"
+    legal_address.state = None
+    legal_address.save()
+
+    assert legal_address.us_state == None
+
+    legal_address.country = "JP"
+    legal_address.save()
+
+    assert legal_address.us_state == None


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

#1588 

#### What's this PR do?

If the user's in the US and has not specified a state, the `us_state` property in `legal_address` should just be None. 

#### How should this be manually tested?

1. Update a user account to have the country set to US and no state specified (you may need to set this up in Django Admin).
2. Attempt to update the edx profile for that user with the `update_edx_profiles --user` command. This should succeed.
