### PR TITLE
Use new hubspot_api version and try to sync contacts individually if a batched sync chunk fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
           POSTGRES_DB: postgres
         ports:
           - 5432:5432
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7.5"
+          python-version: "3.9.6"
 
       - id: cache
         uses: actions/cache@v3
@@ -64,7 +64,7 @@ jobs:
       # disabled for now because it's broken for some reason
       # - name: Lint
       #   run: pylint ./**/*.py
-        
+
       - name: Code Formatting (Black)
         run: black --check .
 
@@ -99,7 +99,7 @@ jobs:
           MITX_ONLINE_ADMIN_EMAIL: example@localhost
           OPENEDX_API_CLIENT_ID: fake_client_id
           OPENEDX_API_CLIENT_SECRET: fake_client_secret
-          OPENEDX_API_KEY: test-openedx-api-key
+          OPENEDX_API_KEY: test-openedx-api-key  # pragma: allowlist secret
 
       - name: Tests
         run: |
@@ -112,7 +112,7 @@ jobs:
           CELERY_TASK_ALWAYS_EAGER: 'True'
           CELERY_BROKER_URL: redis://localhost:6379/4
           CELERY_RESULT_BACKEND: redis://localhost:6379/4
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres  # pragma: allowlist secret
           ELASTICSEARCH_URL: localhost:9200
           MAILGUN_KEY: fake_mailgun_key
           MAILGUN_SENDER_DOMAIN: other.fake.site
@@ -126,7 +126,7 @@ jobs:
           OPENEDX_API_BASE_URL: http://localhost:18000
           OPENEDX_API_CLIENT_ID: fake_client_id
           OPENEDX_API_CLIENT_SECRET: fake_client_secret
-          OPENEDX_API_KEY: test-openedx-api-key
+          OPENEDX_API_KEY: test-openedx-api-key  # pragma: allowlist secret
           SECRET_KEY: local_unsafe_key
 
       - name: Upload coverage to CodeCov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -10,7 +10,7 @@ import celery
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
-from hubspot.crm.objects import BatchInputSimplePublicObjectInput
+from hubspot.crm.objects import ApiException, BatchInputSimplePublicObjectInput
 from mitol.common.decorators import single_task
 from mitol.common.utils.collections import chunks
 from mitol.hubspot_api.api import HubspotApi, HubspotAssociationType, HubspotObjectType
@@ -74,6 +74,50 @@ def batched_chunks(
     if len(batch_ids) <= max_chunk_size:
         return [batch_ids]
     return chunks(batch_ids, chunk_size=max_chunk_size)
+
+
+def sync_failed_contacts(chunk: list[int]) -> list[int]:
+    """
+    Consecutively try individual contact syncs for a failed batch sync
+    Args:
+        chunk[list]: list of user id's
+
+    Returns:
+        list of contact ids that still failed
+    """
+    failed_ids = []
+    for user_id in chunk:
+        try:
+            api.sync_contact_with_hubspot(user_id)
+            time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+        except ApiException:
+            failed_ids.append(user_id)
+    return failed_ids
+
+
+def handle_failed_batch_chunk(chunk: list[int], hubspot_type: str) -> list[int]:
+    """
+    Try reprocessing a chunk of contacts individually, in case conflicting emails are the problem
+
+    Args:
+        chunk [list]: list of object ids
+        hubspot_type: The type of Hubspot object
+
+    Returns:
+        list of still failing object ids
+
+    """
+    failed = chunk
+    if hubspot_type == HubspotObjectType.CONTACTS.value:
+        # Might be due to conflicting emails, try updating individually
+        failed = sync_failed_contacts(chunk)
+    if failed:
+        log.exception(
+            "Exception when batch syncing Hubspot ids %s of type %s",
+            f"{failed}",
+            hubspot_type,
+        )
+    return failed
 
 
 @app.task(
@@ -170,34 +214,47 @@ def batch_create_hubspot_objects_chunked(
     )
     # Chunk again, by max allowed for object type (10 for contacts, 100 for all else)
     chunked_ids = batched_chunks(hubspot_type, object_ids)
+    errored_chunks = []
+    last_error_status = None
     for chunk in chunked_ids:
-        response = HubspotApi().crm.objects.batch_api.create(
-            hubspot_type,
-            BatchInputSimplePublicObjectInput(
-                inputs=[
-                    api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id)
-                    for obj_id in chunk
-                ]
-            ),
-        )
-        for result in response.results:
-            if ct_model_name == "user":
-                object_id = (
-                    User.objects.filter(
-                        email__iexact=result.properties["email"], is_active=True
-                    )
-                    .first()
-                    .id
-                )
-            else:
-                object_id = result.properties["unique_app_id"].split("-")[-1]
-            HubspotObject.objects.update_or_create(
-                content_type=content_type,
-                hubspot_id=result.id,
-                object_id=object_id,
+        try:
+            response = HubspotApi().crm.objects.batch_api.create(
+                hubspot_type,
+                BatchInputSimplePublicObjectInput(
+                    inputs=[
+                        api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id)
+                        for obj_id in chunk
+                    ]
+                ),
             )
-            created_ids.append(result.id)
+            for result in response.results:
+                if ct_model_name == "user":
+                    object_id = (
+                        User.objects.filter(
+                            email__iexact=result.properties["email"], is_active=True
+                        )
+                        .first()
+                        .id
+                    )
+                else:
+                    object_id = result.properties["unique_app_id"].split("-")[-1]
+                HubspotObject.objects.update_or_create(
+                    content_type=content_type,
+                    hubspot_id=result.id,
+                    object_id=object_id,
+                )
+                created_ids.append(result.id)
+        except ApiException as ae:
+            last_error_status = ae.status
+            still_failed = handle_failed_batch_chunk(chunk, hubspot_type)
+            if still_failed:
+                errored_chunks.append(still_failed)
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+    if errored_chunks:
+        raise ApiException(
+            status=last_error_status,
+            reason=f"Batch hubspot create failed for the following chunks: {errored_chunks}",
+        )
     return created_ids
 
 
@@ -226,6 +283,8 @@ def batch_update_hubspot_objects_chunked(
     updated_ids = []
     # Chunk again, by max allowed for object type (10 for contacts, 100 for all else)
     chunked_ids = batched_chunks(hubspot_type, object_ids)
+    errored_chunks = []
+    last_error_status = None
     for chunk in chunked_ids:
         inputs = [
             {
@@ -236,11 +295,22 @@ def batch_update_hubspot_objects_chunked(
             }
             for obj_id in chunk
         ]
-        response = HubspotApi().crm.objects.batch_api.update(
-            hubspot_type, BatchInputSimplePublicObjectInput(inputs=inputs)
-        )
-        updated_ids.extend([result.id for result in response.results])
+        try:
+            response = HubspotApi().crm.objects.batch_api.update(
+                hubspot_type, BatchInputSimplePublicObjectInput(inputs=inputs)
+            )
+            updated_ids.extend([result.id for result in response.results])
+        except ApiException as ae:
+            last_error_status = ae.status
+            still_failed = handle_failed_batch_chunk(chunk, hubspot_type)
+            if still_failed:
+                errored_chunks.append(still_failed)
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+    if errored_chunks:
+        raise ApiException(
+            status=last_error_status,
+            reason=f"Batch hubspot update failed for the following chunks: {errored_chunks}",
+        )
     return updated_ids
 
 

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -302,7 +302,9 @@ def batch_update_hubspot_objects_chunked(
             updated_ids.extend([result.id for result in response.results])
         except ApiException as ae:
             last_error_status = ae.status
-            still_failed = handle_failed_batch_chunk(chunk, hubspot_type)
+            still_failed = handle_failed_batch_chunk(
+                [item[0] for item in chunk], hubspot_type
+            )
             if still_failed:
                 errored_chunks.append(still_failed)
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -214,9 +214,15 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
     mock_hubspot_api.return_value.crm.objects.batch_api.update.side_effect = (
         ApiException(status=status)
     )
+    mocker.patch(
+        "hubspot_sync.tasks.api.sync_contact_with_hubspot",
+        side_effect=(ApiException(status=status)),
+    )
     with pytest.raises(expected_error):
         tasks.batch_update_hubspot_objects_chunked(
-            HubspotObjectType.CONTACTS.value, "user", []
+            HubspotObjectType.CONTACTS.value,
+            "user",
+            [(user.id, "123") for user in UserFactory.create_batch(3)],
         )
 
 
@@ -259,9 +265,15 @@ def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_err
     mock_hubspot_api.return_value.crm.objects.batch_api.create.side_effect = (
         ApiException(status=status)
     )
+    mocker.patch(
+        "hubspot_sync.tasks.api.sync_contact_with_hubspot",
+        side_effect=(ApiException(status=status)),
+    )
     with pytest.raises(expected_error):
         tasks.batch_create_hubspot_objects_chunked(
-            HubspotObjectType.CONTACTS.value, "user", []
+            HubspotObjectType.CONTACTS.value,
+            "user",
+            [user.id for user in UserFactory.create_batch(3)],
         )
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ edx-api-client==1.7.0
 hubspot-api-client==6.1.0
 ipython
 mitol-django-common~=2.7.0
-mitol-django-hubspot-api~=1.1.0
+mitol-django-hubspot-api~=2023.5.10
 mitol-django-mail>=3.3.0
 mitol-django-authentication>=1.6.0
 mitol-django-openedx>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ amqp==5.0.9
     # via kombu
 anyascii==0.2.0
     # via wagtail
-appnope==0.1.3
-    # via ipython
 asgiref==3.3.4
     # via
     #   django
@@ -122,7 +120,7 @@ django==3.2.18
     #   mitol-django-openedx
     #   mitol-django-payment-gateway
     #   wagtail
-django-anymail[mailgun]==9.2
+django-anymail[mailgun]==8.4
     # via
     #   -r requirements.in
     #   mitol-django-authentication
@@ -289,7 +287,7 @@ mitol-django-google-sheets==2.6.0
     #   mitol-django-google-sheets-refunds
 mitol-django-google-sheets-refunds==0.8.0
     # via -r requirements.in
-mitol-django-hubspot-api==1.1.0
+mitol-django-hubspot-api==2023.5.10
     # via -r requirements.in
 mitol-django-mail==3.3.0
     # via
@@ -402,6 +400,7 @@ requests==2.28.2
     #   django-oauth-toolkit
     #   edx-api-client
     #   mitol-django-common
+    #   mitol-django-hubspot-api
     #   premailer
     #   requests-oauthlib
     #   social-auth-core


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1350 

#### What's this PR do?
- Uses the new version of mitol.hubspot_api which can handle conflicts caused by a Hubspot contact having 2 emails associated with different mitxonline users
- Modifies the batch create/update tasks to try syncing contacts individually (to hit code above) if any API exceptions occur when running batch sync operations.

#### How should this be manually tested?
- Ask for access to the mitxonlinedex sandbox account for hubspot if you don't already have it.
- Copy the `HUBSPOT_*` settings values from RC to your .env file

Part 1:
- Create a new user in mitxonline, something like `fake_user+1@gmail.com`
- Find the contact in hubspot (may take a minute or so to show up) and add a secondary email to that contact: `fake_user+2@gmail.com`

<img width="542" alt="Screenshot 2023-05-11 at 10 30 32 AM" src="https://github.com/mitodl/mitxonline/assets/187676/fa1cea9a-4900-4707-89e0-98ec1a301e84">


- Create another new user with that same email - `fake_user+2@gmail.com`
- Check back on hubspot, that secondary email should be gone from the contact, and there should be a new contact with email `fake_user+2@gmail.com`

Part 2:
- Comment out your hubspot .env settings and restart your containers
- Create another new user, `fake_user+3@gmail.com`
- In hubspot, add that email to one of the existing contacts as a secondary email
- Uncomment your hubspot .env settings and restart your containers
- Run `manage.py sync_db_to_hubspot --users create`.  It should complete successfully
- Check hubspot again, the secondary email from the contact should be gone and assigned to a new contact.
