### PR TITLE
1605: get certificate button on approved flexible price leads to empty cart

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1281,6 +1281,14 @@ class FlexiblePricingRequestForm(AbstractForm):
 
         fp_request = self.get_previous_submission(request)
         context["prior_request"] = fp_request
+        product_page = self.get_parent_product_page()
+        product = product_page.product
+        context["product"] = (
+            product.active_products.first()
+            if product.active_products is not None
+            else None
+        )
+        context["product_page"] = product_page.url
 
         return context
 

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -580,3 +580,23 @@ def test_get_current_finaid_with_flex_price_for_expired_course_run(mocker):
     assert course_run.course.page.get_current_finaid(request) is None
     patched_flexible_price_discount.assert_not_called()
     patched_flexible_price_approved.assert_not_called()
+
+
+def test_flexible_pricing_request_form_context():
+    """Tests the flexible pricing request form context contains required information."""
+    rf = RequestFactory()
+    request = rf.get("/")
+    user = UserFactory.create()
+    request.user = user
+    course_page = CoursePageFactory()
+    run = CourseRunFactory.create(course=course_page.course)
+
+    flex_form = FlexiblePricingFormFactory(
+        selected_course=course_page.course, parent=course_page
+    )
+    product = ProductFactory.create(purchasable_object=run)
+
+    context = flex_form.get_context(request=request)
+
+    assert context["product"].id == product.id
+    assert context["product_page"] == course_page.url

--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -64,14 +64,20 @@
         {% endif %}{# end discount amount text #}
 
           {% if page.selected_course %}
-            <form action="/cart/add/" method="get" className="text-center">
-             <input type="hidden" name="course_id" value={{ page.selected_course.id }} />
-              <button
-              type="submit"
-              class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
-              Get Certificate
-              </button>
+            {% if product %}{# product and unexpired course run exist #}
+              <form action="/cart/add" method="get" className="text-center">
+                <input type="hidden" name="product_id" value={{ product.id }} />
+                <button
+                type="submit"
+                class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+                Get Certificate
+                </button>
               </form>
+            {% else %}
+              <a href="{{ product_page }}" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+                Course details
+              </a>
+            {% endif %}
           {% elif page.selected_program %}
             <a href="/dashboard" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
             Go to Dashboard


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1605

#### What's this PR do?
Populates the cart with the product related to the flexible price request when a user clicks the "Get Certificate" button from the approved flexible price request screen.

#### How should this be manually tested?
- Use a course run with a start date and start enrollment date in the past, and end date in the future, which is also configured with a course that has flexible pricing configured.
- Apply for flexible pricing on the course.
- Through the staff dashboard (http://mitxonline.odl.local:8013/staff-dashboard/), approve your flexible pricing request.
- Navigate back to the flexible pricing request screen and you should be presented with a button labeled "Get Certificate".
- Verify that when you click this button you are redirected to the cart page which contains the course run associated with your flexible pricing request.
- This PR also adds in a logic statement in the template to display a "Course details" button instead of the "Get Certificate" button in the event that `get_parent_product_page()` returns `None` or if `product.active_products` is empty.  This button will redirect the user back to the course about page.
