### PR TITLE
Find user by account email not social auth email

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -222,8 +222,7 @@ class LoginEmailSerializer(SocialAuthSerializer):
 
         try:
             user = User.objects.filter(
-                social_auth__uid__iexact=validated_data.get("email"),
-                social_auth__provider=EmailAuth.name,
+                email=validated_data.get("email"),
                 is_active=True,
             ).first()
             if user is None:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1374

#### What's this PR do?
Queries users by their `User` record's email address instead of their `SocialAuth` records email address during the login process.

#### How should this be manually tested?

1. Using an existing user or register a new user, go to the Accounts page (http://mitxonline.odl.local:8013/account-settings/)
2. Update the user's email address to include a period before the @ sign (`myname@email.com` -> `my.name@email.com`). Gmail will treat both of these emails as the same.
3. Confirm the email change using the link in the email you receive.
4. Logout of MITx Online.
5. Verify that you can log back into MITx Online.

#### Any background context you want to provide?
When a user changes their email address, their social auth record is removed.  Before this PR, the login screen would search for a matching social auth record, if found the user would be presented with the password screen, otherwise they would be shown an error message: "Couldn't find your account".  Now, when the user logs in after changing their email address a new social auth record will be created for them upon authenticating.
