### PR TITLE
Fix flexible pricing page for programs

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-Version 0.63.24
+Version 0.63.24 (Released May 15, 2023)
 ---------------
 
 - Find user by account email not social auth email (#1610)

--- a/cms/models.py
+++ b/cms/models.py
@@ -1285,6 +1285,14 @@ class FlexiblePricingRequestForm(AbstractForm):
 
         fp_request = self.get_previous_submission(request)
         context["prior_request"] = fp_request
+        product_page = self.get_parent_product_page()
+        product = product_page.product
+        context["product"] = (
+            product.active_products.first()
+            if product.active_products is not None
+            else None
+        )
+        context["product_page"] = product_page.url
 
         return context
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -1285,14 +1285,6 @@ class FlexiblePricingRequestForm(AbstractForm):
 
         fp_request = self.get_previous_submission(request)
         context["prior_request"] = fp_request
-        product_page = self.get_parent_product_page()
-        product = product_page.product
-        context["product"] = (
-            product.active_products.first()
-            if product.active_products is not None
-            else None
-        )
-        context["product_page"] = product_page.url
 
         return context
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -1289,7 +1289,7 @@ class FlexiblePricingRequestForm(AbstractForm):
         product = product_page.product
         context["product"] = (
             product.active_products.first()
-            if product.active_products is not None
+            if isinstance(product, Course) and product.active_products is not None
             else None
         )
         context["product_page"] = product_page.url

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -580,23 +580,3 @@ def test_get_current_finaid_with_flex_price_for_expired_course_run(mocker):
     assert course_run.course.page.get_current_finaid(request) is None
     patched_flexible_price_discount.assert_not_called()
     patched_flexible_price_approved.assert_not_called()
-
-
-def test_flexible_pricing_request_form_context():
-    """Tests the flexible pricing request form context contains required information."""
-    rf = RequestFactory()
-    request = rf.get("/")
-    user = UserFactory.create()
-    request.user = user
-    course_page = CoursePageFactory()
-    run = CourseRunFactory.create(course=course_page.course)
-
-    flex_form = FlexiblePricingFormFactory(
-        selected_course=course_page.course, parent=course_page
-    )
-    product = ProductFactory.create(purchasable_object=run)
-
-    context = flex_form.get_context(request=request)
-
-    assert context["product"].id == product.id
-    assert context["product_page"] == course_page.url

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -580,3 +580,23 @@ def test_get_current_finaid_with_flex_price_for_expired_course_run(mocker):
     assert course_run.course.page.get_current_finaid(request) is None
     patched_flexible_price_discount.assert_not_called()
     patched_flexible_price_approved.assert_not_called()
+
+
+def test_flexible_pricing_request_form_context():
+    """Tests the flexible pricing request form context contains required information."""
+    rf = RequestFactory()
+    request = rf.get("/")
+    user = UserFactory.create()
+    request.user = user
+    course_page = CoursePageFactory()
+    run = CourseRunFactory.create(course=course_page.course)
+
+    flex_form = FlexiblePricingFormFactory(
+        selected_course=course_page.course, parent=course_page
+    )
+    product = ProductFactory.create(purchasable_object=run)
+
+    context = flex_form.get_context(request=request)
+
+    assert context["product"].id == product.id
+    assert context["product_page"] == course_page.url

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -610,5 +610,5 @@ def test_flexible_pricing_request_form_context(flex_form_for_course):
     if isinstance(product, Course):
         assert context["product"].id == product.id
     else:
-        assert context["product"] == None
+        assert context["product"] is None
     assert context["product_page"] == course_page.url

--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -64,14 +64,20 @@
         {% endif %}{# end discount amount text #}
 
           {% if page.selected_course %}
-            <form action="/cart/add/" method="get" className="text-center">
-             <input type="hidden" name="course_id" value={{ page.selected_course.id }} />
-              <button
-              type="submit"
-              class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
-              Get Certificate
-              </button>
+            {% if product %}{# product and unexpired course run exist #}
+              <form action="/cart/add" method="get" className="text-center">
+                <input type="hidden" name="product_id" value={{ product.id }} />
+                <button
+                  type="submit"
+                  class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+                  Get Certificate
+                </button>
               </form>
+            {% else %}
+              <a href="{{ product_page }}" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+                Course details
+              </a>
+            {% endif %}
           {% elif page.selected_program %}
             <a href="/dashboard" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
             Go to Dashboard

--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -64,20 +64,14 @@
         {% endif %}{# end discount amount text #}
 
           {% if page.selected_course %}
-            {% if product %}{# product and unexpired course run exist #}
-              <form action="/cart/add" method="get" className="text-center">
-                <input type="hidden" name="product_id" value={{ product.id }} />
-                <button
-                type="submit"
-                class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
-                Get Certificate
-                </button>
+            <form action="/cart/add/" method="get" className="text-center">
+             <input type="hidden" name="course_id" value={{ page.selected_course.id }} />
+              <button
+              type="submit"
+              class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+              Get Certificate
+              </button>
               </form>
-            {% else %}
-              <a href="{{ product_page }}" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
-                Course details
-              </a>
-            {% endif %}
           {% elif page.selected_program %}
             <a href="/dashboard" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
             Go to Dashboard

--- a/cms/templates/flexiblepricing/flexible_pricing_request_form.html
+++ b/cms/templates/flexiblepricing/flexible_pricing_request_form.html
@@ -64,14 +64,20 @@
         {% endif %}{# end discount amount text #}
 
           {% if page.selected_course %}
-            <form action="/cart/add/" method="get" className="text-center">
-             <input type="hidden" name="course_id" value={{ page.selected_course.id }} />
-              <button
-              type="submit"
-              class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
-              Get Certificate
-              </button>
+            {% if product %}{# product and unexpired course run exist #}
+              <form action="/cart/add" method="get" className="text-center">
+                <input type="hidden" name="product_id" value={{ product.id }} />
+                <button
+                type="submit"
+                class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+                Get Certificate
+                </button>
               </form>
+            {% else %}
+              <a href="{{ product_page }}" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
+                Course details
+              </a>
+            {% endif %}
           {% elif page.selected_program %}
             <a href="/dashboard" class="btn btn-primary btn-gradient-red flexible-price-certificate-btn">
             Go to Dashboard


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1615

#### What's this PR do?
Fixes an issue in the most recent release which was thrown when user's viewed the flexible pricing form for Programs.  Programs don't have an `active_products` attribute which is used to derive the product ID that is used to populate the Cart from the approved Flexible Pricing page.

#### How should this be manually tested?

1. Configure a Program, Program Run, Product associated with the program, Page and Flexible Price form for the Program through CMS, and a user.
2. View the program page.  You can find the Program page's URL from within the CMS.
3. Apply for Flexible Pricing on the program.
4. Approve the flexible pricing request through http://mitxonline.odl.local:8013/staff-dashboard/
5. From the program page, launch the flexible pricing request form again (same as step 3).  Verify that you don't receive a 500 error and that the "Go to dashboard" button is displayed.
6. For the remaining steps you will need a Course, Course Run, Product associated with the Course, Page and Flexible Price form for the Course.
7. Confirm that a Course's approved flexible pricing request form displays the "Get Certificate" button which redirects to a populated Cart page only if there is an active product for an unexpired course run.
8. Make the Course Run expired (end date and enrollment end date are both in the past).  Visit the approved flexible pricing form for the course and verify the "Course details" button is shown which redirects to the course details page.
