### PR TITLE
Expands edX profile sync.

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -242,6 +242,13 @@ def update_edx_user_profile(user):
             name=user.name,
             country=user.legal_address.country if user.legal_address else None,
             state=user.legal_address.us_state if user.legal_address else None,
+            gender=user.user_profile.gender if user.user_profile else None,
+            year_of_birth=user.user_profile.year_of_birth
+            if user.user_profile
+            else None,
+            level_of_education=user.user_profile.highest_education
+            if user.user_profile
+            else None,
         ),
         headers={
             "Authorization": f"Bearer {auth.access_token}",

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -128,6 +128,13 @@ def create_edx_user(user):
                 name=user.name,
                 country=user.legal_address.country if user.legal_address else None,
                 state=user.legal_address.us_state if user.legal_address else None,
+                gender=user.user_profile.gender if user.user_profile else None,
+                year_of_birth=user.user_profile.year_of_birth
+                if user.user_profile
+                else None,
+                level_of_education=user.user_profile.level_of_education
+                if user.user_profile
+                else None,
                 provider=settings.MITX_ONLINE_OAUTH_PROVIDER,
                 access_token=access_token.token,
                 **OPENEDX_REQUEST_DEFAULTS,
@@ -246,7 +253,7 @@ def update_edx_user_profile(user):
             year_of_birth=user.user_profile.year_of_birth
             if user.user_profile
             else None,
-            level_of_education=user.user_profile.highest_education
+            level_of_education=user.user_profile.level_of_education
             if user.user_profile
             else None,
         ),

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -156,6 +156,10 @@ def test_create_edx_user(user, settings, application, access_token_count):
         "provider": settings.MITX_ONLINE_OAUTH_PROVIDER,
         "access_token": created_access_token.token,
         "country": user.legal_address.country if user.legal_address else None,
+        "year_of_birth": str(user.user_profile.year_of_birth)
+        if user.user_profile
+        else None,
+        "gender": user.user_profile.gender if user.user_profile else None,
         "honor_code": "True",
     }
     assert (

--- a/openedx/tasks.py
+++ b/openedx/tasks.py
@@ -60,3 +60,12 @@ def change_edx_user_name_async(user_id):
     """
     user = User.objects.get(id=user_id)
     api.update_edx_user_name(user)
+
+
+@app.task(acks_late=True)
+def update_edx_user_profile(user_id):
+    """
+    Task to update the edX user profile. This doesn't change the name or email.
+    """
+    user = User.objects.get(id=user_id)
+    api.update_edx_user_profile(user)

--- a/users/models.py
+++ b/users/models.py
@@ -71,6 +71,19 @@ HIGHEST_EDUCATION_CHOICES = (
     ("Other education", "Other education"),
 )
 
+OPENEDX_HIGHEST_EDUCATION_MAPPINGS = (
+    (None, None),
+    ("Doctorate", "p"),
+    ("Master's or professional degree", "m"),
+    ("Bachelor's degree", "b"),
+    ("Associate degree", "a"),
+    ("Secondary/high school", "hs"),
+    ("Junior secondary/junior high/middle school", "jhs"),
+    ("Elementary/primary school", "el"),
+    ("No formal education", "none"),
+    ("Other education", "other"),
+)
+
 
 def _post_create_user(user):
     """
@@ -346,6 +359,15 @@ class UserProfile(TimestampedModel):
         blank=True,
         help_text="The learner identifies as type Other (not professional, student, or educator)",
     )
+
+    @property
+    def level_of_education(self):
+        """Open edX uses codes for this so we need to map our values."""
+        return [
+            item[1]
+            for item in OPENEDX_HIGHEST_EDUCATION_MAPPINGS
+            if item[0] == self.highest_education
+        ][0]
 
     def __str__(self):
         """Str representation for the profile"""

--- a/users/models.py
+++ b/users/models.py
@@ -363,11 +363,15 @@ class UserProfile(TimestampedModel):
     @property
     def level_of_education(self):
         """Open edX uses codes for this so we need to map our values."""
-        return [
-            item[1]
-            for item in OPENEDX_HIGHEST_EDUCATION_MAPPINGS
-            if item[0] == self.highest_education
-        ][0]
+        return (
+            [
+                item[1]
+                for item in OPENEDX_HIGHEST_EDUCATION_MAPPINGS
+                if item[0] == self.highest_education
+            ][0]
+            if self.highest_education
+            else ""
+        )
 
     def __str__(self):
         """Str representation for the profile"""

--- a/users/models_test.py
+++ b/users/models_test.py
@@ -15,7 +15,12 @@ from django.db import transaction
 from cms.constants import CMS_EDITORS_GROUP_NAME
 from openedx.factories import OpenEdxApiAuthFactory, OpenEdxUserFactory
 from users.factories import LegalAddressFactory, UserFactory
-from users.models import LegalAddress, User
+from users.models import (
+    HIGHEST_EDUCATION_CHOICES,
+    OPENEDX_HIGHEST_EDUCATION_MAPPINGS,
+    LegalAddress,
+    User,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -183,3 +188,22 @@ def test_legal_address_us_state():
     legal_address.save()
 
     assert legal_address.us_state == None
+
+
+def test_user_profile_edx_education():
+    user = UserFactory.create()
+
+    user.user_profile.highest_education = HIGHEST_EDUCATION_CHOICES[
+        random.randrange(1, len(HIGHEST_EDUCATION_CHOICES))
+    ][0]
+    user.save()
+
+    test_openedx_flag = [
+        item[1]
+        for item in OPENEDX_HIGHEST_EDUCATION_MAPPINGS
+        if item[0] == user.user_profile.highest_education
+    ][0]
+
+    assert user.user_profile.highest_education is not None
+    assert user.user_profile.level_of_education is not None
+    assert user.user_profile.level_of_education == test_openedx_flag

--- a/users/views.py
+++ b/users/views.py
@@ -53,6 +53,7 @@ class CurrentUserRetrieveUpdateViewSet(
             update_result = super().update(request, *args, **kwargs)
             if user_name != request.data.get("name"):
                 tasks.change_edx_user_name_async.delay(request.user.id)
+            tasks.update_edx_user_profile(request.user.id)
             return update_result
 
 

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -220,6 +220,7 @@ def test_update_user_name_change(mocker, user_client, user, valid_address_dict):
     """Test that updating user's name is properly reflected in MITx Online"""
     new_name = fuzzy.FuzzyText(prefix="Test-").fuzz()
     mocker.patch("openedx.api.update_edx_user_name")
+    mocker.patch("openedx.api.update_edx_user_profile")
     payload = {
         "name": new_name,
         "email": user.email,
@@ -242,6 +243,7 @@ def test_update_user_name_change_edx(mocker, user_client, user, valid_address_di
     """Test that PATCH on user/me also calls update user's name api in edX if there is a name change in MITx Online"""
     new_name = fuzzy.FuzzyText(prefix="Test-").fuzz()
     update_edx_mock = mocker.patch("openedx.api.update_edx_user_name")
+    mocker.patch("openedx.api.update_edx_user_profile")
     payload = {
         "name": new_name,
         "email": user.email,
@@ -258,8 +260,12 @@ def test_update_user_name_change_edx(mocker, user_client, user, valid_address_di
 
 
 def test_update_user_no_name_change_edx(mocker, user_client, user, valid_address_dict):
-    """Test that PATCH on user/me without name change doesn't call update user's name in edX"""
+    """
+    Test that PATCH on user/me without name change doesn't call update user's
+    name in edX, but that the profile update is called.
+    """
     update_edx_mock = mocker.patch("openedx.api.update_edx_user_name")
+    update_edx_profile_mock = mocker.patch("openedx.api.update_edx_user_profile")
     resp = user_client.patch(
         reverse("users_api-me"),
         content_type="application/json",
@@ -274,3 +280,4 @@ def test_update_user_no_name_change_edx(mocker, user_client, user, valid_address
     assert resp.status_code == status.HTTP_200_OK
     # Checks that update edx user was called not called when there is no change in user's name(Full Name)
     update_edx_mock.assert_not_called()
+    update_edx_profile_mock.assert_called()


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1620
Addresses issues raised in https://github.com/mitodl/hq/issues/1118

#### What's this PR do?

- Adds gender, year of birth, and level of education fields to the list of fields we now sync with edX.
- Updates the user profile API to sync the profile data on save. 

#### How should this be manually tested?

You will need to have a working edX instance for this - either Tutor or devstack should work (tested on Tutor). 

Manual sync:
1. Change an account's user profile gender, year of birth, or highest education fields via Django Admin/dbshell/other method that's not the normal frontend.
2. Run `manage.py update_edx_profiles --user <username>` where `<username>` is the username you edited. 
3. Check the data in edX - I found this was easiest to do using the Swagger interface (ex: http://local.overhang.io:8000/api-docs/#/user/user_v1_accounts_read if you're using Tutor)

Automatic sync:
1. Update an account's user profile gender, year of birth, or highest education fields in the normal way through the frontend.
2. Check the data in edX - the changes should be present.

Account creation:
1. Create an account and fill out the gender, year of birth, and highest education fields. 
2. Check the new account's data in edX. The changes should be present.

#### Any background context you want to provide?

Both the gender and the level of education fields in the edX user model use flags. We use the same flags for the gender field in mitxonline but the highest education field is both named differently and does not use flags, so there's a new list to map highest education to level of education in the User model to avoid writing a database migration to mass-update the data and changing it elsewhere in the code.
