### PR TITLE
Update mitol/hubspot_api app

### DIFF
--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -369,11 +369,6 @@ def test_batch_upsert_associations_chunked(settings, mocker):
 def test_sync_failed_contacts(mocker, mode):
     """sync_failed_contacts should try to sync each contact and return a list of failed contact ids"""
     user_ids = sorted(user.id for user in UserFactory.create_batch(4))
-    chunk = (
-        user_ids
-        if mode == "create"
-        else list(zip(user_ids, ["123", "234", "345", "678"]))
-    )
     mock_sync = mocker.patch(
         "hubspot_sync.tasks.api.sync_contact_with_hubspot",
         side_effect=[

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ edx-api-client==1.7.0
 hubspot-api-client==6.1.0
 ipython
 mitol-django-common~=2.7.0
-mitol-django-hubspot-api~=2023.5.10
+mitol-django-hubspot-api~=2023.5.22
 mitol-django-mail>=3.3.0
 mitol-django-authentication>=1.6.0
 mitol-django-openedx>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -294,7 +294,7 @@ mitol-django-google-sheets==2.6.0
     #   mitol-django-google-sheets-refunds
 mitol-django-google-sheets-refunds==0.8.0
     # via -r requirements.in
-mitol-django-hubspot-api==2023.5.10
+mitol-django-hubspot-api==2023.5.22
     # via -r requirements.in
 mitol-django-mail==3.3.0
     # via


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1619 

#### What's this PR do?
Updates mitol/hubspot_api app to the latest version.

#### How should this be manually tested?
The testing instructions for [this older PR](https://github.com/mitodl/mitxonline/pull/1607) should still work as described.

Also try this:
- Manually create a new contact in the mitxonlinedev sandbox account of Hubspot.
- Register a new user in mitxonline with the same email address.
- After verifying email, fill out the user/profile details.  There should be no hubspot ApiExceptions in the log and the details should soon be mirrored for the hubspot account you created manually.
