### PR TITLE
Working

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -222,7 +222,7 @@ class LoginEmailSerializer(SocialAuthSerializer):
 
         try:
             user = User.objects.filter(
-                email=validated_data.get("email"),
+                email__iexact=validated_data.get("email"),
                 is_active=True,
             ).first()
             if user is None:

--- a/authentication/serializers_test.py
+++ b/authentication/serializers_test.py
@@ -165,3 +165,32 @@ def test_login_email_validation_email_changed(mocker):
     )
 
     assert len(LoginEmailSerializer(result).data["field_errors"]) == 0
+
+
+def test_login_email_validation_email_different_case(mocker):
+    """Tests class-level validation of LoginEmailSerializer to handle different case of email entry."""
+
+    mocked_authenticate = mocker.patch(
+        "authentication.serializers.SocialAuthSerializer._authenticate"
+    )
+
+    user = UserFactory.create()
+
+    result = SocialAuthState(
+        SocialAuthState.STATE_LOGIN_PASSWORD, partial=mocker.Mock(), user=user
+    )
+    result.flow = SocialAuthState.FLOW_LOGIN
+    result.provider = EmailAuth.name
+    serializer = LoginEmailSerializer(
+        data={"flow": result.flow, "email": user.email.upper()},
+        context={
+            "backend": mocker.Mock(),
+            "strategy": mocker.Mock(),
+            "request": mocker.Mock(),
+        },
+    )
+    assert serializer.is_valid() is True, "Received errors: {}".format(
+        serializer.errors
+    )
+
+    assert len(LoginEmailSerializer(result).data["field_errors"]) == 0


### PR DESCRIPTION
Ignore case when comparing emails

#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1523

#### What's this PR do?
Ignores the letter case when looking up a user by email on the login page.

#### How should this be manually tested?

1. Register a new user using only lowercase letter in the email address (collinp@mit.edu)
2. Logout of MITx Online.
3. Attempt to login using the same email address from step 1 but all uppercase letters (COLLINP@MIT.EDU)
4. Verify that you are presented with the password screen.

