### PR TITLE
Remove scheduled cron task to sync all HubSpot contacts

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -869,16 +869,6 @@ CELERY_BEAT_SCHEDULE = {
             month_of_year="*",
         ),
     },
-    "sync-hubspot-user-contacts": {
-        "task": "hubspot_sync.tasks.sync_all_contacts_with_hubspot",
-        "schedule": crontab(
-            minute=0,
-            hour=0,
-            day_of_week="*",
-            day_of_month="*",
-            month_of_year="*",
-        ),
-    },
 }
 
 # Hijack


### PR DESCRIPTION
#### What's this PR do?
Removes the scheduled cron task which syncs all of the MITx Online users with HubSpot.  This was run on 05/25/2023 and all MITx Online users, except 85, were synced.  There is no need to run this task nightly since it should only be run when new User fields are intended to synced to HubSpot contacts.
