### PR TITLE
Add row header to order history table

### DIFF
--- a/frontend/public/src/containers/pages/checkout/OrderHistory.js
+++ b/frontend/public/src/containers/pages/checkout/OrderHistory.js
@@ -76,9 +76,9 @@ export class OrderHistory extends React.Component<Props> {
     )
     return (
       <tr scope="row" key={`ordercard_${order.id}`}>
-        <td className="d-flex">
+        <th className="d-flex">
           <span className="flex-grow-1">{orderTitle}</span>
-        </td>
+        </th>
         <td>{orderDate}</td>
         <td>{formatLocalePrice(parseFloat(order.total_price_paid))}</td>
         <td>{order.reference_number}</td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots

#### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/718

#### What's this PR do?
Add row header to order history table

#### How should this be manually tested?
Nothing should break.
Use a screen reader to make sure that it reads the row index.

<img width="1403" alt="Screen Shot 2023-05-26 at 7 51 29 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/567b5091-b848-4435-b455-8e9520a06eaa">



