### PR TITLE
add management command to create local enrollments from edx

### DIFF
--- a/courses/management/commands/create_local_enrollments.py
+++ b/courses/management/commands/create_local_enrollments.py
@@ -1,0 +1,82 @@
+"""
+Management command to create locals enrollments for specific runs from edX in bulk. It doesn't handle updates to local
+enrollment if exists.
+To sync enrollments for specific user and from both direction, use sync_enrollments command instead.
+
+./manage.py create_local_enrollments -—runs=<list of courseware IDs separated by space>
+
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from courses.models import CourseRun, CourseRunEnrollment, User
+from openedx.api import get_edx_api_service_client
+
+
+class Command(BaseCommand):
+    """creates local enrollments for specific runs from edX """
+
+    help = "Creates local enrollments for specific runs from edX"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--runs",
+            nargs="*",
+            type=str,
+            help="list of courseware_ids e.g. --runs course-v1:edX+E2E-101+course course-v1:edX+DemoX+Demo_Course",
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        """Handle command execution"""
+
+        courseware_ids = options["runs"]
+
+        edx_client = get_edx_api_service_client()
+
+        created_count = {}
+        for courseware_id in courseware_ids:
+            run = CourseRun.objects.filter(courseware_id=courseware_id).first()
+            if run is None:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Could not find course run with courseware_id={courseware_id}"
+                    )
+                )
+
+            edx_enrollments = edx_client.enrollments.get_enrollments(
+                course_id=courseware_id
+            )
+
+            created_count[courseware_id] = 0
+            for edx_enrollment in edx_enrollments:
+                try:
+                    user = User.objects.filter(username=edx_enrollment.user).first()
+                    if user:
+                        enrollment, created = CourseRunEnrollment.all_objects.get_or_create(
+                            user=user,
+                            run=run,
+                            defaults=dict(
+                                active=edx_enrollment.is_active,
+                                change_status=None,
+                                edx_emails_subscription=False,
+                                edx_enrolled=True,
+                                enrollment_mode=edx_enrollment.mode
+                            ),
+                        )
+                        if created:
+                            created_count[courseware_id] += 1
+
+                except:
+                    self.stderr.write(
+                        self.style.ERROR(
+                            f"Could not get or create course enrollment for user {edx_enrollment.user} course ID {courseware_id}"
+                        )
+                    )
+
+        for courseware_id, count in created_count.items():
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"\t{count} Enrollments created for {courseware_id} "
+                )
+            )

--- a/courses/management/commands/create_local_enrollments.py
+++ b/courses/management/commands/create_local_enrollments.py
@@ -14,7 +14,7 @@ from openedx.api import get_edx_api_service_client
 
 
 class Command(BaseCommand):
-    """creates local enrollments for specific runs from edX """
+    """creates local enrollments for specific runs from edX"""
 
     help = "Creates local enrollments for specific runs from edX"
 
@@ -53,7 +53,10 @@ class Command(BaseCommand):
                 try:
                     user = User.objects.filter(username=edx_enrollment.user).first()
                     if user:
-                        enrollment, created = CourseRunEnrollment.all_objects.get_or_create(
+                        (
+                            enrollment,
+                            created,
+                        ) = CourseRunEnrollment.all_objects.get_or_create(
                             user=user,
                             run=run,
                             defaults=dict(
@@ -61,7 +64,7 @@ class Command(BaseCommand):
                                 change_status=None,
                                 edx_emails_subscription=False,
                                 edx_enrolled=True,
-                                enrollment_mode=edx_enrollment.mode
+                                enrollment_mode=edx_enrollment.mode,
                             ),
                         )
                         if created:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1597

#### What's this PR do?
Adds a management command to create local enrollments from edx in bulk.
e.g.
```
./manage.py create_local_enrollments --runs course-v1:edX+E2E-101+course course-v1:edX+DemoX+Demo_Course
```
It doesn't handle updates to local enrollments if exist or there are enrollment changes on edx

#### How should this be manually tested?
1. Make sure courses are created in your local edx instance and MITx Online app. If not, create courses from admin/course_overviews/courseoverview/ for edx, and admin/courses/courserun/ for MITx Online app
2. Create some enrollments on your local edx instance from admin/student/courseenrollment/.  To access this URL, `student.courseenrollment_admin` switch needs to be created
3. Run `./manage.py create_local_enrollments --runs <COURSE IDs>`, you should see the following output if these enrollments don't already exist locally
   ```
       3 Enrollments created for course-v1:edX+E2E-101+course 
       2 Enrollments created for course-v1:edX+DemoX+Demo_Course 
```
