### PR TITLE
Make deferral functionality atomic and clarify errors

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -478,7 +478,7 @@ def defer_enrollment(
             keep_failed_enrollments=keep_failed_enrollments,
             mode=from_enrollment.enrollment_mode,
         )
-        if not enroll_success:
+        if not enroll_success and not keep_failed_enrollments:
             raise Exception(
                 "Api call to enroll on edX was not successful for course run '{}'".format(
                     to_run
@@ -489,7 +489,7 @@ def defer_enrollment(
             ENROLL_CHANGE_STATUS_DEFERRED,
             keep_failed_enrollments=keep_failed_enrollments,
         )
-        if not from_enrollment.edx_enrolled:
+        if from_enrollment is None:
             raise Exception(
                 "Api call to deactivate enrollment on edX "
                 "was not successful for course run '{}'".format(from_courseware_id)

--- a/courses/api.py
+++ b/courses/api.py
@@ -480,7 +480,9 @@ def defer_enrollment(
         )
         if not enroll_success:
             raise Exception(
-                "Api call to enroll on edX was not successful for course run '{}'".format(to_run)
+                "Api call to enroll on edX was not successful for course run '{}'".format(
+                    to_run
+                )
             )
         from_enrollment = deactivate_run_enrollment(
             from_enrollment,

--- a/courses/api.py
+++ b/courses/api.py
@@ -471,17 +471,27 @@ def defer_enrollment(
                 from_enrollment.run.course.title, to_run.course.title
             )
         )
-    to_enrollments, _ = create_run_enrollments(
-        user,
-        [to_run],
-        keep_failed_enrollments=keep_failed_enrollments,
-        mode=from_enrollment.enrollment_mode,
-    )
-    from_enrollment = deactivate_run_enrollment(
-        from_enrollment,
-        ENROLL_CHANGE_STATUS_DEFERRED,
-        keep_failed_enrollments=keep_failed_enrollments,
-    )
+    with transaction.atomic():
+        to_enrollments, enroll_success = create_run_enrollments(
+            user,
+            [to_run],
+            keep_failed_enrollments=keep_failed_enrollments,
+            mode=from_enrollment.enrollment_mode,
+        )
+        if not enroll_success:
+            raise Exception(
+                "Api call to enroll on edX was not successful for course run '{}'".format(to_run)
+            )
+        from_enrollment = deactivate_run_enrollment(
+            from_enrollment,
+            ENROLL_CHANGE_STATUS_DEFERRED,
+            keep_failed_enrollments=keep_failed_enrollments,
+        )
+        if not from_enrollment.edx_enrolled:
+            raise Exception(
+                "Api call to deactivate enrollment on edX "
+                "was not successful for course run '{}'".format(from_courseware_id)
+            )
     return from_enrollment, first_or_none(to_enrollments)
 
 

--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -70,6 +70,8 @@ class Command(EnrollmentChangeCommand):
             raise CommandError(message)
         except ValidationError as exc:
             raise CommandError("Invalid enrollment deferral - {}".format(exc))
+        except Exception as exc:
+            raise CommandError("{}".format(exc))
         else:
             if not to_enrollment:
                 raise CommandError(

--- a/courses/management/utils_test.py
+++ b/courses/management/utils_test.py
@@ -12,7 +12,6 @@ from courses.factories import (
 )
 from courses.management.utils import EnrollmentChangeCommand
 from main.test_utils import MockHttpError
-from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE
 from openedx.exceptions import EdxApiEnrollErrorException, UnknownEdxApiEnrollException
 from users.factories import UserFactory
 


### PR DESCRIPTION
#### What are the relevant tickets?
none

#### What's this PR do?
Make deferral functionality atomic and clarify errors when it is not successful.

If any api call to edx is not successful abort the whole procedure and write an appropriate message.

#### How should this be manually tested?
You can test it  by running a management command `defer_enrollment`:

`manage.py defer_enollment --user <username> --from-run <from_course_run_id> --to_run <to_course_run_id> `

If the api call to edx fails then you should see an appropriate message, and the whole operation should be aborted. Check that locally the enrollment was not set to 'deferred'.

And if you run it with another argument `--keep-failed-enrollments` then it should defer the enrollment locally even though the call to edx failed. Then it should still complete the deferral locally.

