### PR TITLE
904: tracking audit enrollments for mitx online courses in hubspot

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Count, Q
 from django.db.models.query import QuerySet
+from django.contrib.contenttypes.models import ContentType
 from mitol.common.utils import now_in_utc
 from mitol.common.utils.collections import (
     first_or_none,
@@ -363,6 +364,9 @@ def deactivate_run_enrollment(
     Returns:
         CourseRunEnrollment: The deactivated enrollment
     """
+    from ecommerce.models import Line, Order
+    from hubspot_sync.api import sync_line_item_with_hubspot
+
     try:
         unenroll_edx_course_run(run_enrollment)
     except Exception:  # pylint: disable=broad-except
@@ -381,6 +385,15 @@ def deactivate_run_enrollment(
         run_enrollment.edx_enrolled = False
         run_enrollment.edx_emails_subscription = False
     run_enrollment.deactivate_and_save(change_status, no_user=True)
+    content_type = ContentType.objects.filter(
+        app_label="courses", model="courserun"
+    ).first()
+    line = Line.objects.get(
+        purchased_object_id=run_enrollment.run.id,
+        purchased_content_type=content_type,
+        order__state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING]
+    )
+    sync_line_item_with_hubspot(line.id)
     return run_enrollment
 
 

--- a/courses/api.py
+++ b/courses/api.py
@@ -385,13 +385,12 @@ def deactivate_run_enrollment(
         run_enrollment.edx_enrolled = False
         run_enrollment.edx_emails_subscription = False
     run_enrollment.deactivate_and_save(change_status, no_user=True)
-    content_type = ContentType.objects.filter(
-        app_label="courses", model="courserun"
-    ).first()
+    content_type = ContentType.objects.get(app_label="courses", model="courserun")
     line_id = Line.objects.get(
         purchased_object_id=run_enrollment.run.id,
         purchased_content_type=content_type,
         order__state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING],
+        order__purchaser=run_enrollment.user,
     ).id
     sync_line_item_with_hubspot(line_id)
     return run_enrollment

--- a/courses/api.py
+++ b/courses/api.py
@@ -391,7 +391,7 @@ def deactivate_run_enrollment(
     line = Line.objects.get(
         purchased_object_id=run_enrollment.run.id,
         purchased_content_type=content_type,
-        order__state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING]
+        order__state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING],
     )
     sync_line_item_with_hubspot(line.id)
     return run_enrollment

--- a/courses/api.py
+++ b/courses/api.py
@@ -388,12 +388,12 @@ def deactivate_run_enrollment(
     content_type = ContentType.objects.filter(
         app_label="courses", model="courserun"
     ).first()
-    line = Line.objects.get(
+    line_id = Line.objects.get(
         purchased_object_id=run_enrollment.run.id,
         purchased_content_type=content_type,
         order__state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING],
-    )
-    sync_line_item_with_hubspot(line.id)
+    ).id
+    sync_line_item_with_hubspot(line_id)
     return run_enrollment
 
 

--- a/courses/management/commands/test_unenroll_enrollment.py
+++ b/courses/management/commands/test_unenroll_enrollment.py
@@ -96,10 +96,14 @@ def test_unenroll_enrollment(patches):
     assert enrollment.edx_enrolled is False
 
 
-def test_unenroll_enrollment_without_edx():
+def test_unenroll_enrollment_without_edx(mocker):
     """
     Test that user unenrolled from the course properly without edx
     """
+    get_line = mocker.patch("ecommerce.models.Line.objects.get")
+    sync_line_item_with_hubspot = mocker.patch(
+        "hubspot_sync.api.sync_line_item_with_hubspot"
+    )
     enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
     assert enrollment.change_status is None
     assert enrollment.active is True
@@ -127,5 +131,5 @@ def test_unenroll_enrollment_without_edx():
     assert enrollment.active is False
     # Enrollment will remain edx_enrolled
     assert enrollment.edx_enrolled is True
-    assert patches.send_unenrollment_email.call_count == 2
-    assert patches.get_line.call_count == 2
+    sync_line_item_with_hubspot.assert_called_once()
+    get_line.assert_called_once()

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -16,16 +16,13 @@ from cms.serializers import CoursePageSerializer
 from courses import models
 from courses.api import create_run_enrollments
 from courses.constants import CONTENT_TYPE_MODEL_COURSE, CONTENT_TYPE_MODEL_PROGRAM
-from courses.utils import get_program_certificate_by_enrollment
 from ecommerce.models import Product
 from ecommerce.serializers import BaseProductSerializer, ProductFlexibilePriceSerializer
 from flexiblepricing.api import is_courseware_flexible_price_approved
 from main import features
 from main.serializers import StrictFieldsSerializer
-from main.settings import AUTH_USER_MODEL
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 from users.models import User
-from users.serializers import UserSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -151,8 +151,6 @@ def create_enrollment_view(request):
     resp, user, run = _validate_enrollment_post_request(request)
     if resp is not None:
         return resp
-    
-    print("in view")
     _, edx_request_success = create_run_enrollments(
         user=user,
         runs=[run],
@@ -182,9 +180,7 @@ def create_enrollment_view(request):
             content_type=ContentType.objects.get_for_model(CourseRun),
         ).first()
         if product is None:
-            log.exception(
-                "No product found for that course with courseware_id %s", run
-            )
+            log.exception("No product found for that course with courseware_id %s", run)
         else:
             order = PendingOrder.create_from_product(product, user)
     else:

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -182,7 +182,7 @@ def create_enrollment_view(request):
         if product is None:
             log.exception("No product found for that course with courseware_id %s", run)
         else:
-            order = PendingOrder.create_from_product(product, user)
+            PendingOrder.create_from_product(product, user)
     else:
         resp = respond(request.headers["Referer"])
         cookie_value = {

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -175,9 +175,8 @@ def create_enrollment_view(request):
             "type": USER_MSG_TYPE_ENROLLED,
             "run": run.title,
         }
-        
-        print("we doin' this")
-                # Create PendingOrder here
+
+        # Create PendingOrder here
         product = Product.objects.filter(
             object_id=run.id,
             content_type=ContentType.objects.get_for_model(CourseRun),

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -9,6 +9,7 @@ from django.db.models import Count, Q
 from django.urls import reverse
 from requests import ConnectionError as RequestsConnectionError
 from requests import HTTPError
+from ecommerce.factories import ProductFactory
 from rest_framework import status
 
 from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
@@ -26,6 +27,7 @@ from courses.serializers import (
     CourseSerializer,
     ProgramSerializer,
 )
+from ecommerce.models import Product, PendingOrder
 from courses.views.v1 import UserEnrollmentsApiViewSet
 from main import features
 from main.constants import (
@@ -469,6 +471,7 @@ def test_create_enrollments(mocker, user_client, api_request):
         return_value=(None, True),
     )
     run = CourseRunFactory.create()
+    product = ProductFactory.create(purchasable_object=run)
     resp = user_client.post(
         reverse("create-enrollment-via-form"),
         data={"run": str(run.id), "isapi": "true"}
@@ -488,7 +491,7 @@ def test_create_enrollments(mocker, user_client, api_request):
                 "run": run.title,
             }
         )
-
+    assert PendingOrder.objects.all().count() == 1
     patched_create_enrollments.assert_called_once()
 
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -35,7 +35,6 @@ from ecommerce.models import (
 )
 from ecommerce.tasks import perform_downgrade_from_order
 from flexiblepricing.api import determine_courseware_flexible_price_discount
-from hubspot_sync.task_helpers import sync_hubspot_deal
 from main.constants import (
     USER_MSG_TYPE_COURSE_NON_UPGRADABLE,
     USER_MSG_TYPE_DISCOUNT_INVALID,

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -628,7 +628,7 @@ class PendingOrder(FulfillableOrder, Order):
 
     @classmethod
     @transaction.atomic()
-    def create_from_product(cls, product: Product, user: User, discount: Discount):
+    def create_from_product(cls, product: Product, user: User, discount: Discount=None):
         """
         Creates a new pending order from a product
 
@@ -648,11 +648,12 @@ class PendingOrder(FulfillableOrder, Order):
 
         # apply all the discounts to the order first
         # this is needed to compute the discounted prices of each line
-        order.discounts.create(
-            redemption_date=now,
-            redeemed_by=user,
-            redeemed_discount=discount,
-        )
+        if discount:
+            order.discounts.create(
+                redemption_date=now,
+                redeemed_by=user,
+                redeemed_discount=discount,
+            )
 
         product_version = Version.objects.get_for_object(product).first()
 

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 import uuid
 from datetime import datetime
 from decimal import Decimal
@@ -579,6 +580,58 @@ class FulfillableOrder:
 class PendingOrder(FulfillableOrder, Order):
     """An order that is pending payment"""
 
+    def _get_or_create(
+        self, products: List[Product], user: User, discounts: List[Discount] = None
+    ):
+        # Get the details from each Product.
+        product_versions, product_object_ids, product_content_types = [], [], []
+        for product in products:
+            product_versions.append(Version.objects.get_for_object(product).first())
+            product_object_ids.append(product.object_id)
+            product_content_types.append(product.content_type_id)
+
+        # Get or create a PendingOrder
+        order, created = Order.objects.select_for_update().get_or_create(
+            lines__purchased_object_id__in=product_object_ids,
+            lines__purchased_content_type_id__in=product_content_types,
+            lines__product_version__in=product_versions,
+            state=Order.STATE.PENDING,
+            purchaser=user,
+            defaults=dict(
+                total_price_paid=0,
+            ),
+        )
+
+        # Apply any discounts to the PendingOrder
+        if discounts:
+            now = now_in_utc()
+            for discount in discounts:
+                if discount:
+                    order.discounts.create(
+                        redemption_date=now,
+                        redeemed_by=user,
+                        redeemed_discount=discount,
+                    )
+
+        # Create or get Line for each product.  Calculate the Order total based on Lines and discount.
+        total = 0
+        for i, product in enumerate(products):
+            line, created = order.lines.get_or_create(
+                order=order,
+                purchased_object_id=product.object_id,
+                purchased_content_type_id=product.content_type_id,
+                defaults=dict(
+                    product_version=product_versions[i],
+                    quantity=1,
+                ),
+            )
+            total += line.discounted_price
+
+        order.total_price_paid = total
+
+        order.save()
+        return order
+
     @classmethod
     @transaction.atomic()
     def create_from_basket(cls, basket: Basket):
@@ -591,44 +644,20 @@ class PendingOrder(FulfillableOrder, Order):
         Returns:
             PendingOrder: the created pending order
         """
-        order = cls.objects.select_for_update().create(
-            total_price_paid=0, purchaser=basket.user
-        )
-        total = 0
-        now = now_in_utc()
-
-        # apply all the discounts to the order first
-        # this is needed to compute the discounted prices of each line
-        for basket_discount in basket.discounts.all():
-            order.discounts.create(
-                redemption_date=now,
-                redeemed_by=basket_discount.redeemed_by,
-                redeemed_discount=basket_discount.redeemed_discount,
-            )
-
-        for product in basket.get_products():
-            product_version = Version.objects.get_for_object(product).first()
-
-            line, created = order.lines.get_or_create(
-                order=order,
-                purchased_object_id=product.object_id,
-                purchased_content_type_id=product.content_type_id,
-                defaults=dict(
-                    product_version=product_version,
-                    quantity=1,
-                ),
-            )
-            if created:
-                total += line.discounted_price
-
-        order.total_price_paid = total
-        order.save()
+        products = basket.get_products()
+        discounts = [
+            basket_discount.redeemed_discount
+            for basket_discount in basket.discounts.all()
+        ]
+        order = cls._get_or_create(cls, products, basket.user, discounts)
 
         return order
 
     @classmethod
     @transaction.atomic()
-    def create_from_product(cls, product: Product, user: User, discount: Discount=None):
+    def create_from_product(
+        cls, product: Product, user: User, discount: Discount = None
+    ):
         """
         Creates a new pending order from a product
 
@@ -640,37 +669,8 @@ class PendingOrder(FulfillableOrder, Order):
         Returns:
             PendingOrder: the created pending order
         """
-        order = cls.objects.select_for_update().create(
-            total_price_paid=0, purchaser=user
-        )
-        total = 0
-        now = now_in_utc()
 
-        # apply all the discounts to the order first
-        # this is needed to compute the discounted prices of each line
-        if discount:
-            order.discounts.create(
-                redemption_date=now,
-                redeemed_by=user,
-                redeemed_discount=discount,
-            )
-
-        product_version = Version.objects.get_for_object(product).first()
-
-        line, created = order.lines.get_or_create(
-            order=order,
-            purchased_object_id=product.object_id,
-            purchased_content_type_id=product.content_type_id,
-            defaults=dict(
-                product_version=product_version,
-                quantity=1,
-            ),
-        )
-        if created:
-            total += line.discounted_price
-
-        order.total_price_paid = total
-        order.save()
+        order = cls._get_or_create(cls, [product], user, [discount])
 
         return order
 

--- a/hubspot_sync/conftest.py
+++ b/hubspot_sync/conftest.py
@@ -66,7 +66,9 @@ def hubspot_order():
         product = factories.ProductFactory.create(price=Decimal(200.00))
 
     factories.LineFactory.create(
-        order=order, product_version=Version.objects.get_for_object(product).first()
+        order=order,
+        product_version=Version.objects.get_for_object(product).first(),
+        purchased_object=product.purchasable_object,
     )
 
     HubspotObjectFactory.create(

--- a/hubspot_sync/management/commands/configure_hubspot_properties.py
+++ b/hubspot_sync/management/commands/configure_hubspot_properties.py
@@ -4,6 +4,7 @@ Management command to configure custom Hubspot properties for Contacts, Deals, P
 import sys
 
 from django.core.management import BaseCommand
+from courses.constants import ALL_ENROLL_CHANGE_STATUSES
 from mitol.hubspot_api.api import (
     delete_object_property,
     delete_property_group,
@@ -19,6 +20,7 @@ from ecommerce.constants import (
     DISCOUNT_TYPE_FIXED_PRICE,
     DISCOUNT_TYPE_PERCENT_OFF,
 )
+from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
 from users.models import (
     GENDER_CHOICES,
@@ -558,6 +560,62 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                 "fieldType": "text",
                 "hasUniqueValue": True,
                 "hidden": True,
+            },
+            {
+                "name": "enrollment_mode",
+                "label": "Enrollment Mode",
+                "description": "The enrollment mode the user is currently enrolled into the product as.",
+                "groupName": "lineiteminformation",
+                "type": "enumeration",
+                "fieldType": "select",
+                "options": [
+                    {
+                        "value": EDX_ENROLLMENT_AUDIT_MODE,
+                        "label": EDX_ENROLLMENT_AUDIT_MODE,
+                        "displayOrder": 0,
+                        "hidden": False,
+                    },
+                    {
+                        "value": EDX_ENROLLMENT_VERIFIED_MODE,
+                        "label": EDX_ENROLLMENT_VERIFIED_MODE,
+                        "displayOrder": 1,
+                        "hidden": False,
+                    },
+                ],
+            },
+            {
+                "name": "change_status",
+                "label": "Change Status",
+                "description": "Any change in enrollment status.",
+                "groupName": "lineiteminformation",
+                "type": "enumeration",
+                "fieldType": "select",
+                "options": [
+                    {
+                        "value": ALL_ENROLL_CHANGE_STATUSES[0],
+                        "label": ALL_ENROLL_CHANGE_STATUSES[0],
+                        "displayOrder": 0,
+                        "hidden": False,
+                    },
+                    {
+                        "value": ALL_ENROLL_CHANGE_STATUSES[1],
+                        "label": ALL_ENROLL_CHANGE_STATUSES[1],
+                        "displayOrder": 1,
+                        "hidden": False,
+                    },
+                    {
+                        "value": ALL_ENROLL_CHANGE_STATUSES[2],
+                        "label": ALL_ENROLL_CHANGE_STATUSES[2],
+                        "displayOrder": 2,
+                        "hidden": False,
+                    },
+                    {
+                        "value": ALL_ENROLL_CHANGE_STATUSES[3],
+                        "label": ALL_ENROLL_CHANGE_STATUSES[3],
+                        "displayOrder": 3,
+                        "hidden": False,
+                    },
+                ],
             },
         ],
     },

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -240,22 +240,22 @@ class UserSerializer(serializers.ModelSerializer):
                 )
 
         username = data.get("username")
-        # if username:
-            # try:
-            #     openedx_validation_msg = validate_username_with_edx(username)
-            #     openedx_validation_msg = OPENEDX_USERNAME_VALIDATION_MSGS_MAP.get(
-            #         openedx_validation_msg, openedx_validation_msg
-            #     )
-            # except (
-            #     HTTPError,
-            #     RequestsConnectionError,
-            #     EdxApiRegistrationValidationException,
-            # ) as exc:
-            #     log.exception("Unable to create user account", exc)
-            #     raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)
+        if username:
+            try:
+                openedx_validation_msg = validate_username_with_edx(username)
+                openedx_validation_msg = OPENEDX_USERNAME_VALIDATION_MSGS_MAP.get(
+                    openedx_validation_msg, openedx_validation_msg
+                )
+            except (
+                HTTPError,
+                RequestsConnectionError,
+                EdxApiRegistrationValidationException,
+            ) as exc:
+                log.exception("Unable to create user account", exc)
+                raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)
 
-            # if openedx_validation_msg:
-            #     raise serializers.ValidationError({"username": openedx_validation_msg})
+            if openedx_validation_msg:
+                raise serializers.ValidationError({"username": openedx_validation_msg})
 
         return data
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -240,22 +240,22 @@ class UserSerializer(serializers.ModelSerializer):
                 )
 
         username = data.get("username")
-        if username:
-            try:
-                openedx_validation_msg = validate_username_with_edx(username)
-                openedx_validation_msg = OPENEDX_USERNAME_VALIDATION_MSGS_MAP.get(
-                    openedx_validation_msg, openedx_validation_msg
-                )
-            except (
-                HTTPError,
-                RequestsConnectionError,
-                EdxApiRegistrationValidationException,
-            ) as exc:
-                log.exception("Unable to create user account", exc)
-                raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)
+        # if username:
+            # try:
+            #     openedx_validation_msg = validate_username_with_edx(username)
+            #     openedx_validation_msg = OPENEDX_USERNAME_VALIDATION_MSGS_MAP.get(
+            #         openedx_validation_msg, openedx_validation_msg
+            #     )
+            # except (
+            #     HTTPError,
+            #     RequestsConnectionError,
+            #     EdxApiRegistrationValidationException,
+            # ) as exc:
+            #     log.exception("Unable to create user account", exc)
+            #     raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)
 
-            if openedx_validation_msg:
-                raise serializers.ValidationError({"username": openedx_validation_msg})
+            # if openedx_validation_msg:
+            #     raise serializers.ValidationError({"username": openedx_validation_msg})
 
         return data
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/904

#### What's this PR do?
1. When a user enrolls into a course, a Deal is created in HubSpot along with Line items that contain information on the `enrollment_mode` and `change_status` related to the user's enrollment in the associated course run.
2. When a user proceeds to upgrade or pay for the certificate track (verified) for a course run, the existing `PendingOrder` is used for initializing the checkout workflow.
3. At the time of checkout, if there are no PendingOrders associated with the user that contain Line items matching the products found in the cart, then a new PendingOrder is created.
4. When a user unenrolls from a course run, the Line item in HubSpot is updated.
5. When a user has a FulfilledOrder but their associated CourseRunEnrollment is not synced with Edx, and the user attempts to enroll into the course again (From the course about page) then no new PendingOrder shall be created.

#### How should this be manually tested?

1. Have a Course, CourseRun, User, Product, Discount, link the Discount with the Product.
2. Enroll your user into the Course from the course about page.
3. Verify that a PendingOrder is created after selecting an option on the upsell modal.
4. Verify that a HubSpot Deal is created and the associated Line displays the correct enrollment information for enrollment mode and change status.
5. Ensure that Edx is not running or is not connected with your MITx Online instance.
6. Upgrade and pay for your course enrollment using a Discount code.
7. Verify that a FulFilledOrder exists.
8. Verify that the HubSpot Deal from step 4 has been updated to reflect a closed deal.
9. Verify that the HubSpot Deal's Line from step 4 has been updated to reflect the `verified` enrollment mode.
10. From the course about page, attempt to enroll in the course again.
11. Verify that no PendingOrder is created from step 10.
12. Unenroll from your course.
13. Ensure that the HubSpot Deal's Line from step 4 has been updated to reflect the change_status of the CourseRunEnrollment.

#### Where should the reviewer start?

1. Have the required access to HubSpot for testing MITx Online locally.  Ask if you need it.
14. Configure HubSpot with your local instance of MITx Online.

#### Any background context you want to provide?

- There are a few places where I've removed unused imports that were not related to this work.
- I refactored `create_from_basket()` and `create_from_product()` to both call a private method since much of their functionality was shared.

