### PR TITLE
Updates the email address on the frontend to use the value from settings

### DIFF
--- a/frontend/public/scss/receipt.scss
+++ b/frontend/public/scss/receipt.scss
@@ -113,7 +113,7 @@ $label-color: #8a8b8c;
 }
 
 .receipt-mit-info {
-  max-width: 226px;
+  max-width: 320px;
   font-size: 16px;
   line-height: 21px;
 

--- a/frontend/public/src/components/ReceiptPageDetailCard.js
+++ b/frontend/public/src/components/ReceiptPageDetailCard.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import {
   parseDateString,
@@ -56,7 +57,9 @@ export class ReceiptPageDetailCard extends React.Component<Props> {
                 Cambridge, MA 02139 USA
                 <br />
                 Support:{" "}
-                <a href="mailto:support@mitxonline.mit.edu">support@mit.edu</a>
+                <a href={`mailto:${SETTINGS.support_email}`}>
+                  {SETTINGS.support_email}
+                </a>
                 <br />
                 <a
                   target="_blank"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

https://github.com/mitodl/hq/issues/1521

#### What's this PR do?

Updates the receipt code in the frontend to use the global support email setting. It was hardcoded (twice, once incorrectly) before.

Updates the stylesheet to make room for the support email address.

#### How should this be manually tested?

Open a receipt. The email address listed under Support should be support@mitxonline.mit.edu both in the text and in the URL.

#### Screenshots (if appropriate)

(See the top left to see what Bootstrap breakpoint is being targeted for the first 4.)

![image](https://github.com/mitodl/mitxonline/assets/945611/6ec62f47-e639-466a-a29b-a6edeb910385)
![image](https://github.com/mitodl/mitxonline/assets/945611/f220e7c6-58bc-46a7-a4bf-91269383ef51)
![image](https://github.com/mitodl/mitxonline/assets/945611/d9d0e12b-36d0-4859-8111-8eea9e3b548d)
![image](https://github.com/mitodl/mitxonline/assets/945611/812f462c-0a73-4388-8889-d1c1f37a9f1a)
![image](https://github.com/mitodl/mitxonline/assets/945611/f8eb9e2a-12a7-4043-a147-c03c6a39e253)
