### PR TITLE
Adds validation for edX profile fields

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -248,8 +248,8 @@ def update_edx_user_profile(user):
         json=dict(
             name=user.name,
             country=user.legal_address.country if user.legal_address else None,
-            state=user.legal_address.us_state if user.legal_address else None,
-            gender=user.user_profile.gender if user.user_profile else None,
+            state=user.legal_address.edx_us_state if user.legal_address else None,
+            gender=user.user_profile.edx_gender if user.user_profile else None,
             year_of_birth=user.user_profile.year_of_birth
             if user.user_profile
             else None,

--- a/users/models.py
+++ b/users/models.py
@@ -378,8 +378,8 @@ class LegalAddress(TimestampedModel):
     def edx_us_state(self):
         """Validates the us_state against the list from edx."""
 
-        if self.us_state is not None and self.state in EDX_STATE_CHOICES:
-            return self.state
+        if self.us_state is not None and self.us_state in EDX_STATE_CHOICES:
+            return self.us_state
         else:
             return EDX_DEFAULT_STATE_CHOICE
 

--- a/users/models_test.py
+++ b/users/models_test.py
@@ -207,3 +207,28 @@ def test_user_profile_edx_education():
     assert user.user_profile.highest_education is not None
     assert user.user_profile.level_of_education is not None
     assert user.user_profile.level_of_education == test_openedx_flag
+
+
+@pytest.mark.parametrize("should_exist", [True, False])
+def test_user_profile_edx_properties(should_exist):
+    user = UserFactory.create()
+
+    user.legal_address.country = "US"
+
+    if should_exist:
+        user.user_profile.gender = "f"
+        user.legal_address.state = "US-MA"
+    else:
+        user.user_profile.gender = "nb"
+        user.user_profile.state = "US-AS"
+
+    assert (
+        user.user_profile.edx_gender == "f"
+        if should_exist
+        else user.user_profile.edx_gender == "o"
+    )
+    assert (
+        user.legal_address.edx_us_state == "MA"
+        if should_exist
+        else user.legal_address.edx_us_state is None
+    )


### PR DESCRIPTION
- Adds lookup tables for gender and US state
- Adds some edx-specific properties for gender and US state
- Updates the profile sync API to use the edx properties

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1649 

#### What's this PR do?

@collinpreston noted that the edX profile sync was failing; some investigation found that the gender codes and states that edX uses are a subset of the ones supported in MITx Online. This PR adds lookup tables for those and adds some edx-specific properties that the sync API will now use.

#### How should this be manually tested?

Change your country to United States and state to one of the ones listed in `EDX_STATE_CHOICES`. The choice should sync to edX when your profile is saved, or if you manually sync from the command line.

Change your country to United States and state to one of the ones _not_ listed in `EDX_STATE_CHOICES` (such as American Samoa). The choice should sync to edX when your profile is saved, or if you manually sync from the command line.

Change your gender to Male, Female, or Other/Prefer Not to Say. The choice should sync to edX when your profile is saved, or if you manually sync from the command line.

Change your gender to not Male, Female, or Other/Prefer Not to Say. Your edX profile should be set to "Other/Prefer not to say". 

Change your gender to null (you may need to do this from Django Admin). Your edX profile should reflect this change.
