### PR TITLE
703: navigation drawer component not screen reader accessible round 2

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -512,7 +512,7 @@ export class EnrolledItemCard extends React.Component<
                     more_vert
                   </span>
                 </DropdownToggle>
-                <DropdownMenu right>
+                <DropdownMenu end>
                   <span id={`unenrollButtonWrapper-${enrollment.id}`}>
                     <DropdownItem
                       className="unstyled d-block"
@@ -611,8 +611,6 @@ export class EnrolledItemCard extends React.Component<
                   <a
                     rel="noopener noreferrer"
                     href="#program_enrollment_drawer"
-                    aria-flowto="program_enrollment_drawer"
-                    aria-haspopup="dialog"
                     onClick={() => this.toggleProgramInfo()}
                   >
                     {title}
@@ -632,7 +630,7 @@ export class EnrolledItemCard extends React.Component<
                     more_vert
                   </span>
                 </DropdownToggle>
-                <DropdownMenu right>
+                <DropdownMenu end>
                   <span id={`unenrollButtonWrapper-${enrollment.id}`}>
                     <DropdownItem
                       className="unstyled d-block"
@@ -655,8 +653,6 @@ export class EnrolledItemCard extends React.Component<
                   className="program-course-count pe-2"
                   rel="noopener noreferrer"
                   href="#program_enrollment_drawer"
-                  aria-flowto="program_enrollment_drawer"
-                  aria-haspopup="dialog"
                   aria-label="Program's courses"
                   onClick={() => this.toggleProgramInfo()}
                 >

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -256,7 +256,9 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
           </div>
           <div className="row chrome">
             <p>
-              <span id="program-overview">Program overview: {this.renderProgramOverview()}</span>
+              <span id="program-overview">
+                Program overview: {this.renderProgramOverview()}
+              </span>
               <br />
               <a
                 href={`/records/${enrollment.program.id}/`}

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -206,6 +206,11 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
 
     if (isHidden) {
       this.restrictFocusToDialog()
+      document.addEventListener("keydown", function(e) {
+        if (e.key === "Escape") {
+          closeDrawer()
+        }
+      })
     }
 
     const backgroundClass = isHidden
@@ -233,7 +238,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
           role="dialog"
           tabIndex="-1"
           aria-modal="true"
-          aria-label={enrollment.program.title}
+          aria-labeledby="dialog-title"
           aria-description={`${courseNumbers[0]} courses, ${courseNumbers[1]} passed`}
         >
           <div

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -228,8 +228,6 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
         ? this.renderFlatCourseCards()
         : this.renderCourseCards()
 
-    const courseNumbers = this.getNumberOfCoursesInProgram()
-
     return (
       <div className={backgroundClass}>
         <div
@@ -238,8 +236,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
           role="dialog"
           tabIndex="-1"
           aria-modal="true"
-          aria-labeledby="dialog-title"
-          aria-description={`${courseNumbers[0]} courses, ${courseNumbers[1]} passed`}
+          aria-describedby="program-overview"
         >
           <div
             className="row chrome d-flex flex-row mr-3"
@@ -259,7 +256,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
           </div>
           <div className="row chrome">
             <p>
-              Program overview: {this.renderProgramOverview()}
+              <span id="program-overview">Program overview: {this.renderProgramOverview()}</span>
               <br />
               <a
                 href={`/records/${enrollment.program.id}/`}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/703

#### What's this PR do?
1. Removes `aria-haspopup`.
2. Removes `aria-flowto`.
3. Uses `aria-describedby` instead of `aria-description`.
4. Enables the Program Dashboard to close when the escape key is pressed

#### How should this be manually tested?

1. Enroll a user into a Program.
2. From the Dashboard, open the Program tab and Program Dashboard.
3. Ensure that the screen reader performs as expected by identifying the modal and description.
4. Ensure that pressing the escape key will close the Program Dashboard.

