### PR TITLE
Updating refund_order API to check for PayPal

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -422,6 +422,12 @@ def refund_order(*, order_id: int = None, reference_number: str = None, **kwargs
 
         transaction_dict = order_recent_transaction.data
 
+        # Check for a PayPal payment - if there's one, we can't process it
+        if "paypal_token" in transaction_dict:
+            raise Exception(
+                f"PayPal: Order {order.reference_number} contains a PayPal transaction. Please contact Finance to refund this order."
+            )
+
         # The refund amount can be different then the payment amount, so we override
         # that before PaymentGateway processing.
         # e.g. While refunding order from Django Admin we can select custom amount.


### PR DESCRIPTION
If the supplied order was paid for via PayPal, throw an exception immediately and quit.

#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #1654

#### What's this PR do?

In `refund_order`, if the order contains a transaction that's a PayPal one, throw an exception with an appropriate error message and stop processing. This should ensure a more useful error message gets written to the Google Sheet.

#### How should this be manually tested?

Automated tests should pass. Full testing will require that you have a refund workflow set up (including the Google Sheets integration). Test by completing checkout using PayPal as the payment method, and then attempting to refund through the sheet; you should get a "PayPal: Order x contains a PayPal transaction" error. 
