### PR TITLE
Handle un-enrollment prior to audit enrollment Order creation feature

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -386,13 +386,15 @@ def deactivate_run_enrollment(
         run_enrollment.edx_emails_subscription = False
     run_enrollment.deactivate_and_save(change_status, no_user=True)
     content_type = ContentType.objects.get(app_label="courses", model="courserun")
-    line_id = Line.objects.get(
+    line = Line.objects.filter(
         purchased_object_id=run_enrollment.run.id,
         purchased_content_type=content_type,
         order__state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING],
         order__purchaser=run_enrollment.user,
-    ).id
-    sync_line_item_with_hubspot(line_id)
+    )
+    if line:
+        line_id = line.id
+        sync_line_item_with_hubspot(line_id)
     return run_enrollment
 
 

--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -125,7 +125,7 @@ class TransactionFactory(DjangoModelFactory):
 class LineFactory(DjangoModelFactory):
     quantity = 1
     order = SubFactory(OrderFactory)
-    purchased_object=SubFactory(CourseRunFactory)
+    purchased_object = SubFactory(CourseRunFactory)
 
     class Meta:
         model = models.Line

--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -124,6 +124,8 @@ class TransactionFactory(DjangoModelFactory):
 
 class LineFactory(DjangoModelFactory):
     quantity = 1
+    order = SubFactory(OrderFactory)
+    purchased_object=SubFactory(CourseRunFactory)
 
     class Meta:
         model = models.Line


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1662

#### What's this PR do?
Handles the scenario where a user un-enrolls from a course which is not associated with an Order or Line object in MITx Online.  These situations exist for audit enrollments prior to 06/08/2023 when Orders and Lines are created at the time of enrollment.

#### How should this be manually tested?
1. Enroll into a course run.
2. [Through Django Admin](http://mitxonline.odl.local:8013/admin/ecommerce/order/), delete the associated Order created.  This will replicate the environment that enrollments prior to the merging of https://github.com/mitodl/mitxonline/pull/1644 look like.
3. Through MITx Online, unenroll your user from the course from step 1.
4. Verify that no errors are shown in the logs.