### PR TITLE
Handle HubSpot exceptions when unenrolling from a course

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -365,7 +365,7 @@ def deactivate_run_enrollment(
         CourseRunEnrollment: The deactivated enrollment
     """
     from ecommerce.models import Line, Order
-    from hubspot_sync.api import sync_line_item_with_hubspot
+    from hubspot_sync.task_helpers import sync_hubspot_line_by_line_id
 
     try:
         unenroll_edx_course_run(run_enrollment)
@@ -385,6 +385,8 @@ def deactivate_run_enrollment(
         run_enrollment.edx_enrolled = False
         run_enrollment.edx_emails_subscription = False
     run_enrollment.deactivate_and_save(change_status, no_user=True)
+
+    # Find an associated Line and update HubSpot.
     content_type = ContentType.objects.get(app_label="courses", model="courserun")
     line = Line.objects.filter(
         purchased_object_id=run_enrollment.run.id,
@@ -395,7 +397,7 @@ def deactivate_run_enrollment(
     if line:
         line_id = line.first().id
         try:
-            sync_line_item_with_hubspot(line_id)
+            sync_hubspot_line_by_line_id(line_id)
         except Exception:
             log.exception(
                 "Failed to sync Line '%s' for user '%s' with HubSpot",

--- a/courses/api.py
+++ b/courses/api.py
@@ -393,8 +393,15 @@ def deactivate_run_enrollment(
         order__purchaser=run_enrollment.user,
     )
     if line:
-        line_id = line.id
-        sync_line_item_with_hubspot(line_id)
+        line_id = line.first().id
+        try:
+            sync_line_item_with_hubspot(line_id)
+        except Exception:
+            log.exception(
+                "Failed to sync Line '%s' for user '%s' with HubSpot",
+                line_id,
+                run_enrollment.user.email,
+            )
     return run_enrollment
 
 

--- a/courses/api.py
+++ b/courses/api.py
@@ -396,14 +396,7 @@ def deactivate_run_enrollment(
     )
     if line:
         line_id = line.first().id
-        try:
-            sync_hubspot_line_by_line_id(line_id)
-        except Exception:
-            log.exception(
-                "Failed to sync Line '%s' for user '%s' with HubSpot",
-                line_id,
-                run_enrollment.user.email,
-            )
+        sync_hubspot_line_by_line_id(line_id)
     return run_enrollment
 
 

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -54,8 +54,8 @@ from courses.models import (
     ProgramEnrollment,
     ProgramRequirement,
 )
-from ecommerce.models import Order
-from ecommerce.factories import LineFactory, ProductFactory
+from ecommerce.models import Line, Order
+from ecommerce.factories import LineFactory, OrderFactory, ProductFactory
 from main.test_utils import MockHttpError
 from openedx.constants import (
     EDX_DEFAULT_ENROLLMENT_MODE,
@@ -579,15 +579,6 @@ class TestDeactivateEnrollments:
         send_unenrollment_email = mocker.patch(
             "courses.api.mail_api.send_course_run_unenrollment_email"
         )
-        with reversion.create_revision():
-            product = ProductFactory.create()
-        version = Version.objects.get_for_object(product).first()
-        line = LineFactory.create(
-            purchased_object=product.purchasable_object, product_version=version
-        )
-        get_line = mocker.patch(
-            "ecommerce.models.Line.objects.filter", return_value=line
-        )
         sync_line_item_with_hubspot = mocker.patch(
             "hubspot_sync.api.sync_line_item_with_hubspot"
         )
@@ -596,7 +587,6 @@ class TestDeactivateEnrollments:
             edx_unenroll=edx_unenroll,
             send_unenrollment_email=send_unenrollment_email,
             log_exception=log_exception,
-            get_line=get_line,
             sync_line_item_with_hubspot=sync_line_item_with_hubspot,
         )
 
@@ -606,19 +596,21 @@ class TestDeactivateEnrollments:
         local enrollment record to inactive
         """
         enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
+        with reversion.create_revision():
+            product = ProductFactory.create(purchasable_object=enrollment.run)
+        version = Version.objects.get_for_object(product).first()
+        order = OrderFactory.create(
+            state=Order.STATE.PENDING, purchaser=enrollment.user
+        )
+        LineFactory.create(
+            order=order, purchased_object=enrollment.run, product_version=version
+        )
 
         returned_enrollment = deactivate_run_enrollment(
             enrollment, change_status=ENROLL_CHANGE_STATUS_REFUNDED
         )
         patches.edx_unenroll.assert_called_once_with(enrollment)
         patches.send_unenrollment_email.assert_called_once_with(enrollment)
-        content_type = ContentType.objects.get(app_label="courses", model="courserun")
-        patches.get_line.assert_called_once_with(
-            purchased_object_id=enrollment.run.id,
-            purchased_content_type=content_type,
-            order__state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING],
-            order__purchaser=enrollment.user,
-        )
         patches.sync_line_item_with_hubspot.assert_called_once()
         enrollment.refresh_from_db()
         assert enrollment.change_status == ENROLL_CHANGE_STATUS_REFUNDED
@@ -633,6 +625,15 @@ class TestDeactivateEnrollments:
         If a flag is provided, deactivate_run_enrollment should set local enrollment record to inactive even if the API call fails
         """
         enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
+        with reversion.create_revision():
+            product = ProductFactory.create(purchasable_object=enrollment.run)
+        version = Version.objects.get_for_object(product).first()
+        order = OrderFactory.create(
+            state=Order.STATE.PENDING, purchaser=enrollment.user
+        )
+        LineFactory.create(
+            order=order, purchased_object=enrollment.run, product_version=version
+        )
         patches.edx_unenroll.side_effect = Exception
 
         deactivate_run_enrollment(
@@ -641,10 +642,8 @@ class TestDeactivateEnrollments:
             keep_failed_enrollments=keep_failed_enrollments,
         )
         if not keep_failed_enrollments:
-            patches.get_line.assert_not_called()
             patches.sync_line_item_with_hubspot.assert_not_called()
         else:
-            patches.get_line.assert_called_once()
             patches.sync_line_item_with_hubspot.assert_called_once()
         patches.edx_unenroll.assert_called_once_with(enrollment)
         patches.send_unenrollment_email.assert_not_called()
@@ -665,6 +664,15 @@ class TestDeactivateEnrollments:
             run__course=course,
             active=True,
         )
+        for course_run_enrollment in course_run_enrollments:
+            run = course_run_enrollment.run
+            with reversion.create_revision():
+                product = ProductFactory.create(purchasable_object=run)
+            version = Version.objects.get_for_object(product).first()
+            order = OrderFactory.create(state=Order.STATE.PENDING, purchaser=user)
+            LineFactory.create(
+                order=order, purchased_object=run, product_version=version
+            )
 
         (
             returned_program_enrollment,
@@ -681,7 +689,6 @@ class TestDeactivateEnrollments:
         }
         assert patches.edx_unenroll.call_count == len(course_run_enrollments)
         assert patches.send_unenrollment_email.call_count == len(course_run_enrollments)
-        assert patches.get_line.call_count == len(course_run_enrollments)
         assert patches.sync_line_item_with_hubspot.call_count == len(
             course_run_enrollments
         )
@@ -699,14 +706,39 @@ class TestDeactivateEnrollments:
         If the enrollment does not have an associated Line object, don't call sync_line_item_with_hubspot()
         """
         enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
-        patches.get_line.return_value = None
 
         deactivate_run_enrollment(
             enrollment,
             change_status=ENROLL_CHANGE_STATUS_REFUNDED,
         )
-        patches.get_line.assert_called_once()
         patches.sync_line_item_with_hubspot.assert_not_called()
+
+    def test_deactivate_run_enrollment_sync_line_item_with_hubspot_exception(
+        self,
+        patches,
+    ):
+        """
+        If the call to sync_line_item_with_hubspot() returns an exception, continue with the unenrollment.
+        """
+        enrollment = CourseRunEnrollmentFactory.create(edx_enrolled=True)
+        with reversion.create_revision():
+            product = ProductFactory.create(purchasable_object=enrollment.run)
+        version = Version.objects.get_for_object(product).first()
+        order = OrderFactory.create(
+            state=Order.STATE.PENDING, purchaser=enrollment.user
+        )
+        LineFactory.create(
+            order=order, purchased_object=enrollment.run, product_version=version
+        )
+
+        patches.sync_line_item_with_hubspot.side_effect = Exception
+
+        deactivate_run_enrollment(
+            enrollment,
+            change_status=ENROLL_CHANGE_STATUS_REFUNDED,
+        )
+        enrollment.refresh_from_db()
+        assert enrollment.active is False
 
 
 @pytest.mark.parametrize("keep_failed_enrollments", [True, False])

--- a/courses/management/commands/test_unenroll_enrollment.py
+++ b/courses/management/commands/test_unenroll_enrollment.py
@@ -29,7 +29,7 @@ def patches(mocker):  # pylint: disable=missing-docstring
     line = LineFactory.create(
         purchased_object=product.purchasable_object, product_version=version
     )
-    get_line = mocker.patch("ecommerce.models.Line.objects.filter", return_value=line)
+    get_line = mocker.patch("ecommerce.models.Line.objects.filter", return_value=[line])
     sync_line_item_with_hubspot = mocker.patch(
         "hubspot_sync.api.sync_line_item_with_hubspot"
     )
@@ -115,7 +115,7 @@ def test_unenroll_enrollment_without_edx(mocker):
     line = LineFactory.create(
         purchased_object=product.purchasable_object, product_version=version
     )
-    get_line = mocker.patch("ecommerce.models.Line.objects.filter", return_value=line)
+    get_line = mocker.patch("ecommerce.models.Line.objects.filter", return_value=[line])
     sync_line_item_with_hubspot = mocker.patch(
         "hubspot_sync.api.sync_line_item_with_hubspot"
     )

--- a/hubspot_sync/task_helpers.py
+++ b/hubspot_sync/task_helpers.py
@@ -43,6 +43,23 @@ def sync_hubspot_deal(order):
             )
 
 
+def sync_hubspot_line_by_line_id(line_id: int):
+    """
+    Trigger celery task to sync a Line to Hubspot.
+    Use a delay of 10 seconds to make sure state is updated first.
+
+    Args:
+        line_id (int): The ID of the Line to sync with HubSpot
+    """
+    if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN and line_id is not None:
+        try:
+            tasks.sync_line_with_hubspot.apply_async(args=(line_id,), countdown=10)
+        except:
+            log.exception(
+                "Exception calling sync_line_with_hubspot for line ID %d", line_id
+            )
+
+
 def sync_hubspot_product(product):
     """
     Trigger celery task to sync a Product to Hubspot

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -191,6 +191,28 @@ def sync_deal_with_hubspot(order_id: int) -> str:
 
 @app.task(
     acks_late=True,
+    autoretry_for=(TooManyRequestsException, BlockingIOError),
+    max_retries=3,
+    retry_backoff=60,
+    retry_jitter=True,
+)
+@raise_429
+@single_task(10, key=task_obj_lock)
+def sync_line_with_hubspot(line_id: int) -> str:
+    """
+    Sync a Line with a hubspot line
+
+    Args:
+        line_id(int): The Line id
+
+    Returns:
+        str: The hubspot id for the line
+    """
+    return api.sync_line_item_with_hubspot(line_id).id
+
+
+@app.task(
+    acks_late=True,
     autoretry_for=(TooManyRequestsException,),
     max_retries=3,
     retry_backoff=60,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1666

#### What's this PR do?

1. Handles the return from the filter query for Line objects correctly.
2. Handles any exception returned by HubSpot as to not hinder the user from unenrolling from the course.

#### How should this be manually tested?
- Enroll a user into a course.
- Verify that an Order object is created in MITx Online for the enrollment.
- Unenroll from the course.
- Verify no errors are being displayed in the logs and the user is able to unenroll.
- Enroll a user into a course again.
- Remove or comment out your HubSpot settings from your `.env` file.
- Restart MITx Online and attempt to unenroll from the course again.
- Verify that the user is not hindered from unenrolling from the course.
