### PR TITLE
1669: Handle enrollment for users with multiple PendingOrder records

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -609,16 +609,23 @@ class PendingOrder(FulfillableOrder, Order):
             product_content_types.append(product.content_type_id)
 
         # Get or create a PendingOrder
-        order, _ = Order.objects.select_for_update().get_or_create(
+        orders = Order.objects.select_for_update().filter(
             lines__purchased_object_id__in=product_object_ids,
             lines__purchased_content_type_id__in=product_content_types,
             lines__product_version__in=product_versions,
             state=Order.STATE.PENDING,
             purchaser=user,
-            defaults=dict(
-                total_price_paid=0,
-            ),
         )
+        # Previously, multiple PendingOrders could be created for a single user
+        # for the same product, if multiple exist, grab the first.
+        if orders:
+            order = orders.first()
+        else:
+            order = Order.objects.create(
+                state=Order.STATE.PENDING,
+                purchaser=user,
+                total_price_paid=0,
+            )
 
         # Apply any discounts to the PendingOrder
         if discounts:

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -28,12 +28,14 @@ from ecommerce.models import (
     BasketItem,
     DiscountRedemption,
     FulfilledOrder,
+    Line,
     Order,
     PendingOrder,
     Product,
     Transaction,
 )
 from users.factories import UserFactory
+from reversion.models import Version
 
 pytestmark = [pytest.mark.django_db]
 
@@ -438,4 +440,49 @@ def test_new_pending_order_is_created_if_product_is_different():
     order = PendingOrder.create_from_product(product=products[1], user=user)
     order.save()
     assert order.lines.count() == 1
+    assert Order.objects.filter(state=Order.STATE.PENDING).count() == 2
+
+
+def test_pending_order_is_reused_if_multiple_exist(basket):
+    """
+    Test that an existing PendingOrder is reused even if there are
+    multiple existing PendingOrders which match the current PendingOrder.
+    """
+
+    with reversion.create_revision():
+        product = ProductFactory.create()
+    product_version = Version.objects.get_for_object(product).first()
+
+    # Create 2 PendingOrders
+    order1 = Order.objects.create(
+        state=Order.STATE.PENDING,
+        purchaser=basket.user,
+        total_price_paid=0,
+    )
+    Line.objects.create(
+        order=order1,
+        purchased_object_id=product.object_id,
+        purchased_content_type_id=product.content_type_id,
+        product_version=product_version,
+        quantity=1,
+    )
+    order2 = Order.objects.create(
+        state=Order.STATE.PENDING,
+        purchaser=basket.user,
+        total_price_paid=0,
+    )
+    Line.objects.create(
+        order=order2,
+        purchased_object_id=product.object_id,
+        purchased_content_type_id=product.content_type_id,
+        product_version=product_version,
+        quantity=1,
+    )
+
+    basket_item = BasketItem(product=product, basket=basket, quantity=1)
+    basket_item.save()
+    order = PendingOrder.create_from_basket(basket)
+    order.save()
+    # Verify that one of the existing PendingOrder's is reused insteading of
+    # creating a third.
     assert Order.objects.filter(state=Order.STATE.PENDING).count() == 2


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1669

#### What's this PR do?
Adds logic to handle the enrollment and creation of a PendingOrder for users who already have multiple prior PendingOrders for the same product.

#### How should this be manually tested?

1. Enroll a user into a course run
2. You should see a new pending Order created here: http://mitxonline.odl.local:8013/admin/ecommerce/order/
3. Manually create a second pending Order through Django Admin that matches the pending Order from step 2.
4. Unenroll from the course.
5. Enroll into the course again.
6. Verify that there exists only 2 pending Orders for the user.
7. Verify that the corresponding Line object in HubSpot is updated for only one of the PendingOrders


#### Any background context you want to provide?
Prior to recent changes, PendingOrders were created whenever a user would start the checkout process, usually by visiting the cart page after clicking "get certificate" buttons in the application.  This has resulted in a some users having multiple PendingOrders for the same product.  Recent changes have changed this functionality so that PendingOrders are reused and only one is ever created.

