### PR TITLE
1664: management command to create Order from enrollment

### DIFF
--- a/courses/management/commands/create_verified_enrollment.py
+++ b/courses/management/commands/create_verified_enrollment.py
@@ -152,7 +152,6 @@ class Command(BaseCommand):
             fulfill_completed_order(
                 order, payment_data=ZERO_PAYMENT_DATA, already_enrolled=True
             )
-            sync_hubspot_deal(order)
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/courses/management/commands/create_verified_enrollment.py
+++ b/courses/management/commands/create_verified_enrollment.py
@@ -24,7 +24,6 @@ from ecommerce.api import fulfill_completed_order
 from ecommerce.constants import PAYMENT_TYPE_FINANCIAL_ASSISTANCE, ZERO_PAYMENT_DATA
 from ecommerce.discounts import DiscountType
 from ecommerce.models import Discount, PendingOrder, Product
-from hubspot_sync.task_helpers import sync_hubspot_deal
 from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
 from users.api import fetch_user
 

--- a/courses/management/commands/create_verified_enrollment.py
+++ b/courses/management/commands/create_verified_enrollment.py
@@ -24,6 +24,7 @@ from ecommerce.api import fulfill_completed_order
 from ecommerce.constants import PAYMENT_TYPE_FINANCIAL_ASSISTANCE, ZERO_PAYMENT_DATA
 from ecommerce.discounts import DiscountType
 from ecommerce.models import Discount, PendingOrder, Product
+from hubspot_sync.task_helpers import sync_hubspot_deal
 from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
 from users.api import fetch_user
 
@@ -151,6 +152,7 @@ class Command(BaseCommand):
             fulfill_completed_order(
                 order, payment_data=ZERO_PAYMENT_DATA, already_enrolled=True
             )
+            sync_hubspot_deal(order)
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -195,12 +195,13 @@ def create_enrollment_view(request):
                 lines__purchased_object_id=product_object_id,
                 lines__purchased_content_type_id=product_content_type,
                 lines__product_version=product_version,
-            ).first()
+            )
             if not order:
                 # Create PendingOrder
                 order = PendingOrder.create_from_product(product, user)
-
-            sync_hubspot_deal(order)
+                sync_hubspot_deal(order)
+            else:
+                sync_hubspot_deal(order.first())
     else:
         resp = respond(request.headers["Referer"])
         cookie_value = {

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from requests import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
+from hubspot_sync.task_helpers import sync_hubspot_deal
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -188,16 +189,18 @@ def create_enrollment_view(request):
             product_version = Version.objects.get_for_object(product).first()
             product_object_id = product.object_id
             product_content_type = product.content_type_id
-            existing_fulfilled_order = FulfilledOrder.objects.filter(
+            order = FulfilledOrder.objects.filter(
                 state=Order.STATE.FULFILLED,
                 purchaser=user,
                 lines__purchased_object_id=product_object_id,
                 lines__purchased_content_type_id=product_content_type,
                 lines__product_version=product_version,
-            )
-            if not existing_fulfilled_order:
+            ).first()
+            if not order:
                 # Create PendingOrder
-                PendingOrder.create_from_product(product, user)
+                order = PendingOrder.create_from_product(product, user)
+
+            sync_hubspot_deal(order)
     else:
         resp = respond(request.headers["Referer"])
         cookie_value = {

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -139,7 +139,6 @@ def generate_checkout_payload(request):
                     },
                 ),
             }
-    sync_hubspot_deal(order)
 
     callback_uri = request.build_absolute_uri(reverse("checkout-result-callback"))
 
@@ -307,7 +306,6 @@ def process_cybersource_payment_response(request, order):
         log.debug("Transaction declined: {msg}".format(msg=processor_response.message))
         order.decline()
         order.save()
-        sync_hubspot_deal(order)
         return_message = order.state
     elif processor_response.state == ProcessorResponse.STATE_ERROR:
         # Error - something went wrong with the request
@@ -318,7 +316,6 @@ def process_cybersource_payment_response(request, order):
         )
         order.error()
         order.save()
-        sync_hubspot_deal(order)
         return_message = order.state
     elif processor_response.state in [
         ProcessorResponse.STATE_CANCELLED,
@@ -336,7 +333,6 @@ def process_cybersource_payment_response(request, order):
         )
         order.cancel()
         order.save()
-        sync_hubspot_deal(order)
         return_message = order.state
 
     elif (
@@ -365,9 +361,9 @@ def process_cybersource_payment_response(request, order):
         )
         order.cancel()
         order.save()
-        sync_hubspot_deal(order)
         return_message = order.state
 
+    sync_hubspot_deal(order)
     return return_message
 
 

--- a/ecommerce/management/commands/refund_fulfilled_order.py
+++ b/ecommerce/management/commands/refund_fulfilled_order.py
@@ -23,6 +23,7 @@ from django.db.models import Q
 from courses.api import deactivate_run_enrollment
 from courses.models import CourseRunEnrollment
 from ecommerce.models import Order
+from hubspot_sync.task_helpers import sync_hubspot_deal
 from openedx.api import enroll_in_edx_course_runs
 
 
@@ -63,6 +64,7 @@ class Command(BaseCommand):
 
         order.state = Order.STATE.REFUNDED
         order.save()
+        sync_hubspot_deal(order)
 
         run_enrollments = (
             CourseRunEnrollment.objects.filter(user=order.purchaser)

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -300,7 +300,7 @@ def test_product_multiple_active_for_single_purchasable_object():
         pass
 
 
-def test_order_update_reference_number(mocked_hubspot_deal_sync, user):
+def test_order_update_reference_number(user):
     """Test when order is created/updated, reference_number is updated in db"""
     order = Order(purchaser=user, total_price_paid=10)
     order.save()
@@ -314,7 +314,6 @@ def test_order_update_reference_number(mocked_hubspot_deal_sync, user):
     assert (
         existing_order.reference_number == existing_order._generate_reference_number()
     )
-    assert mocked_hubspot_deal_sync.call_count == 2
 
 
 def test_duplicated_product_lines_validation(basket):

--- a/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
+++ b/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
@@ -7,6 +7,7 @@ from django.core.management import BaseCommand
 
 from courses.models import CourseRun, CourseRunEnrollment
 from ecommerce.models import Order, PendingOrder, Product
+from hubspot_sync.task_helpers import sync_hubspot_deal
 from reversion.models import Version
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE
 

--- a/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
+++ b/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management import BaseCommand
 
 from courses.models import CourseRun, CourseRunEnrollment
-from ecommerce.models import FulfilledOrder, Order, PendingOrder, Product
+from ecommerce.models import Order, PendingOrder, Product
 from reversion.models import Version
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE
 
@@ -33,8 +33,8 @@ class Command(BaseCommand):
                 product_version = Version.objects.get_for_object(product).first()
                 product_object_id = product.object_id
                 product_content_type = product.content_type_id
-                existing_fulfilled_order = FulfilledOrder.objects.filter(
-                    state=Order.STATE.FULFILLED,
+                existing_fulfilled_order = Order.objects.filter(
+                    state__in=[Order.STATE.FULFILLED, Order.STATE.PENDING],
                     purchaser=course_run_enrollment.user,
                     lines__purchased_object_id=product_object_id,
                     lines__purchased_content_type_id=product_content_type,

--- a/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
+++ b/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
@@ -46,3 +46,4 @@ class Command(BaseCommand):
                     PendingOrder.create_from_product(
                         product, course_run_enrollment.user
                     )
+        self.stdout.write("'sync_db_to_hubspot --deals create' should be run next. \n")

--- a/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
+++ b/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
@@ -1,0 +1,47 @@
+"""
+Management command to create Orders for CourseRunEnrollments which were created in the past
+"""
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import BaseCommand
+
+from courses.models import CourseRun, CourseRunEnrollment
+from ecommerce.models import FulfilledOrder, Order, PendingOrder, Product
+from reversion.models import Version
+from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE
+
+
+class Command(BaseCommand):
+    """
+    Create Orders for each audit CourseRunEnrollment as long as there is a Product associated with the CourseRun.
+    """
+
+    def handle(self, *args, **options):
+        course_run_enrollments = CourseRunEnrollment.objects.filter(
+            enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
+        )
+        for course_run_enrollment in course_run_enrollments:
+            product = Product.objects.filter(
+                object_id=course_run_enrollment.run.id,
+                content_type=ContentType.objects.get_for_model(CourseRun),
+            ).first()
+            if product is None:
+                self.stdout.write(
+                    f"No product found for that course with courseware_id {course_run_enrollment.run.id} \n"
+                )
+            else:
+                product_version = Version.objects.get_for_object(product).first()
+                product_object_id = product.object_id
+                product_content_type = product.content_type_id
+                existing_fulfilled_order = FulfilledOrder.objects.filter(
+                    state=Order.STATE.FULFILLED,
+                    purchaser=course_run_enrollment.user,
+                    lines__purchased_object_id=product_object_id,
+                    lines__purchased_content_type_id=product_content_type,
+                    lines__product_version=product_version,
+                )
+                if not existing_fulfilled_order:
+                    # Create PendingOrder
+                    PendingOrder.create_from_product(
+                        product, course_run_enrollment.user
+                    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1664

#### What's this PR do?
A recent PR ([ref](https://github.com/mitodl/mitxonline/pull/1644)) now creates an Order object when a user enrolls into a course.  The Order object's information is synced with HubSpot which allows Marketing team members to view user enrollment information.  **This PR** intends to add a management command that will create an Order for each of the existing audit enrollments.

#### How should this be manually tested?

1. Setup a Course, CourseRun, Product, User, and the CMS page for the course.
2. Configure the required HubSpot environment variables in your `.env` file.
3. Enroll your user into the Audit track of the course by clicking the "Enroll now" button but not purchasing the course.
4. Through Django Admin, delete the Order associated with your enrollment: http://mitxonline.odl.local:8013/admin/ecommerce/order/
5. In a terminal and from the root of the project, run `docker-compose run web ./manage.py create_order_from_course_run_enrollments`
6. Verify that an Order is created for your enrollment.
7. Run step 5 again and confirm that only a single Order exists for your enrollment.
8. Verify that the Order details are synced with HubSpot.
9. Upgrade your course enrollment to the Verified track by paying for the course.
10. Run step 5 again and confirm that only a single fulfilled Order exists for your enrollment: http://mitxonline.odl.local:8013/admin/ecommerce/fulfilledorder/


#### Any background context you want to provide?
Users that have a "verified" enrollment, will already have an Order associated with their enrollment since, prior to the recent change of Orders being created during enrollment, Orders were historically created at the time of initiating the checkout process.

A second management command that already exists in MITx Online, `sync_db_with_hubspot`, can be used to sync all of the Orders with HubSpot.
