### PR TITLE
feat: remove link and add description for unenrollable runs in more dates

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -938,7 +938,7 @@ class CoursePage(ProductPage):
         relevant_runs = list(
             get_user_relevant_course_run_qset(
                 course=self.product, user=request.user
-            ).values("courseware_id", "start_date")
+            )
         )
         is_enrolled = (
             False

--- a/cms/models.py
+++ b/cms/models.py
@@ -936,9 +936,7 @@ class CoursePage(ProductPage):
             course=self.product, user=request.user
         )
         relevant_runs = list(
-            get_user_relevant_course_run_qset(
-                course=self.product, user=request.user
-            )
+            get_user_relevant_course_run_qset(course=self.product, user=request.user)
         )
         is_enrolled = (
             False

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -126,7 +126,7 @@ def test_course_page_context(
     else:
         finaid_price = None
         product = None
-    relevant_runs = list(CourseRun.objects.values("courseware_id", "start_date"))
+    relevant_runs = list(CourseRun.objects.all())
     course_page = CoursePageFactory.create(**course_page_kwargs)
     if enrolled:
         CourseRunEnrollmentFactory.create(user=staff_user, run=run)

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -58,7 +58,7 @@
                             {% if course_run.is_not_beyond_enrollment %}
                               <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
                             {% else %}
-                              <p id='{{ course_run.courseware_id }}' >{{ course_run.start_date|date:'F j, Y' }} (enrollment opens {{ course_run.enrollment_start|date:'F j, Y' }})</p>
+                              <p class='date-link-disabled' id='{{ course_run.courseware_id }}' >{{ course_run.start_date|date:'F j, Y' }}(enrollment opens {{ course_run.enrollment_start|date:'F j, Y' }})</p>
                             {% endif %}
                           </div>
                       {% endfor %}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -55,7 +55,11 @@
                       </div>
                       {% for course_run in course_runs %}
                           <div>
-                            <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
+                            {% if course_run.is_not_beyond_enrollment %}
+                              <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
+                            {% else %}
+                              <p id='{{ course_run.courseware_id }}' >{{ course_run.start_date|date:'F j, Y' }} (enrollment opens {{ course_run.enrollment_start|date:'F j, Y' }})</p>
+                            {% endif %}
                           </div>
                       {% endfor %}
                     ">

--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -487,3 +487,8 @@
   background-color: transparent;
   border: none;
 }
+
+.date-link-disabled {
+  padding: 5px 5px 0;
+  margin: 0;
+}


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/1647

# Description (What does it do?)
<!--- Describe your changes in detail -->
Updates more dates popup. Removes the link for the future course runs(enrollment date in future). Also, display the enrollment date for such runs.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
- [ ] Mobile width screenshots
<img width="1716" alt="Screen Shot 2023-06-22 at 5 06 24 PM" src="https://github.com/mitodl/mitxonline/assets/52656433/2d2b7a65-444a-4ef0-b7c1-e4778d5f2f2a">

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Create 2-course runs. One with an enrollment date in the past and one with an enrollment start date in the future. Visit the course detail page. Verfiy that the more dates pop up has 2 runs, 1 is a clickable link and other one is just date with enrollment start date as well.

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
