### PR TITLE
Fixes the course count on cards in My Programs

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -576,12 +576,7 @@ export class EnrolledItemCard extends React.Component<
     const pageLocation = null
     const courseRunStatusMessageText = null
     const menuTitle = `Program information for ${enrollment.program.title}`
-    const courseCount =
-      enrollment.program.requirements &&
-      enrollment.program.requirements.required
-        ? enrollment.program.requirements.electives.length +
-          enrollment.program.requirements.required.length
-        : enrollment.program.courses.length
+    const courseCount = enrollment.program.courses.length
     const hasPassed = enrollment.certificate ? true : false
 
     return (


### PR DESCRIPTION
# What are the relevant tickets?

Part of #1685 

# Description (What does it do?)

The course count in the program cards in the My Programs tab was incorrect - it was looking through the program requirements, but we have a flat list of courses in the data structure that can be used instead.

# How can this be tested?

Add a program with a nested operator and course requirements within that operator. (Use DEDP as an example of this - you can take one elective, or one of a set of two electives, to satisfy the electives requirement.) The course count should display the correct number. 
