### PR TITLE
Remove call to `transaction.rollback` if the payment gateway does something unexpected

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -8,7 +8,6 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, Validat
 from django.db import transaction
 from django.db.models import Q
 from django.urls import reverse
-from hubspot_sync.task_helpers import sync_hubspot_deal
 from ipware import get_client_ip
 from mitol.common.utils.datetime import now_in_utc
 from mitol.payment_gateway.api import CartItem as GatewayCartItem
@@ -42,6 +41,7 @@ from ecommerce.models import (
 )
 from ecommerce.tasks import perform_downgrade_from_order
 from flexiblepricing.api import determine_courseware_flexible_price_discount
+from hubspot_sync.task_helpers import sync_hubspot_deal
 from main.constants import (
     USER_MSG_TYPE_COURSE_NON_UPGRADABLE,
     USER_MSG_TYPE_DISCOUNT_INVALID,
@@ -459,7 +459,6 @@ def refund_order(*, order_id: int = None, reference_number: str = None, **kwargs
             )
             # PaymentGateway didn't raise an exception and instead gave a Response but the response status was not
             # success so we manually rollback the transaction in this case.
-            transaction.rollback()
             raise Exception(f"Payment gateway returned an error: {response.message}")
 
     # If unenroll requested, perform unenrollment after successful refund

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -389,6 +389,23 @@ def test_paypal_refunds(fulfilled_paypal_transaction):
         assert "PayPal" in exc
 
 
+def test_unknown_refund_response(mocker, fulfilled_transaction):
+    """If we get a weird response, this should fail gracefully."""
+    error_return = {
+        "state": "Something weird here! Definitely not a regular response!",
+        "message": "This is an error message.",
+    }
+
+    mocker.patch(
+        "mitol.payment_gateway.api.PaymentGateway.start_refund",
+        returns=error_return,
+    )
+
+    with pytest.raises(Exception) as exc:
+        refund_order(order_id=fulfilled_paypal_transaction.order.id)
+        assert "returned an error" in exc
+
+
 def test_unenrollment_unenrolls_learner(mocker, user):
     """
     Test that unenroll_learner_from_order unenrolls the learner from an order


### PR DESCRIPTION
It's in a `with` block so explicit rollbacks aren't necessary or supported.

# What are the relevant tickets?

Closes #1686 

# Description (What does it do?)

During a refund, if the PaymentGateway gets an unexpected response from the processor, it gives up processing the refund. It was explicitly rolling back the transaction in this case, though, which was unnecessary.

# How can this be tested?

This appears to happen when CyberSource returns "Created" rather than something we expect. I'm not sure how to fake that specific case, but re-running a processed transaction should also generate an error, I think, which should hit the same code branch.

1. Complete an order.
2. Attempt to refund the order using the Google Sheets system. 
3. The refund should fail successfully.

