### PR TITLE
1702: line serializer cannot handle orders with no current enrollment

### DIFF
--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -97,14 +97,10 @@ def test_make_line_item_sync_message(
         user=line.order.purchaser,
         enrollment_mode=enrollment_mode,
         change_status=change_status,
-    )
-    mock_course_run_enrollment_query = mocker.patch(
-        "courses.models.CourseRunEnrollment.all_objects.get",
-        return_value=course_run_enrollment,
+        run=line.purchased_object,
     )
     serialized_line = LineSerializer(line).data
     line_item_sync_message = api.make_line_item_sync_message(line.id)
-    mock_course_run_enrollment_query.assert_called()
 
     assert line_item_sync_message.properties == {
         "name": serialized_line["name"],
@@ -244,10 +240,6 @@ def test_sync_line_item_with_hubspot(
     """Test that the hubspot CRM API is called properly for a line_item sync"""
     line = hubspot_order.lines.first()
     course_run_enrollment = CourseRunEnrollmentFactory.create(user=line.order.purchaser)
-    mock_course_run_enrollment_query = mocker.patch(
-        "courses.models.CourseRunEnrollment.all_objects.get",
-        return_value=course_run_enrollment,
-    )
     api.sync_line_item_with_hubspot(line.id)
     assert (
         api.HubspotObject.objects.get(
@@ -255,7 +247,6 @@ def test_sync_line_item_with_hubspot(
         ).hubspot_id
         == FAKE_HUBSPOT_ID
     )
-    mock_course_run_enrollment_query.assert_called()
     mock_hubspot_api.return_value.crm.objects.associations_api.create.assert_called_once_with(
         api.HubspotObjectType.LINES.value,
         FAKE_HUBSPOT_ID,

--- a/hubspot_sync/serializers.py
+++ b/hubspot_sync/serializers.py
@@ -63,18 +63,21 @@ class LineSerializer(serializers.ModelSerializer):
         return self._product
 
     def _get_enrollment(self, instance):
-        self._enrollment = CourseRunEnrollment.all_objects.get(
+        """Returns the CourseRunEnrollment associated with the Order, if one exists, else None"""
+        self._enrollment = CourseRunEnrollment.all_objects.filter(
             run=instance.purchased_object, user=instance.order.purchaser
-        )
+        ).first()
         return self._enrollment
 
     def get_enrollment_mode(self, instance):
+        """Returns the CourseRunEnrollment's mode associated with the Order, if a CourseRunEnrollment exists, else None"""
         enrollment = self._get_enrollment(instance)
-        return enrollment.enrollment_mode
+        return enrollment.enrollment_mode if enrollment is not None else None
 
     def get_change_status(self, instance):
+        """Returns the CourseRunEnrollment's change_status associated with the Order, if a CourseRunEnrollment exists, else None"""
         enrollment = self._get_enrollment(instance)
-        return enrollment.change_status
+        return enrollment.change_status if enrollment is not None else None
 
     def get_unique_app_id(self, instance):
         """Get the app_id for the object"""


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1702

# Description (What does it do?)
Until recently, the Line serializer did not rely on CourseRunEnrollment.  There is the possibility that old data exists for a learner who unenrolls or has no enrollment for an Order and Line.


# How can this be tested?

1. Create a user, course, course run, product.
2. Create an order for your user referencing the items from step 1.
3. Run the following management command `sync_db_to_hubspot --deals create`.


