### PR TITLE
fix courses migration conflict

### DIFF
--- a/courses/migrations/0033_populate_letter_grades.py
+++ b/courses/migrations/0033_populate_letter_grades.py
@@ -5,7 +5,21 @@ import pytz
 from django.db import migrations
 
 from courses.models import Program
-from courses.utils import convert_to_letter
+
+
+def convert_to_letter(grade):
+    """Convert a decimal number to letter grade"""
+    grade = round(grade, 1)
+    if grade >= 0.825:
+        return "A"
+    elif grade >= 0.65:
+        return "B"
+    elif grade >= 0.55:
+        return "C"
+    elif grade >= 0.50:
+        return "D"
+    else:
+        return "F"
 
 
 def populate_letter_grade(apps, schema_editor):
@@ -27,11 +41,11 @@ def populate_letter_grade(apps, schema_editor):
     )
     for grade in grades:
         grade.letter_grade = convert_to_letter(grade.grade)
+        grade.set_by_admin = True
         grade.save()
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("courses", "0032_add_related_programs_table"),
     ]

--- a/courses/migrations/0033_populate_letter_grades.py
+++ b/courses/migrations/0033_populate_letter_grades.py
@@ -9,12 +9,15 @@ from courses.utils import convert_to_letter
 
 
 def populate_letter_grade(apps, schema_editor):
-    """Populate the certificate_available_date from course run's end_date"""
+    """Populate the letter grade with A/B/C/D for the DEDP courses prior to 3T2022"""
     CourseRunGrade = apps.get_model("courses", "CourseRunGrade")
 
-    dedp_program = Program.objects.filter(readable_id="program-v1:MITx+DEDP").get()
+    dedp_program = Program.objects.filter(readable_id="program-v1:MITx+DEDP").first()
 
-    dedp_course_ids = [course[0].id for course in dedp_program.courses]
+    if dedp_program is not None:
+        dedp_course_ids = [course[0].id for course in dedp_program.courses]
+    else:
+        dedp_course_ids = []
 
     grades = CourseRunGrade.objects.filter(
         passed=True,

--- a/courses/migrations/0033_populate_letter_grades.py
+++ b/courses/migrations/0033_populate_letter_grades.py
@@ -4,16 +4,22 @@ import datetime
 import pytz
 from django.db import migrations
 
+from courses.models import Program
 from courses.utils import convert_to_letter
 
 
 def populate_letter_grade(apps, schema_editor):
     """Populate the certificate_available_date from course run's end_date"""
     CourseRunGrade = apps.get_model("courses", "CourseRunGrade")
+
+    dedp_program = Program.objects.filter(readable_id="program-v1:MITx+DEDP").get()
+
+    dedp_course_ids = [course[0].id for course in dedp_program.courses]
+
     grades = CourseRunGrade.objects.filter(
         passed=True,
         letter_grade__contains="Pass",
-        course_run__course__program__title__startswith="Data",
+        course_run__course_id__in=dedp_course_ids,
         course_run__start_date__lt=datetime.datetime(2022, 9, 1, tzinfo=pytz.UTC),
     )
     for grade in grades:
@@ -24,7 +30,7 @@ def populate_letter_grade(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("courses", "0030_remove_course_position_in_program"),
+        ("courses", "0032_add_related_programs_table"),
     ]
 
     operations = [

--- a/courses/migrations/0034_backfill_enrollments_from_certificates.py
+++ b/courses/migrations/0034_backfill_enrollments_from_certificates.py
@@ -25,7 +25,7 @@ def backfill_enrollments_from_certificates(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("courses", "0030_remove_course_position_in_program"),
+        ("courses", "0033_populate_letter_grades"),
     ]
 
     operations = [

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -67,18 +67,3 @@ def get_program_certificate_by_enrollment(enrollment, program=None):
         return ProgramCertificate.objects.get(user_id=user_id, program_id=program_id)
     except ProgramCertificate.DoesNotExist:
         return None
-
-
-def convert_to_letter(grade):
-    """Convert a decimal number to letter grade"""
-    grade = round(grade, 1)
-    if grade >= 0.825:
-        return "A"
-    elif grade >= 0.65:
-        return "B"
-    elif grade >= 0.55:
-        return "C"
-    elif grade >= 0.50:
-        return "D"
-    else:
-        return "F"


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/mitxonline/pull/1651
https://github.com/mitodl/mitxonline/pull/1687


# Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes course migrations conflict on the main branch

`
Static file directory was missing: /home/runner/work/mitxonline/mitxonline/frontend/public/build Static file directory was missing: /home/runner/work/mitxonline/mitxonline/frontend/staff-dashboard/build CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0031_backfill_enrollments_from_certificates, 0031_populate_letter_grades, 0032_add_related_programs_table in courses). To fix them run 'python manage.py makemigrations --merge'
`

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run migrations from 0030
```
manage.py migrate --fake courses 0029 (run this if you have already applied 0030_remove_course_position_in_program.py)
manage.py migrate courses 0030
 ```

