### PR TITLE
1691: program certificate generation does not adhere to nested program electives

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -899,19 +899,6 @@ def _has_earned_program_cert(user, program):
 
     return _has_earned(root)
 
-    # passed_all_requirements = all(
-    #     required_course in passed_courses
-    #     for required_course in program.required_courses
-    # )
-    # if program.elective_courses:
-    #     met_elective_requirement = (
-    #         len(list(set(passed_courses).intersection(program.elective_courses)))
-    #         >= program.minimum_elective_courses_requirement
-    #     )
-    #     return passed_all_requirements and met_elective_requirement
-    # else:
-    #     return passed_all_requirements
-
 
 def generate_program_certificate(user, program, force_create=False):
     """

--- a/courses/management/commands/test_manage_program_certificate.py
+++ b/courses/management/commands/test_manage_program_certificate.py
@@ -122,11 +122,13 @@ def test_program_certificate_management_create(user, program_with_empty_requirem
     Test that create operation for program certificate management command
     creates the program certificate for a user
     """
-    course = CourseFactory.create()
-    program_with_empty_requirements.add_requirement(course)
-    course_run = CourseRunFactory.create(course=course)
-    CourseRunGradeFactory.create(course_run=course_run, user=user, passed=True, grade=1)
-    CourseRunCertificateFactory.create(user=user, course_run=course_run)
+    courses = CourseFactory.create_batch(2)
+    program_with_empty_requirements.add_requirement(courses[0])
+    program_with_empty_requirements.add_elective(courses[1])
+    course_runs = CourseRunFactory.create_batch(2, course=factory.Iterator(courses))
+    CourseRunCertificateFactory.create_batch(
+        2, user=user, course_run=factory.Iterator(course_runs)
+    )
     manage_program_certificates.Command().handle(
         create=True,
         program=program_with_empty_requirements.readable_id,


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1691

# Description (What does it do?)
This was a regression that was introduced with https://github.com/mitodl/mitxonline/pull/1685.


# How can this be tested?
Required: User, program, 3 courses.
Using a program which has electives like:
- Minimum of 2 course certificates from the following courses:
- Course1
    - Only one certificate is counted from the courses below:
    - Course2
    - Course3

- Add course certificates for your user for Course2, Course3.
- A program certificate is generated for your user.
