### PR TITLE
Update MM grade import, add missing enrollment import script

### DIFF
--- a/micromasters_import/management/commands/queries/008_import_combined_final_grade.sql
+++ b/micromasters_import/management/commands/queries/008_import_combined_final_grade.sql
@@ -82,9 +82,12 @@ SELECT
   combined_grades.updated_on,
   combined_grades.passed,
   ROUND(CAST(combined_grades.calculated_grade/100 AS decimal), 3),
-  CASE
-      WHEN combined_grades.passed = true THEN 'Pass'
-      ELSE NULL
+ CASE
+      WHEN combined_grades.calculated_grade >= 82.5 THEN 'A'
+      WHEN combined_grades.calculated_grade >= 65 THEN 'B'
+      WHEN combined_grades.calculated_grade >= 55 THEN 'C'
+      WHEN combined_grades.calculated_grade >= 50 THEN 'D'
+      ELSE 'F'
   END AS letter_grade,
   False AS set_by_admin,
   mo_courserun.id,

--- a/micromasters_import/management/commands/queries/013_add_missing_enrollments_from_certificates.sql
+++ b/micromasters_import/management/commands/queries/013_add_missing_enrollments_from_certificates.sql
@@ -1,0 +1,31 @@
+----This script is to add missing DEDP course enrollments for the imported MicroMasters data
+----For MM, enrollments could be deleted from dashboard_cachedenrollment if users unenroll.
+--- It need to be ran after 009_import_course_certificate
+
+INSERT INTO public.courses_courserunenrollment(
+    run_id,
+    user_id,
+    change_status,
+    active,
+    edx_enrolled,
+    edx_emails_subscription,
+    enrollment_mode,
+    created_on,
+    updated_on
+)
+SELECT
+    certificate.course_run_id
+    , certificate.user_id
+    , ''
+    , true
+    , true
+    , false
+    , 'verified'
+    , certificate.created_on
+    , certificate.updated_on
+FROM public.courses_courseruncertificate as certificate
+LEFT JOIN public.courses_courserunenrollment as enrolled
+      ON certificate.course_run_id = enrolled.run_id
+      AND certificate.user_id = enrolled.user_id
+WHERE enrolled.run_id IS NULL
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/1561

# Description (What does it do?)
<!--- Describe your changes in detail -->
This PR is to modify `letter_grade` in the grade script for MicroMasters import. It also adds a new script to populate the missing enrollments after certificates migration as enrollments might be deleted from MM

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run `docker-compose run --rm web ./manage.py import_micromasters_data --num 013` for the new script
If you need to run other scripts, please follow [this](https://github.com/mitodl/mitxonline/tree/main/micromasters_import#local-setup) instruction 

# Additional Context
There are some MM users who register on MITx Online after we ran the initial migration in Oct 2022, those users data are still in MicroMasters so we need to run micromasters_import script to bring over their enrollment/grades/certificates

<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
