### PR TITLE
Clears discounts when reusing an existing PendingOrder

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -640,12 +640,16 @@ class PendingOrder(FulfillableOrder, Order):
             product_content_types.append(product.content_type_id)
 
         # Get or create a PendingOrder
-        orders = Order.objects.select_for_update().filter(
-            lines__purchased_object_id__in=product_object_ids,
-            lines__purchased_content_type_id__in=product_content_types,
-            lines__product_version__in=product_versions,
-            state=Order.STATE.PENDING,
-            purchaser=user,
+        orders = (
+            Order.objects.select_for_update()
+            .prefetch_related("discounts")
+            .filter(
+                lines__purchased_object_id__in=product_object_ids,
+                lines__purchased_content_type_id__in=product_content_types,
+                lines__product_version__in=product_versions,
+                state=Order.STATE.PENDING,
+                purchaser=user,
+            )
         )
         # Previously, multiple PendingOrders could be created for a single user
         # for the same product, if multiple exist, grab the first.

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -651,6 +651,10 @@ class PendingOrder(FulfillableOrder, Order):
         # for the same product, if multiple exist, grab the first.
         if orders:
             order = orders.first()
+
+            for old_discount in order.discounts.all():
+                old_discount.delete()
+
         else:
             order = Order.objects.create(
                 state=Order.STATE.PENDING,

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -451,6 +451,8 @@ def test_pending_order_is_reused_but_discounts_cleared(basket, unlimited_discoun
 
     order = PendingOrder.create_from_basket(basket)
     order.save()
+    order.refresh_from_db()
+
     # Verify that the existing PendingOrder is reused and a duplicate is not created.
     # This is to ensure that we also reuse the HubSpot Deal associated with Orders.
     # Also ensure the discounts aren't reattached to the order

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -7,6 +7,7 @@ import reversion
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from mitol.common.utils import now_in_utc
+from reversion.models import Version
 
 from ecommerce.constants import (
     DISCOUNT_TYPE_DOLLARS_OFF,
@@ -36,7 +37,6 @@ from ecommerce.models import (
     Transaction,
 )
 from users.factories import UserFactory
-from reversion.models import Version
 
 pytestmark = [pytest.mark.django_db]
 
@@ -421,6 +421,41 @@ def test_pending_order_is_reused(basket):
     # Verify that the existing PendingOrder is reused and a duplicate is not created.
     # This is to ensure that we also reuse the HubSpot Deal associated with Orders.
     assert Order.objects.filter(state=Order.STATE.PENDING).count() == 1
+
+
+def test_pending_order_is_reused_but_discounts_cleared(basket, unlimited_discount):
+    """
+    If a pending order is reused and had discounts, then we want those discounts
+    to clear.
+    """
+
+    with reversion.create_revision():
+        product = ProductFactory.create()
+
+    basket_item = BasketItem(product=product, basket=basket, quantity=1)
+    basket_item.save()
+    order = PendingOrder.create_from_basket(basket)
+    order.save()
+    assert Order.objects.filter(state=Order.STATE.PENDING).count() == 1
+
+    redemption = DiscountRedemption(
+        redeemed_discount=unlimited_discount,
+        redemption_date=now_in_utc(),
+        redeemed_order=order,
+        redeemed_by=order.purchaser,
+    )
+    redemption.save()
+
+    order.refresh_from_db()
+    assert order.discounts.count() == 1
+
+    order = PendingOrder.create_from_basket(basket)
+    order.save()
+    # Verify that the existing PendingOrder is reused and a duplicate is not created.
+    # This is to ensure that we also reuse the HubSpot Deal associated with Orders.
+    # Also ensure the discounts aren't reattached to the order
+    assert Order.objects.filter(state=Order.STATE.PENDING).count() == 1
+    assert order.discounts.count() == 0
 
 
 def test_new_pending_order_is_created_if_product_is_different():


### PR DESCRIPTION
# What are the relevant tickets?

Closes #1715 

# Description (What does it do?)

When a learner attempts to check out, their basket is converted to a pending Order. If there's already a pending Order for the learner with the same items in it, the system will reuse that existing Order. This is fine, but if the pending Order had discounts applied to it, those discount redemptions will stick around in the new order - they don't have an effect on the amount charged but they do count as redemptions for the discount, which could potentially result in a discount code becoming invalid when it shouldn't. (And, it definitely causes issues for reporting as we only support a single discount per order.) 

This adds some code to delete any DiscountRedemptions that exist for the order if it's being reused. Any discounts applied are applied to the user's basket first, so they will just be copied back into the order when the basket is converted into an order (which includes automatically applied discounts and financial assistance). 

# How can this be tested?

1. Set up a cart with a product in it.
2. Apply a discount (either manually or via financial assistance). Do not apply a discount that fully discounts the cart - doing this will cause it to automatically process, so your order won't stay in the Pending state. 
3. Proceed to the payment processor, and stop.
4. In a separate window/session/etc., pull up the resulting Order record in Django Admin. The order should have one discount redemption on it. 
5. In the first window, go back to the MITx Online system and set up the same cart again. Do not cancel out from CyberSource - either use the Back button or type the URL in.
6. Apply the same discount.
7. Proceed to the payment processor, and then stop.
8. In the Django Admin window, check the order again. You should see only the new discount redemption. 
