### PR TITLE
Added support for featured images in programs

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -129,3 +129,28 @@ class CoursePageSerializer(serializers.ModelSerializer):
             "instructors",
             "live",
         ]
+
+
+class ProgramPageSerializer(serializers.ModelSerializer):
+    """Program page model serializer"""
+
+    feature_image_src = serializers.SerializerMethodField()
+    page_url = serializers.SerializerMethodField()
+
+    def get_feature_image_src(self, instance):
+        """Serializes the source of the feature_image"""
+        feature_img_src = None
+        if hasattr(instance, "feature_image"):
+            feature_img_src = get_wagtail_img_src(instance.feature_image)
+
+        return feature_img_src or static(DEFAULT_COURSE_IMG_PATH)
+
+    def get_page_url(self, instance):
+        return instance.get_url()
+
+    class Meta:
+        model = models.ProgramPage
+        fields = [
+            "feature_image_src",
+            "page_url",
+        ]

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -11,8 +11,8 @@ from django.templatetags.static import static
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from cms.models import CoursePage
-from cms.serializers import CoursePageSerializer
+from cms.models import CoursePage, ProgramPage
+from cms.serializers import CoursePageSerializer, ProgramPageSerializer
 from courses import models
 from courses.api import create_run_enrollments
 from courses.constants import CONTENT_TYPE_MODEL_COURSE, CONTENT_TYPE_MODEL_PROGRAM
@@ -279,6 +279,7 @@ class ProgramSerializer(serializers.ModelSerializer):
     courses = serializers.SerializerMethodField()
     requirements = serializers.SerializerMethodField()
     req_tree = serializers.SerializerMethodField()
+    page = serializers.SerializerMethodField()
 
     def get_courses(self, instance):
         """Serializer for courses"""
@@ -316,6 +317,15 @@ class ProgramSerializer(serializers.ModelSerializer):
 
         return ProgramRequirementTreeSerializer(instance=req_root).data
 
+    def get_page(self, instance):
+        return (
+            ProgramPageSerializer(
+                instance=ProgramPage.objects.filter(program=instance).get()
+            ).data
+            if ProgramPage.objects.filter(program=instance).exists()
+            else None
+        )
+
     class Meta:
         model = models.Program
         fields = [
@@ -325,6 +335,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "courses",
             "requirements",
             "req_tree",
+            "page",
         ]
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.utils.timezone import now
 
 from cms.factories import CoursePageFactory, FlexiblePricingFormFactory
+from cms.serializers import ProgramPageSerializer
 from courses.factories import (
     CourseFactory,
     CourseRunEnrollmentFactory,
@@ -121,6 +122,7 @@ def test_serialize_program(mock_context, remove_tree, program_with_empty_require
             "req_tree": ProgramRequirementTreeSerializer(
                 program_with_empty_requirements.requirements_root
             ).data,
+            "page": ProgramPageSerializer(program_with_empty_requirements.page).data,
         },
     )
 

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -587,7 +587,7 @@ export class EnrolledItemCard extends React.Component<
         <div className="row flex-grow-1">
           <div className="col-12 col-md-auto px-0 px-md-3">
             <div className="img-container">
-              <img src="/static/images/mit-dome.png" alt="" />
+              <img src={enrollment.program.page.feature_image_src} alt="" />
             </div>
           </div>
 

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -252,7 +252,11 @@ export const makeProgram = (): Program => ({
   id:          genProgramId.next().value,
   title:       casual.text,
   readable_id: casual.word,
-  courses:     [makeCourseDetailWithRuns()]
+  courses:     [makeCourseDetailWithRuns()],
+  page:        {
+    financial_assistance_form_url: casual.url,
+    feature_image_src:             casual.url
+  }
 })
 
 export const makeProgramWithReqTree = (): Program => {

--- a/frontend/public/src/flow/courseTypes.js
+++ b/frontend/public/src/flow/courseTypes.js
@@ -73,12 +73,13 @@ export type Program = {
   courses: Array<CourseDetailWithRuns>,
   requirements: ?ProgramEnrollments,
   req_tree: Array<ProgramRequirement>,
+  page: ?Page,
 }
 
 export type ProgramEnrollment = {
   program: Program,
   enrollments: Array<RunEnrollment>,
-  certificate: ?Certificate
+  certificate: ?Certificate,
 }
 
 export type PartnerSchool = {


### PR DESCRIPTION
# What are the relevant tickets?

Closes #1714 

# Description (What does it do?)

- Adds a ProgramPageSerializer
- Updates the ProgramSerializer to include the featured image if there is one (same logic as for courses - you get the MIT dome if there isn't one)
- Updates EnrolledItemCard to include the featured image
- Fixes tests and types accordingly

# Screenshots (if appropriate):

![image](https://github.com/mitodl/mitxonline/assets/945611/995237a2-1e9f-4c21-8965-8bbfeb08aec9)

# How can this be tested?

You will need to make sure your local copy can serve static images uploaded via Wagtail. (For me, this involved making some minor adjustments to the `docker-compose.yml` and the `nginx.conf.erb` files.) 

1. In Wagtail, update a program page for a program that you're enrolled in so that it has a featured image. 
2. Navigate to the dashboard and switch to the My Programs tab when it appears.
3. Observe. The program you updated should show the new image, and any remaining ones should get the standard MIT dome image. 
