### PR TITLE
1718 improve hubspot bulk update database queries

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -627,7 +627,7 @@ def sync_product_with_hubspot(product: Product) -> SimplePublicObject:
         product(Product): The Product object.
 
     Returns:
-        SimplePublicObject: The hubspot product object
+        SimplePublicObject: The hubspot product object.
     """
     body = make_product_sync_message_from_product(product)
     content_type = ContentType.objects.get_for_model(Product)
@@ -645,28 +645,23 @@ def sync_contact_with_hubspot(user: User):
         user User: User object.
 
     Returns:
-        bool: True if the contact upsert to HubSpot was successful, otherwise False.
+        SimplePublicObject: The hubspot contact object.
 
     Raises:
         ApiException: Raised if HubSpot upsert request fails.
     """
     content_type = ContentType.objects.get_for_model(User)
     body = make_contact_sync_message_from_user(user)
-    try:
-        upsert_object_request(
-            content_type,
-            HubspotObjectType.CONTACTS.value,
-            object_id=user.id,
-            body=body,
-        )
-    except ApiException:
-        return False
-    time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
-
+    result = upsert_object_request(
+        content_type,
+        HubspotObjectType.CONTACTS.value,
+        object_id=user.id,
+        body=body,
+    )
     user.hubspot_sync_datetime = now_in_utc()
     user.save()
 
-    return True
+    return result
 
 
 MODEL_CREATE_FUNCTION_MAPPING = {

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -64,7 +64,7 @@ def make_contact_update_message_list_from_user_ids(
     Create the body of a HubSpot contact update message from a dictionary..
 
     Args:
-        chunk_dictionary (List[tuple(int, str)]): List of tuples of (User ID, HubSpot Object ID).
+        chunk (List[tuple(int, str)]): List of tuples of (User ID, HubSpot Object ID).
 
     Returns:
         List[dict]: List of dictionaries containing User properties.
@@ -211,7 +211,7 @@ def make_line_item_update_message_list_from_line_ids(
     Create the body of a HubSpot Line batch update message from a dictionary.
 
     Args:
-        chunk_dictionary (List[tuple(int, str)]): List of tuples of (Line ID, HubSpot Object ID).
+        chunk (List[tuple(int, str)]): List of tuples of (Line ID, HubSpot Object ID).
 
     Returns:
         List[dict]: List of dictionaries containing Line properties.
@@ -273,7 +273,7 @@ def make_product_update_message_list_from_product_ids(
     Create the body of a HubSpot Product batch update message from a dictionary.
 
     Args:
-        chunk_dictionary (List[tuple(int, str)]): List of tuples of (Product ID, HubSpot Object ID).
+        chunk (List[tuple(int, str)]): List of tuples of (Product ID, HubSpot Object ID).
 
     Returns:
         List[dict]: List of dictionaries containing Product properties.

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -49,7 +49,7 @@ def make_contact_create_message_list_from_user_ids(
     Returns:
         List[SimplePublicObjectInput]: List of input objects for upserting User data to Hubspot
     """
-    users = list(User.objects.filter(id__in=user_ids))
+    users = list(User.objects.filter(id__in=user_ids).order_by("id"))
     message_list = []
     for user in users:
         message_list.append(make_contact_sync_message_from_user(user))

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -3,7 +3,7 @@ import logging
 import re
 from decimal import Decimal
 import time
-from typing import List, Tuple
+from typing import List
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -127,6 +127,15 @@ def make_contact_sync_message_from_user(user: User) -> SimplePublicObjectInput:
 def make_deal_create_message_list_from_order_ids(
     order_ids: List[int],
 ) -> SimplePublicObjectInput:
+    """
+    Create the body of a sync message for a list of Order IDs.
+
+    Args:
+        order_ids (List[int]): List of Order ids.
+
+    Returns:
+        List[SimplePublicObjectInput]: List of input objects for upserting Order data to Hubspot
+    """
     orders = Order.objects.fetch(id__in=order_ids)
     message_list = []
     for order in orders:
@@ -138,10 +147,10 @@ def make_deal_update_message_list_from_order_ids(
     chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
-    Create the body of a HubSpot deal batch update message from a dictionary..
+    Create the body of a HubSpot deal batch update message from a dictionary.
 
     Args:
-        chunk_dictionary (List[tuple(int, str)]): List of tuples of (Order ID, HubSpot Object ID).
+        chunk (List[tuple(int, str)]): List of tuples of (Order ID, HubSpot Object ID).
 
     Returns:
         List[dict]: List of dictionaries containing Order properties.
@@ -179,6 +188,15 @@ def make_deal_sync_message_from_order(order: Order) -> SimplePublicObjectInput:
 def make_line_item_create_messages_list_from_line_ids(
     line_ids: List[int],
 ) -> SimplePublicObjectInput:
+    """
+    Create the body of a sync message for a list of Line IDs.
+
+    Args:
+        line_ids (List[int]): List of Line ids.
+
+    Returns:
+        List[SimplePublicObjectInput]: List of input objects for upserting Line data to Hubspot
+    """
     lines = Line.objects.fetch(id__in=line_ids)
     message_list = []
     for line in lines:
@@ -235,7 +253,7 @@ def make_product_create_message_list_from_product_ids(
     Create a hubspot sync input object for a product.
 
     Args:
-        product_ids (List[int]): List of product ids..
+        product_ids (List[int]): List of product ids.
 
     Returns:
         List[SimplePublicObjectInput]: List of input objects for upserting Product data to Hubspot.
@@ -645,7 +663,7 @@ def sync_contact_with_hubspot(user: User):
         return False
     time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
 
-    user.hubspot_sync_datetime=now_in_utc()
+    user.hubspot_sync_datetime = now_in_utc()
     user.save()
 
     return True

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -49,7 +49,9 @@ def make_contact_create_message_list_from_user_ids(
     Returns:
         List[SimplePublicObjectInput]: List of input objects for upserting User data to Hubspot
     """
-    users = list(User.objects.filter(id__in=user_ids).order_by("id"))
+    users = list(
+        User.objects.filter(id__in=user_ids).order_by("id")
+    )  # Sorted to support unit test.
     message_list = []
     for user in users:
         message_list.append(make_contact_sync_message_from_user(user))

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -242,7 +242,6 @@ def make_line_item_sync_message_from_line(line: Line) -> SimplePublicObjectInput
     """
     from hubspot_sync.serializers import LineSerializer
 
-    print(line)
     properties = LineSerializer(line).data
     return make_object_properties_message(properties)
 
@@ -596,7 +595,6 @@ def sync_deal_with_hubspot(order: Order) -> SimplePublicObject:
     Returns:
         SimplePublicObject: The hubspot deal object
     """
-    print("in sync_deal_with_hubspot")
     body = make_deal_sync_message_from_order(order)
     content_type = ContentType.objects.get_for_model(Order)
 
@@ -607,7 +605,6 @@ def sync_deal_with_hubspot(order: Order) -> SimplePublicObject:
     result = upsert_object_request(
         content_type, HubspotObjectType.DEALS.value, object_id=order.id, body=body
     )
-    print("before association")
     # Create association between deal and contact
     associate_objects_request(
         HubspotObjectType.DEALS.value,
@@ -616,7 +613,6 @@ def sync_deal_with_hubspot(order: Order) -> SimplePublicObject:
         get_hubspot_id_for_object(order.purchaser),
         HubspotAssociationType.DEAL_CONTACT.value,
     )
-    print("after association")
 
     for line in order.lines.all():
         sync_line_item_with_hubspot(line)

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -597,7 +597,7 @@ def sync_deal_with_hubspot(order: Order) -> SimplePublicObject:
     )
 
     for line in order.lines.all():
-        sync_line_item_with_hubspot(line.id)
+        sync_line_item_with_hubspot(line)
     return result
 
 
@@ -645,7 +645,8 @@ def sync_contact_with_hubspot(user: User):
         return False
     time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
 
-    user.update(hubspot_sync_datetime=now_in_utc())
+    user.hubspot_sync_datetime=now_in_utc()
+    user.save()
 
     return True
 

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -649,6 +649,7 @@ def sync_contact_with_hubspot(user: User):
 
     Raises:
         ApiException: Raised if HubSpot upsert request fails.
+        TooManyRequestsException: Too many requests against HubSpot's API.
     """
     content_type = ContentType.objects.get_for_model(User)
     body = make_contact_sync_message_from_user(user)

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -641,7 +641,7 @@ def sync_product_with_hubspot(product: Product) -> SimplePublicObject:
 
 def sync_contact_with_hubspot(user: User):
     """
-    Sync a list of User objects with their hubspot_sync contacts.
+    Sync a user with a hubspot_sync contact.
 
     Args:
         user User: User object.

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -41,7 +41,7 @@ def make_contact_create_message_list_from_user_ids(
     user_ids: List[int],
 ) -> List[SimplePublicObjectInput]:
     """
-    Create the body of a sync message for a list of User IDs.
+    Create the body of a HubSpot create message for a list of User IDs.
 
     Args:
         user_ids (List[int]): List of user ids.
@@ -61,7 +61,7 @@ def make_contact_update_message_list_from_user_ids(
     chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
-    Create the body of a HubSpot contact batch update message from a dictionary..
+    Create the body of a HubSpot contact update message from a dictionary..
 
     Args:
         chunk_dictionary (List[tuple(int, str)]): List of tuples of (User ID, HubSpot Object ID).
@@ -85,7 +85,7 @@ def make_contact_update_message_list_from_user_ids(
 
 def make_contact_sync_message_from_user(user: User) -> SimplePublicObjectInput:
     """
-    Create the body of a sync message for a contact. This will flatten the contained LegalAddress and Profile
+    Create the body of a HubSpot sync message for a contact. This will flatten the contained LegalAddress and Profile
     serialized data into one larger serializable dict
 
     Args:
@@ -128,7 +128,7 @@ def make_deal_create_message_list_from_order_ids(
     order_ids: List[int],
 ) -> SimplePublicObjectInput:
     """
-    Create the body of a sync message for a list of Order IDs.
+    Create the body of a HubSpot Deal create message for a list of Order IDs.
 
     Args:
         order_ids (List[int]): List of Order ids.
@@ -147,7 +147,7 @@ def make_deal_update_message_list_from_order_ids(
     chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
-    Create the body of a HubSpot deal batch update message from a dictionary.
+    Create the body of a HubSpot Deal batch update message from a dictionary.
 
     Args:
         chunk (List[tuple(int, str)]): List of tuples of (Order ID, HubSpot Object ID).
@@ -171,7 +171,7 @@ def make_deal_update_message_list_from_order_ids(
 
 def make_deal_sync_message_from_order(order: Order) -> SimplePublicObjectInput:
     """
-    Create a hubspot sync input object for an Order.
+    Create a hubspot sync message for an Order.
 
     Args:
         order (Order): Order object.
@@ -189,7 +189,7 @@ def make_line_item_create_messages_list_from_line_ids(
     line_ids: List[int],
 ) -> SimplePublicObjectInput:
     """
-    Create the body of a sync message for a list of Line IDs.
+    Create the body of a HubSpot Line create message for a list of Line IDs.
 
     Args:
         line_ids (List[int]): List of Line ids.
@@ -208,7 +208,7 @@ def make_line_item_update_message_list_from_line_ids(
     chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
-    Create the body of a HubSpot line batch update message from a dictionary.
+    Create the body of a HubSpot Line batch update message from a dictionary.
 
     Args:
         chunk_dictionary (List[tuple(int, str)]): List of tuples of (Line ID, HubSpot Object ID).
@@ -251,13 +251,13 @@ def make_product_create_message_list_from_product_ids(
     product_ids: List[int],
 ) -> SimplePublicObjectInput:
     """
-    Create a hubspot sync input object for a product.
+    Create the body of a HubSpot Product create message for a list of Product IDs.
 
     Args:
         product_ids (List[int]): List of product ids.
 
     Returns:
-        List[SimplePublicObjectInput]: List of input objects for upserting Product data to Hubspot.
+        List[SimplePublicObjectInput]: List of input objects for createing Product data to Hubspot.
     """
     message_list = []
     products = Product.objects.filter(id__in=product_ids)
@@ -270,7 +270,7 @@ def make_product_update_message_list_from_product_ids(
     chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
-    Create the body of a HubSpot product batch update message from a dictionary.
+    Create the body of a HubSpot Product batch update message from a dictionary.
 
     Args:
         chunk_dictionary (List[tuple(int, str)]): List of tuples of (Product ID, HubSpot Object ID).
@@ -296,7 +296,7 @@ def make_product_update_message_list_from_product_ids(
 
 def make_product_sync_message_from_product(product: Product) -> SimplePublicObjectInput:
     """
-    Create a hubspot sync input object for a product.
+    Create a hubspot sync input object for a Product.
 
     Args:
         product (Product): Product object.
@@ -312,7 +312,7 @@ def make_product_sync_message_from_product(product: Product) -> SimplePublicObje
 
 def format_product_name(product: Product) -> str:
     """
-    Get the product name as it should appear in Hubspot
+    Get the Product name as it should appear in Hubspot
 
     Args:
         product(Product): The product to return a name for

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -58,7 +58,7 @@ def make_contact_create_message_list_from_user_ids(
 
 
 def make_contact_update_message_list_from_user_ids(
-    chunk: List[Tuple[int, str]]
+    chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
     Create the body of a HubSpot contact batch update message from a dictionary..
@@ -72,8 +72,8 @@ def make_contact_update_message_list_from_user_ids(
     chunk_dictionary = dict(chunk)
     users = User.objects.filter(id__in=chunk_dictionary.keys())
     request_input = []
-    for user_id, hubspot_id in chunk_dictionary:
-        user = users.filter(id=user_id)
+    for user_id, hubspot_id in chunk_dictionary.items():
+        user = users.filter(id=user_id).first()
         request_input.append(
             {
                 "id": hubspot_id,
@@ -135,7 +135,7 @@ def make_deal_create_message_list_from_order_ids(
 
 
 def make_deal_update_message_list_from_order_ids(
-    chunk: List[Tuple[int, str]]
+    chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
     Create the body of a HubSpot deal batch update message from a dictionary..
@@ -149,7 +149,7 @@ def make_deal_update_message_list_from_order_ids(
     chunk_dictionary = dict(chunk)
     orders = Order.objects.filter(id__in=chunk_dictionary.keys())
     request_input = []
-    for order_id, hubspot_id in chunk_dictionary:
+    for order_id, hubspot_id in chunk_dictionary.items():
         order = orders.filter(id=order_id)
         request_input.append(
             {
@@ -187,7 +187,7 @@ def make_line_item_create_messages_list_from_line_ids(
 
 
 def make_line_item_update_message_list_from_line_ids(
-    chunk: List[Tuple[int, str]]
+    chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
     Create the body of a HubSpot line batch update message from a dictionary.
@@ -201,7 +201,7 @@ def make_line_item_update_message_list_from_line_ids(
     chunk_dictionary = dict(chunk)
     lines = Line.objects.filter(id__in=chunk_dictionary.keys())
     request_input = []
-    for line_id, hubspot_id in chunk_dictionary:
+    for line_id, hubspot_id in chunk_dictionary.items():
         line = lines.filter(id=line_id)
         request_input.append(
             {
@@ -248,7 +248,7 @@ def make_product_create_message_list_from_product_ids(
 
 
 def make_product_update_message_list_from_product_ids(
-    chunk: List[Tuple[int, str]]
+    chunk: List[tuple[int, str]]
 ) -> List[dict]:
     """
     Create the body of a HubSpot product batch update message from a dictionary.
@@ -262,7 +262,7 @@ def make_product_update_message_list_from_product_ids(
     chunk_dictionary = dict(chunk)
     products = Product.objects.filter(id__in=chunk_dictionary.keys())
     request_input = []
-    for product_id, hubspot_id in chunk_dictionary:
+    for product_id, hubspot_id in chunk_dictionary.items():
         product = products.filter(id=product_id)
         request_input.append(
             {

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -135,7 +135,7 @@ def test_make_product_sync_message():
 def test_sync_contact_with_hubspot(mock_hubspot_api):
     """Test that the hubspot CRM API is called properly for a contact sync"""
     user = UserFactory.create()
-    api.sync_contact_with_hubspot(user.id)
+    api.sync_contact_with_hubspot(user)
     assert (
         api.HubspotObject.objects.get(
             object_id=user.id, content_type__model="user"
@@ -166,7 +166,7 @@ def test_sync_contact_with_hubspot_error(mocker, mock_hubspot_api):
         )
     )
     with pytest.raises(ApiException) as exc:
-        api.sync_contact_with_hubspot(user.id)
+        api.sync_contact_with_hubspot(user)
     user.refresh_from_db()
     assert user.hubspot_sync_datetime is None
 
@@ -191,7 +191,7 @@ def test_existing_user_sync_contact_with_hubspot_error(mocker, mock_hubspot_api)
         )
     )
     with pytest.raises(ApiException) as exc:
-        api.sync_contact_with_hubspot(user.id)
+        api.sync_contact_with_hubspot(user)
     user.refresh_from_db()
     assert user.hubspot_sync_datetime == current_datetime
 

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -165,7 +165,8 @@ def test_sync_contact_with_hubspot_error(mocker, mock_hubspot_api):
             status=400,
         )
     )
-    assert api.sync_contact_with_hubspot(user) is False
+    with pytest.raises(ApiException) as exc:
+        api.sync_contact_with_hubspot(user)
     user.refresh_from_db()
     assert user.hubspot_sync_datetime is None
 
@@ -189,7 +190,8 @@ def test_existing_user_sync_contact_with_hubspot_error(mocker, mock_hubspot_api)
             status=400,
         )
     )
-    assert api.sync_contact_with_hubspot(user) is False
+    with pytest.raises(ApiException) as exc:
+        api.sync_contact_with_hubspot(user)
     user.refresh_from_db()
     assert user.hubspot_sync_datetime == current_datetime
 

--- a/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
+++ b/hubspot_sync/management/commands/create_order_from_course_run_enrollments.py
@@ -7,7 +7,6 @@ from django.core.management import BaseCommand
 
 from courses.models import CourseRun, CourseRunEnrollment
 from ecommerce.models import Order, PendingOrder, Product
-from hubspot_sync.task_helpers import sync_hubspot_deal
 from reversion.models import Version
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE
 

--- a/hubspot_sync/task_helpers.py
+++ b/hubspot_sync/task_helpers.py
@@ -2,7 +2,7 @@
 import logging
 
 from django.conf import settings
-from ecommerce.models import Line, Order, Product
+from ecommerce.models import Order, Product
 
 from hubspot_sync import tasks
 from users.models import User

--- a/hubspot_sync/task_helpers.py
+++ b/hubspot_sync/task_helpers.py
@@ -19,7 +19,7 @@ def sync_hubspot_user(user):
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN:
         try:
-            tasks.sync_contact_with_hubspot.delay(user.id)
+            tasks.sync_contact_with_hubspot.delay(user)
         except:
             log.exception(
                 "Exception calling sync_contact_with_hubspot for user %s", user.username

--- a/hubspot_sync/task_helpers.py
+++ b/hubspot_sync/task_helpers.py
@@ -36,7 +36,7 @@ def sync_hubspot_deal(order):
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN and order.lines.first() is not None:
         try:
-            tasks.sync_deal_with_hubspot.apply_async(args=(order,), countdown=10)
+            tasks.sync_deal_with_hubspot.apply_async(args=(order), countdown=10)
         except:
             log.exception(
                 "Exception calling sync_deal_with_hubspot for order %d", order.id

--- a/hubspot_sync/task_helpers.py
+++ b/hubspot_sync/task_helpers.py
@@ -36,7 +36,7 @@ def sync_hubspot_deal(order):
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN and order.lines.first() is not None:
         try:
-            tasks.sync_deal_with_hubspot.apply_async(args=(order.id,), countdown=10)
+            tasks.sync_deal_with_hubspot.apply_async(args=(order,), countdown=10)
         except:
             log.exception(
                 "Exception calling sync_deal_with_hubspot for order %d", order.id
@@ -69,7 +69,7 @@ def sync_hubspot_product(product):
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN:
         try:
-            tasks.sync_product_with_hubspot.delay(product.id)
+            tasks.sync_product_with_hubspot.delay(product)
         except:
             log.exception(
                 "Exception calling sync_product_with_hubspot for product %d", product.id

--- a/hubspot_sync/task_helpers.py
+++ b/hubspot_sync/task_helpers.py
@@ -2,15 +2,17 @@
 import logging
 
 from django.conf import settings
+from ecommerce.models import Line, Order, Product
 
 from hubspot_sync import tasks
+from users.models import User
 
 # pylint:disable-bare-except
 
 log = logging.getLogger(__name__)
 
 
-def sync_hubspot_user(user):
+def sync_hubspot_user(user: User):
     """
     Trigger celery task to sync a User to Hubspot
 
@@ -19,14 +21,14 @@ def sync_hubspot_user(user):
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN:
         try:
-            tasks.sync_contact_with_hubspot.delay(user)
+            tasks.sync_contact_with_hubspot.delay(user.id)
         except:
             log.exception(
                 "Exception calling sync_contact_with_hubspot for user %s", user.username
             )
 
 
-def sync_hubspot_deal(order):
+def sync_hubspot_deal(order: Order):
     """
     Trigger celery task to sync an order to Hubspot if it has lines.
     Use a delay of 10 seconds to make sure state is updated first.
@@ -36,7 +38,7 @@ def sync_hubspot_deal(order):
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN and order.lines.first() is not None:
         try:
-            tasks.sync_deal_with_hubspot.apply_async(args=(order), countdown=10)
+            tasks.sync_deal_with_hubspot.apply_async(args=(order.id,), countdown=10)
         except:
             log.exception(
                 "Exception calling sync_deal_with_hubspot for order %d", order.id
@@ -60,7 +62,7 @@ def sync_hubspot_line_by_line_id(line_id: int):
             )
 
 
-def sync_hubspot_product(product):
+def sync_hubspot_product(product: Product):
     """
     Trigger celery task to sync a Product to Hubspot
 
@@ -69,7 +71,7 @@ def sync_hubspot_product(product):
     """
     if settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN:
         try:
-            tasks.sync_product_with_hubspot.delay(product)
+            tasks.sync_product_with_hubspot.delay(product.id)
         except:
             log.exception(
                 "Exception calling sync_product_with_hubspot for product %d", product.id

--- a/hubspot_sync/task_helpers_test.py
+++ b/hubspot_sync/task_helpers_test.py
@@ -26,7 +26,7 @@ def test_sync_hubspot_deal(mocker, mock_exception_log, hubspot_order, raise_exc)
         side_effect=(ConnectionError if raise_exc else None),
     )
     sync_hubspot_deal(hubspot_order)
-    mock_sync.assert_called_once_with(args=(hubspot_order.id,), countdown=10)
+    mock_sync.assert_called_once_with(args=(hubspot_order), countdown=10)
     if raise_exc:
         mock_exception_log.assert_called_once_with(
             "Exception calling sync_deal_with_hubspot for order %d", hubspot_order.id
@@ -43,7 +43,7 @@ def test_sync_hubspot_user(mocker, mock_exception_log, user, raise_exc):
         side_effect=(ConnectionError if raise_exc else None),
     )
     sync_hubspot_user(user)
-    mock_sync.assert_called_once_with(user.id)
+    mock_sync.assert_called_once_with(user)
     if raise_exc:
         mock_exception_log.assert_called_once_with(
             "Exception calling sync_contact_with_hubspot for user %s", user.username
@@ -61,7 +61,7 @@ def test_sync_hubspot_product(mocker, mock_exception_log, raise_exc):
     )
     product = ProductFactory.build()
     sync_hubspot_product(product)
-    mock_sync.assert_called_once_with(product.id)
+    mock_sync.assert_called_once_with(product)
     if raise_exc:
         mock_exception_log.assert_called_once_with(
             "Exception calling sync_product_with_hubspot for product %d", product.id

--- a/hubspot_sync/task_helpers_test.py
+++ b/hubspot_sync/task_helpers_test.py
@@ -26,7 +26,7 @@ def test_sync_hubspot_deal(mocker, mock_exception_log, hubspot_order, raise_exc)
         side_effect=(ConnectionError if raise_exc else None),
     )
     sync_hubspot_deal(hubspot_order)
-    mock_sync.assert_called_once_with(args=(hubspot_order), countdown=10)
+    mock_sync.assert_called_once_with(args=(hubspot_order.id,), countdown=10)
     if raise_exc:
         mock_exception_log.assert_called_once_with(
             "Exception calling sync_deal_with_hubspot for order %d", hubspot_order.id
@@ -43,7 +43,7 @@ def test_sync_hubspot_user(mocker, mock_exception_log, user, raise_exc):
         side_effect=(ConnectionError if raise_exc else None),
     )
     sync_hubspot_user(user)
-    mock_sync.assert_called_once_with(user)
+    mock_sync.assert_called_once_with(user.id)
     if raise_exc:
         mock_exception_log.assert_called_once_with(
             "Exception calling sync_contact_with_hubspot for user %s", user.username
@@ -61,7 +61,7 @@ def test_sync_hubspot_product(mocker, mock_exception_log, raise_exc):
     )
     product = ProductFactory.build()
     sync_hubspot_product(product)
-    mock_sync.assert_called_once_with(product)
+    mock_sync.assert_called_once_with(product.id)
     if raise_exc:
         mock_exception_log.assert_called_once_with(
             "Exception calling sync_product_with_hubspot for product %d", product.id

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -142,9 +142,9 @@ def sync_contact_with_hubspot(user_id: int) -> str:
         user_id(int): The User ID.
 
     Returns:
-        bool: True if the HubSpot contact was successfully updated, otherwise False.
+        str: The HubSpot ID for the User.
     """
-    return api.sync_contact_with_hubspot(User.objects.get(id=user_id))
+    return api.sync_contact_with_hubspot(User.objects.get(id=user_id)).id
 
 
 @app.task(

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -258,7 +258,9 @@ def batch_create_hubspot_objects_chunked(
                 if ct_model_name == "user":
                     user = User.objects.filter(
                         email__iexact=result.properties["email"], is_active=True
-                    ).update(hubspot_sync_datetime=now_in_utc())
+                    ).first()
+                    user.hubspot_sync_datetime = now_in_utc()
+                    user.save()
                     object_id = user.id
                 else:
                     object_id = result.properties["unique_app_id"].split("-")[-1]

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -20,7 +20,7 @@ from mitol.hubspot_api.decorators import raise_429
 from mitol.hubspot_api.exceptions import TooManyRequestsException
 from mitol.hubspot_api.models import HubspotObject
 
-from ecommerce.models import Order, Product
+from ecommerce.models import Line, Order, Product
 from hubspot_sync import api
 from hubspot_sync.api import (
     get_hubspot_id_for_object,
@@ -142,10 +142,10 @@ def sync_contact_with_hubspot(user_id: int) -> str:
         user(User): The User object.
 
     Returns:
-        str: The hubspot id for the contact
+        bool: True if the HubSpot contact was successfully updated, otherwise False.
     """
     user = User.objects.get(id=user_id)
-    return api.sync_contact_with_hubspot(user).id
+    return api.sync_contact_with_hubspot(user)
 
 
 @app.task(
@@ -213,7 +213,8 @@ def sync_line_with_hubspot(line_id: int) -> str:
     Returns:
         str: The hubspot id for the line
     """
-    return api.sync_line_item_with_hubspot(line_id).id
+    line = Line.objects.get(id=line_id)
+    return api.sync_line_item_with_hubspot(line).id
 
 
 @app.task(

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -134,7 +134,7 @@ def handle_failed_batch_chunk(chunk: List[int], hubspot_type: str) -> List[int]:
 )
 @raise_429
 @single_task(10, key=task_obj_lock)
-def sync_contact_with_hubspot(user: User) -> str:
+def sync_contact_with_hubspot(user_id: int) -> str:
     """
     Sync a User with a hubspot contact
 
@@ -144,6 +144,7 @@ def sync_contact_with_hubspot(user: User) -> str:
     Returns:
         str: The hubspot id for the contact
     """
+    user = User.objects.get(id=user_id)
     return api.sync_contact_with_hubspot(user).id
 
 
@@ -156,7 +157,7 @@ def sync_contact_with_hubspot(user: User) -> str:
 )
 @raise_429
 @single_task(10, key=task_obj_lock)
-def sync_product_with_hubspot(product: Product) -> str:
+def sync_product_with_hubspot(product_id: int) -> str:
     """
     Sync a MITxOnline Product with a hubspot product
 
@@ -166,6 +167,7 @@ def sync_product_with_hubspot(product: Product) -> str:
     Returns:
         str: The hubspot id for the product
     """
+    product = Product.objects.get(id=product_id)
     return api.sync_product_with_hubspot(product).id
 
 
@@ -178,7 +180,7 @@ def sync_product_with_hubspot(product: Product) -> str:
 )
 @raise_429
 @single_task(10, key=task_obj_lock)
-def sync_deal_with_hubspot(order: Order) -> str:
+def sync_deal_with_hubspot(order_id: int) -> str:
     """
     Sync an Order with a hubspot deal
 
@@ -188,6 +190,7 @@ def sync_deal_with_hubspot(order: Order) -> str:
     Returns:
         str: The hubspot id for the deal
     """
+    order = Order.objects.get(id=order_id)
     return api.sync_deal_with_hubspot(order).id
 
 

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -139,13 +139,12 @@ def sync_contact_with_hubspot(user_id: int) -> str:
     Sync a User with a hubspot contact
 
     Args:
-        user(User): The User object.
+        user_id(int): The User ID.
 
     Returns:
         bool: True if the HubSpot contact was successfully updated, otherwise False.
     """
-    user = User.objects.get(id=user_id)
-    return api.sync_contact_with_hubspot(user)
+    return api.sync_contact_with_hubspot(User.objects.get(id=user_id))
 
 
 @app.task(
@@ -162,7 +161,7 @@ def sync_product_with_hubspot(product_id: int) -> str:
     Sync a MITxOnline Product with a hubspot product
 
     Args:
-        product(Product): The Product object.
+        product_id(int): The Product ID.
 
     Returns:
         str: The hubspot id for the product

--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -167,8 +167,7 @@ def sync_product_with_hubspot(product_id: int) -> str:
     Returns:
         str: The hubspot id for the product
     """
-    product = Product.objects.get(id=product_id)
-    return api.sync_product_with_hubspot(product).id
+    return api.sync_product_with_hubspot(Product.objects.get(id=product_id)).id
 
 
 @app.task(
@@ -185,13 +184,12 @@ def sync_deal_with_hubspot(order_id: int) -> str:
     Sync an Order with a hubspot deal
 
     Args:
-        order(Order): The Order object.
+        order_id(int): The Order ID.
 
     Returns:
         str: The hubspot id for the deal
     """
-    order = Order.objects.get(id=order_id)
-    return api.sync_deal_with_hubspot(order).id
+    return api.sync_deal_with_hubspot(Order.objects.get(id=order_id)).id
 
 
 @app.task(
@@ -213,8 +211,7 @@ def sync_line_with_hubspot(line_id: int) -> str:
     Returns:
         str: The hubspot id for the line
     """
-    line = Line.objects.get(id=line_id)
-    return api.sync_line_item_with_hubspot(line).id
+    return api.sync_line_item_with_hubspot(Line.objects.get(id=line_id)).id
 
 
 @app.task(

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -273,7 +273,7 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
     contacts = UserFactory.create_batch(id_count)
-    mock_ids = sorted(user.id for user in contacts)
+    mock_ids = [user.id for user in contacts]
     mock_hubspot_api = mocker.patch("hubspot_sync.tasks.HubspotApi")
     mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
         mocker.Mock(
@@ -294,9 +294,7 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     mock_hubspot_api.return_value.crm.objects.batch_api.create.assert_any_call(
         HubspotObjectType.CONTACTS.value,
         BatchInputSimplePublicObjectInput(
-            inputs=make_contact_create_message_list_from_user_ids(
-                mock_ids[0 : min(id_count, 10)]
-            )
+            inputs=make_contact_create_message_list_from_user_ids(mock_ids[0 : min(id_count, 10)])
         ),
     )
 

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -272,7 +272,7 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
 @pytest.mark.parametrize("id_count", [5, 15])
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
-    contacts = UserFactory.create_batch(id_count)
+    contacts = sorted(UserFactory.create_batch(id_count), key = lambda user: user.id)
     mock_ids = [user.id for user in contacts]
     mock_hubspot_api = mocker.patch("hubspot_sync.tasks.HubspotApi")
     mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
@@ -291,6 +291,7 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
         mock_hubspot_api.return_value.crm.objects.batch_api.create.call_count
         == expected_batches
     )
+
     mock_hubspot_api.return_value.crm.objects.batch_api.create.assert_any_call(
         HubspotObjectType.CONTACTS.value,
         BatchInputSimplePublicObjectInput(

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -272,7 +272,7 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
 @pytest.mark.parametrize("id_count", [5, 15])
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
-    contacts = sorted(UserFactory.create_batch(id_count), key=lambda user: user.id)
+    contacts = UserFactory.create_batch(id_count)
     mock_ids = [user.id for user in contacts]
     mock_hubspot_api = mocker.patch("hubspot_sync.tasks.HubspotApi")
     mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
@@ -291,7 +291,6 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
         mock_hubspot_api.return_value.crm.objects.batch_api.create.call_count
         == expected_batches
     )
-
     mock_hubspot_api.return_value.crm.objects.batch_api.create.assert_any_call(
         HubspotObjectType.CONTACTS.value,
         BatchInputSimplePublicObjectInput(
@@ -300,7 +299,6 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
             )
         ),
     )
-
     for user in contacts:
         user.refresh_from_db()
         assert user.hubspot_sync_datetime is not None

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -25,6 +25,9 @@ from hubspot_sync import tasks
 from hubspot_sync.tasks import (
     batch_upsert_associations,
     batch_upsert_associations_chunked,
+    sync_contact_with_hubspot,
+    sync_deal_with_hubspot,
+    sync_product_with_hubspot,
 )
 from users.factories import UserFactory, UserSocialAuthFactory
 from users.models import User
@@ -39,21 +42,42 @@ SYNC_FUNCTIONS = [
 ]
 
 
-@pytest.mark.parametrize("task_func", SYNC_FUNCTIONS)
-def test_task_functions(mocker, task_func):
+def test_task_sync_contact_with_hubspot(mocker):
     """These task functions should call the api function of the same name and return a hubspot id"""
-    mock_result = SimplePublicObjectFactory()
-    mock_api_call = mocker.patch(
-        f"hubspot_sync.tasks.api.{task_func}", return_value=mock_result
-    )
-    if task_func == "sync_contact_with_hubspot":
-        mock_object = UserFactory.create()
-    elif task_func == "sync_product_with_hubspot":
-        mock_object = ProductFactory.create()
-    else:
-        mock_object = OrderFactory.create()
+    mock_object = UserFactory.create()
+    mock_result = True
 
-    assert getattr(tasks, task_func)(mock_object.id) == mock_result.id
+    mock_api_call = mocker.patch(
+        f"hubspot_sync.tasks.api.sync_contact_with_hubspot", return_value=mock_result
+    )
+
+    assert sync_contact_with_hubspot(mock_object.id) == mock_result
+    mock_api_call.assert_called_once_with(mock_object)
+
+
+def test_task_sync_product_with_hubspot(mocker):
+    """These task functions should call the api function of the same name and return a hubspot id"""
+    mock_object = ProductFactory.create()
+    mock_result = SimplePublicObjectFactory()
+
+    mock_api_call = mocker.patch(
+        f"hubspot_sync.tasks.api.sync_product_with_hubspot", return_value=mock_result
+    )
+
+    assert sync_product_with_hubspot(mock_object.id) == mock_result.id
+    mock_api_call.assert_called_once_with(mock_object)
+
+
+def test_task_sync_deal_with_hubspot(mocker):
+    """These task functions should call the api function of the same name and return a hubspot id"""
+    mock_object = OrderFactory.create()
+    mock_result = SimplePublicObjectFactory()
+
+    mock_api_call = mocker.patch(
+        f"hubspot_sync.tasks.api.sync_deal_with_hubspot", return_value=mock_result
+    )
+
+    assert sync_deal_with_hubspot(mock_object.id) == mock_result.id
     mock_api_call.assert_called_once_with(mock_object)
 
 

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -278,7 +278,8 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
         mocker.Mock(
             results=[
-                SimplePublicObjectFactory(id=user.id, properties={"email": user.email}) for user in contacts
+                SimplePublicObjectFactory(id=user.id, properties={"email": user.email})
+                for user in contacts
             ]
         )
     )

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -319,7 +319,7 @@ def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_err
         side_effect=(ApiException(status=status)),
     )
     users = UserFactory.create_batch(3)
-    chunk = sorted([user.id for user in users])
+    chunk = [user.id for user in users]
     with pytest.raises(expected_error):
         tasks.batch_create_hubspot_objects_chunked(
             HubspotObjectType.CONTACTS.value,
@@ -414,7 +414,7 @@ def test_batch_upsert_associations_chunked(mocker):
 
 def test_sync_failed_contacts(mocker):
     """sync_failed_contacts should try to sync each contact and return a list of failed contact ids"""
-    user_ids = sorted(user.id for user in UserFactory.create_batch(4))
+    user_ids = [user.id for user in UserFactory.create_batch(4)]
     mock_sync = mocker.patch(
         "hubspot_sync.tasks.api.sync_contact_with_hubspot",
         side_effect=[

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -294,7 +294,9 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     mock_hubspot_api.return_value.crm.objects.batch_api.create.assert_any_call(
         HubspotObjectType.CONTACTS.value,
         BatchInputSimplePublicObjectInput(
-            inputs=make_contact_create_message_list_from_user_ids(mock_ids[0 : min(id_count, 10)])
+            inputs=make_contact_create_message_list_from_user_ids(
+                mock_ids[0 : min(id_count, 10)]
+            )
         ),
     )
 

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -273,13 +273,12 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
     contacts = UserFactory.create_batch(id_count)
-    mock_ids = [contact.id for contact in contacts]
+    mock_ids = sorted(user.id for user in contacts)
     mock_hubspot_api = mocker.patch("hubspot_sync.tasks.HubspotApi")
     mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
         mocker.Mock(
             results=[
-                SimplePublicObjectFactory(id=user.id, properties={"email": user.email})
-                for user in contacts
+                SimplePublicObjectFactory(id=user.id, properties={"email": user.email}) for user in contacts
             ]
         )
     )

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -272,7 +272,7 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
 @pytest.mark.parametrize("id_count", [5, 15])
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
-    contacts = sorted(UserFactory.create_batch(id_count), key = lambda user: user.id)
+    contacts = sorted(UserFactory.create_batch(id_count), key=lambda user: user.id)
     mock_ids = [user.id for user in contacts]
     mock_hubspot_api = mocker.patch("hubspot_sync.tasks.HubspotApi")
     mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -45,13 +45,13 @@ SYNC_FUNCTIONS = [
 def test_task_sync_contact_with_hubspot(mocker):
     """These task functions should call the api function of the same name and return a hubspot id"""
     mock_object = UserFactory.create()
-    mock_result = True
+    mock_result = SimplePublicObjectFactory()
 
     mock_api_call = mocker.patch(
         f"hubspot_sync.tasks.api.sync_contact_with_hubspot", return_value=mock_result
     )
 
-    assert sync_contact_with_hubspot(mock_object.id) == mock_result
+    assert sync_contact_with_hubspot(mock_object.id) == mock_result.id
     mock_api_call.assert_called_once_with(mock_object)
 
 


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1718

# Description (What does it do?)
This PR makes a few improvements to the current HubSpot api in MITx Online, specifically:
1. Retrieves all objects (User, Order, Product, Line) in one database query when making batch update/create calls to HubSpot.
2. Passes objects (User, Order, Product, Line) as parameters when possible to avoid repetitive database queries.

# How can this be tested?
The steps below just ensure that everything still functions as expected.  To really test whether this PR will improve the speed of bulk create/update requests to HubSpot, we will need to test this in RC.
1. Configure MITx Online with HubSpot (ask if you need assistance with this).
2. Create a new product through Django Admin.
3. Register a new user in MITx Online and verify that a new contact is created in HubSpot.
4. Update the user through MITx Online (change their name or other attribute) and verify that the contact is updated in HubSpot.
5. Enroll the user into a course for free and verify that a new Deal is created in HubSpot.  Verify that the Deal includes a Line item matching the user's enrollment.
6. Upgrade the user's enrollment and verify that Deal in HubSpot is closed and the Line item is updated to reflect the enrollment mode.
7. Unenroll the user from the course run and verify that the Line item in HubSpot is updated to reflect the enrollment mode and change status.
8. Manually update one of the user's attributes through Django Admin.
9. Run `./manage.py sync_db_to_hubspot --users update`
10. Verify that the Contact in HubSpot is updated to reflect the change from step 8.
11. Manually update the user's enrollment mode through Django Admin.
12. Run `./manage.py sync_db_to_hubspot --lines update`
13. Verify that the Line in HubSpot is updated to reflect the change from step 11.
14. Manually create a new user through Django Admin.
15. Run `./manage.py sync_db_to_hubspot --users create`
16. Verify that a new Contact is created in HubSpot for the user from step 14.
17. Manually create a new course run enrollment and Order for the user from step 14.  The Order should reference the same course as the course run enrollment.  The Order's product should reference the product created in step 2.  The rest of the information can be random.
18. Run `./manage.py sync_db_to_hubspot --deals create`
19. Verify that a new Deal is created in HubSpot with a Line item that matches the user's course run enrollment.
