### PR TITLE
When course run is updated sync grades and generate certificates

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -785,9 +785,7 @@ def generate_course_run_certificates_for_course(run):
     For given course run syncs grades and
     if certificate_available_date is in the past, also generates certificates.
     """
-    edx_grade_user_iter = exception_logging_generator(
-        get_edx_grades_with_users(run)
-    )
+    edx_grade_user_iter = exception_logging_generator(get_edx_grades_with_users(run))
     created_grades_count, updated_grades_count, generated_certificates_count = (
         0,
         0,

--- a/courses/api.py
+++ b/courses/api.py
@@ -783,7 +783,7 @@ def generate_course_run_certificates():
 def generate_course_run_certificates_for_course(run):
     """
     For given course run syncs grades and
-    if certificate_available_date is in the past, also generates certificates.
+    if certificate_available_date is in the past or course id self paced, also generates certificates.
 
     Args:
         run (models.CourseRun): a course run instance.

--- a/courses/api.py
+++ b/courses/api.py
@@ -784,6 +784,9 @@ def generate_course_run_certificates_for_course(run):
     """
     For given course run syncs grades and
     if certificate_available_date is in the past, also generates certificates.
+
+    Args:
+        run (models.CourseRun): a course run instance.
     """
     edx_grade_user_iter = exception_logging_generator(get_edx_grades_with_users(run))
     created_grades_count, updated_grades_count, generated_certificates_count = (

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -10,9 +10,13 @@ from mitol.common.utils import now_in_utc
 
 from courses.models import (
     CourseRunCertificate,
-    Program, CourseRun,
+    Program,
+    CourseRun,
 )
-from courses.api import generate_multiple_programs_certificate, generate_course_run_certificates_for_course
+from courses.api import (
+    generate_multiple_programs_certificate,
+    generate_course_run_certificates_for_course,
+)
 from main import settings
 
 
@@ -52,7 +56,10 @@ def handle_update_course_run(
     """
     if not created:
         now = now_in_utc()
-        if instance.certificate_available_date and instance.certificate_available_date <= now:
+        if (
+            instance.certificate_available_date
+            and instance.certificate_available_date <= now
+        ):
             transaction.on_commit(
                 lambda: generate_course_run_certificates_for_course(instance)
             )

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -1,15 +1,19 @@
 """
 Signals for mitxonline course certificates
 """
+from datetime import timedelta
+
 from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from mitol.common.utils import now_in_utc
 
 from courses.models import (
     CourseRunCertificate,
-    Program,
+    Program, CourseRun,
 )
-from courses.api import generate_multiple_programs_certificate
+from courses.api import generate_multiple_programs_certificate, generate_course_run_certificates_for_course
+from main import settings
 
 
 @receiver(
@@ -32,4 +36,23 @@ def handle_create_course_run_certificate(
         if programs:
             transaction.on_commit(
                 lambda: generate_multiple_programs_certificate(user, programs)
+            )
+
+
+@receiver(
+    post_save,
+    sender=CourseRun,
+    dispatch_uid="courserun_post_save",
+)
+def handle_update_course_run(
+    sender, instance, created, **kwargs
+):  # pylint: disable=unused-argument
+    """
+    When a CourseRun model is updated, sync course run grades and generate missing certificates
+    """
+    if not created:
+        now = now_in_utc()
+        if instance.certificate_available_date and instance.certificate_available_date <= now:
+            transaction.on_commit(
+                lambda: generate_course_run_certificates_for_course(instance)
             )

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -1,7 +1,6 @@
 """
 Signals for mitxonline course certificates
 """
-from datetime import timedelta
 
 from django.db import transaction
 from django.db.models.signals import post_save
@@ -17,7 +16,6 @@ from courses.api import (
     generate_multiple_programs_certificate,
     generate_course_run_certificates_for_course,
 )
-from main import settings
 
 
 @receiver(

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -53,11 +53,6 @@ def handle_update_course_run(
     When a CourseRun model is updated, sync course run grades and generate missing certificates
     """
     if not created:
-        now = now_in_utc()
-        if (
-            instance.certificate_available_date
-            and instance.certificate_available_date <= now
-        ):
-            transaction.on_commit(
-                lambda: generate_course_run_certificates_for_course(instance)
-            )
+        transaction.on_commit(
+            lambda: generate_course_run_certificates_for_course(instance)
+        )

--- a/courses/signals_test.py
+++ b/courses/signals_test.py
@@ -1,18 +1,20 @@
 """
 Tests for signals
 """
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from mitol.common.utils import now_in_utc
 
 from courses.factories import (
     CourseFactory,
     CourseRunCertificateFactory,
     CourseRunFactory,
     ProgramFactory,
-    ProgramRequirementFactory,
     UserFactory,
 )
+from main import settings
 
 pytestmark = pytest.mark.django_db
 
@@ -51,3 +53,30 @@ def test_generate_program_certificate_not_called(
     cert = CourseRunCertificateFactory.create(user=user, course_run=course_run)
     cert.save()
     generate_program_cert_mock.assert_not_called()
+
+
+# pylint: disable=unused-argument
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("courses.signals.generate_course_run_certificates_for_course", autospec=True)
+@pytest.mark.parametrize("certificates_date_past", [True, False])
+def test_courserun_post_update_signal(
+    generate_course_run_cert_mock, mock_on_commit, certificates_date_past
+):
+    """
+    Test that generate_course_run_certificates_for_course is not called when
+    certificate_available_date is in the future
+    """
+    course = CourseFactory.create()
+    now = now_in_utc()
+    delta = timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
+    course_run = CourseRunFactory.create(
+        course=course,
+        certificate_available_date=now - delta
+        if certificates_date_past
+        else now + delta,
+    )
+    course_run.save()
+    if certificates_date_past:
+        generate_course_run_cert_mock.assert_called_once()
+    else:
+        generate_course_run_cert_mock.assert_not_called()

--- a/courses/signals_test.py
+++ b/courses/signals_test.py
@@ -58,10 +58,7 @@ def test_generate_program_certificate_not_called(
 # pylint: disable=unused-argument
 @patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
 @patch("courses.signals.generate_course_run_certificates_for_course", autospec=True)
-@pytest.mark.parametrize("certificates_date_past", [True, False])
-def test_courserun_post_update_signal(
-    generate_course_run_cert_mock, mock_on_commit, certificates_date_past
-):
+def test_courserun_post_update_signal(generate_course_run_cert_mock, mock_on_commit):
     """
     Test that generate_course_run_certificates_for_course is not called when
     certificate_available_date is in the future
@@ -69,14 +66,7 @@ def test_courserun_post_update_signal(
     course = CourseFactory.create()
     now = now_in_utc()
     delta = timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
-    course_run = CourseRunFactory.create(
-        course=course,
-        certificate_available_date=now - delta
-        if certificates_date_past
-        else now + delta,
-    )
+    course_run = CourseRunFactory.create(course=course)
+    generate_course_run_cert_mock.assert_not_called()
     course_run.save()
-    if certificates_date_past:
-        generate_course_run_cert_mock.assert_called_once()
-    else:
-        generate_course_run_cert_mock.assert_not_called()
+    generate_course_run_cert_mock.assert_called_once()


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/mitxonline/issues/1675

# Description (What does it do?)
Adds a signal on updating a course run to sync in current grades and certificates.

The problem is that certificates get generated with 24 hour widow of 'certificate_available_date'. If any grades are updated on edX after that, the grades don't get sync and no certificates generated.

This PR allows for the generated of certificates to take place if in the django admin you update the course run.


# How can this be tested?
1) Make sure you have a course run with a past certificate_available_date. 
2) Create user enrollment for this course run. 
3) Go to django admin and set the certificate_available_date to now.
4) Check the logs that an api call was made to edx to sync grades.