### PR TITLE
No audit grades in program records

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -719,10 +719,18 @@ class LearnerRecordSerializer(serializers.BaseSerializer):
                 "grade": None,
                 "certificate": None,
             }
+            verified_enrollment_course_runs_list = (
+                models.CourseRunEnrollment.objects.filter(
+                    user=user,
+                    run__course=course,
+                    enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+                    change_status=None,
+                ).values_list("run__id", flat=True)
+            )
 
             grade = (
                 models.CourseRunGrade.objects.filter(
-                    user=user, course_run__course=course
+                    user=user, course_run__in=verified_enrollment_course_runs_list
                 )
                 .order_by("-grade")
                 .first()


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/mitxonline/issues/1742

# Description (What does it do?)
This PR filter only grades earned in a verified more of enrollment for display on the Learner Records page.

# How can this be tested?
1. create a course run grade for your user
2. create a verified enrollment for that course run
3. view Program records, the grade should show
4. then set the enrollment to audit
5. Check the Program Records again, now the grade should not be there

