### PR TITLE
Updates the discount redemption cleanup code to be more resilient

### DIFF
--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -655,10 +655,6 @@ class PendingOrder(FulfillableOrder, Order):
         # for the same product, if multiple exist, grab the first.
         if orders:
             order = orders.first()
-
-            for old_discount in order.discounts.all():
-                old_discount.delete()
-
         else:
             order = Order.objects.create(
                 state=Order.STATE.PENDING,
@@ -694,6 +690,17 @@ class PendingOrder(FulfillableOrder, Order):
         order.total_price_paid = total
 
         order.save()
+
+        # Clear discounts except for the most recent one
+        # If there aren't any discounts in the basket, clear them all
+        for idx, old_discount in enumerate(
+            order.discounts.order_by("-created_on").all()
+        ):
+            if discounts and idx == 0:
+                continue
+
+            old_discount.delete()
+
         return order
 
     @classmethod

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -655,6 +655,12 @@ class PendingOrder(FulfillableOrder, Order):
         # for the same product, if multiple exist, grab the first.
         if orders:
             order = orders.first()
+            # Clear discounts except for the most recent one
+            # If there aren't any discounts in the basket, clear them all
+            for old_discount in order.discounts.all():
+                old_discount.delete()
+
+            order.refresh_from_db()
         else:
             order = Order.objects.create(
                 state=Order.STATE.PENDING,
@@ -690,16 +696,6 @@ class PendingOrder(FulfillableOrder, Order):
         order.total_price_paid = total
 
         order.save()
-
-        # Clear discounts except for the most recent one
-        # If there aren't any discounts in the basket, clear them all
-        for idx, old_discount in enumerate(
-            order.discounts.order_by("-created_on").all()
-        ):
-            if discounts and idx == 0:
-                continue
-
-            old_discount.delete()
 
         return order
 


### PR DESCRIPTION
# What are the relevant tickets?

#1734 

# Description (What does it do?)

Updated the discount redemption code slightly to help eliminate the possibility that discounts aren't reapplied from the basket if the order is reused. (I think the issue is that clearing the old discounts from the order object works, but then the order object becomes stale and at that point the basket discounts can't be reattached. The fix is to just explicitly refresh the order object.) 

# How can this be tested?

This will be easiest to do with Django Admin open in a separate window from the app. (I have been testing with a new user account so things are easier to see.) 

0. Ensure either financial assistance or a set of discounts are set up in the system. 
1. Create an order in the system. Progress to the CyberSource portion of it and ensure the proper price is set, then abandon the cart manually (go back to MITx Online - don't use the Cancel functionality in CyberSource). 
2. In Django Admin, you should see a Pending Order with no discount redemptions.
3. If you want to test with a financial assistance discount, apply for and approve financial assistance for the product you attempted to order.
4. Re-create the same order. On the Cart page, either make sure the financial assistance discount is applied or apply a discount manually to the cart. Progress to CyberSource, check the price (it should reflect the applied discount), then manually abandon the cart.
5. In DJango Admin, the existing Pending Order should be there and it should have the appropriate discount attached.
6. Re-create the same order again, but apply a different discount manually. Proceed to CyberSource, ensure the discounted price is applied. 
