### PR TITLE
ProgramSerializer should now return default image if there's no program page

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -302,13 +302,12 @@ class ProgramSerializer(serializers.ModelSerializer):
         return ProgramRequirementTreeSerializer(instance=req_root).data
 
     def get_page(self, instance):
-        return (
-            ProgramPageSerializer(
+        if ProgramPage.objects.filter(program=instance).exists():
+            return ProgramPageSerializer(
                 instance=ProgramPage.objects.filter(program=instance).get()
             ).data
-            if ProgramPage.objects.filter(program=instance).exists()
-            else None
-        )
+        else:
+            return {"feature_image_src": _get_thumbnail_url(None)}
 
     class Meta:
         model = models.Program

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -616,3 +616,11 @@ def test_learner_record_serializer(mock_context, program_with_empty_requirements
     assert user_info_payload == serialized_data["user"]
     assert program_requirements_payload == serialized_data["program"]["requirements"]
     assert course_0_payload == serialized_data["program"]["courses"][0]
+
+
+def test_program_serializer_returns_default_image():
+    """If the program has no page, we should still get a featured_image_url."""
+
+    program = ProgramFactory.create(page=None)
+
+    assert "feature_image_src" in ProgramSerializer(program).data["page"]

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -31,8 +31,6 @@ from courses.models import (
     PartnerSchool,
     Program,
     ProgramEnrollment,
-    ProgramRequirement,
-    ProgramRequirementNodeType,
 )
 from courses.serializers import (
     CourseRunEnrollmentSerializer,


### PR DESCRIPTION
# What are the relevant tickets?

Related to #1738

# Description (What does it do?)

If the program doesn't have a page, the frontend will crash because it expects a featured image. This adds a default featured image if there's no page, so it doesn't. 

# How can this be tested?

1. Create a new program. (Manually using the Django Admin is the recommended method so you don't inadvertently get a page created or anything.) 
2. Create a program enrollment for one of your accounts.
3. Log in and navigate to the dashboard.
4. Click the My Programs page. You should see the new program.
