### PR TITLE
1694: added stipulations to program electives causes 500 error in Django admin

### DIFF
--- a/courses/forms.py
+++ b/courses/forms.py
@@ -257,11 +257,10 @@ class ProgramAdminForm(ModelForm):
                 if operator["data"]["title"] == "":
                     raise ValidationError("Section must have a Title.")
 
-    def save(self, commit=False):
+    def save(self, commit=True):
         """Save requirements"""
-        program = super().save(commit=False)
+        program = super().save(commit=commit)
         transaction.on_commit(self._save_requirements)
-        self.save_m2m()
         return program
 
     def _save_requirements(self):

--- a/courses/forms.py
+++ b/courses/forms.py
@@ -272,7 +272,7 @@ class ProgramAdminForm(ModelForm):
                     )
 
                 # Check all of the child nodes to count the total number of elective courses
-                # and find if an elective stipulation exists.
+                # and validate any elective stipulations.
                 total_child_courses = 0
                 for child in operator["children"]:
                     if child["data"]["node_type"] == "operator":

--- a/courses/forms.py
+++ b/courses/forms.py
@@ -231,10 +231,11 @@ class ProgramAdminForm(ModelForm):
 
         return [_serialize(node) for node in data]
 
-    def save(self, commit=True):
+    def save(self, commit=False):
         """Save requirements"""
-        program = super().save(commit=commit)
+        program = super().save(commit=False)
         transaction.on_commit(self.save_requirements)
+        program.save_m2m()
         return program
 
     def save_requirements(self):


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1694

# Description (What does it do?)
Add validations to the Program Django Admin page to display error messages instead of throwing a 500 error if the requirements tree contains misconfigurations.

# How can this be tested?

1. Ensure you have a couple courses created in your MITx Online instance.
2. Click "ADD PROGRAM" from http://mitxonline.odl.local:8013/admin/courses/program/
3. Define the title and readable ID to be anything unique.
4. Expand the "Required Courses" section.
5. Change the Operation from "All of" to "Minimum # of".
6. Verify that the Value field is displayed.
7. Enter 1 in the Value field.
8. Delete the Elective Courses section.
9. Change the Title to "Elective Courses".
10. Add a course to the Elective Courses section.
11. Verify that the program can be saved.
12. Select the program saved during step 11.
13. Change the Value field to 2.
14. Verify that the program cannot be saved because the value is larger than the number of courses in the Elective Courses section.
15. Change the Value field to be empty.
16. Verify that the program cannot be saved if the Value field is empty.
17. Change the Value field to be 1.
18. Change the Title field to be empty.
19. Verify that the program cannot be saved if the Title field is empty.
20. Set the Title field back to "Elective Courses".
21. Add a nested operation to the Elective Courses section by selecting "Add requirement".
22. Change the nested operation Type from "Course" to "Operator".
23. Verify that the program cannot be saved if the Title of the nested operation is blank.
24. Set the Title field of the nested operation to "Elective stipulation".
25. Verify that the program can be saved if the Title of the nested operation is filled in.
26. Add a course to the nested operation by clicking "Add course".
27. Change the "Operation" field in the nested operation to "Minimum # of".
28. Set the Value field of the nested operation to 2.
29. Verify that the program cannot be saved if the nested operation's Value field's value is larger than the number of courses in the nested operation.
30. Change the Value field of the nested operation to be blank.
31. Verify that the program cannot be saved if the nested operation's Value field's value is empty.
32. Set the Value field of the nested operation to 1.
33. Set the Title field of the nested operation to be blank.
34. Verify that the program cannot be saved if the Title of the nested operation is blank.
35. Set the Title of the nested operation back to "Elective stipulation".
36. Verify that the program can be saved.
