### PR TITLE
Updates to the dashboard functionality

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -60,7 +60,9 @@ type EnrolledItemCardProps = {
   isLoading: boolean,
   toggleProgramDrawer: Function | null,
   isProgramCard: boolean,
-  redirectToCourseHomepage: Function
+  redirectToCourseHomepage: Function,
+  onUnenroll: Function | undefined,
+  onUpdateDrawerEnrollment: Function | undefined
 }
 
 type EnrolledItemCardState = {
@@ -124,7 +126,7 @@ export class EnrolledItemCard extends React.Component<
   }
 
   async onRunUnenrollment(enrollment: RunEnrollment) {
-    const { deactivateEnrollment, addUserNotification } = this.props
+    const { deactivateEnrollment, addUserNotification, onUnenroll } = this.props
 
     this.toggleRunUnenrollmentModalVisibility()
 
@@ -135,6 +137,9 @@ export class EnrolledItemCard extends React.Component<
       if (isSuccessResponse(resp)) {
         messageType = ALERT_TYPE_SUCCESS
         userMessage = `You have been successfully unenrolled from ${enrollment.run.title}.`
+        if (onUnenroll !== undefined) {
+          onUnenroll()
+        }
       } else {
         messageType = ALERT_TYPE_DANGER
         userMessage = `Something went wrong with your request to unenroll. Please contact support at ${SETTINGS.support_email}.`
@@ -155,7 +160,11 @@ export class EnrolledItemCard extends React.Component<
   }
 
   async onProgramUnenrollment(program: Program) {
-    const { deactivateProgramEnrollment, addUserNotification } = this.props
+    const {
+      deactivateProgramEnrollment,
+      addUserNotification,
+      onUnenroll
+    } = this.props
 
     this.toggleProgramUnenrollmentModalVisibility()
 
@@ -166,6 +175,9 @@ export class EnrolledItemCard extends React.Component<
       if (isSuccessResponse(resp)) {
         messageType = ALERT_TYPE_SUCCESS
         userMessage = `You have been successfully unenrolled from ${program.title}.`
+        if (onUnenroll !== undefined) {
+          onUnenroll()
+        }
       } else {
         throw new Error("program unenrollment failed")
       }
@@ -495,6 +507,12 @@ export class EnrolledItemCard extends React.Component<
                       Enrolled in certificate track
                     </span>
                   ) : null}
+                  {startDateDescription !== null &&
+                  startDateDescription.active ? (
+                      <span className="badge badge-in-progress mr-2">
+                      In Progress
+                      </span>
+                    ) : null}
                 </div>
 
                 <h2 className="my-0 mr-3">{title}</h2>
@@ -564,6 +582,16 @@ export class EnrolledItemCard extends React.Component<
         </div>
       </div>
     )
+  }
+
+  componentDidUpdate(prevProps: EnrolledItemCardProps) {
+    const { onUpdateDrawerEnrollment } = this.props
+
+    if (this.props.enrollment !== prevProps.enrollment) {
+      if (onUpdateDrawerEnrollment !== undefined) {
+        onUpdateDrawerEnrollment(this.props.enrollment)
+      }
+    }
   }
 
   renderProgramEnrollment() {

--- a/frontend/public/src/components/EnrolledProgramList.js
+++ b/frontend/public/src/components/EnrolledProgramList.js
@@ -8,18 +8,22 @@ import type { ProgramEnrollment, Program } from "../flow/courseTypes"
 
 type EnrolledProgramListProps = {
   enrollments: ProgramEnrollment[],
-  toggleDrawer: Function
+  toggleDrawer: Function,
+  onUnenroll: Function | undefined,
+  onUpdateDrawerEnrollment: Function | undefined
 }
 
 export class EnrolledProgramList extends React.Component<EnrolledProgramListProps> {
   renderEnrolledProgramCard(enrollment: Program) {
-    const { toggleDrawer } = this.props
+    const { toggleDrawer, onUnenroll, onUpdateDrawerEnrollment } = this.props
 
     return (
       <EnrolledItemCard
         key={`program-item-${enrollment.program.id}`}
         enrollment={enrollment}
         toggleProgramDrawer={toggleDrawer}
+        onUnenroll={onUnenroll}
+        onUpdateDrawerEnrollment={onUpdateDrawerEnrollment}
       ></EnrolledItemCard>
     )
   }
@@ -29,9 +33,7 @@ export class EnrolledProgramList extends React.Component<EnrolledProgramListProp
 
     return enrollments && enrollments.length > 0 ? (
       enrollments.map<ProgramEnrollment>(enrollment =>
-        enrollment.enrollments.length > 0
-          ? this.renderEnrolledProgramCard(enrollment)
-          : null
+        this.renderEnrolledProgramCard(enrollment)
       )
     ) : (
       <div className="card no-enrollments p-3 p-md-5 rounded-0">

--- a/frontend/public/src/components/ProgramEnrollmentDrawer.js
+++ b/frontend/public/src/components/ProgramEnrollmentDrawer.js
@@ -13,11 +13,12 @@ interface ProgramEnrollmentDrawerProps {
   showDrawer: Function,
   isHidden: boolean,
   redirectToCourseHomepage: Function,
+  onUnenroll: Function | undefined,
 }
 
 export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDrawerProps> {
   renderCourseInfoCard(course: CourseDetailWithRuns) {
-    const { enrollment } = this.props
+    const { enrollment, onUnenroll } = this.props
 
     let found = undefined
 
@@ -49,6 +50,7 @@ export class ProgramEnrollmentDrawer extends React.Component<ProgramEnrollmentDr
         enrollment={found}
         isProgramCard={true}
         redirectToCourseHomepage={this.redirectToCourseHomepage}
+        onUnenroll={onUnenroll}
       ></EnrolledItemCard>
     )
   }

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -122,7 +122,6 @@ export class ProductDetailEnrollApp extends React.Component<
         : this.getCurrentCourseRun()
 
     if (!upgradeEnrollmentDialogVisibility) {
-      console.log(`creating enrollment for ${run.id}`)
       createEnrollment(run)
     } else {
       window.location = "/dashboard/"

--- a/frontend/public/src/containers/pages/DashboardPage.js
+++ b/frontend/public/src/containers/pages/DashboardPage.js
@@ -47,7 +47,8 @@ type DashboardPageProps = {
   ) => Promise<any>,
   updateAddlFields: (currentUser: User) => Promise<any>,
   addUserNotification: Function,
-  closeDrawer: Function
+  closeDrawer: Function,
+  forceRequest: Function | undefined
 }
 
 const DashboardTab = {
@@ -80,6 +81,19 @@ export class DashboardPage extends React.Component<
       programDrawerEnrollments: enrollment,
       programDrawerVisibility:  !this.state.programDrawerVisibility
     })
+  }
+
+  updateDrawerEnrollments(enrollment: any) {
+    const { programDrawerEnrollments } = this.state
+
+    if (
+      programDrawerEnrollments !== null &&
+      programDrawerEnrollments.program.id === enrollment.program.id
+    ) {
+      this.setState({
+        programDrawerEnrollments: enrollment
+      })
+    }
   }
 
   toggleTab(tab: string) {
@@ -140,7 +154,7 @@ export class DashboardPage extends React.Component<
   }
 
   renderCurrentTab() {
-    const { enrollments, programEnrollments } = this.props
+    const { enrollments, programEnrollments, forceRequest } = this.props
 
     if (this.state.currentTab === DashboardTab.programs) {
       return (
@@ -150,6 +164,8 @@ export class DashboardPage extends React.Component<
             key={"enrolled-programs"}
             enrollments={programEnrollments}
             toggleDrawer={this.toggleDrawer.bind(this)}
+            onUpdateDrawerEnrollment={this.updateDrawerEnrollments.bind(this)}
+            onUnenroll={forceRequest}
           ></EnrolledProgramList>
         </div>
       )
@@ -162,6 +178,7 @@ export class DashboardPage extends React.Component<
           key={"enrolled-courses"}
           enrollments={enrollments}
           redirectToCourseHomepage={this.redirectToCourseHomepage.bind(this)}
+          onUnenroll={forceRequest}
         ></EnrolledCourseList>
       </div>
     )
@@ -206,7 +223,7 @@ export class DashboardPage extends React.Component<
   }
 
   render() {
-    const { isLoading, programEnrollments } = this.props
+    const { isLoading, programEnrollments, forceRequest } = this.props
 
     const myCourseClasses = `dash-tab${
       this.state.currentTab === DashboardTab.courses ? " active" : ""
@@ -248,14 +265,17 @@ export class DashboardPage extends React.Component<
               {this.renderCurrentTab()}
             </div>
 
-            <ProgramEnrollmentDrawer
-              isHidden={this.state.programDrawerVisibility}
-              enrollment={this.state.programDrawerEnrollments}
-              showDrawer={() =>
-                this.setState({ programDrawerVisibility: false })
-              }
-              redirectToCourseHomepage={this.redirectToCourseHomepage}
-            ></ProgramEnrollmentDrawer>
+            {!isLoading ? (
+              <ProgramEnrollmentDrawer
+                isHidden={this.state.programDrawerVisibility}
+                enrollment={this.state.programDrawerEnrollments}
+                showDrawer={() =>
+                  this.setState({ programDrawerVisibility: false })
+                }
+                redirectToCourseHomepage={this.redirectToCourseHomepage}
+                onUnenroll={forceRequest}
+              ></ProgramEnrollmentDrawer>
+            ) : null}
 
             {this.renderAddlProfileFieldsModal()}
           </Loader>


### PR DESCRIPTION

# What are the relevant tickets?

Closes #1692 
Closes #1693 

# Description (What does it do?)

This adds a few updates to the dashboard:

- Adds In Progress badges everywhere that a course is in progress #1692
- Display program enrollments even if there's no enrollments #1693
- Actually reload the data if we unenroll from something, rather than displaying stale data

# Screenshots (if appropriate):

In Progress badges for enrolled courses:
![image](https://github.com/mitodl/mitxonline/assets/945611/508fd3ec-0678-4931-bb20-2975dfe425f5)

Program Enrollments in place even with no Course Enrollments:
![image](https://github.com/mitodl/mitxonline/assets/945611/f3548844-24a3-42e4-9a6c-d7bcdfbcdd96)

# How can this be tested?

Courses that are in progress should show the In Progress badge regardless of whether or not your account is enrolled in the course.

Unenrolling from all courses in a program (or just creating a bare program enrollment) should result in the program displaying and being navigable on the dashboard. You should be able to get to the course details for all associated courses (but you should not be able to get to the course itself).

Unenrolling from a course should refresh the data, even in an open program drawer.

# Additional Context

There's some questions around the In Progress tag at least - the first two of these are pretty easy to back out if necessary.
