### PR TITLE
Django Admin course validation for Program nested elective operators

### DIFF
--- a/courses/forms.py
+++ b/courses/forms.py
@@ -244,8 +244,8 @@ class ProgramAdminForm(ModelForm):
         Raises:
             ValidationError: operator_value does not exist.
             ValidationError: operator_value does exist but is empty.
-            ValidationError: operator_value is not equal to or less than the total number of courses
-                which can apply towards the program certificate..
+            ValidationError: operator_value is not equal to or less than the number of courses
+                which can apply towards the program certificate.
         """
 
         def _validate_elective_value(operator):
@@ -322,15 +322,15 @@ class ProgramAdminForm(ModelForm):
                     total_child_courses = 0
                     for child in operator["children"]:
                         if child["data"]["node_type"] == "operator":
-                            # The value of the nested elective stipulation defines the number of courses
-                            # within that nested stipulation which are allowed to apply towards a program's
-                            # elective requirement.
                             _validate_operator_title(child)
                             if (
                                 operator["data"]["operator"]
                                 == ProgramRequirement.Operator.MIN_NUMBER_OF.value
                             ):
                                 _validate_elective_value(child)
+                                # The value of the nested elective stipulation defines the number of courses
+                                # within that nested stipulation which are allowed to apply towards a program's
+                                # elective requirement.
                                 total_child_courses += int(
                                     child["data"]["operator_value"]
                                 )


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1758

# Description
With the program configuration created from the steps to reproduce (in the issue), a program certificate will never be attainable by a learner. This is because, even if the learner earns course certificates from all 3 courses defined under electives, only a single course certificate from the two courses belonging to the nested operator will be counted. So there is no way to earn the required 3 applicable course certificates to satisfy the elective requirement.

# Screenshots:
![image](https://github.com/mitodl/mitxonline/assets/8311573/a27bb667-6242-4582-bec9-49767eec379f)


# How can this be tested?

1. Visit http://mitxonline.odl.local:8013/admin/courses/program/
2. Select "ADD PROGRAM"
3. Define a Title and Readable id
4. Expand the "Elective Courses" section.
5. Set the Value to 3.
6. Click "Add Requirement".
7. Click "Add Requirement".
8. On the item created from step 6, add a Title.
9. On the item created from step 6, change the Type to "Operator".
10. On the item created from step 6, change the Operation to "Minimum # of".
11. Click "Add Course".
12. Click "Add Course".
13. Click "Save".
14. Verify that the Program is not saved and you receive the following error message: "Minimum # of" operator must have Value equal to or less than the number of elective courses which can apply towards the program certificate."
