### PR TITLE
Updates import_course a bit for program requirements

### DIFF
--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -181,21 +181,6 @@ class Command(BaseCommand):
                         )
                     )
 
-                    if kwargs["make_elective"]:
-                        program.add_elective(course)
-                        self.stdout.write(
-                            self.style.SUCCESS(
-                                f"Added course {course_readable_id} to program {program.readable_id} as an elective"
-                            )
-                        )
-                    else:
-                        program.add_requirement(course)
-                        self.stdout.write(
-                            self.style.SUCCESS(
-                                f"Added course {course_readable_id} to program {program.readable_id} as required course"
-                            )
-                        )
-
                 new_run = CourseRun.objects.create(
                     course=course,
                     run_tag=courserun_tag,

--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -55,6 +55,12 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
+            "--make-elective",
+            action="store_true",
+            help="If the course has to be created, add it to the program as an elective. Otherwise, it will be a requirement.",
+        )
+
+        parser.add_argument(
             "--run-tag",
             type=str,
             nargs="?",
@@ -162,7 +168,6 @@ class Command(BaseCommand):
                 (course, created) = Course.objects.get_or_create(
                     readable_id=course_readable_id,
                     defaults={
-                        "program": program,
                         "title": edx_course.name,
                         "readable_id": course_readable_id,
                         "live": kwargs["live"],
@@ -175,6 +180,21 @@ class Command(BaseCommand):
                             f"Created course for {course_readable_id}: {course}"
                         )
                     )
+
+                    if kwargs["make_elective"]:
+                        program.add_elective(course)
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"Added course {course_readable_id} to program {program.readable_id} as an elective"
+                            )
+                        )
+                    else:
+                        program.add_requirement(course)
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"Added course {course_readable_id} to program {program.readable_id} as required course"
+                            )
+                        )
 
                 new_run = CourseRun.objects.create(
                     course=course,

--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -55,12 +55,6 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "--make-elective",
-            action="store_true",
-            help="If the course has to be created, add it to the program as an elective. Otherwise, it will be a requirement.",
-        )
-
-        parser.add_argument(
             "--run-tag",
             type=str,
             nargs="?",


### PR DESCRIPTION
# What are the relevant tickets?

Closes #1680

# Description (What does it do?)

Fixes a minor error when creating a standalone course using import_course. (This came about after testing the command for #1680.) The command would try to add a program to the new course (even if the program was None), which would cause an error because there's no FK to Program anymore.

# How can this be tested?

Full test:
1. In Studio, create three courses. 
2. In MITx Online, create two matching courses (but no courseruns) and assign them to a program. (These can be all electives, all requirements, or a mix.)
3. Run `manage.py import_courseware --program <your program> --run-tag <run tag>`. It should pick up the course runs from edX successfully. 
4. Run `manage.py import_courseware --courserun <the remaining one>` (add whatever other flags you like). It should pick up the courserun and create the course as well. 
