### PR TITLE
Manage certificates command: require letter grades when overriding grade

### DIFF
--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1270,26 +1270,28 @@ def test_course_run_certificates_access():
 
 
 @pytest.mark.parametrize(
-    "grade, should_force_pass, is_passed",
+    "grade, letter_grade, should_force_pass, is_passed",
     [
-        (0.0, True, False),
-        (0.1, True, True),
-        (0.5, False, False),
-        (0.5, True, True),
+        (0.0, 'F', True, False),
+        (0.1, 'F', True, True),
+        (0.5, 'C', False, False),
+        (0.5, 'C', True, True),
     ],
 )
-def test_override_user_grade(grade, should_force_pass, is_passed):
+def test_override_user_grade(grade, letter_grade, should_force_pass, is_passed):
     """Test the override grade overrides the user grade properly"""
     test_grade = CourseRunGradeFactory.create()
     override_user_grade(
         user=test_grade.user,
         override_grade=grade,
+        letter_grade=letter_grade,
         courseware_id=test_grade.course_run.courseware_id,
         should_force_pass=should_force_pass,
     )
     test_grade.refresh_from_db()
     assert test_grade.grade == grade
     assert test_grade.passed is is_passed
+    assert test_grade.letter_grade is letter_grade
     assert test_grade.set_by_admin is True
 
 

--- a/courses/management/commands/manage_certificates.py
+++ b/courses/management/commands/manage_certificates.py
@@ -73,6 +73,12 @@ class Command(BaseCommand):
             required=False,
         )
         parser.add_argument(
+            "--letter_grade",
+            type=float,
+            help="Override a grade with a corresponding letter grade. Range: A-F",
+            required=False,
+        )
+        parser.add_argument(
             "--revoke", dest="revoke", action="store_true", required=False
         )
         parser.add_argument(
@@ -92,6 +98,7 @@ class Command(BaseCommand):
         create = options.get("create")
         run = options.get("run")
         override_grade = options.get("grade")
+        letter_grade = options.get("letter_grade")
 
         if not (revoke or unrevoke) and not create:
             raise CommandError(
@@ -142,6 +149,11 @@ class Command(BaseCommand):
 
             if override_grade and not is_grade_valid(override_grade):
                 raise CommandError("Invalid value for grade. Allowed range: 0.0 - 1.0.")
+
+            if override_grade and not letter_grade:
+                raise CommandError(
+                    "Override grade needs a letter grade, allowed range: A-F"
+                )
 
             if override_grade and not user:
                 raise CommandError(

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -1,6 +1,7 @@
 """Utilities for courses"""
 
 import logging
+import re
 
 from requests.exceptions import HTTPError
 
@@ -24,6 +25,10 @@ def exception_logging_generator(generator):
 
 def is_grade_valid(override_grade: float):
     return 0.0 <= override_grade <= 1.0
+
+
+def is_letter_grade_valid(letter_grade: str):
+    return False if re.match("^[A-F]$", letter_grade) is None else True
 
 
 def get_program_certificate_by_enrollment(enrollment, program=None):


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/mitxonline/issues/1762

# Description (What does it do?)
require a letter grade when overriding learners grade.



# How can this be tested?
Run the management command 
`./manage.py manage_certificates --user <username> --run <run_id>  --grade <score> --create`
This should show a validation error asking you to provide a letter grade
The run:
`./manage.py manage_certificates --user <username> --run <run_id>  --grade <score> --letter-grade <letter_grade> --create`
