### PR TITLE
Program records: show verified grades or grades with certificate

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -16,7 +16,6 @@ from cms.serializers import CoursePageSerializer, ProgramPageSerializer
 from courses import models
 from courses.api import create_run_enrollments
 from courses.constants import CONTENT_TYPE_MODEL_COURSE, CONTENT_TYPE_MODEL_PROGRAM
-from courses.models import CourseRunCertificate
 from ecommerce.models import Product
 from ecommerce.serializers import BaseProductSerializer, ProductFlexibilePriceSerializer
 from flexiblepricing.api import is_courseware_flexible_price_approved
@@ -719,7 +718,7 @@ class LearnerRecordSerializer(serializers.BaseSerializer):
                 "grade": None,
                 "certificate": None,
             }
-            runs_ids = CourseRunCertificate.objects.filter(
+            runs_ids = models.CourseRunCertificate.objects.filter(
                 user=user, course_run__course=course, is_revoked=False
             ).values_list("course_run__id", flat=True)
 


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/1525

# Description (What does it do?)
Some users have a passing grade, payment, and certificate but no verified enrollment for a course run.
This PR attempts to show grades only if the user enrolled in verified track or received a certificate.

# How can this be tested?
Set up your data to test that the following grades are showing up on the Program Records page:
1) The user has a grade and a certificate for course
2) The user has a grade and a verified enrollment for a course run (the grade may be failing)