### PR TITLE
Deferrals better message

### DIFF
--- a/sheets/deferrals_plugin.py
+++ b/sheets/deferrals_plugin.py
@@ -23,7 +23,7 @@ class DeferralPlugin:
         )
         if to_courseware_id and not to_enrollment:
             message = "Failed to create/update the target enrollment ({})".format(
-                    to_courseware_id
-                )
+                to_courseware_id
+            )
             return DeferralResult(ResultType.FAILED, message)
         return DeferralResult(ResultType.PROCESSED)

--- a/sheets/deferrals_plugin.py
+++ b/sheets/deferrals_plugin.py
@@ -15,10 +15,15 @@ class DeferralPlugin:
         from_courseware_id = deferral_request_row.from_courseware_id
         to_courseware_id = deferral_request_row.to_courseware_id
 
-        defer_enrollment(
+        from_enrollment, to_enrollment = defer_enrollment(
             user,
             from_courseware_id,
             to_courseware_id,
             force=True,
         )
+        if to_courseware_id and not to_enrollment:
+            message = "Failed to create/update the target enrollment ({})".format(
+                    to_courseware_id
+                )
+            return DeferralResult(ResultType.FAILED, message)
         return DeferralResult(ResultType.PROCESSED)


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
Makes sure the a failed status is returned if enrollment to a course run was not successful.

Removes the atomic block and allows for repeating reruns of the deferral procedure. This is helpful if this deferral request was already processed and partially succeeded.
If an api call was made to to edx to uneroll a user but they already have been unenrolled edx would return 400 and the deferral procedure would throw an error.

# How can this be tested?
There are few things to check:
1) There have been cases where the deferral would not succeed and no exception would get raised, and the row would get marked as completed. An example here https://github.com/mitodl/hq/issues/2009
I was not able to fully replicate that scenario locally, but I would like to pass a message to deferral result for better messaging.
2) If the user's deferment already happened the google sheet procedure should be able to reflect that on the spreadsheet, instead of trying to process it again and throwing an error.
3) if the enrollment into course did not happen the error row should state that.
4) if the user has unenrolled from course, but was not enrolled into a repeated processing of the row (by deleting the error message) should try to complete the enrollment.