### PR TITLE
remove assertRaises

### DIFF
--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -16,7 +16,6 @@ import {
 } from "ramda"
 import _truncate from "lodash/truncate"
 import qs from "query-string"
-import { assert } from "chai"
 import * as R from "ramda"
 import moment from "moment-timezone"
 
@@ -121,22 +120,6 @@ export const objectToFormData = (object: Object) => {
     }
   })
   return formData
-}
-
-export const assertRaises = async (
-  asyncFunc: Function,
-  expectedMessage: string
-) => {
-  let exception
-  try {
-    await asyncFunc()
-  } catch (ex) {
-    exception = ex
-  }
-  if (!exception) {
-    throw new Error("No exception caught")
-  }
-  assert.equal(exception.message, expectedMessage)
 }
 
 // Example return values: "January 1, 2019", "December 31, 2019"

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -4,7 +4,6 @@ import { assert } from "chai"
 import moment from "moment"
 
 import {
-  assertRaises,
   wait,
   enumerate,
   isEmptyText,
@@ -176,42 +175,6 @@ describe("utility functions", () => {
       ].forEach(([inputArr, expectedStr]) => {
         assert.deepEqual(spaceSeparated(inputArr), expectedStr)
       })
-    })
-  })
-
-  describe("assertRaises", () => {
-    it("should assert raising an exception", async () => {
-      const message = "a message"
-      await assertRaises(async () => {
-        throw new Error(message)
-      }, message)
-    })
-
-    it("should raise an error if an exception was not raised", async () => {
-      const expectedMessage = "No exception caught"
-      let exception
-      try {
-        await assertRaises(async () => {}, "")
-      } catch (ex) {
-        exception = ex
-      }
-
-      // $FlowFixMe
-      assert.equal(exception.message, expectedMessage)
-    })
-
-    it("should raise an error if the exception has the wrong message", async () => {
-      let exception
-      try {
-        await assertRaises(async () => {
-          throw new Error("other message")
-        }, "")
-      } catch (ex) {
-        exception = ex
-      }
-
-      // $FlowFixMe
-      assert.equal(exception.message, "expected 'other message' to equal ''")
     })
   })
 


### PR DESCRIPTION
### What are the relevant tickets?
#1075

###  Description (What does it do?)
This PR removes `assertRaises`. It was not being used, and was causing part of `chai` (our assertion library) to be included in the frontend bundle.

###  Screenshots (if appropriate):
**Before**:
<img width="1255" alt="Screenshot 2023-07-28 at 4 08 13 PM" src="https://github.com/mitodl/mitxonline/assets/9010790/047d2e88-5ee4-4e21-a257-e33880cd855c">

**Now:** 
<img width="918" alt="Screenshot 2023-07-28 at 4 19 30 PM" src="https://github.com/mitodl/mitxonline/assets/9010790/e4957aa5-bb84-4aef-af22-7adac82fe0d3">

# How can this be tested?
Everything should work as before.

