### PR TITLE
When deferring enrollment set to verified

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -530,7 +530,7 @@ def defer_enrollment(
         user,
         [to_run],
         keep_failed_enrollments=keep_failed_enrollments,
-        mode=from_enrollment.enrollment_mode,
+        mode=EDX_ENROLLMENT_VERIFIED_MODE,
     )
     if not enroll_success and not keep_failed_enrollments:
         raise Exception(

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -823,7 +823,7 @@ def test_defer_enrollment(
             existing_enrollment.user,
             [target_run],
             keep_failed_enrollments=keep_failed_enrollments,
-            mode=existing_enrollment.enrollment_mode,
+            mode=EDX_ENROLLMENT_VERIFIED_MODE,
         )
         patched_deactivate_enrollments.assert_called_once_with(
             existing_enrollment,


### PR DESCRIPTION
# What are the relevant tickets?
None

# Description (What does it do?)
When an enrollment is deferred we always want the enrollment to be verified instead of copying the mode of the enrollment of the "from course".
There has been a case where the user was deferred to a course successfully but set to audit. I don't know why the "from course" was in audit mode, but I think it is safe to assume that when the deferral procedure is run we want to enroll the user in a verified mode.
This would allow for a deferral of cases that were partially complete. 

# How can this be tested?
Try to run the deferral management command while having current 'verified' enrollment for a "From course". Make sure that the user get's successfully unenrolled from the course, and enrolled into the verified mode of the "To course".

Then try the same with an 'audit' enrollment. The same result should proceed.

