### PR TITLE
Make hashed webpack output filenames more stable

### DIFF
--- a/frontend/public/webpack.config.js
+++ b/frontend/public/webpack.config.js
@@ -21,8 +21,8 @@ module.exports = function (env, argv) {
     output: {
       path: path.resolve(__dirname, "build"),
       ...(isProduction ? {
-        filename: "[name]-[chunkhash].js",
-        chunkFilename: "[id]-[chunkhash].js",
+        filename: "[name]-[contenthash].js",
+        chunkFilename: "[id]-[contenthash].js",
         crossOriginLoading: "anonymous",
         hashFunction: "xxhash64"
       } : {


### PR DESCRIPTION
### What are the relevant tickets?
#1075 

### Description (What does it do?)
This PR changes how filenames are generated by webpack: Now, filenames only change when content changes. If you change a CSS file, the JS filename will not change.

# How can this be tested?
1. Enter the `watch` container: `docker compose exec watch bash`
2. Run production build: `yarn workspace mitx-online-public build --clean`, `ls frontends/public/build`.
    - note the filenames for `requirementsAdmin` chunk
3. Make a temporary change to `requirements.scss` 
4. Run production build: `yarn workspace mitx-online-public build --clean`, `ls frontends/public/build`.
    - note the filenames for `requirementsAdmin` chunk
    - The JS file should have the same name, the CSS file should have a different name.

