### PR TITLE
Fixes per-course instructor page migrations

### DIFF
--- a/cms/management/commands/convert_faculty_to_pages.py
+++ b/cms/management/commands/convert_faculty_to_pages.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
                 course = Course.objects.filter(readable_id=kwargs["courseware"])
 
                 if course.exists():
-                    pages = [course.page]
+                    pages = [course.get().page]
                 else:
                     pages = [Program.objects.get(readable_id=kwargs["courseware"]).page]
             except ObjectDoesNotExist:


### PR DESCRIPTION
# What are the relevant tickets?

n/a

# Description (What does it do?)

Noticed that trying to convert instructors to pages for a single course failed - this fixes that.

# How can this be tested?

Run `convert_faculty_to_pages --only <course>` for a course (ideally, one with old-style faculty members in it). The command should run successfully. 
