### PR TITLE
Adds the PostHog settings to the JS settings so we can use it in React

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -14,12 +14,11 @@ from django.http import HttpRequest, HttpResponseRedirect
 from mitol.common.utils.urls import remove_password_from_url
 from rest_framework import status
 from rest_framework.response import Response
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from main import features
 from main.constants import USER_MSG_COOKIE_MAX_AGE, USER_MSG_COOKIE_NAME
 from main.settings import TIME_ZONE
-
-from wagtail import VERSION as WAGTAIL_VERSION
 
 
 class FeatureFlag(Flag):
@@ -56,6 +55,8 @@ def get_js_settings(request: HttpRequest):
                 features.ENABLE_ADDL_PROFILE_FIELDS
             )
         },
+        "posthog_api_token": settings.POSTHOG_API_TOKEN,
+        "posthog_api_host": settings.POSTHOG_API_HOST,
     }
 
 

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -49,6 +49,8 @@ def test_get_js_settings(settings, rf):
         "features": {
             "enable_addl_profile_fields": False,
         },
+        "posthog_api_token": settings.POSTHOG_API_TOKEN,
+        "posthog_api_host": settings.POSTHOG_API_HOST,
     }
 
 


### PR DESCRIPTION
# What are the relevant tickets?

https://github.com/mitodl/hq/issues/1981

# Description (What does it do?)

@JenniWhitman added the PostHog libraries in https://github.com/mitodl/mitxonline/pull/1809 - this adds the settings (`POSTHOG_API_HOST` and `POSTHOG_API_TOKEN`) to the JS `SETTINGS` global so we can use it in the React app. (Basically, I did this already for another PR but splitting it out to not make people wait on it.) 

# How can this be tested?

You'll have to have a Posthog account set up. There's a free tier. You can also self-host it (but that's a lot more stuff to do). You'll also need to follow the instructions at https://github.com/mitodl/hq/discussions/2116 - the easiest method is to use the "JS SDK - component level listening" section to just grab a feature flag out in somewhere (choose a component!) and see if it works or not. You should see some analytics and stuff in the Posthog account.

Example: I wrapped the upsell message in `ProductDetailEnrollApp.js` in a feature flag:

```javascript
import posthog from "posthog-js"

/* global SETTINGS:false */
posthog.init(SETTINGS.posthog_api_token, { api_host: SETTINGS.posthog_api_host })

...later in the render()...

render() {
    ...yadda...

    const testFeatureFlag = posthog.isFeatureEnabled("enable-upsell-dialog")

    console.log("testFeatureFlag", testFeatureFlag)
}
```

# Additional Context

I did not make a decision on wrapping the _entire_ app in a Posthog provider - we can discuss that but this PR doesn't do it.