### PR TITLE
Update to Enrolled in certificate track label to count for audit enrollment with certificates

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -502,11 +502,12 @@ export class EnrolledItemCard extends React.Component<
                       passed
                     </span>
                   ) : null}
-                  {enrollment.enrollment_mode === "verified" ? (
-                    <span className="badge badge-enrolled-verified mr-2">
+                  {enrollment.enrollment_mode === "verified" ||
+                  enrollment.certificate ? (
+                      <span className="badge badge-enrolled-verified mr-2">
                       Enrolled in certificate track
-                    </span>
-                  ) : null}
+                      </span>
+                    ) : null}
                 </div>
 
                 <h2 className="my-0 mr-3">{title}</h2>


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/2024

# Description (What does it do?)
<!--- Describe your changes in detail -->
This PR fixes the " Enrolled in certificate track" label to count for audit enrollment with a certificate. Currently, if a learner had audit enrollment but earned a certificate (records that migrated from MM) doesn't display " Enrolled in certificate track" on the dashboard, even though there is a link to "view certificate", this PR is to fix that inconsistency.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
Before
![image](https://github.com/mitodl/mitxonline/assets/3138890/cabba8fa-5ce6-4137-8261-7897a1bafd47)

After 

![image](https://github.com/mitodl/mitxonline/assets/3138890/2437462b-5f2a-47c7-a68f-57392cd7c805)



# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Create audit enrollment, passing grade, and certificate for a run
- Go to My Course or My Program on your dashboard
- "Enrolled in certificate track" should now display
- Create verified enrollment, and passing grades for a run, labels should not be affected
