### PR TITLE
update full name on user profile

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -662,7 +662,7 @@ def sync_contact_with_hubspot(user: User):
         body=body,
     )
     user.hubspot_sync_datetime = now_in_utc()
-    user.save()
+    user.save(update_fields=["hubspot_sync_datetime"])
 
     return result
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -338,7 +338,6 @@ class UserSerializer(serializers.ModelSerializer):
 
             user = super().update(instance, validated_data)
 
-        sync_hubspot_user(user)
         return user
 
     class Meta:

--- a/users/views.py
+++ b/users/views.py
@@ -10,6 +10,7 @@ from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
+from hubspot_sync.task_helpers import sync_hubspot_user
 from main.permissions import UserIsOwnerPermission
 from main.views import RefinePagination
 from openedx import tasks
@@ -54,6 +55,7 @@ class CurrentUserRetrieveUpdateViewSet(
             if user_name != request.data.get("name"):
                 tasks.change_edx_user_name_async.delay(request.user.id)
             tasks.update_edx_user_profile(request.user.id)
+            sync_hubspot_user(request.user)
             return update_result
 
 


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/2182

# Description (What does it do?)
<!--- Describe your changes in detail -->
This PR allows full name get updated on user profile from dashboard. Currently full name isn't updated on MITx Online but it gets updated on edX because `sync_hubspot_user` is called before the update on`CurrentUserRetrieveUpdateViewSet` runs so User.name gets overwritten.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Go to http://mitxonline.odl.local:8013/profile/
- Edit `Full Name`, `First Name`, `Last Name`, updates should go through locally
![image](https://github.com/mitodl/mitxonline/assets/3138890/d307c584-85cd-46aa-bc8a-7020269856c3)

- Check `Name` field on your edX instance, it should be updated to match with `Full Name` from MITx Online
![image](https://github.com/mitodl/mitxonline/assets/3138890/6a0aae4a-27ef-48f2-afe2-c3fa2c05ead7)

- Check  `First Name`, ` Last Name` field of contact in Hubspot `rl-mitxonline-dev`
   Full Name on MITx Online doesn't map to any field in Hubspot  
![image](https://github.com/mitodl/mitxonline/assets/3138890/66221e91-1f44-4f3a-8c24-5abd8966501a)
