### PR TITLE
Fixes text alignment for the Enrolled button, hide the upsell card in new design

### DIFF
--- a/frontend/public/scss/meta-product-page.scss
+++ b/frontend/public/scss/meta-product-page.scss
@@ -1,4 +1,12 @@
-@import "layout";
+@import "variables";
+@import "~@material/layout-grid/dist/mdc.layout-grid";
+@import "~@material/top-app-bar/dist/mdc.top-app-bar";
+@import "~react-picky/dist/picky";
+@import "~react-day-picker/lib/style";
+@import "~bootstrap/scss/bootstrap";
+@import "~video.js/dist/video-js";
+
+
 @import "product-page/user-menu";
 @import "product-page/product-details";
 @import "product-page/product-faculty-members";

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -278,6 +278,11 @@
         height: 50px;
         width: 100%;
         padding: 0!important;
+        text-align: center;
+      }
+
+      a.btn-enrollment-button {
+        padding: 9px 0 0 0 !important;
       }
 
       .enrollment-info-box, .program-info-box {

--- a/frontend/public/src/containers/UpsellCardApp.js
+++ b/frontend/public/src/containers/UpsellCardApp.js
@@ -25,6 +25,8 @@ import { getCookie } from "../lib/api"
 import type { User } from "../flow/authTypes"
 import users, { currentUserSelector } from "../lib/queries/users"
 
+import { checkFeatureFlag } from "../lib/util"
+
 type Props = {
   courseId: string,
   isLoading: ?boolean,
@@ -112,12 +114,12 @@ export class UpsellCardApp extends React.Component<Props, ProductDetailState> {
 
     const run = courseRuns ? courseRuns[0] : null
 
-    return (
+    return !checkFeatureFlag("mitxonline-new-product-page") ? (
       // $FlowFixMe: isLoading null or undefined
       <Loader isLoading={isLoading}>
         {run ? this.renderUpgradeEnrollmentDialog(run) : null}
       </Loader>
-    )
+    ) : null
   }
 }
 


### PR DESCRIPTION
# What are the relevant tickets?

Part of #1773

# Description (What does it do?)

The text on the Enrolled button wasn't aligned properly, and the upsell card was appearing erroneously when the new design is turned on. This fixes both of those issues.

Additionally, after a discussion with @JenniWhitman , I've reworked what gets imported by default in here to just pull in the framework stuff and global variables into the feature flagged CSS loader. This should keep different flagged features from stepping on each other. This should be functionally equivalent to the previous code - it should all work the same.

# How can this be tested?

Toggle the new design on and go to a course that you have an audit enrollment in. The text for the Enrolled button should be centered in the button, and you should not see the upsell card.

Toggle the new design off and reload the page a couple of times (to allow the changes to take effect). The upsell card should appear.
