### PR TITLE
New extended certificate generation window

### DIFF
--- a/app.json
+++ b/app.json
@@ -62,8 +62,8 @@
       "description": "Early executed tasks propagate exceptions",
       "required": false
     },
-    "CERTIFICATE_CREATION_DELAY_IN_HOURS": {
-      "description": "The number of hours to delay automated certificate creation after a course run ends.",
+    "CERTIFICATE_CREATION_WINDOW_IN_DAYS": {
+      "description": "The number of days a course run is eligible for certificate creation after it ends.",
       "required": false
     },
     "CLOUDFRONT_DIST": {

--- a/courses/api.py
+++ b/courses/api.py
@@ -775,15 +775,15 @@ def get_certificate_grade_eligible_runs(now):
     """
     Get the list of course runs that are eligible for Grades update/creation and certificates creation
     """
-    # Get all the course runs valid course runs for certificates/Grades
-    # For a valid run it would be live, certificate_available_date would be in future with addition of
-    # delay settings.CERTIFICATE_CREATION_DELAY_IN_HOURS.
+    # Get all the course runs eligible for certificates generation
+    # For a valid run it would be live, certificate_available_date would be in future or within a month of passing
+    # the certificate_available_date.
 
     course_runs = CourseRun.objects.live().filter(
         Q(certificate_available_date__isnull=True)
         | Q(
             certificate_available_date__gt=now
-            - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
+            - timedelta(days=settings.CERTIFICATE_CREATION_WINDOW_IN_DAYS)
         )
     )
     return course_runs

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1134,7 +1134,7 @@ def test_generate_course_certificates_no_valid_course_run(settings, courses_api_
         5,
         is_self_paced=False,
         certificate_available_date=now_in_utc()
-        - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS + 1),
+        - timedelta(days=settings.CERTIFICATE_CREATION_WINDOW_IN_DAYS + 1),
     )
     generate_course_run_certificates()
     assert (

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1184,7 +1184,6 @@ def test_course_certificates_with_course_end_date_self_paced_combination(
     end_date,
 ):
     """Test that correct certificates are created when there are course runs with end_date and self_paced combination"""
-    settings.CERTIFICATE_CREATION_DELAY_IN_HOURS = 1
     course_run = passed_grade_with_enrollment.course_run
     course_run.is_self_paced = self_paced
     course_run.certificate_available_date = end_date
@@ -1213,7 +1212,6 @@ def test_generate_course_certificates_with_course_end_date(
     mocker, courses_api_logs, passed_grade_with_enrollment, settings
 ):
     """Test that certificates are generated for passed grades when there are valid course runs for certificates"""
-    settings.CERTIFICATE_CREATION_DELAY_IN_HOURS = 1
     course_run = passed_grade_with_enrollment.course_run
     course_run.certificate_available_date = now_in_utc()
     course_run.save()

--- a/main/settings.py
+++ b/main/settings.py
@@ -808,6 +808,12 @@ CERTIFICATE_CREATION_DELAY_IN_HOURS = get_int(
     description="The number of hours to delay automated certificate creation after a course run ends.",
 )
 
+CERTIFICATE_CREATION_WINDOW_IN_DAYS = get_int(
+    name="CERTIFICATE_CREATION_WINDOW_IN_DAYS",
+    default=31,
+    description="The number of days a course run is eligible for certificate creation after it ends.",
+)
+
 RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY = get_int(
     name="RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY",
     default=60 * 30,

--- a/main/settings.py
+++ b/main/settings.py
@@ -802,12 +802,6 @@ CRON_ORPHAN_CHECK_DAYS = get_string(
     description="'day_of_week' value for 'check-for-program-orphans' scheduled task (default will run once a day).",
 )
 
-CERTIFICATE_CREATION_DELAY_IN_HOURS = get_int(
-    name="CERTIFICATE_CREATION_DELAY_IN_HOURS",
-    default=24,
-    description="The number of hours to delay automated certificate creation after a course run ends.",
-)
-
 CERTIFICATE_CREATION_WINDOW_IN_DAYS = get_int(
     name="CERTIFICATE_CREATION_WINDOW_IN_DAYS",
     default=31,


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1675

# Description (What does it do?)
Increase the window for certificate generation (and current grade syncing) to 30 days. After 30 days current grades on edx get frozen and do not get updated anymore.

# How can this be tested?
Checkout the tests. Tests should pass.
Make sure that course runs with certificate_available_date in the past still get processed as long as it has been less than a month.
