### PR TITLE
Changes to feature-flag related scss files and imports

### DIFF
--- a/frontend/public/scss/home-page/featured-product-cards.scss
+++ b/frontend/public/scss/home-page/featured-product-cards.scss
@@ -1,7 +1,3 @@
-@import "variables";
-@import "~bootstrap/scss/bootstrap";
-@import "~video.js/dist/video-js";
-
 // TODO: `featured-product-section h1` should replace `course-section h1` in home.css on feature merge
 .featured-product-section h1 {
   color: $home-page-header-blue;

--- a/frontend/public/scss/home-page/home-page-hero.scss
+++ b/frontend/public/scss/home-page/home-page-hero.scss
@@ -1,6 +1,3 @@
-@import "variables";
-@import "~bootstrap/scss/bootstrap";
-
 .home-page-hero-row {
   width: 100%;
   height: 600px;

--- a/frontend/public/scss/home-page/home-page-video-component.scss
+++ b/frontend/public/scss/home-page/home-page-video-component.scss
@@ -1,7 +1,3 @@
-@import "variables";
-@import "~bootstrap/scss/bootstrap";
-@import "~video.js/dist/video-js";
-
 .home-page-video-row {
     width: 100%;
     margin: 0;

--- a/frontend/public/scss/layout.scss
+++ b/frontend/public/scss/layout.scss
@@ -28,6 +28,9 @@
 @import "learner-records";
 @import "order-history";
 @import "catalog";
+@import "home-page/featured-product-cards";
+@import "home-page/home-page-hero";
+@import "home-page/home-page-video-component";
 
 body {
   font-family: "Montserrat", "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/frontend/public/scss/meta-product-page.scss
+++ b/frontend/public/scss/meta-product-page.scss
@@ -1,11 +1,5 @@
 @import "variables";
-@import "~@material/layout-grid/dist/mdc.layout-grid";
-@import "~@material/top-app-bar/dist/mdc.top-app-bar";
-@import "~react-picky/dist/picky";
-@import "~react-day-picker/lib/style";
-@import "~bootstrap/scss/bootstrap";
-@import "~video.js/dist/video-js";
-
+@import "~bootstrap/scss/bootstrap-utilities";
 
 @import "product-page/user-menu";
 @import "product-page/product-details";

--- a/frontend/public/src/entry/style.js
+++ b/frontend/public/src/entry/style.js
@@ -1,17 +1,5 @@
 import { checkFeatureFlag } from "../lib/util"
-import("../../scss/layout.scss")
-
-if (checkFeatureFlag("mitxonline-new-featured-carousel")) {
-  import("../../scss/featured-product-cards.scss")
-}
-
-if (checkFeatureFlag("mitxonline-new-featured-hero")) {
-  import("../../scss/home-page-hero.scss")
-}
-
-if (checkFeatureFlag("mitxonline-new-home-page-video-component")) {
-  import("../../scss/home-page-video-component.scss")
-}
+import "../../scss/layout.scss"
 
 if (checkFeatureFlag("mitxonline-new-product-page")) {
   import("../../scss/meta-product-page.scss")


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1837

# Description (What does it do?)
This PR moves the home-page related files to their own directory, removes unnecessary imports from the product-details page to stop the writing over of the container css, and cuts down on the extra css imports. It would be helpful to also revisit the naming of the product page and use new class names in order to cut back on this more, but James is on vacation and this solution works with what we have.

# How can this be tested?
Check that the homepage has not been altered (some of this is on RC, not all)
Check that product pages look as they did before this (RC is current)
Check that your local `/profile` looks as it does at mitxonline.mit.edu/profile/

# Additional Context
You can see the CSS in its incorrect state at https://rc.mitxonline.mit.edu/profile/
