### PR TITLE
Anonymous user handling for posthog

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import re
+import uuid
 from datetime import datetime, timedelta
 from json import dumps
 from urllib.parse import quote_plus
@@ -749,7 +750,12 @@ class HomePage(VideoPlayerConfigMixin):
         return page_data
 
     def get_context(self, request, *args, **kwargs):
-        user = request.user.email
+        if request.user.is_authenticated:
+            user = request.user.email
+        else:
+            if "anonymous_session_id" not in request.session:
+                request.session["anonymous_session_id"] = str(uuid.uuid4())
+            user = request.session["anonymous_session_id"]
         posthog = Posthog(settings.POSTHOG_API_TOKEN, host=settings.POSTHOG_API_HOST)
         show_new_featured_carousel = posthog.feature_enabled(
             "mitxonline-new-featured-carousel",
@@ -763,7 +769,7 @@ class HomePage(VideoPlayerConfigMixin):
         )
         show_home_page_video_component = posthog.feature_enabled(
             "mitxonline-new-home-page-video-component",
-            "randomID",
+            user,
             person_properties={"environment": settings.ENVIRONMENT},
         )
 


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://mit-office-of-digital-learning.sentry.io/issues/4435442344/?environment=rc&project=5864687&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

# Description (What does it do?)
Added a conditional for un-authenticated users to generate and store a session uuid to track each user's session in the feature flag history 

# How can this be tested?
Load up the application, make sure you are not logged in. You should be able to navigate around and in the [posthog event history](https://app.posthog.com/events), see a random UUID on your requests - but it should be the same UUID for your requests.

The home page should no longer 500 whether you are logged in or not.
