### PR TITLE
Posthog refactor 

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -19,7 +19,6 @@ from django.urls import reverse
 from django.utils.text import slugify
 from mitol.common.utils.datetime import now_in_utc
 from modelcluster.fields import ParentalKey
-from posthog import Posthog
 from wagtail.admin.panels import FieldPanel, InlinePanel, PageChooserPanel
 from wagtail.blocks import PageChooserBlock, StreamBlock
 from wagtail.contrib.forms.forms import FormBuilder
@@ -67,6 +66,7 @@ from flexiblepricing.models import (
     FlexiblePrice,
     FlexiblePricingRequestSubmission,
 )
+from main import features
 from main.views import get_base_context
 
 log = logging.getLogger()
@@ -754,21 +754,14 @@ class HomePage(VideoPlayerConfigMixin):
             if "anonymous_session_id" not in request.session:
                 request.session["anonymous_session_id"] = str(uuid.uuid4())
             user = request.session["anonymous_session_id"]
-        posthog = Posthog(settings.POSTHOG_API_TOKEN, host=settings.POSTHOG_API_HOST)
-        show_new_featured_carousel = posthog.feature_enabled(
-            "mitxonline-new-featured-carousel",
-            user,
-            person_properties={"environment": settings.ENVIRONMENT},
+        show_new_featured_carousel = features.is_enabled(
+            features.ENABLE_NEW_HOME_PAGE_FEATURED, False, user
         )
-        show_new_design_hero = posthog.feature_enabled(
-            "mitxonline-new-featured-hero",
-            user,
-            person_properties={"environment": settings.ENVIRONMENT},
+        show_new_design_hero = features.is_enabled(
+            features.ENABLE_NEW_HOME_PAGE_HERO, False, user
         )
-        show_home_page_video_component = posthog.feature_enabled(
-            "mitxonline-new-home-page-video-component",
-            user,
-            person_properties={"environment": settings.ENVIRONMENT},
+        show_home_page_video_component = features.is_enabled(
+            features.ENABLE_NEW_HOME_PAGE_VIDEO, False, user
         )
 
         return {

--- a/main/features.py
+++ b/main/features.py
@@ -20,8 +20,9 @@ def is_enabled(name, default=None, unique_id=settings.HOSTNAME):
         name (str): feature flag name
         default (bool): default value if not set in settings
         unique_id (str): person identifier passed back to posthog which is the display value for person. I recommend
-                         this be a readable id for logged-in users to allow for user flags as well as troubleshooting.
-                         For anonymous users, a persistent ID will help with troubleshooting and tracking efforts.
+                         this be user.id for logged-in users to allow for more readable user flags as well as more clear
+                         troubleshooting. For anonymous users, a persistent ID will help with troubleshooting and
+                         tracking efforts.
 
     Returns:
         bool: True if the feature flag is enabled

--- a/main/features.py
+++ b/main/features.py
@@ -1,28 +1,27 @@
 """MITxOnline feature flags"""
-import os
+import posthog
 from functools import wraps
 
 from django.conf import settings
-from posthog import Posthog
-
-if "IN_TEST_SUITE" not in os.environ:
-    posthog = Posthog(settings.POSTHOG_API_TOKEN, host=settings.POSTHOG_API_HOST)
-else:
-    posthog = None
-
 
 IGNORE_EDX_FAILURES = "IGNORE_EDX_FAILURES"
 SYNC_ON_DASHBOARD_LOAD = "SYNC_ON_DASHBOARD_LOAD"
 ENABLE_NEW_DESIGN = "mitxonline-new-product-page"
+ENABLE_NEW_HOME_PAGE_FEATURED = "mitxonline-new-featured-carousel"
+ENABLE_NEW_HOME_PAGE_HERO = "mitxonline-new-featured-hero"
+ENABLE_NEW_HOME_PAGE_VIDEO = "mitxonline-new-home-page-video-component"
 
 
-def is_enabled(name, default=None):
+def is_enabled(name, default=None, unique_id=settings.HOSTNAME):
     """
     Returns True if the feature flag is enabled
 
     Args:
         name (str): feature flag name
         default (bool): default value if not set in settings
+        unique_id (str): person identifier passed back to posthog which is the display value for person. I recommend
+                         this be a readable id for logged-in users to allow for user flags as well as troubleshooting.
+                         For anonymous users, a persistent ID will help with troubleshooting and tracking efforts.
 
     Returns:
         bool: True if the feature flag is enabled
@@ -32,6 +31,7 @@ def is_enabled(name, default=None):
         posthog
         and posthog.feature_enabled(
             name,
+            unique_id,
             settings.HOSTNAME,
             person_properties={"environment": settings.ENVIRONMENT},
         )

--- a/main/features.py
+++ b/main/features.py
@@ -1,5 +1,5 @@
 """MITxOnline feature flags"""
-import posthog
+import os
 from functools import wraps
 
 from django.conf import settings
@@ -26,6 +26,11 @@ def is_enabled(name, default=None, unique_id=settings.HOSTNAME):
     Returns:
         bool: True if the feature flag is enabled
     """
+
+    if "IN_TEST_SUITE" not in os.environ:
+        import posthog
+    else:
+        posthog = None
 
     return (
         posthog

--- a/main/settings.py
+++ b/main/settings.py
@@ -5,6 +5,7 @@ Django settings for main.
 import logging
 import os
 import platform
+import posthog
 from datetime import timedelta
 from urllib.parse import urljoin, urlparse
 
@@ -1144,3 +1145,9 @@ POSTHOG_API_HOST = get_string(
     default="",
     description="API host for PostHog",
 )
+
+posthog.api_key = POSTHOG_API_TOKEN
+posthog.host = POSTHOG_API_HOST
+
+if "IN_TEST_SUITE" in os.environ:
+    posthog.disabled = True

--- a/main/settings.py
+++ b/main/settings.py
@@ -1145,6 +1145,6 @@ POSTHOG_API_HOST = get_string(
     default="",
     description="API host for PostHog",
 )
-
-posthog.api_key = POSTHOG_API_TOKEN
-posthog.host = POSTHOG_API_HOST
+if "IN_TEST_SUITE" not in os.environ:
+    posthog.api_key = POSTHOG_API_TOKEN
+    posthog.host = POSTHOG_API_HOST

--- a/main/settings.py
+++ b/main/settings.py
@@ -1150,4 +1150,4 @@ posthog.api_key = POSTHOG_API_TOKEN
 posthog.host = POSTHOG_API_HOST
 
 if "IN_TEST_SUITE" in os.environ:
-    posthog.disabled = True
+    posthog = None

--- a/main/settings.py
+++ b/main/settings.py
@@ -1134,6 +1134,7 @@ HUBSPOT_TASK_DELAY = get_int(
     description="Number of milliseconds to wait between consecutive Hubspot calls",
 )
 
+# PostHog related settings
 POSTHOG_API_TOKEN = get_string(
     name="POSTHOG_API_TOKEN",
     default="",

--- a/main/settings.py
+++ b/main/settings.py
@@ -1148,6 +1148,3 @@ POSTHOG_API_HOST = get_string(
 
 posthog.api_key = POSTHOG_API_TOKEN
 posthog.host = POSTHOG_API_HOST
-
-if "IN_TEST_SUITE" in os.environ:
-    posthog = None


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1850

# Description (What does it do?)
Removed the initialization of the posthog client from features.py and models.py and created the client in settings to be imported as used.

# How can this be tested?
Ensure feature flags still work and can be toggled while active. Trying to come up with a meaningful load test, but it might need to happen on RC (anything I've thought up is more cumbersome than I think we should be doing for this)

# Additional Context
I ended up using more of this: https://posthog.com/tutorials/django-analytics#installing-and-using-the-library than the documentation as documentation's method looks like it's importing the client, but really importing the library without a client connected and does not yet work. 