### PR TITLE
Fix the inclusion of an extra variable in the posthog call

### DIFF
--- a/main/features.py
+++ b/main/features.py
@@ -38,7 +38,6 @@ def is_enabled(name, default=None, unique_id=settings.HOSTNAME):
         and posthog.feature_enabled(
             name,
             unique_id,
-            settings.HOSTNAME,
             person_properties={"environment": settings.ENVIRONMENT},
         )
     ) or settings.FEATURES.get(name, default or settings.FEATURES_DEFAULT)


### PR DESCRIPTION
# What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/4447043519/events/ac4b94e2c30541f1b8961a32a0605775/

# Description (What does it do?)
Removes the extra line in the posthog call
