### PR TITLE
fix expandable Read More 500 error

### DIFF
--- a/cms/templatetags/expand.py
+++ b/cms/templatetags/expand.py
@@ -1,12 +1,14 @@
 """
-Adds an expandable Read More section to a text block. 
+Adds an expandable Read More section to a text block.
 
 The following rules are followed to determine where the content is split:
-- If the text is HTML and contains a special tag (class="expand_here"), then 
+- If the text is HTML and contains a special tag (class="expand_here"), then
   that will be where the split occurs.
-- If the text is HTML, the content will be split in two after the first <p> or
-  <div> tag. 
-- If the text is not HTML, then split after the first two concurrent newlines.
+- If the text is HTML and contains at least two paragraphs, the content will
+  be split in two after the first <p> or <div> tag.
+- If the text contains two paragraphs separated by two concurrent newlines,
+  then split after the first two concurrent newlines.
+- else for single paragraph, no need to split just return the content
 
 This is intended for use with a Wagtail RichText field.
 """
@@ -33,16 +35,17 @@ def expand(text):
         post = "".join([str(sib) for sib in expand_here.find_next_siblings()])
 
         output = f'{pre}<p class="expand_here_container"><a href="#" class="expand_here_link" data-expand-body="{container_uuid}">Show More</a></p><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[0])}{post}</div>'
-    elif len(soup.find_all(["p", "div"])) > 0:
+    elif len(soup.find_all(["p", "div"])) > 1:
         expand_here = soup.find_all(["p", "div"], limit=2)
 
         pre = str(expand_here[0])
         post = "".join([str(sib) for sib in expand_here[1].find_next_siblings()])
 
         output = f'<!-- pre -->{pre}<!-- /pre --><p class="expand_here_container"><a href="#" class="expand_here_link" data-expand-body="{container_uuid}">Show More</a></p><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[1])}{post}</div>'
-    else:
+    elif len(text.split("\n\n")) > 1:
         (pre, post) = text.split("\n\n", maxsplit=1)
 
         output = f'{pre}<p class="expand_here_container"><a href="#" class="expand_here_link" data-expand-body="exp{container_uuid}">Show More</a></p><div class="expand_here_body" id="{container_uuid}">{post}</div>'
-
+    else:
+        output = text
     return output


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/mitxonline/issues/1856

# Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing 500 error on About section if text is less than 2 paragraphs

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
When there are more than 2 paragraphs, and Show More is displayed
![image](https://github.com/mitodl/mitxonline/assets/3138890/eb24717b-d821-40f5-88ee-1c269c3b990f)
When there is only 1 sentence, display the original text
![image](https://github.com/mitodl/mitxonline/assets/3138890/edfa4b93-65b7-443d-af83-097e1a66f6d1)


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Edit About section from a course cms page
   - add one sentence there, make sure no 500 error
   - add more than one paragraphs, 'Show More' should be displayed. It can be toggled which implemented in https://github.com/mitodl/mitxonline/pull/1816

