### PR TITLE
1870: Remove duplicate catalog URL path

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -87,7 +87,6 @@ urlpatterns = [
     re_path(r"^documents/", include(wagtaildocs_urls)),
     path("", include(wagtail_urls)),
     path("", include("cms.urls")),
-    path("catalog/", index, name="catalog"),
     # Example view
     path("", index, name="main-index"),
 ] + (


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1870

# Description (What does it do?)
Removes a duplicate URL path.

# How can this be tested?

- http://mitxonline.odl.local:8013/catalog/ should still be accessible when `ENABLE_NEW_DESIGN = True`
- http://mitxonline.odl.local:8013/catalog/ should display a 404 page when `ENABLE_NEW_DESIGN = False` 
