### PR TITLE
Course passed if has course run certificate

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -35,7 +35,7 @@ import {
   isFinancialAssistanceAvailable,
   isLinkableCourseRun,
   generateStartDateText,
-  courseRunStatusMessage,
+  courseRunStatusMessage
 } from "../lib/courseApi"
 import { isSuccessResponse } from "../lib/util"
 

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -36,7 +36,6 @@ import {
   isLinkableCourseRun,
   generateStartDateText,
   courseRunStatusMessage,
-  enrollmentHasPassingGrade
 } from "../lib/courseApi"
 import { isSuccessResponse } from "../lib/util"
 

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -467,8 +467,6 @@ export class EnrolledItemCard extends React.Component<
 
     const courseRunStatusMessageText = courseRunStatusMessage(enrollment.run)
 
-    const hasPassed = enrollmentHasPassingGrade(enrollment)
-
     return (
       <div
         className="enrolled-item container card mb-4 rounded-0 pb-0 pt-md-3"
@@ -496,7 +494,7 @@ export class EnrolledItemCard extends React.Component<
             <div className="d-flex justify-content-between align-content-start flex-nowrap w-100">
               <div className="d-flex flex-column">
                 <div className="align-content-start d-flex enrollment-mode-container flex-wrap pb-1">
-                  {hasPassed ? (
+                  {enrollment.certificate ? (
                     <span className="badge badge-enrolled-passed mr-2">
                       <img src="/static/images/done.svg" alt="Check" /> Course
                       passed

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -147,7 +147,7 @@ describe("EnrolledItemCard", () => {
     })
   })
 
-  it("doesn't renders the course passed label if course is not passed", async () => {
+  it("doesn't renders the course passed label if course is passed but no certificate", async () => {
     // If there are no grades at all
     let inner = await renderedCard()
     let coursePassed = inner
@@ -155,33 +155,31 @@ describe("EnrolledItemCard", () => {
       .find(".badge-enrolled-passed")
     assert.isFalse(coursePassed.exists())
 
-    // If the user has grades but not passed
+    // If the user has passed grades but no certificate
     const grade = makeLearnerRecordGrade()
-    grade.passed = false
+    grade.passed = true
     enrollmentCardProps.enrollment.grades = [grade]
     inner = await renderedCard()
     coursePassed = inner.find(".enrolled-item").find(".badge-enrolled-passed")
     assert.isFalse(coursePassed.exists())
   })
   ;[true, false].forEach(isSelfPaced => {
-    it("renders the course passed label based on self_paced and course passed", async () => {
+    it("renders the course passed label based on course certificate independent of course pacing", async () => {
       enrollmentCardProps.enrollment.run.is_self_paced = isSelfPaced
       const grade = makeLearnerRecordGrade()
       grade.passed = true
       enrollmentCardProps.enrollment.grades = [grade]
+      enrollmentCardProps.enrollment.certificate = { url: "url" }
+
       const inner = await renderedCard()
       const coursePassed = inner
         .find(".enrolled-item")
         .find(".badge-enrolled-passed")
-      if (isSelfPaced) {
-        assert.isTrue(coursePassed.exists())
-      } else {
-        assert.isFalse(coursePassed.exists())
-      }
+      assert.isTrue(coursePassed.exists())
     })
   })
   ;[true, false].forEach(past => {
-    it("renders the course passed label based on course end and certificate available dates in past", async () => {
+    it("doesn't render the course passed label based on course end and certificate available dates in past", async () => {
       enrollmentCardProps.enrollment.run.is_self_paced = false
       if (past) {
         enrollmentCardProps.enrollment.run.end_date = moment("2021-02-08")
@@ -202,11 +200,8 @@ describe("EnrolledItemCard", () => {
       const coursePassed = inner
         .find(".enrolled-item")
         .find(".badge-enrolled-passed")
-      if (past) {
-        assert.isTrue(coursePassed.exists())
-      } else {
-        assert.isFalse(coursePassed.exists())
-      }
+
+      assert.isFalse(coursePassed.exists())
     })
   })
 

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -163,47 +163,6 @@ describe("EnrolledItemCard", () => {
     coursePassed = inner.find(".enrolled-item").find(".badge-enrolled-passed")
     assert.isFalse(coursePassed.exists())
   })
-  ;[true, false].forEach(isSelfPaced => {
-    it("renders the course passed label based on course certificate independent of course pacing", async () => {
-      enrollmentCardProps.enrollment.run.is_self_paced = isSelfPaced
-      const grade = makeLearnerRecordGrade()
-      grade.passed = true
-      enrollmentCardProps.enrollment.grades = [grade]
-      enrollmentCardProps.enrollment.certificate = { url: "url" }
-
-      const inner = await renderedCard()
-      const coursePassed = inner
-        .find(".enrolled-item")
-        .find(".badge-enrolled-passed")
-      assert.isTrue(coursePassed.exists())
-    })
-  })
-  ;[true, false].forEach(past => {
-    it("doesn't render the course passed label based on course end and certificate available dates in past", async () => {
-      enrollmentCardProps.enrollment.run.is_self_paced = false
-      if (past) {
-        enrollmentCardProps.enrollment.run.end_date = moment("2021-02-08")
-        enrollmentCardProps.enrollment.run.certificate_available_date = moment(
-          "2021-02-08"
-        )
-      } else {
-        enrollmentCardProps.enrollment.run.end_date = moment().add(7, "d")
-        enrollmentCardProps.enrollment.run.certificate_available_date = moment().add(
-          7,
-          "d"
-        )
-      }
-      const grade = makeLearnerRecordGrade()
-      grade.passed = true
-      enrollmentCardProps.enrollment.grades = [grade]
-      const inner = await renderedCard()
-      const coursePassed = inner
-        .find(".enrolled-item")
-        .find(".badge-enrolled-passed")
-
-      assert.isFalse(coursePassed.exists())
-    })
-  })
 
   it("Course detail shows `Active` when start date in past", async () => {
     enrollmentCardProps.enrollment.run.start_date = moment("2021-02-08")

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -105,32 +105,6 @@ export const isFinancialAssistanceAvailable = (run: CourseRunDetail) => {
   return run.page ? !!run.page.financial_assistance_form_url : false
 }
 
-export const enrollmentHasPassingGrade = (enrollment: RunEnrollment) => {
-  if (enrollment.grades && enrollment.grades.length > 0) {
-    for (let i = 0; i < enrollment.grades.length; i++) {
-      if (enrollment.grades[i].passed && isPassBadgeEligible(enrollment.run)) {
-        return true
-      }
-    }
-  }
-
-  return false
-}
-
-const isPassBadgeEligible = (run: CourseRunDetail) => {
-  if (run.is_self_paced) {
-    return true
-  } else {
-    const now = moment()
-    return (
-      notNil(run.end_date) &&
-      moment(run.end_date).isBefore(now) &&
-      notNil(run.certificate_available_date) &&
-      moment(run.certificate_available_date).isBefore(now)
-    )
-  }
-}
-
 const isNodeCompleted = (
   node: RequirementNode,
   learnerRecord: LearnerRecord

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -12,7 +12,6 @@ import type Moment from "moment"
 import type {
   CourseRunDetail,
   CourseRun,
-  RunEnrollment,
   RequirementNode,
   LearnerRecord,
   ProgramRequirement,


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2319

# Description (What does it do?)
Don't show green label "Course Passed" if there is no certificate.

# Screenshots (if appropriate):
This green label "Course Passed" shouldn't show, if there is no certificate.
<img width="514" alt="Screen Shot 2023-09-11 at 3 33 30 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/89060a3b-03da-4fc1-9932-996af45cfbaf">


# How can this be tested?
create a passing grade for user and a revoked coure run certificate. Check the dashboard course card enrollment info. It should not show the certificate and not show the "Course Passed" tag.