### PR TITLE
Updating video player CSS to work better in the new design

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -4,6 +4,7 @@
 {% load static wagtail_img_src feature_img_src %}
 {% load wagtailcore_tags wagtailembeds_tags %}
 {% load expand %}
+{% load videojs %}
 
 {% block title %}{{ page.title }} | {{ site_name }}{% endblock %}
 
@@ -79,13 +80,7 @@
             <div class="px-4 py-2 border align-items-center justify-items-top d-flex flex-column">
               <div class="hero-media">
                 {% if page.video_url %}
-                <video-js
-                  class="vjs-default-skin vjs-big-play-centered"
-                  controls
-                  data-setup="{{page.video_player_config}}"
-                  preload="metadata"
-                >
-                </video-js>
+                  {% videojs page %}
                 {% else %}
                 <img src="{% feature_img_src page.feature_image %}" alt="">
                 {% endif %}

--- a/cms/templates/videojs_tag.html
+++ b/cms/templates/videojs_tag.html
@@ -1,0 +1,7 @@
+<video-js
+class="vjs-default-skin vjs-big-play-centered"
+controls
+data-setup="{{page.video_player_config}}"
+preload="metadata"
+>
+</video-js>

--- a/cms/templatetags/videojs.py
+++ b/cms/templatetags/videojs.py
@@ -1,0 +1,12 @@
+"""
+Generates a <video-js> tag. Expects the page object, which should use the 
+VideoPlayerConfigMixin. 
+"""
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag("videojs_tag.html", name="videojs")
+def videojs(page):
+    return {"page": page}

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -90,10 +90,56 @@ body.new-design {
 
       .hero-media {
         margin: 7px 15px;
+        max-width: 350px;
 
         img {
           border-radius: 5px;
           max-width: 350px;
+        }
+
+        .vjs-default-skin {
+          width: 325px;
+          max-height: 240px;
+        }
+
+        .video-js {
+          .vjs-big-play-button {
+            background: black;
+            opacity: 0.8;
+            width: 64px;
+            height: 64px;
+            border: none;
+            border-radius: 50%;
+    
+            &:hover {
+              opacity: 0.6;
+            }
+          }
+    
+          .vjs-poster {
+            height: fit-content;
+          }
+        }
+    
+        .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+          top: 0.3em;
+        }
+    
+        .vjs-youtube {
+    
+          .vjs-big-play-button {
+            display: none;
+          }
+        }
+    
+        .video-holder {
+          background: $sirocco;
+          margin-top: 10px;
+    
+          img {
+            display: block;
+            width: 100%;
+          }
         }
       }
 


### PR DESCRIPTION

# What are the relevant tickets?

Closes #1880

# Description (What does it do?)

The relevant VideoJS CSS was located in a set of CSS selectors that meant it wouldn't be applied on the new design product page, which broke the player. This moves those styles where they will apply, and makes some tweaks to the styles to make videos fit better in the sidebar.

This also adds a new `videojs` tag that can be used to drop our standard VideoJS tag, and will allow us to make global changes to this (as we'll be able to update the tag template in one place). 

# Screenshots (if appropriate):

YouTube embed:
![image](https://github.com/mitodl/mitxonline/assets/945611/3d098609-2cdc-486d-b56a-318eafd63e2d)

HLS embed:
![image](https://github.com/mitodl/mitxonline/assets/945611/90e240ac-a1aa-4ad7-be5a-324d53259c5f)

# How can this be tested?

Set up a course with a video URL. Viewing the course should give you a play button and video controls (in some fashion - embedded ones for HLS video, YouTube ones for a YouTube video). 
