### PR TITLE
Hero sits over dropdown because of carousel z index change

### DIFF
--- a/frontend/public/scss/home-page/home-page-hero.scss
+++ b/frontend/public/scss/home-page/home-page-hero.scss
@@ -6,7 +6,6 @@ body.new-design {
   height: 600px;
   background: $home-page-dark-blue;
   position: relative;
-  z-index: 9999;
   @include media-breakpoint-down(md) {
     width: 100%;
     height: 470px;


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/1896

# Description (What does it do?)
Remove the z-index which is no longer necessary

# How can this be tested?
Open the home page, click the drop down on the top right while logged in - you should see it, it should not be covered by the hero.
