### PR TITLE
Updates the code behind the More Dates selector to work without the course page

### DIFF
--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -156,6 +156,10 @@ export class ProductDetailEnrollApp extends React.Component<
   }
 
   setCurrentCourseRun = (courseRun: EnrollmentFlaggedCourseRun) => {
+    console.log(
+      "==> we're setting currentCourseRun but is the context right??",
+      courseRun
+    )
     this.setState({
       currentCourseRun: courseRun
     })
@@ -405,16 +409,12 @@ export class ProductDetailEnrollApp extends React.Component<
     const csrfToken = getCookie("csrftoken")
 
     let run =
-      !this.getCurrentCourseRun() && courseRuns
-        ? courseRuns[0]
-        : this.getCurrentCourseRun() && courseRuns
-          ? courseRuns[0].page && this.getCurrentCourseRun().page
-            ? courseRuns[0].page.page_url ===
-            this.getCurrentCourseRun().page.page_url
-              ? this.getCurrentCourseRun()
-              : courseRuns[0]
-            : courseRuns[0]
-          : null
+      !this.getCurrentCourseRun() && !courseRuns
+        ? null
+        : !this.getCurrentCourseRun() && courseRuns
+          ? courseRuns[0]
+          : this.getCurrentCourseRun()
+
     if (run) this.updateDate(run)
     let product = run && run.products ? run.products[0] : null
     if (courseRuns) {
@@ -423,6 +423,7 @@ export class ProductDetailEnrollApp extends React.Component<
         // $FlowFixMe
         document.addEventListener("click", function(e) {
           if (e.target && e.target.id === courseRun.courseware_id) {
+            console.log(`${e.target.id} === ${courseRun.courseware_id}`)
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -156,10 +156,6 @@ export class ProductDetailEnrollApp extends React.Component<
   }
 
   setCurrentCourseRun = (courseRun: EnrollmentFlaggedCourseRun) => {
-    console.log(
-      "==> we're setting currentCourseRun but is the context right??",
-      courseRun
-    )
     this.setState({
       currentCourseRun: courseRun
     })
@@ -423,7 +419,6 @@ export class ProductDetailEnrollApp extends React.Component<
         // $FlowFixMe
         document.addEventListener("click", function(e) {
           if (e.target && e.target.id === courseRun.courseware_id) {
-            console.log(`${e.target.id} === ${courseRun.courseware_id}`)
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null


### PR DESCRIPTION
The course page was removed from the courserun API response in [an earlier PR](https://github.com/mitodl/mitxonline/pull/1872), but the More Dates selector depended on it being there to determine which course run to show you. This PR changes that logic to something more simple - either you've selected a course run or you haven't. 

# What are the relevant tickets?

Fixes mitol/hq#2396 partially

# Description (What does it do?)

If a course run has been selected, use that instead of the default (which is just the first courserun that appears in the list when we go to fetch them). 

# How can this be tested?

Set up a course with multiple concurrent runs. (For my testing, I made two with run tags ending in A and B so it'd be obvious which is which.) Then, load the course page. You should see the More Dates selector. 

Clicking Enroll Now without choosing a course in the More Dates selector should enroll you in the first course on the list. 

Choosing a course from the More Dates selector and then clicking Enroll Now should enroll you in that specific course run. 

# Additional Context

Your Enroll Now button may not change to Enrolled depending on whether or not you have a working edX instance and a corresponding course there for your test course runs. For example, I am enrolled in both these courses. However, Tutor isn't aware of either - I set one manually to be EdX Enrolled = True. (These screenshots also demonstrate that the selector works.)

![Screenshot 2023-09-18 at 1 14 18 PM](https://github.com/mitodl/mitxonline/assets/945611/175bd6f3-d9cc-4dba-83d0-2dad489f6ef5)
![Screenshot 2023-09-18 at 1 14 26 PM](https://github.com/mitodl/mitxonline/assets/945611/06113afa-01f1-456b-bfd0-9c12a63e1a13)

