### PR TITLE
Assorted fixes for More Dates selector in existing design

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1129,11 +1129,15 @@ class CoursePage(ProductPage):
         return f"{self.course.readable_id} | {self.title}"
 
     def get_context(self, request, *args, **kwargs):
+        now = now_in_utc()
+
         relevant_run = get_user_relevant_course_run(
             course=self.product, user=request.user
         )
         relevant_runs = list(
-            get_user_relevant_course_run_qset(course=self.product, user=request.user)
+            get_user_relevant_course_run_qset(
+                course=self.product, user=request.user
+            ).filter(models.Q(enrollment_end=None) | models.Q(enrollment_end__gt=now))
         )
         is_enrolled = (
             False

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -222,13 +222,15 @@
                         <p>Click below to enroll in one of these dates</p>
                       </div>
                       {% for course_run in course_runs %}
-                          <div>
-                            {% if course_run.is_not_beyond_enrollment %}
-                              <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
-                            {% else %}
-                              <p class='date-link-disabled' id='{{ course_run.courseware_id }}' >{{ course_run.start_date|date:'F j, Y' }}(enrollment opens {{ course_run.enrollment_start|date:'F j, Y' }})</p>
+                        <div>
+                          {% if course_run.is_not_beyond_enrollment %}
+                            <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
+                          {% else %}
+                            {% if not course_run.is_past %}
+                            <p class='date-link-disabled' id='{{ course_run.courseware_id }}' >{{ course_run.start_date|date:'F j, Y' }}(enrollment opens {{ course_run.enrollment_start|date:'F j, Y' }})</p>
                             {% endif %}
-                          </div>
+                          {% endif %}
+                        </div>
                       {% endfor %}
                     ">
                     More Dates

--- a/courses/api.py
+++ b/courses/api.py
@@ -83,7 +83,7 @@ def _relevant_course_qset_filter(
     """
     now = now or now_in_utc()
     run_qset = (
-        course.courseruns.exclude(start_date=None)
+        run_qset.exclude(start_date=None)
         .exclude(enrollment_start=None)
         .filter(live=True)
     )

--- a/courses/api.py
+++ b/courses/api.py
@@ -81,7 +81,12 @@ def _relevant_course_qset_filter(
     Does the actual filtering for user_relevant_course_run_qset and
     user_relevant_program_course_run_qset.
     """
-
+    now = now or now_in_utc()
+    run_qset = (
+        course.courseruns.exclude(start_date=None)
+        .exclude(enrollment_start=None)
+        .filter(live=True)
+    )
     if user and user.is_authenticated:
         user_enrollments = Count(
             "enrollments",

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -148,11 +148,23 @@ export class CourseProductDetailEnroll extends React.Component<
     return this.state.currentCourseRun
   }
 
+  getFirstUnenrolledCourseRun = (): EnrollmentFlaggedCourseRun => {
+    const { courseRuns } = this.props
+
+    return courseRuns
+      ? courseRuns.find(
+        (run: EnrollmentFlaggedCourseRun) =>
+          run.is_enrolled === false &&
+            moment(run.enrollment_start) <= moment.now()
+      ) || courseRuns[0]
+      : null
+  }
+
   renderUpgradeEnrollmentDialog(showNewDesign: boolean) {
     const { courseRuns, courses } = this.props
     const run =
       !this.getCurrentCourseRun() && courseRuns
-        ? courseRuns[0]
+        ? this.getFirstUnenrolledCourseRun()
         : this.getCurrentCourseRun()
 
     const course =
@@ -504,7 +516,11 @@ export class CourseProductDetailEnroll extends React.Component<
       courseRuns.map(courseRun => {
         // $FlowFixMe
         document.addEventListener("click", function(e) {
-          if (e.target && e.target.id === courseRun.courseware_id) {
+          if (
+            e.target &&
+            e.target.tagName.toLowerCase() === "button" &&
+            e.target.id === courseRun.courseware_id
+          ) {
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null


### PR DESCRIPTION
_Removed the Needs Review from this since Program Page will require this to be refactored to work._

# What are the relevant tickets?

Fixes mitodl/hq#2396
Fixes #1793 

# Description (What does it do?)

This incorporates a few changes:
- In the CoursePage model, the relevant runs should now filter out runs with enrollment end dates in the past, so past course runs should not display
- In the More Dates selector, items that were listed as inactive were actually selectable - this fixes that, only `button` elements are handled now
- The ProductDetailEnrollApp component should now favor the first apparent unenrolled courserun rather than just grabbing the first if one isn't explicitly selected. 
- The relevant course runs queryset function now only includes live courses

Note that the course runs API considers whether or not the enrollment was successful in edX as part of its determination of enrollment - if your edX enrollment failed, you'll still get the Enroll Now button, essentially. 

# How can this be tested?

Set up a course with several course runs:
- One that has a start date and enrollment start date in the past, and end date and enrollment end date in the future.
- Another one that has a start date and enrollment start date in the past, and end date and enrollment end date in the future. The dates for this run should overlap the first course run (i.e. make one start in August and one in September or something).
- One that has an enrollment start date in the future, and end date and enrollment end date in the future
- One that exists totally in the past.

When navigating to the course page, the first course run should be selected by default. Selecting More Dates should show you a selectable item for the second course run and a disabled item for the third. The fourth should not be shown.

Enroll in the first course. (You will likely also need to adjust the enrollment manually to flip the "EdX Enrolled" checkbox to on.) Then, return to the course page. The _second_ course run should be selected and you should see the Enroll Now button. (You can ensure the course run is the correct one in React Devtools). Flipping back to the first course run should show you an Enrolled button. You should also be able to see a disabled choice for the future course. 

Enroll in the second course. You should now see the Enrolled button. You should be able to select between the two current course runs, and each should display the Enrolled button. 
