### PR TITLE
Swap posthog to use js sdk with minimal settings

### DIFF
--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -35,12 +35,6 @@ import { checkFeatureFlag } from "../lib/util"
 import AddlProfileFieldsForm from "../components/forms/AddlProfileFieldsForm"
 import CourseInfoBox from "../components/CourseInfoBox"
 
-import posthog from "posthog-js"
-
-/* global SETTINGS:false */
-posthog.init(SETTINGS.posthog_api_token, {
-  api_host: SETTINGS.posthog_api_host
-})
 
 const expandExpandBlock = (event: MouseEvent) => {
   const blockTarget = event.target

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -35,7 +35,6 @@ import { checkFeatureFlag } from "../lib/util"
 import AddlProfileFieldsForm from "../components/forms/AddlProfileFieldsForm"
 import CourseInfoBox from "../components/CourseInfoBox"
 
-
 const expandExpandBlock = (event: MouseEvent) => {
   const blockTarget = event.target
 

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -36,13 +36,13 @@ if (SETTINGS.posthog_api_host && SETTINGS.posthog_api_token) {
     posthog.debug()
   }
   posthog.init(SETTINGS.posthog_api_token, {
-    api_host: SETTINGS.posthog_api_host,
-    autocapture: false,
-    capture_pageview: false,
-    capture_pageleave: false,
+    api_host:               SETTINGS.posthog_api_host,
+    autocapture:            false,
+    capture_pageview:       false,
+    capture_pageleave:      false,
     cross_subdomain_cookie: false,
-    persistence: "localStorage+cookie",
-    loaded: function (posthog) {
+    persistence:            "localStorage+cookie",
+    loaded:                 function(posthog) {
       posthog.setPersonPropertiesForFlags({
         environment: environment
       })

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -31,11 +31,22 @@ import {
 } from "../constants"
 
 if (SETTINGS.posthog_api_host && SETTINGS.posthog_api_token) {
+  const environment = SETTINGS.environment
+  if (environment === "dev") {
+    posthog.debug()
+  }
   posthog.init(SETTINGS.posthog_api_token, {
-    api_host: SETTINGS.posthog_api_host
-  })
-  posthog.setPersonPropertiesForFlags({
-    environment: SETTINGS.environment
+    api_host: SETTINGS.posthog_api_host,
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    cross_subdomain_cookie: false,
+    persistence: "localStorage+cookie",
+    loaded: function (posthog) {
+      posthog.setPersonPropertiesForFlags({
+        environment: environment
+      })
+    }
   })
 }
 


### PR DESCRIPTION
# What are the relevant tickets?
Updates https://github.com/mitodl/hq/issues/2353
Updates https://github.com/mitodl/hq/issues/2388

# Description (What does it do?)
This takes the posthog setup into one place, out of the util function, and removes most of the config options.  I also turned on posthog debug when environment is dev to assist in debugging.

# How can this be tested?
Load pages - the flags should still work and you should see the ph cookie is not very small (126 bytes give or take, instead of over 1500 as on RC presently). when using locally, should see posthog request info in console. You should also see user data for posthog in the session storage. There should not be events generated for everything you do on the page any more in the posthog application.

# Additional Info
Will have a follow up PR to swap to the React SDK instead. This one will help alleviate short term 400 issues.