### PR TITLE
Skip courses if they don't have a published CMS page

### DIFF
--- a/cms/templatetags/course_list.py
+++ b/cms/templatetags/course_list.py
@@ -19,6 +19,9 @@ def course_list(courses):
 
     for course in courses:
         try:
+            if not course.page.live:
+                continue
+
             start_descriptor = (
                 f"Starts {format_course_start_time(course.first_unexpired_run.start_date)}"
                 if course.first_unexpired_run and course.first_unexpired_run.start_date

--- a/cms/templatetags/course_list.py
+++ b/cms/templatetags/course_list.py
@@ -18,19 +18,25 @@ def course_list(courses):
     cards = []
 
     for course in courses:
-        start_descriptor = (
-            f"Starts {format_course_start_time(course.first_unexpired_run.start_date)}"
-            if course.first_unexpired_run and course.first_unexpired_run.start_date
-            else "Start Anytime"
-        )
-        featured_image = feature_img_src(course.page.feature_image)
+        try:
+            start_descriptor = (
+                f"Starts {format_course_start_time(course.first_unexpired_run.start_date)}"
+                if course.first_unexpired_run and course.first_unexpired_run.start_date
+                else "Start Anytime"
+            )
 
-        cards.append(
-            {
-                "course": course,
-                "start_descriptor": start_descriptor,
-                "featured_image": featured_image,
-            }
-        )
+            featured_image = feature_img_src(course.page.feature_image)
+            page = course.page
+
+            cards.append(
+                {
+                    "course": course,
+                    "page": page,
+                    "start_descriptor": start_descriptor,
+                    "featured_image": featured_image,
+                }
+            )
+        except Exception:
+            pass
 
     return {"cards": cards}


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#2427

# Description (What does it do?)

After deploying the program page code to RC, I was getting 500 errors on some programs - turns out there were courses missing CMS pages in some of the programs. This fixes the `course_list` template tag to handle that case better by not listing the course (since you can't enroll in it if there's no CMS page anyway). 

# How can this be tested?

Create a program with some (>2) courses in it, and set up CMS pages for the program and two of the courses. Leave one course page unpublished. 

Navigate to the program page. You should see the page, and you should only see a course page for the course with a published CMS page.

Publish the remaining course page. The course should show up in the program. 

Optionally create and publish a course page for any other courses in the program. They should appear in the course listing as well. 
