### PR TITLE
Re-add the fix from PR 1900 to the reworked product page components

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -490,16 +490,12 @@ export class CourseProductDetailEnroll extends React.Component<
     const showNewDesign = checkFeatureFlag("mitxonline-new-product-page")
 
     let run =
-      !this.getCurrentCourseRun() && courseRuns
-        ? courseRuns[0]
-        : this.getCurrentCourseRun() && courseRuns
-          ? courseRuns[0].page && this.getCurrentCourseRun().page
-            ? courseRuns[0].page.page_url ===
-            this.getCurrentCourseRun().page.page_url
-              ? this.getCurrentCourseRun()
-              : courseRuns[0]
-            : courseRuns[0]
-          : null
+      !this.getCurrentCourseRun() && !courseRuns
+        ? null
+        : !this.getCurrentCourseRun() && courseRuns
+          ? courseRuns[0]
+          : this.getCurrentCourseRun()
+
     if (run) this.updateDate(run)
 
     let product = run && run.products ? run.products[0] : null


### PR DESCRIPTION
# What are the relevant tickets?

https://github.com/mitodl/mitxonline/pull/1900

# Description (What does it do?)
https://github.com/mitodl/mitxonline/pull/1900 fixed an issue with the course selector in the More Dates section, which then didn't get migrated into the Program Page code (which split out the upsell stuff into separate components for course and program pages). This re-adds it to the new course page component.

# How can this be tested?

See testing parameters in https://github.com/mitodl/mitxonline/pull/1900 - it should be exactly the same. 
