### PR TITLE
Self paced dates -> start any time

### DIFF
--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -198,6 +198,7 @@ def test_home_page_featured_products(mocker):
             "start_date": run.start_date if run is not None else None,
             "url_path": course_page.get_url(),
             "is_program": False,
+            "is_self_paced": run.is_self_paced if run is not None else None,
             "program_type": None,
         }
     ]
@@ -223,6 +224,7 @@ def test_home_page_featured_products_sorting(mocker):
                 "start_date": run.start_date if run is not None else None,
                 "url_path": course_page.get_url(),
                 "is_program": False,
+                "is_self_paced": run.is_self_paced if run is not None else None,
                 "program_type": None,
             }
         )

--- a/cms/models.py
+++ b/cms/models.py
@@ -723,6 +723,7 @@ class HomePage(VideoPlayerConfigMixin):
                     "start_date": run.start_date if run is not None else None,
                     "url_path": product_page.get_url(),
                     "is_program": product_page.is_program_page,
+                    "is_self_paced": run.is_self_paced if run is not None else None,
                     "program_type": product_page.product.program_type
                     if product_page.is_program_page
                     else None,

--- a/main/templates/partials/featured_product_card.html
+++ b/main/templates/partials/featured_product_card.html
@@ -8,7 +8,7 @@
       <div class="badge badge-program-type{% if not product.program_type %}-none{% endif %}">{% if product.program_type %}{{ product.program_type }}{% endif %}</div>
     </div>
     <div class="featured-product-info">
-      {% if product.start_date and not product.is_program %}
+      {% if product.start_date and not product.relevant_run.is_self_paced and not product.is_program %}
       <p class="date">
         Starts {{ product.start_date | date:"F j, Y" }}
       </p>

--- a/main/templates/partials/featured_product_card.html
+++ b/main/templates/partials/featured_product_card.html
@@ -8,7 +8,7 @@
       <div class="badge badge-program-type{% if not product.program_type %}-none{% endif %}">{% if product.program_type %}{{ product.program_type }}{% endif %}</div>
     </div>
     <div class="featured-product-info">
-      {% if product.start_date and not product.relevant_run.is_self_paced and not product.is_program %}
+      {% if product.start_date and not product.is_self_paced and not product.is_program %}
       <p class="date">
         Starts {{ product.start_date | date:"F j, Y" }}
       </p>


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2375

# Description (What does it do?)
adds self paced on the relevant run to the context & logic to make it visible on the page.

# How can this be tested?
Having a CMS page for a self paced and a non self paced course. Non self paced should show the relevant start date (next in the future, or recently passed with enrollment still open), self paced should show "start anytime".