### PR TITLE
Product Page Start Anyime

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -30,7 +30,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     const product = run && run.products.length > 0 && run.products[0]
 
     const startDate =
-      run && !emptyOrNil(run.start_date)
+      run && !emptyOrNil(run.start_date) && !run.is_self_paced
         ? moment(new Date(run.start_date))
         : null
 


### PR DESCRIPTION
# What are the relevant tickets?
Updates https://github.com/mitodl/hq/issues/2375

# Description (What does it do?)
Updates the product page to display start anytime when the course is self paced

# Screenshots (if appropriate):
![Screenshot from 2023-09-25 08-11-06](https://github.com/mitodl/mitxonline/assets/7756053/83143fb9-dfce-44bc-bb80-2bb05fd9099b)

# How can this be tested?
Have a course with or without a start date, but that is noted as self paced and it should display with "start anytime". 
