### PR TITLE
Add FAQ cert link and prerequisites to product_page.html

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -28,8 +28,8 @@
                   {% if page.about %}<li class="nav-item"><a href="#about-this-class">About</a></li>{% endif %}
                   {% if page.is_program_page %}<li class="nav-item"><a href="#program-courses">Courses</a></li>{% endif %}
                   {% if page.what_you_learn %}<li class="nav-item"><a href="#what-youll-learn">What you'll learn</a></li>{% endif %}
-                  {% if instructors %}<li class="nav-item"><a href="#instructors">Instructors</a></li>{% endif %}
                   {% if page.prerequisites %}<li class="nav-item"><a href="#prerequisites">Prerequisites</a></li>{% endif %}
+                  {% if instructors %}<li class="nav-item"><a href="#instructors">Instructors</a></li>{% endif %}
                   {% if page.faq_url %}<li class="nav-item"><a href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
                 </ul>
               </nav>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -29,6 +29,7 @@
                   {% if page.is_program_page %}<li class="nav-item"><a href="#program-courses">Courses</a></li>{% endif %}
                   {% if page.what_you_learn %}<li class="nav-item"><a href="#what-youll-learn">What you'll learn</a></li>{% endif %}
                   {% if instructors %}<li class="nav-item"><a href="#instructors">Instructors</a></li>{% endif %}
+                  {% if page.prerequisites %}<li class="nav-item"><a href="#prerequisites">Prerequisites</a></li>{% endif %}
                   {% if page.faq_url %}<li class="nav-item"><a href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
                 </ul>
               </nav>
@@ -58,6 +59,10 @@
                 <h2>What you&apos;ll learn</h2>
                 {{ page.what_you_learn |richtext }}
               </section>{% endif %}
+              {% if page.prerequisites %}<section class="prerequisites about-richtext-container" id="prerequisites">
+                <h2>Prerequisites</h2>
+                {{ page.prerequisites |richtext }}
+                </section>{% endif %}
     
               {% if instructors or page.faculty_members %}
               <section class="faculty-section" id="instructors">

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -98,8 +98,11 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     </>
                   ) : null}
                   <div>
-                    <a target="_blank" rel="noreferrer"
-                      href="https://mitxonline.zendesk.com/hc/en-us/articles/16928404973979-Does-MITx-Online-offer-free-certificates-">
+                    <a
+                      target="_blank"
+                      rel="noreferrer"
+                      href="https://mitxonline.zendesk.com/hc/en-us/articles/16928404973979-Does-MITx-Online-offer-free-certificates-"
+                    >
                       What's the certificate track?
                     </a>
                   </div>

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -98,7 +98,8 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     </>
                   ) : null}
                   <div>
-                    <a target="_blank" rel="noreferrer" href="#">
+                    <a target="_blank" rel="noreferrer"
+                      href="https://mitxonline.zendesk.com/hc/en-us/articles/16928404973979-Does-MITx-Online-offer-free-certificates-">
                       What's the certificate track?
                     </a>
                   </div>


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2344

# Description (What does it do?)
Adds a link in for the certificate track on the right hand side.
Adds prerequisites to the nav bar and about sections, if it is present.

# Screenshots (if appropriate):
![Screenshot from 2023-09-25 11-38-15](https://github.com/mitodl/mitxonline/assets/7756053/1a339ec9-aee2-457f-b4d6-de99405bc946)

# How can this be tested?
1. Have a course with prerequisites (and preferably other data as well) set
2. Go to that course, you should see Prerequisites in the gray nav bar below the title. This section should display with whatever information you entered.
3. Click the link on the right hand side of the page "What's the certificate track?" and make sure it goes to the zendesk article Peter linked in the issue.
4. On another course, without prerequisites set (or the same, but without prerequisites), make sure the section & nav are gone.

# Additional Context
The program links are working for me - I will say, since that's part of the issue, if the reviewer could double check that those links work for them as well on RC, a sanity check is always helpful :)
