### PR TITLE
Fix Duplicate Courses on Catalog Page

### DIFF
--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -125,17 +125,27 @@ class CourseFilterSet(django_filters.FilterSet):
                 & Q(enrollment_start__lt=now)
                 & (Q(enrollment_end=None) | Q(enrollment_end__gt=now))
             )
-            return queryset.prefetch_related(
-                Prefetch("courseruns", queryset=enrollable_runs)
-            ).filter(courseruns__id__in=enrollable_runs.values_list("id", flat=True)).distinct()
+            return (
+                queryset.prefetch_related(
+                    Prefetch("courseruns", queryset=enrollable_runs)
+                )
+                .filter(courseruns__id__in=enrollable_runs.values_list("id", flat=True))
+                .distinct()
+            )
 
         else:
             unenrollable_runs = CourseRun.objects.filter(
                 Q(live=False) | Q(start_date__isnull=True) | Q(enrollment_end__lte=now)
             )
-            return queryset.prefetch_related(
-                Prefetch("courseruns", queryset=unenrollable_runs)
-            ).filter(courseruns__id__in=unenrollable_runs.values_list("id", flat=True)).distinct()
+            return (
+                queryset.prefetch_related(
+                    Prefetch("courseruns", queryset=unenrollable_runs)
+                )
+                .filter(
+                    courseruns__id__in=unenrollable_runs.values_list("id", flat=True)
+                )
+                .distinct()
+            )
 
     class Meta:
         model = Course

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -127,7 +127,7 @@ class CourseFilterSet(django_filters.FilterSet):
             )
             return queryset.prefetch_related(
                 Prefetch("courseruns", queryset=enrollable_runs)
-            ).filter(courseruns__id__in=enrollable_runs.values_list("id", flat=True))
+            ).filter(courseruns__id__in=enrollable_runs.values_list("id", flat=True)).distinct()
 
         else:
             unenrollable_runs = CourseRun.objects.filter(
@@ -135,7 +135,7 @@ class CourseFilterSet(django_filters.FilterSet):
             )
             return queryset.prefetch_related(
                 Prefetch("courseruns", queryset=unenrollable_runs)
-            ).filter(courseruns__id__in=unenrollable_runs.values_list("id", flat=True))
+            ).filter(courseruns__id__in=unenrollable_runs.values_list("id", flat=True)).distinct()
 
     class Meta:
         model = Course


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2411

# Description (What does it do?)
Because the filter for enrollable courses is built on course run, if there are more than one enrollable course run, the course would show multiple times on the catalog page.  To fix this, I added distinct to the course queryset to make sure we're only choosing each course once.

# How can this be tested?
Prior to pulling branch:
1. Create a course or courses with multiple course runs that are enrollable (enroll dates overlap today's date)
2. Go to /catalog and you should see this course more than once - more precisely, you should see it as many times as it has course runs that are open to enroll today
3. You can ALSO see this at /api/courses/?page=1&live=true&page__live=true&courserun_is_enrollable=true if you prefer data over gui

Pull the branch

Once the branch is updated:
1. Open the same page (/catalog and/or /api/courses...)
2. You should only see each course once.
