### PR TITLE
Course Calatog: Stay on selected department

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -239,7 +239,6 @@ export class CatalogPage extends React.Component<Props> {
    */
   changeSelectedTab = (selectTabName: string) => {
     this.setState({ tabSelected: selectTabName })
-    this.changeSelectedDepartment(ALL_DEPARTMENTS, selectTabName)
 
     if (selectTabName === PROGRAMS_TAB) {
       const { programs, programsIsLoading } = this.props

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -722,7 +722,7 @@ describe("CatalogPage", function() {
 
     // Change to the programs tab.
     inner.instance().changeSelectedTab("programs")
-    // Confirm that the selected department resets to "All Departments".
+    // Confirm that the selected department is the same as before.
     expect(inner.state().selectedDepartment).equals("History")
 
     // Change back to the courses tab.

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -727,9 +727,9 @@ describe("CatalogPage", function() {
 
     // Change back to the courses tab.
     inner.instance().changeSelectedTab("courses")
-    // All of the courses should be visible.
+    // Confirm the courses filtered are those which have a department name matching the selected department.
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
-      JSON.stringify(courses)
+      JSON.stringify([course2, course3])
     )
   })
 

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -722,8 +722,8 @@ describe("CatalogPage", function() {
 
     // Change to the programs tab.
     inner.instance().changeSelectedTab("programs")
-    // Confirm that the selected departement resets to "All Departments".
-    expect(inner.state().selectedDepartment).equals("All Departments")
+    // Confirm that the selected department resets to "All Departments".
+    expect(inner.state().selectedDepartment).equals("History")
 
     // Change back to the courses tab.
     inner.instance().changeSelectedTab("courses")


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/mitxonline/issues/1919

# Description (What does it do?)
Don't switch departments when courses or programs tab is selected.


# How can this be tested?
Go to catalog page. Select a department, switch to the programs tab. The same department should be selected.