### PR TITLE
Update course info bar to respond to archived courses

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -178,14 +178,30 @@ body.new-design {
           }
 
           .callout {
-
+            padding: 0.9375rem;
+            gap: 0.625rem;
+            flex-wrap: nowrap;
+            i.warning {
+              font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+              color: $warning;
+              padding: 0;
+              margin-top: .25rem;
+              width: fit-content;
+            }
+            p{
+              width: 95%;
+              font-size: 0.875rem;
+              color: $home-page-header-blue;
+              font-family: Inter, sans-serif;
+              margin: 0;
+            }
           }
           .callout-warning{
+            border: 1px solid rgba(255, 171, 0, 0.30);
             border-left: 2px solid $warning;
+            background: #FFF3CC;
           }
-          i.warning {
 
-          }
 
 
           .enrollment-info-icon {

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -202,8 +202,6 @@ body.new-design {
             background: #FFF3CC;
           }
 
-
-
           .enrollment-info-icon {
             max-width: 20px;
             margin-right: 12px;

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -177,6 +177,17 @@ body.new-design {
             margin: 20px 0;
           }
 
+          .callout {
+
+          }
+          .callout-warning{
+            border-left: 2px solid $warning;
+          }
+          i.warning {
+
+          }
+
+
           .enrollment-info-icon {
             max-width: 20px;
             margin-right: 12px;

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -45,7 +45,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
             <div className="row d-flex align-self-stretch callout callout-warning">
               <i className="material-symbols-outlined warning">error</i>
               <p>
-                This course is no longer active, but you can still enroll and
+                This course is no longer active, but you can still 
                 access selected content.
               </p>
             </div>

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -29,7 +29,9 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
     const product = run && run.products.length > 0 && run.products[0]
 
-    const isArchived = (moment().isAfter(run.end_date) && moment().isBefore(run.enrollment_end)) || emptyOrNil(run.enrollment_end)
+    const isArchived =
+      moment().isAfter(run.end_date) &&
+      (moment().isBefore(run.enrollment_end) || emptyOrNil(run.enrollment_end))
 
     const startDate =
       run && !emptyOrNil(run.start_date) && !run.is_self_paced && !isArchived

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -29,7 +29,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
     const product = run && run.products.length > 0 && run.products[0]
 
-    const isArchived = moment().isAfter(run.end_date) || emptyOrNil(run.end_date)
+    const isArchived = moment().isAfter(run.end_date)
 
     const startDate =
       run && !emptyOrNil(run.start_date) && !run.is_self_paced && !isArchived

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -42,9 +42,12 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
           {isArchived ? (
             <div className="row d-flex align-self-stretch callout callout-warning">
               <i className="material-symbols-outlined warning">error</i>
-              <p>This course is no longer active, but you can still enroll and access selected content.</p>
-            </div>) :
-            null}
+              <p>
+                This course is no longer active, but you can still enroll and
+                access selected content.
+              </p>
+            </div>
+          ) : null}
           <div className="row d-flex align-items-center">
             <div className="enrollment-info-icon">
               <img
@@ -53,7 +56,11 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               />
             </div>
             <div className="enrollment-info-text">
-              {startDate ? formatPrettyDate(startDate) : isArchived ? "Course content available anytime" : "Start Anytime"}
+              {startDate
+                ? formatPrettyDate(startDate)
+                : isArchived
+                  ? "Course content available anytime"
+                  : "Start Anytime"}
             </div>
           </div>
           {course && course.page ? (
@@ -127,7 +134,8 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                   >
                     Financial assistance available
                   </a>
-                </div>) : null}
+                </div>
+              ) : null}
             </div>
           </div>
         </div>

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -29,7 +29,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
     const product = run && run.products.length > 0 && run.products[0]
 
-    const isArchived = moment().isAfter(run.end_date)
+    const isArchived = moment().isAfter(run.end_date) || emptyOrNil(run.end_date)
 
     const startDate =
       run && !emptyOrNil(run.start_date) && !run.is_self_paced && !isArchived

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -45,8 +45,8 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
             <div className="row d-flex align-self-stretch callout callout-warning">
               <i className="material-symbols-outlined warning">error</i>
               <p>
-                This course is no longer active, but you can still 
-                access selected content.
+                This course is no longer active, but you can still access
+                selected content.
               </p>
             </div>
           ) : null}

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -39,10 +39,12 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     return (
       <>
         <div className="enrollment-info-box componentized">
-          <div className="row d-flex align-self-stretch callout callout-warning">
-            <i className="material-symbols-outlined warning col-1">error</i>
-            <p className="col-11">This course is no longer active, but you can still enroll and access selected content.</p>
-          </div>
+          {isArchived ? (
+            <div className="row d-flex align-self-stretch callout callout-warning">
+              <i className="material-symbols-outlined warning">error</i>
+              <p>This course is no longer active, but you can still enroll and access selected content.</p>
+            </div>) :
+            null}
           <div className="row d-flex align-items-center">
             <div className="enrollment-info-icon">
               <img

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -29,14 +29,20 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
     const product = run && run.products.length > 0 && run.products[0]
 
+    const isArchived = moment().isAfter(run.end_date)
+
     const startDate =
-      run && !emptyOrNil(run.start_date) && !run.is_self_paced
+      run && !emptyOrNil(run.start_date) && !run.is_self_paced && !isArchived
         ? moment(new Date(run.start_date))
         : null
 
     return (
       <>
         <div className="enrollment-info-box componentized">
+          <div className="row d-flex align-self-stretch callout callout-warning">
+            <i className="material-symbols-outlined warning col-1">error</i>
+            <p className="col-11">This course is no longer active, but you can still enroll and access selected content.</p>
+          </div>
           <div className="row d-flex align-items-center">
             <div className="enrollment-info-icon">
               <img
@@ -45,7 +51,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               />
             </div>
             <div className="enrollment-info-text">
-              {startDate ? formatPrettyDate(startDate) : "Start Anytime"}
+              {startDate ? formatPrettyDate(startDate) : isArchived ? "Course content available anytime" : "Start Anytime"}
             </div>
           </div>
           {course && course.page ? (
@@ -97,30 +103,29 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                       </div>
                     </>
                   ) : null}
-                  <div>
-                    <a
-                      target="_blank"
-                      rel="noreferrer"
-                      href="https://mitxonline.zendesk.com/hc/en-us/articles/16928404973979-Does-MITx-Online-offer-free-certificates-"
-                    >
-                      What's the certificate track?
-                    </a>
-                  </div>
-                  {course.page.financial_assistance_form_url ? (
-                    <div>
-                      <a
-                        target="_blank"
-                        rel="noreferrer"
-                        href={course.page.financial_assistance_form_url}
-                      >
-                        Financial assistance available
-                      </a>
-                    </div>
-                  ) : null}
                 </>
               ) : (
                 "No certificate available."
               )}
+              <div>
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://mitxonline.zendesk.com/hc/en-us/articles/16928404973979-Does-MITx-Online-offer-free-certificates-"
+                >
+                  What's the certificate track?
+                </a>
+              </div>
+              {course.page.financial_assistance_form_url ? (
+                <div>
+                  <a
+                    target="_blank"
+                    rel="noreferrer"
+                    href={course.page.financial_assistance_form_url}
+                  >
+                    Financial assistance available
+                  </a>
+                </div>) : null}
             </div>
           </div>
         </div>

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -29,7 +29,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
     const product = run && run.products.length > 0 && run.products[0]
 
-    const isArchived = moment().isAfter(run.end_date)
+    const isArchived = (moment().isAfter(run.end_date) && moment().isBefore(run.enrollment_end)) || emptyOrNil(run.enrollment_end)
 
     const startDate =
       run && !emptyOrNil(run.start_date) && !run.is_self_paced && !isArchived

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -16,6 +16,7 @@
       media="all"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
       media="none" onload="if(media!='all') media='all'">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     {% js_settings %}
     {% render_bundle 'style' %}
     {% noindex_meta %}


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2472

# Description (What does it do?)
This PR conditionally displays "Course content available anytime", the callout, and "No certificate available" on courses which fall under "isArchived" which is:
- end date is earlier than now AND
- enrollment_end is empty or later than now

# Screenshots (if appropriate):
![Screenshot from 2023-09-26 12-58-09](https://github.com/mitodl/mitxonline/assets/7756053/3ca470a4-5d23-4542-9433-316085868821)


# How can this be tested?
To test this properly, before pulling, set up 2 courses (amongst others) with course runs that match the following:
For both: start_date and _end date are both in the past, enrollment start is in the past.
1. enrollment_end is in the future
2. enrollment_end is empty

Open these prior and should see the old behavior (look like other pages)
pull the PR
reload page
Should see the new callout & words.