### PR TITLE
Update the Certificate field for archived courses

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -102,7 +102,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               />
             </div>
             <div className="enrollment-info-text">
-              {product ? (
+              {product && !isArchived ? (
                 <>
                   Certificate track:{" "}
                   {formatLocalePrice(getFlexiblePriceForProduct(product))}


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2472

# Description (What does it do?)
Updates the course about page to have certificate not shown when archived course.

# Screenshots (if appropriate):
![Screenshot from 2023-09-28 11-10-49](https://github.com/mitodl/mitxonline/assets/7756053/36d10dab-c6a8-4560-80ee-eb70887740ce)


# How can this be tested?
Using an archived course, ensure that the certificate option is no longer shown. This should read "No certificate available" for courses that match `isArchived()`
This should align with the figma linked in Additional Context

Ensure that other courses still display certificate information as before.

# Additional Context
[Figma](https://www.figma.com/file/Gs4zIhOFv5gVvafawwl6PF/MITx-Online?type=design&node-id=1592-6996&mode=dev)