### PR TITLE
don't leak grades in program record before course completed

### DIFF
--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -44,6 +44,7 @@ from flexiblepricing.constants import FlexiblePriceStatus
 from flexiblepricing.factories import FlexiblePriceFactory
 from main.test_utils import assert_drf_json_equal, drf_datetime
 from main import features
+from mitol.common.utils.datetime import now_in_utc
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
 pytestmark = [pytest.mark.django_db]
@@ -483,8 +484,21 @@ def test_program_requirement_deletion():
 @pytest.mark.parametrize(
     "enrollment_mode", [EDX_ENROLLMENT_VERIFIED_MODE, EDX_ENROLLMENT_AUDIT_MODE]
 )
+# @pytest.mark.parametrize(
+#     "certificate_generated, certificate_available_date_ended, course_ended",
+#     (
+#         [True, False, False],
+#         [False, True, False],
+#         [False, False, True],
+#     ),
+# )
 def test_learner_record_serializer(
-    mock_context, program_with_empty_requirements, enrollment_mode
+    mock_context,
+    program_with_empty_requirements,
+    enrollment_mode,
+    # certificate_generated,
+    # certificate_available_date_ended,
+    # course_ended,
 ):
     """Verify that saving the requirements for one program doesn't affect other programs"""
 
@@ -634,6 +648,11 @@ def test_learner_record_serializer(
         "title": courses[0].title,
     }
     if enrollment_mode == EDX_ENROLLMENT_AUDIT_MODE:
+        course_0_payload["grade"] = None
+    if course_runs[0].certificate_available_date >= now_in_utc() or (
+        not course_runs[0].certificate_available_date
+        and course_runs[0].end_date >= now_in_utc()
+    ):
         course_0_payload["grade"] = None
     assert user_info_payload == serialized_data["user"]
     assert program_requirements_payload == serialized_data["program"]["requirements"]

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -484,21 +484,8 @@ def test_program_requirement_deletion():
 @pytest.mark.parametrize(
     "enrollment_mode", [EDX_ENROLLMENT_VERIFIED_MODE, EDX_ENROLLMENT_AUDIT_MODE]
 )
-# @pytest.mark.parametrize(
-#     "certificate_generated, certificate_available_date_ended, course_ended",
-#     (
-#         [True, False, False],
-#         [False, True, False],
-#         [False, False, True],
-#     ),
-# )
 def test_learner_record_serializer(
-    mock_context,
-    program_with_empty_requirements,
-    enrollment_mode,
-    # certificate_generated,
-    # certificate_available_date_ended,
-    # course_ended,
+    mock_context, program_with_empty_requirements, enrollment_mode
 ):
     """Verify that saving the requirements for one program doesn't affect other programs"""
 


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/2303

# Description (What does it do?)
<!--- Describe your changes in detail -->
Updates `LearnerRecordSerializer` to only return grades if one of these conditions are met:
- A certificate is generated (this has already covered in existing code)
- The course's certificate available date has passed
- If there is no course certificate available date, then the course has ended


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Setup a program and related courses
- Setup a run 
     - start date is in the pass and end date is in the future
     - certificate available date in the future
- Enroll in program
- Create passing grade for run created above
- Go to your program record, make sure grade is not displayed for that run
- Test any condition mentioned in the description, grade should be displayed for that run

<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
