### PR TITLE
Fix start date test on course info card

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -23,11 +23,13 @@ type CourseInfoBoxProps = {
 }
 
 const getStartDateText = (run: BaseCourseRun, isArchived: boolean = false) => {
+  if (isArchived) {
+    return "Course content available anytime"
+  }
   return run && !emptyOrNil(run.start_date) && !run.is_self_paced
-    ? formatPrettyDate(moment(new Date(run.start_date)))
-    : isArchived
-      ? "Course content available anytime"
-      : "Start Anytime"
+    ? (run.start_date > moment() ? "Starts: " : "Started: ") +
+        formatPrettyDate(moment(new Date(run.start_date)))
+    : "Start Anytime"
 }
 
 export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProps> {
@@ -120,7 +122,6 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
         }
       })
     }
-    const startedText = run.start_date > moment() ? "Starts: " : "Started: "
     return (
       <>
         <div className="enrollment-info-box componentized">
@@ -141,21 +142,20 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               />
             </div>
             <div className="enrollment-info-text">
-              {startedText}
               {getStartDateText(run, isArchived)}
             </div>
-            <button
-              className="more-enrollment-info"
-              onClick={() => this.toggleShowMoreEnrollDates()}
-            >
-              {moreEnrollableCourseRuns
-                ? this.state.showMoreEnrollDates
-                  ? "Show Less"
-                  : "More Dates"
-                : null}
-            </button>
-            {this.state.showMoreEnrollDates ? (
-              <ul className="more-dates-enrollment-list">{startDates}</ul>
+            {!isArchived && moreEnrollableCourseRuns ? (
+              <>
+                <button
+                  className="more-enrollment-info"
+                  onClick={() => this.toggleShowMoreEnrollDates()}
+                >
+                  {this.state.showMoreEnrollDates ? "Show Less" : "More Dates"}
+                </button>
+                {this.state.showMoreEnrollDates ? (
+                  <ul className="more-dates-enrollment-list">{startDates}</ul>
+                ) : null}
+              </>
             ) : null}
           </div>
           {course && course.page ? (


### PR DESCRIPTION
# What are the relevant tickets?
Fix this release https://github.com/mitodl/mitxonline/pull/1930

# Description (What does it do?)
If the course is archived it shows:
`Course content available anytime`
If course is self paced:
`Start Anytime`

if course has start date shows:
`Started: September 22, 2023`
# Screenshots (if appropriate):
<img width="392" alt="Screen Shot 2023-09-29 at 8 23 13 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/6b143cbd-ef27-40a5-9e1b-169cde264816">
<img width="432" alt="Screen Shot 2023-09-29 at 8 23 47 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/3de59d5c-6b3d-40a1-9c62-f2a1cc884933">





