### PR TITLE
Carousel Fixes

### DIFF
--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -59,7 +59,7 @@
         </div>
       </div>
       <div class="featured-product-listing">
-        <div class="carousel-content d-flex" role="listbox">
+        <div class="carousel-content d-flex">
             {% for product in products %}
               {% include "partials/featured_product_card.html" with product=product order=forloop.counter %}
             {% endfor %}

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
-{% block bodyclass %}{% if show_new_design_hero or show_new_featured_carousel or show_home_page_video_component %}new-design{% endif %}{% endblock %}
 
 {% load static wagtail_img_src feature_img_src %}
 {% load wagtailcore_tags wagtailembeds_tags %}
 
 {% block title %}{{ site_name }}{% endblock %}
+
+{% block bodyclass %}{% if show_new_design_hero or show_new_featured_carousel or show_home_page_video_component %}new-design{% endif %}{% endblock %}
 
 {% block content %}
 {% if show_new_design_hero %}
@@ -43,18 +44,18 @@
 {% endif %}
 {% if show_new_featured_carousel %}
   <div class="featured-product-section-container d-flex flex-column container">
-    <div class="featured-product-section d-flex row carousel slide" id="featuredProductCarousel">
+    <div class="featured-product-section d-flex row" id="featuredProductCarousel">
       <div class="featured-product-header d-flex row col-12">
         {% if product_cards_section_title %}
           <h3 class="featured-product-header-title col-8">{{ product_cards_section_title }}</h3>
         {% endif %}
         <div class="featured-product-arrows col-4">
-          <a data-bs-target="#featuredProductCarousel" class="prev-slides"  data-bs-slide-to id="featuredCarouselPrev">
+          <button class="prev-slides"  id="featuredCarouselPrev" aria-label="Previous">
             <img class="arrow prev-arrow" src="/static/images/featured-products-left-arrow.svg" alt="Previous Arrow" />
-          </a>
-          <a data-bs-target="#featuredProductCarousel" class="next-slides" data-bs-slide-to id="featuredCarouselNext">
+          </button>
+          <button class="next-slides" id="featuredCarouselNext" aria-label="Next">
             <img class="arrow next-arrow" src="/static/images/featured-products-right-arrow.svg" alt="Next Arrow" />
-          </a>
+          </button>
         </div>
       </div>
       <div class="featured-product-listing">
@@ -200,4 +201,3 @@
   </div>
 {% endif %}
 {% endblock %}
-

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -50,16 +50,16 @@
           <h3 class="featured-product-header-title col-8">{{ product_cards_section_title }}</h3>
         {% endif %}
         <div class="featured-product-arrows col-4">
-          <button class="prev-slides"  id="featuredCarouselPrev" aria-label="Previous">
+          <button class="prev-button"  id="featuredCarouselPrev" aria-label="Previous">
             <img class="arrow prev-arrow" src="/static/images/featured-products-left-arrow.svg" alt="Previous Arrow" />
           </button>
-          <button class="next-slides" id="featuredCarouselNext" aria-label="Next">
+          <button class="next-button" id="featuredCarouselNext" aria-label="Next">
             <img class="arrow next-arrow" src="/static/images/featured-products-right-arrow.svg" alt="Next Arrow" />
           </button>
         </div>
       </div>
       <div class="featured-product-listing">
-        <div class="carousel-inner d-flex" role="listbox">
+        <div class="carousel-content d-flex" role="listbox">
             {% for product in products %}
               {% include "partials/featured_product_card.html" with product=product order=forloop.counter %}
             {% endfor %}

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -49,10 +49,10 @@
           <h3 class="featured-product-header-title col-8">{{ product_cards_section_title }}</h3>
         {% endif %}
         <div class="featured-product-arrows col-4">
-          <a href="#featuredProductCarousel" class="prev" id="featuredCarouselPrev">
+          <a data-bs-target="#featuredProductCarousel" class="prev"  data-bs-slide-to id="featuredCarouselPrev">
             <img class="arrow prev-arrow" src="/static/images/featured-products-left-arrow.svg" alt="Previous Arrow" />
           </a>
-          <a href="#featuredProductCarousel" class="next" id="featuredCarouselNext">
+          <a data-bs-target="#featuredProductCarousel" class="next" data-bs-slide-to id="featuredCarouselNext">
             <img class="arrow next-arrow" src="/static/images/featured-products-right-arrow.svg" alt="Next Arrow" />
           </a>
         </div>

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -49,10 +49,10 @@
           <h3 class="featured-product-header-title col-8">{{ product_cards_section_title }}</h3>
         {% endif %}
         <div class="featured-product-arrows col-4">
-          <a href="#featuredProductCarousel" class="prev" data-bs-slide="prev" onclick="handleNavigationClick('prev');">
+          <a href="#featuredProductCarousel" class="prev" id="featuredCarouselPrev">
             <img class="arrow prev-arrow" src="/static/images/featured-products-left-arrow.svg" alt="Previous Arrow" />
           </a>
-          <a href="#featuredProductCarousel" class="next" data-bs-slide="next" onclick="handleNavigationClick('next');">
+          <a href="#featuredProductCarousel" class="next" id="featuredCarouselNext">
             <img class="arrow next-arrow" src="/static/images/featured-products-right-arrow.svg" alt="Next Arrow" />
           </a>
         </div>
@@ -200,47 +200,4 @@
   </div>
 {% endif %}
 {% endblock %}
-{% block scripts %}
-<script>
 
-    let scrollPosition = 0;
-    let numberOfCards = 4;
-
-    function updatePosition () {
-        position = 0;
-    }
-
-  function handleNavigationClick(e) {
-      let carouselWidth = $(".carousel-inner")[0].scrollWidth;
-      let cardWidth = ($(".carousel-item").width() + 20);
-      if (window.matchMedia("(max-width: 1199.98px)").matches) {
-        numberOfCards = 3;
-      }
-      else if (window.matchMedia("(max-width: 991.98px)").matches) {
-        numberOfCards = 2;
-      }
-      else if (window.matchMedia("(max-width: 767.98px)").matches) {
-        numberOfCards = 1;
-      }
-      if (e==="next") {
-          if (scrollPosition < carouselWidth - (cardWidth * numberOfCards)) {
-            scrollPosition += cardWidth * numberOfCards;
-            $(".carousel-inner").animate(
-              { scrollLeft: scrollPosition },
-              600
-            );
-          }
-      } else if (e==="prev") {
-          if (scrollPosition > 0) {
-            scrollPosition -= cardWidth * numberOfCards;
-            $(".carousel-inner").animate(
-              { scrollLeft: scrollPosition },
-              600
-            );
-          }
-        }
-      }
-  window.addEventListener("resize", updatePosition);
-
-</script>
-{% endblock %}

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -49,10 +49,10 @@
           <h3 class="featured-product-header-title col-8">{{ product_cards_section_title }}</h3>
         {% endif %}
         <div class="featured-product-arrows col-4">
-          <a data-bs-target="#featuredProductCarousel" class="prev"  data-bs-slide-to id="featuredCarouselPrev">
+          <a data-bs-target="#featuredProductCarousel" class="prev-slides"  data-bs-slide-to id="featuredCarouselPrev">
             <img class="arrow prev-arrow" src="/static/images/featured-products-left-arrow.svg" alt="Previous Arrow" />
           </a>
-          <a data-bs-target="#featuredProductCarousel" class="next" data-bs-slide-to id="featuredCarouselNext">
+          <a data-bs-target="#featuredProductCarousel" class="next-slides" data-bs-slide-to id="featuredCarouselNext">
             <img class="arrow next-arrow" src="/static/images/featured-products-right-arrow.svg" alt="Next Arrow" />
           </a>
         </div>

--- a/frontend/public/package.json
+++ b/frontend/public/package.json
@@ -112,6 +112,7 @@
     "serialize-javascript": "3.1.0",
     "shelljs": "0.8.5",
     "sinon": "4.5.0",
+    "slick-carousel": "^1.8.1",
     "style-loader": "3.3.1",
     "styled-components": "4.4.1",
     "url-join": "4.0.1",

--- a/frontend/public/scss/home-page/featured-product-cards.scss
+++ b/frontend/public/scss/home-page/featured-product-cards.scss
@@ -126,18 +126,17 @@
         padding-top: 2rem;
       }
 
-      .carousel-inner {
-          width: 110%;
-          max-width: unset;
+      .carousel-content {
+          width: 100%;
           gap: 20px;
           padding-bottom: 2rem;
         @include media-breakpoint-down(sm) {
           max-width: 100%;
         }
 
-          a.carousel-item {
+          a.featured-product-card-link {
             text-decoration: none;
-            width: 20%;
+            width: 25%;
             margin-right: 0;
             flex: 0 0 20%;
             display: block;
@@ -145,25 +144,7 @@
             padding-left: inherit;
             padding-right: inherit;
             transition: transform 0.6s linear;
-            @include media-breakpoint-down(xl) {
-              width: 25%;
-              flex: 0 0 25%;
-            }
-            @include media-breakpoint-down(lg) {
-              width: 33.33333%;
-              flex: 0 0 33.33333%;
-            }
-            @include media-breakpoint-down(md) {
-              width: 50%;
-              flex: 0 0 50%;
-            }
-            @include media-breakpoint-down(sm) {
-              width: 100%;
-              flex: 0 0 100%;
-              height: unset;
-              padding-left: 2.44rem;
-              padding-right: 2.44rem;
-            }
+
             .featured-product-card {
               height: 100%;
               border-radius: 5px;
@@ -176,9 +157,7 @@
               box-shadow: 0 2px 3px 0 rgba(18, 38, 49, 0.15);
               @include media-breakpoint-down(sm) {
                 padding: unset;
-
               }
-
               .featured-product-thumb {
                 display: flex;
                 position: relative;

--- a/frontend/public/scss/home-page/featured-product-cards.scss
+++ b/frontend/public/scss/home-page/featured-product-cards.scss
@@ -88,6 +88,12 @@
           margin-top: 30px;
         }
 
+        button {
+          border: none;
+          background: transparent;
+          padding: 0;
+        }
+
         .arrow {
           display: flex;
           padding: 8px 15px;
@@ -125,127 +131,110 @@
         margin-top: 0;
         padding-top: 2rem;
       }
-
       .carousel-content {
           width: 100%;
-          gap: 20px;
           padding-bottom: 2rem;
-        @include media-breakpoint-down(sm) {
-          max-width: 100%;
+        .slick-slide {
+          margin: 0 .75rem;
+        }
+        .slick-list {
+          margin: 0 -.75rem;
+        }
+        .slick-slider {
+          overflow-x: hidden;
         }
 
-          a.featured-product-card-link {
-            text-decoration: none;
-            width: 25%;
-            margin-right: 0;
-            flex: 0 0 20%;
-            display: block;
-            height: 260.953px;
-            padding-left: inherit;
-            padding-right: inherit;
-            transition: transform 0.6s linear;
-
-            .featured-product-card {
-              height: 100%;
+        a.featured-product-card-link {
+          text-decoration: none;
+          margin-right: 0;
+          flex: 0 0 20%;
+          height: 290px;
+          .featured-product-card {
+            height: 95%;
+            border-radius: 5px;
+            flex-direction: column;
+            align-items: center;
+            border: 1px solid $home-page-grey-lite;
+            background: #FFF;
+            padding: 0;
+            flex: none;
+            box-shadow: 0 2px 3px 0 rgba(18, 38, 49, 0.15);
+            @include media-breakpoint-down(sm) {
+              padding: unset;
+            }
+            .featured-product-thumb {
+              display: flex;
+              position: relative;
+              justify-content: center;
               border-radius: 5px;
+              width: 100%;
+              height: 10.6875rem;
+            }
+
+            img {
+              width: 100%;
+              height: 10.6875rem;
+              border-radius: 5px 5px 0 0;
+              background: rgba(0, 0, 0, 0.20);
+              object-position: center;
+              object-fit: cover;
+            }
+            .badge-program-type {
+              display: inline-flex;
+              padding: 8px 15px;
+              align-items: flex-start;
+              border-radius: 0px 3px 0px 0px;
+              background: $home-page-header-blue;
+              position: absolute;
+              left: 0;
+              bottom: 0;
+              color: #FFF;
+              font-size: 0.75rem;
+              font-weight: 700;
+              font-family: Inter, sans-serif;
+            }
+            .badge-program-type-none {
+              background: transparent;
+            }
+
+            .featured-product-info {
+              padding: 15px;
+              display: flex;
               flex-direction: column;
-              align-items: center;
-              border: 1px solid $home-page-grey-lite;
-              background: #FFF;
-              padding: 0;
-              flex: none;
-              box-shadow: 0 2px 3px 0 rgba(18, 38, 49, 0.15);
-              @include media-breakpoint-down(sm) {
-                padding: unset;
-              }
-              .featured-product-thumb {
-                display: flex;
-                position: relative;
-                justify-content: center;
-                border-radius: 5px;
-                width: 100%;
-                height: 10.6875rem;
-              }
+              align-items: flex-start;
+              gap: .31rem;
+              align-self: stretch;
 
-              img {
-                width: 100%;
-                height: 10.6875rem;
-                border-radius: 5px 5px 0 0;
-                background: rgba(0, 0, 0, 0.20);
-                object-position: center;
-                object-fit: cover;
-              }
-              .badge-program-type {
-                display: inline-flex;
-                padding: 8px 15px;
-                align-items: flex-start;
-                border-radius: 0px 3px 0px 0px;
-                background: $home-page-header-blue;
-                position: absolute;
-                left: 0;
-                bottom: 0;
-                color: #FFF;
-                font-size: 0.75rem;
-                font-weight: 700;
-                font-family: Inter, sans-serif;
-              }
-              .badge-program-type-none {
-                background: transparent;
-              }
-
-              .featured-product-info {
-                padding: 15px;
-                display: flex;
-                flex-direction: column;
-                align-items: flex-start;
-                gap: .31rem;
+              p.date {
+                color: $home-page-grey-text;
+                font-size: 12px;
+                margin-bottom: 5px;
+                overflow: hidden;
                 align-self: stretch;
+                text-overflow: ellipsis;
+                font-weight: 400;
+              }
 
-                p.date {
-                  color: $home-page-grey-text;
-                  font-size: 12px;
-                  margin-bottom: 5px;
-                  overflow: hidden;
-                  align-self: stretch;
-                  text-overflow: ellipsis;
-                  font-weight: 400;
-                }
-
-                h2.featured-product-card-title {
-                  height: 38px;
-                  align-self: stretch;
-                  color: $home-page-header-blue;
-                  font-size: 0.875rem;
-                  font-family: Inter, sans-serif;
-                  margin-top: 0;
-                  display: -webkit-box;
-                  -webkit-line-clamp: 2;
-                  -webkit-box-orient: vertical;
-                  overflow: hidden;
-                  line-height: 18px;
-                }
-                h2.featured-product-card-title.program-title {
-                  height: 57.953px;
-                }
+              h2.featured-product-card-title {
+                height: 38px;
+                align-self: stretch;
+                color: $home-page-header-blue;
+                font-size: 0.875rem;
+                font-family: Inter, sans-serif;
+                margin-top: 0;
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                line-height: 18px;
+              }
+              h2.featured-product-card-title.program-title {
+                height: 57.953px;
               }
             }
           }
         }
-      }
-
-      @include media-breakpoint-down(sm) {
-        .carousel-inner .carousel-item > div {
-          display: none;
         }
-        .carousel-inner .carousel-item > div:first-child {
-          display: block;
-        }
-      }
-
-      .carousel-inner .carousel-item.active,
-      .carousel-inner .carousel-item-next,
-      .carousel-inner .carousel-item-prev {
-        display: flex;
       }
     }
 

--- a/frontend/public/scss/home-page/featured-product-cards.scss
+++ b/frontend/public/scss/home-page/featured-product-cards.scss
@@ -58,9 +58,12 @@
       padding: 3rem 0 1.8rem 0;
       flex-shrink: 0;
       fill: $home-page-grey-lite;
-      @include media-breakpoint-down(sm) {
+      @media (max-width: 601px) {
+        padding-top: 5rem;
+      }
+      @media (max-width: 481px) {
         width: 100%;
-        padding-top: 0;
+        padding-top: 1rem;
         justify-content: space-between;
       }
 
@@ -69,11 +72,10 @@
         font-size: 25px;
         padding-left: 0;
         margin-bottom: 0;
-        @include media-breakpoint-down(sm) {
+        @media (max-width: 481px)  {
           width: 176px;
           font-size: 18px;
           margin-left: 15px;
-          margin-top: 30px;
         }
       }
 
@@ -83,9 +85,8 @@
         justify-content: flex-end;
         gap: 10px;
         padding: 0;
-        @include media-breakpoint-down(sm) {
+        @media (max-width: 481px)  {
           margin-right: 15px;
-          margin-top: 30px;
         }
 
         button {
@@ -125,11 +126,11 @@
       flex-shrink: 0;
       padding: 0 0 17px 0;
 
-      @include media-breakpoint-down(sm) {
-        width: 100%;
+      @media (max-width: 481px) {
+        width: calc(100% - 4.88rem);
         padding-bottom: 0;
-        margin-top: 0;
-        padding-top: 2rem;
+        margin-top: .5rem;
+        padding-top: 3rem;
       }
       .carousel-content {
           width: 100%;
@@ -243,12 +244,12 @@
       display: flex;
       margin-top: 17px;
       width: 100%;
-      @include media-breakpoint-down(sm) {
+      @media (max-width: 481px)  {
         width: 100%;
-        margin-top: 30px;
+        margin-top: 3rem;
         padding-bottom: 0;
-        padding-left: 2.44rem;
-        padding-right: 2.44rem;
+        padding-left: 15px;
+        padding-right: 15px;
       }
 
       a.view-catalog-button {
@@ -264,7 +265,7 @@
         font-weight: 700;
         margin: auto;
         text-decoration: none;
-        @include media-breakpoint-down(sm) {
+        @media (max-width: 481px)  {
           width: 100%;
         }
       }

--- a/frontend/public/scss/home-page/featured-product-cards.scss
+++ b/frontend/public/scss/home-page/featured-product-cards.scss
@@ -170,32 +170,33 @@
               border-radius: 5px;
               width: 100%;
               height: 10.6875rem;
-            }
 
-            img {
-              width: 100%;
-              height: 10.6875rem;
-              border-radius: 5px 5px 0 0;
-              background: rgba(0, 0, 0, 0.20);
-              object-position: center;
-              object-fit: cover;
-            }
-            .badge-program-type {
-              display: inline-flex;
-              padding: 8px 15px;
-              align-items: flex-start;
-              border-radius: 0px 3px 0px 0px;
-              background: $home-page-header-blue;
-              position: absolute;
-              left: 0;
-              bottom: 0;
-              color: #FFF;
-              font-size: 0.75rem;
-              font-weight: 700;
-              font-family: Inter, sans-serif;
-            }
-            .badge-program-type-none {
-              background: transparent;
+              img {
+                width: 100%;
+                height: 10.6875rem;
+                border-radius: 5px 5px 0 0;
+                object-position: center;
+                object-fit: cover;
+              }
+
+              .badge-program-type {
+                display: inline-flex;
+                padding: 8px 15px;
+                align-items: flex-start;
+                border-radius: 0px 3px 0px 0px;
+                background: $home-page-header-blue;
+                position: absolute;
+                left: 0;
+                bottom: 0;
+                color: #FFF;
+                font-size: 0.75rem;
+                font-weight: 700;
+                font-family: Inter, sans-serif;
+              }
+
+              .badge-program-type-none {
+                background: transparent;
+              }
             }
 
             .featured-product-info {

--- a/frontend/public/scss/home-page/featured-product-cards.scss
+++ b/frontend/public/scss/home-page/featured-product-cards.scss
@@ -233,7 +233,7 @@
                 }
 
                 h2.featured-product-card-title {
-                  height: 33px;
+                  height: 38px;
                   align-self: stretch;
                   color: $home-page-header-blue;
                   font-size: 0.875rem;

--- a/frontend/public/scss/layout.scss
+++ b/frontend/public/scss/layout.scss
@@ -5,6 +5,8 @@
 @import "~react-day-picker/lib/style";
 @import "~bootstrap/scss/bootstrap";
 @import "~video.js/dist/video-js";
+@import "~slick-carousel/slick/slick.css";
+@import "~slick-carousel/slick/slick-theme.css";
 @import "common";
 @import "loader";
 @import "auth";

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -28,20 +28,13 @@ $(".dates-tooltip").on("shown.bs.popover", () => {
 })
 
 $(document).ready(function() {
-  $('#featuredProductCarousel').slick({
+  $('.carousel-content').slick({
     accessibility: true,
     arrows:        true,
-    appendArrows:  $('.featured-product-arrows'),
-    prevArrow:     $('.prev-slides'),
-    nextArrow:     $('.next-slides'),
+    prevArrow:     $('.prev-button'),
+    nextArrow:     $('.next-button'),
+    focusOnChange: true,
     responsive:    [{
-      breakpoint: 1024,
-      settings:   {
-        slidesToShow:   4,
-        slidesToScroll: 4
-      }
-    },
-    {
       breakpoint: 960,
       settings:   {
         slidesToShow:   3,
@@ -63,7 +56,7 @@ $(document).ready(function() {
       }
     }
     ],
-    slidesToShow:   5,
+    slidesToShow:   4,
     slidesToScroll: 4,
   })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -28,35 +28,36 @@ $(".dates-tooltip").on("shown.bs.popover", () => {
 })
 
 $(document).ready(function() {
-  $('.carousel-content').slick({
+  $(".carousel-content").slick({
     accessibility: true,
     arrows:        true,
-    prevArrow:     $('.prev-button'),
-    nextArrow:     $('.next-button'),
+    prevArrow:     $(".prev-button"),
+    nextArrow:     $(".next-button"),
     focusOnChange: true,
-    responsive:    [{
-      breakpoint: 1025,
-      settings:   {
-        slidesToShow:   3,
-        slidesToScroll: 3
+    responsive:    [
+      {
+        breakpoint: 1025,
+        settings:   {
+          slidesToShow:   3,
+          slidesToScroll: 3
+        }
+      },
+      {
+        breakpoint: 605,
+        settings:   {
+          slidesToShow:   2,
+          slidesToScroll: 2
+        }
+      },
+      {
+        breakpoint: 480,
+        settings:   {
+          slidesToShow:   1,
+          slidesToScroll: 1
+        }
       }
-    },
-    {
-      breakpoint: 605,
-      settings:   {
-        slidesToShow:   2,
-        slidesToScroll: 2
-      }
-    },
-    {
-      breakpoint: 480,
-      settings:   {
-        slidesToShow:   1,
-        slidesToScroll: 1
-      }
-    }
     ],
     slidesToShow:   4,
-    slidesToScroll: 4,
+    slidesToScroll: 4
   })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -25,3 +25,35 @@ $(".dates-tooltip").on("shown.bs.popover", () => {
     $(".dates-tooltip").focus()
   })
 })
+
+document.addEventListener("DOMContentLoaded", function() {
+  const prevButton = document.getElementById("featuredCarouselPrev")
+  const nextButton = document.getElementById("featuredCarouselNext")
+  const featuredCarouselElement = document.getElementById("featuredProductCarousel")
+  const carouselInner = document.getElementsByClassName("carousel-inner")[0]
+
+  prevButton.addEventListener("click", function() {
+    setToPosition("prev")
+  })
+  nextButton.addEventListener("click", function() {
+    setToPosition("next")
+  })
+
+  function setToPosition(direction) {
+    const bootstrap = require("bootstrap")
+    const featuredCarousel = bootstrap.Carousel.getInstance(featuredCarouselElement)
+    const cardOffset = window.matchMedia("(max-width: 1199.98px)").matches ? 3 : window.matchMedia("(max-width: 991.98px)").matches ? 2 : window.matchMedia("(max-width: 767.98px)").matches ? 1 : 4
+    const currentCard = carouselInner.getElementsByClassName("active")[0]
+    const cardArray = Array.from(carouselInner.children)
+    const currentPosition = cardArray.indexOf(currentCard)
+    const numberOfCards = cardArray.length - 1
+    let prevPosition = currentPosition - cardOffset
+    prevPosition = prevPosition >= 0 ? prevPosition : 0
+    let nextPosition = currentPosition + cardOffset
+    nextPosition = currentPosition + cardOffset <= numberOfCards ? nextPosition : numberOfCards
+    let toPosition = direction === "prev" ? prevPosition : nextPosition
+    toPosition = toPosition.toString()
+    console.log(toPosition)
+    featuredCarousel.to(toPosition)
+  }
+})

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -35,14 +35,14 @@ $(document).ready(function() {
     nextArrow:     $('.next-button'),
     focusOnChange: true,
     responsive:    [{
-      breakpoint: 960,
+      breakpoint: 1025,
       settings:   {
         slidesToShow:   3,
         slidesToScroll: 3
       }
     },
     {
-      breakpoint: 600,
+      breakpoint: 605,
       settings:   {
         slidesToShow:   2,
         slidesToScroll: 2

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -55,6 +55,6 @@ document.addEventListener("DOMContentLoaded", function() {
     let toPosition = direction === "prev" ? prevPosition : nextPosition
     toPosition = toPosition.toString()
     console.log(toPosition)
-    featuredCarousel.to(featuredCarousel[toPosition])
+    featuredCarousel.to(toPosition)
   }
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -44,6 +44,7 @@ document.addEventListener("DOMContentLoaded", function() {
     const featuredCarousel = bootstrap.Carousel.getInstance(featuredCarouselElement)
     const cardOffset = window.matchMedia("(max-width: 1199.98px)").matches ? 3 : window.matchMedia("(max-width: 991.98px)").matches ? 2 : window.matchMedia("(max-width: 767.98px)").matches ? 1 : 4
     const currentCard = carouselInner.getElementsByClassName("active")[0]
+    console.log(currentCard)
     const cardArray = Array.from(carouselInner.children)
     const currentPosition = cardArray.indexOf(currentCard)
     const numberOfCards = cardArray.length - 1
@@ -54,6 +55,6 @@ document.addEventListener("DOMContentLoaded", function() {
     let toPosition = direction === "prev" ? prevPosition : nextPosition
     toPosition = toPosition.toString()
     console.log(toPosition)
-    featuredCarousel.to(toPosition)
+    featuredCarousel.to(featuredCarousel[toPosition])
   }
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -3,6 +3,7 @@ import "jquery"
 import "bootstrap"
 import "video.js"
 import "videojs-youtube/dist/Youtube"
+import "slick-carousel"
 import $ from "jquery"
 $(document).ready(function() {
   $(".dates-tooltip").popover({
@@ -26,35 +27,43 @@ $(".dates-tooltip").on("shown.bs.popover", () => {
   })
 })
 
-document.addEventListener("DOMContentLoaded", function() {
-  const prevButton = document.getElementById("featuredCarouselPrev")
-  const nextButton = document.getElementById("featuredCarouselNext")
-  const featuredCarouselElement = document.getElementById("featuredProductCarousel")
-  const carouselInner = document.getElementsByClassName("carousel-inner")[0]
-
-  prevButton.addEventListener("click", function() {
-    setToPosition("prev")
+$(document).ready(function() {
+  $('#featuredProductCarousel').slick({
+    accessibility: true,
+    arrows:        true,
+    appendArrows:  $('.featured-product-arrows'),
+    prevArrow:     $('.prev-slides'),
+    nextArrow:     $('.next-slides'),
+    responsive:    [{
+      breakpoint: 1024,
+      settings:   {
+        slidesToShow:   4,
+        slidesToScroll: 4
+      }
+    },
+    {
+      breakpoint: 960,
+      settings:   {
+        slidesToShow:   3,
+        slidesToScroll: 3
+      }
+    },
+    {
+      breakpoint: 600,
+      settings:   {
+        slidesToShow:   2,
+        slidesToScroll: 2
+      }
+    },
+    {
+      breakpoint: 480,
+      settings:   {
+        slidesToShow:   1,
+        slidesToScroll: 1
+      }
+    }
+    ],
+    slidesToShow:   5,
+    slidesToScroll: 4,
   })
-  nextButton.addEventListener("click", function() {
-    setToPosition("next")
-  })
-
-  function setToPosition(direction) {
-    const bootstrap = require("bootstrap")
-    const featuredCarousel = bootstrap.Carousel.getInstance(featuredCarouselElement)
-    const cardOffset = window.matchMedia("(max-width: 1199.98px)").matches ? 3 : window.matchMedia("(max-width: 991.98px)").matches ? 2 : window.matchMedia("(max-width: 767.98px)").matches ? 1 : 4
-    const currentCard = carouselInner.getElementsByClassName("active")[0]
-    console.log(currentCard)
-    const cardArray = Array.from(carouselInner.children)
-    const currentPosition = cardArray.indexOf(currentCard)
-    const numberOfCards = cardArray.length - 1
-    let prevPosition = currentPosition - cardOffset
-    prevPosition = prevPosition >= 0 ? prevPosition : 0
-    let nextPosition = currentPosition + cardOffset
-    nextPosition = currentPosition + cardOffset <= numberOfCards ? nextPosition : numberOfCards
-    let toPosition = direction === "prev" ? prevPosition : nextPosition
-    toPosition = toPosition.toString()
-    console.log(toPosition)
-    featuredCarousel.to(toPosition)
-  }
 })

--- a/main/templates/partials/featured_product_card.html
+++ b/main/templates/partials/featured_product_card.html
@@ -1,5 +1,5 @@
 {% load static wagtail_img_src feature_img_src %}
-<a href="{{ product.url_path }}" class="featured-product-card-link carousel-item{% if order == 1 %} active{% endif %}">
+<a href="{{ product.url_path }}" class="featured-product-card-link{% if order == 1 %} active{% endif %}">
   <div class="col featured-product-card">
     <div class="featured-product-thumb">
       <img src="{% feature_img_src product.feature_image %}" alt="" />

--- a/main/templates/partials/featured_product_card.html
+++ b/main/templates/partials/featured_product_card.html
@@ -1,6 +1,4 @@
 {% load static wagtail_img_src feature_img_src %}
-
-
 <a href="{{ product.url_path }}" class="featured-product-card-link carousel-item{% if order == 1 %} active{% endif %}">
   <div class="col featured-product-card">
     <div class="featured-product-thumb">

--- a/yarn.lock
+++ b/yarn.lock
@@ -13621,6 +13621,7 @@ __metadata:
     serialize-javascript: 3.1.0
     shelljs: 0.8.5
     sinon: 4.5.0
+    slick-carousel: ^1.8.1
     style-loader: 3.3.1
     styled-components: 4.4.1
     url-join: 4.0.1
@@ -18810,6 +18811,15 @@ __metadata:
     astral-regex: ^2.0.0
     is-fullwidth-code-point: ^3.0.0
   checksum: 4a82d7f085b0e1b070e004941ada3c40d3818563ac44766cca4ceadd2080427d337554f9f99a13aaeb3b4a94d9964d9466c807b3d7b7541d1ec37ee32d308756
+  languageName: node
+  linkType: hard
+
+"slick-carousel@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "slick-carousel@npm:1.8.1"
+  peerDependencies:
+    jquery: ">=1.8.0"
+  checksum: acaad391e4d8bc1c7fdb8d361faa1f1d60829b31d618b54bc38c0550a59b26de36537e0ab4bc0364176ec11d1a61d0cf11e99d8d5b1285d656673c9a1a719257
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2456
Fixes https://github.com/mitodl/hq/issues/2445
Fixes https://github.com/mitodl/hq/issues/2290

# Description (What does it do?)

I swapped over to use [Slick Carousel](https://github.com/kenwheeler/slick/). This carousel has some built in responsiveness, allows for teh advancement of however many slides we choose, and has accessibility bits available.

This PR:

- Makes the carousel accessible (Slick Carousel has this built in, I also swapped the arrows to buttons instead of links). Hidden items are hidden, things are swipable as well as clickable. Items are now read correctly.
- Animation responsiveness is no longer a mess - Slick Carousel has this as well.
- Font descenders are no longer cut off on the bottom row.

# Screenshots (if appropriate):
![Screenshot from 2023-10-02 11-17-30](https://github.com/mitodl/mitxonline/assets/7756053/34d81bb5-dae0-428f-9fbd-9541a6bde52f)
![Screenshot from 2023-10-02 11-17-48](https://github.com/mitodl/mitxonline/assets/7756053/f95bc2c3-a026-45e0-bdea-e9cd2903db05)
![Screenshot from 2023-10-02 11-18-10](https://github.com/mitodl/mitxonline/assets/7756053/ac727016-db4c-46d8-80da-764694eb2e34)
![Screenshot from 2023-10-02 11-18-19](https://github.com/mitodl/mitxonline/assets/7756053/b2fb753f-c5c2-450e-8c2e-177b58aedc8a)


# How can this be tested?
Load up the carousel with things set on it (make sure you set featured items in `/cms`
I suggest having one long title with characters toward the end with descenders - g, y, p, etc.

You should be able to navigate this with the keyboard, the slides should advance the correct number. You should have responsive cards.

# Additional Context
[Figma](https://www.figma.com/file/Gs4zIhOFv5gVvafawwl6PF/MITx-Online?node-id=110%3A1389&mode=dev)
