### PR TITLE
Revert "Assorted fixes for More Dates selector in existing design"

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1129,15 +1129,11 @@ class CoursePage(ProductPage):
         return f"{self.course.readable_id} | {self.title}"
 
     def get_context(self, request, *args, **kwargs):
-        now = now_in_utc()
-
         relevant_run = get_user_relevant_course_run(
             course=self.product, user=request.user
         )
         relevant_runs = list(
-            get_user_relevant_course_run_qset(
-                course=self.product, user=request.user
-            ).filter(models.Q(enrollment_end=None) | models.Q(enrollment_end__gt=now))
+            get_user_relevant_course_run_qset(course=self.product, user=request.user)
         )
         is_enrolled = (
             False

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -222,15 +222,13 @@
                         <p>Click below to enroll in one of these dates</p>
                       </div>
                       {% for course_run in course_runs %}
-                        <div>
-                          {% if course_run.is_not_beyond_enrollment %}
-                            <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
-                          {% else %}
-                            {% if not course_run.is_past %}
-                            <p class='date-link-disabled' id='{{ course_run.courseware_id }}' >{{ course_run.start_date|date:'F j, Y' }}(enrollment opens {{ course_run.enrollment_start|date:'F j, Y' }})</p>
+                          <div>
+                            {% if course_run.is_not_beyond_enrollment %}
+                              <button class='date-link' id='{{ course_run.courseware_id }}' >Start Date {{ course_run.start_date|date:'F j, Y' }}</button>
+                            {% else %}
+                              <p class='date-link-disabled' id='{{ course_run.courseware_id }}' >{{ course_run.start_date|date:'F j, Y' }}(enrollment opens {{ course_run.enrollment_start|date:'F j, Y' }})</p>
                             {% endif %}
-                          {% endif %}
-                        </div>
+                          </div>
                       {% endfor %}
                     ">
                     More Dates

--- a/courses/api.py
+++ b/courses/api.py
@@ -81,12 +81,7 @@ def _relevant_course_qset_filter(
     Does the actual filtering for user_relevant_course_run_qset and
     user_relevant_program_course_run_qset.
     """
-    now = now or now_in_utc()
-    run_qset = (
-        run_qset.exclude(start_date=None)
-        .exclude(enrollment_start=None)
-        .filter(live=True)
-    )
+
     if user and user.is_authenticated:
         user_enrollments = Count(
             "enrollments",

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -148,23 +148,11 @@ export class CourseProductDetailEnroll extends React.Component<
     return this.state.currentCourseRun
   }
 
-  getFirstUnenrolledCourseRun = (): EnrollmentFlaggedCourseRun => {
-    const { courseRuns } = this.props
-
-    return courseRuns
-      ? courseRuns.find(
-        (run: EnrollmentFlaggedCourseRun) =>
-          run.is_enrolled === false &&
-            moment(run.enrollment_start) <= moment.now()
-      ) || courseRuns[0]
-      : null
-  }
-
   renderUpgradeEnrollmentDialog(showNewDesign: boolean) {
     const { courseRuns, courses } = this.props
     const run =
       !this.getCurrentCourseRun() && courseRuns
-        ? this.getFirstUnenrolledCourseRun()
+        ? courseRuns[0]
         : this.getCurrentCourseRun()
 
     const course =
@@ -514,11 +502,7 @@ export class CourseProductDetailEnroll extends React.Component<
       courseRuns.map(courseRun => {
         // $FlowFixMe
         document.addEventListener("click", function(e) {
-          if (
-            e.target &&
-            e.target.tagName.toLowerCase() === "button" &&
-            e.target.id === courseRun.courseware_id
-          ) {
+          if (e.target && e.target.id === courseRun.courseware_id) {
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -502,11 +502,7 @@ export class CourseProductDetailEnroll extends React.Component<
       courseRuns.map(courseRun => {
         // $FlowFixMe
         document.addEventListener("click", function(e) {
-          if (
-            e.target &&
-            e.target.tagName.toLowerCase() === "button" &&
-            e.target.id === courseRun.courseware_id
-          ) {
+          if (e.target && e.target.id === courseRun.courseware_id) {
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -148,6 +148,18 @@ export class CourseProductDetailEnroll extends React.Component<
     return this.state.currentCourseRun
   }
 
+  getFirstUnenrolledCourseRun = (): EnrollmentFlaggedCourseRun => {
+    const { courseRuns } = this.props
+
+    return courseRuns
+      ? courseRuns.find(
+        (run: EnrollmentFlaggedCourseRun) =>
+          run.is_enrolled === false &&
+            moment(run.enrollment_start) <= moment.now()
+      ) || courseRuns[0]
+      : null
+  }
+
   renderUpgradeEnrollmentDialog(showNewDesign: boolean) {
     const { courseRuns, courses } = this.props
     const run =
@@ -491,7 +503,7 @@ export class CourseProductDetailEnroll extends React.Component<
       !this.getCurrentCourseRun() && !courseRuns
         ? null
         : !this.getCurrentCourseRun() && courseRuns
-          ? courseRuns[0]
+          ? this.getFirstUnenrolledCourseRun()
           : this.getCurrentCourseRun()
 
     if (run) this.updateDate(run)

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -502,7 +502,11 @@ export class CourseProductDetailEnroll extends React.Component<
       courseRuns.map(courseRun => {
         // $FlowFixMe
         document.addEventListener("click", function(e) {
-          if (e.target && e.target.id === courseRun.courseware_id) {
+          if (
+            e.target &&
+            e.target.tagName.toLowerCase() === "button" &&
+            e.target.id === courseRun.courseware_id
+          ) {
             thisScope.setCurrentCourseRun(courseRun)
             run = thisScope.getCurrentCourseRun()
             product = run && run.products ? run.products[0] : null


### PR DESCRIPTION
Reverts mitodl/mitxonline#1903

# What are the relevant tickets?

mitodl/hq#2573

# Description (What does it do?)

Reverts most of #1903. Specficially:

* In the CoursePage model, the relevant runs should now filter out runs with enrollment end dates in the past, so past course runs should not display
* The ProductDetailEnrollApp component should now favor the first apparent unenrolled courserun rather than just grabbing the first if one isn't explicitly selected.
* The relevant course runs queryset function now only includes live courses

(I kept the code to stop you from being able to choose a date that wasn't enrollable.) 

# How can this be tested?

Testing should be pretty close to the scenario described in mitodl/hq#2573 
