### PR TITLE
Remove start date from ProgramInfoBox.js

### DIFF
--- a/frontend/public/src/components/ProgramInfoBox.js
+++ b/frontend/public/src/components/ProgramInfoBox.js
@@ -127,17 +127,6 @@ export default class ProgramInfoBox extends React.PureComponent<ProgramInfoBoxPr
               ) : null}
             </div>
           </div>
-          <div className="row d-flex align-items-center">
-            <div className="enrollment-info-icon">
-              <img
-                src="/static/images/products/start-date.png"
-                alt="Course Timing"
-              />
-            </div>
-            <div className="enrollment-info-text">
-              {startDate ? formatPrettyDateUtc(startDate) : "Start Anytime"}
-            </div>
-          </div>
           {program && program.page ? (
             <div className="row d-flex align-items-top">
               <div className="enrollment-info-icon">

--- a/frontend/public/src/components/ProgramInfoBox.js
+++ b/frontend/public/src/components/ProgramInfoBox.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { formatPrettyDateUtc, emptyOrNil } from "../lib/util"
+import { emptyOrNil } from "../lib/util"
 import moment from "moment-timezone"
 
 import type {
@@ -87,11 +87,6 @@ export default class ProgramInfoBox extends React.PureComponent<ProgramInfoBoxPr
     const run = this.findFirstCourseRun()
 
     const product = run && run.products.length > 0 && run.products[0]
-
-    const startDate =
-      run && !emptyOrNil(run.start_date)
-        ? moment(new Date(run.start_date))
-        : null
 
     const reqCount = program.requirements.required.length
     const electiveCount = program.requirements.electives.length


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2552

# Description (What does it do?)
Removes the start date from the ProgramInfoBox

# Screenshots (if appropriate):
![Screenshot from 2023-10-02 16-05-21](https://github.com/mitodl/mitxonline/assets/7756053/2a41c2cd-27df-4967-a5fb-6a2b760e7837)


# How can this be tested?
Have a program setup in your mitxonline instance. Go to the about page for that program. You should NOT see a start date.
