### PR TITLE
Updated get_financial_assistance_form_url to also consider related programs

### DIFF
--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -246,10 +246,22 @@ def test_serialized_course_finaid_form_url(
     own_program_has_form, related_program, related_program_has_form
 ):
     """
-    Tests the financial assistance form URL returned for a course that's in a
-    program that has no financial assistance form and is related to a program
-    that does have a financial assistance form. (The course should get the
-    form URL for the program that does have the financial assistance form.)
+    Tests a few scenarios for financial assistance form URL retrieval to ensure
+    that the proper form is displayed. The FA form URL should prefer the form
+    that belongs to the program that the course is a member of; if that program
+    lacks a FA form, it should use the FA form of a related program.
+
+    - own_program_has_form flags whether or not the course under test's program
+    has its own financial assistance form. If this is set, then the course
+    should return back the form for the program it's in directly.
+
+    - related_program flags whether or not the course under test's program is
+    related to another program at all. (We also want to make sure the financial
+    assistance form for the other program isn't used by the course under test.)
+
+    - related_program_has_form flags whether or not the secondary related
+    program has a financial assistance form. This form will then be used only if
+    own_program_has_form is False.
     """
 
     program1 = ProgramFactory.create()

--- a/courses/models.py
+++ b/courses/models.py
@@ -185,7 +185,7 @@ class Program(TimestampedModel, ValidateOnSaveMixin):
 
         program_list = []
 
-        for related_program in self.related_programs_qs.all():
+        for related_program in self.related_programs_qs.all().iterator():
             if related_program.first_program == self:
                 program_list.append(related_program.second_program)
             else:


### PR DESCRIPTION

# What are the relevant tickets?

Closes mitodl/hq#2391

# Description (What does it do?)

Updates the course page serializer to include related programs in its search for a financial assistance form URL. 

# How can this be tested?

Create two programs. One should have a full financial assistance buildout (published form, tiers, etc.); one should not. The two programs should have a RelatedProgram record and should have independent courses with products.

Attempt to view a course in the program that does not have financial assistance. You should see links to the other program's financial assistance forms, and you should be able to apply for and be approved for financial assistance as per usual. 

Attempt to purchase the verified track for a non-FA program's course after approving your financial aid request. You should get the personalized pricing for the course. (This has not changed - you should have gotten this before - but it should still work.) 

# Additional Context

We already consider related programs to determine whether or not to grant financial assistance; this just shores up the courses API for that. 

The serializer unrolls the course programs so combining the directly related course programs and the related programs for the course programs don't end up overwriting the course programs.
