### PR TITLE
Catalog Page: Add content loader 

### DIFF
--- a/frontend/public/src/components/CourseLoader.js
+++ b/frontend/public/src/components/CourseLoader.js
@@ -1,7 +1,7 @@
 import React from "react"
 import ContentLoader from "react-content-loader"
 
-const SkeletonLoader = props => (
+const CourseLoader = props => (
   <ContentLoader
     width={305}
     height={229}
@@ -16,4 +16,4 @@ const SkeletonLoader = props => (
   </ContentLoader>
 )
 
-export default SkeletonLoader
+export default CourseLoader

--- a/frontend/public/src/components/SkeletonLoader.js
+++ b/frontend/public/src/components/SkeletonLoader.js
@@ -1,0 +1,19 @@
+import React from "react"
+import ContentLoader from "react-content-loader"
+
+const SkeletonLoader = props => (
+  <ContentLoader
+    width={305}
+    height={229}
+    viewBox="0 0 305 229"
+    backgroundColor="#f0f0f0"
+    foregroundColor="#dedede"
+    {...props}
+  >
+    <rect x="0" y="150" rx="4" ry="4" width="271" height="9" />
+    <rect x="0" y="170" rx="3" ry="3" width="119" height="6" />
+    <rect x="0" y="0" rx="10" ry="10" width="303" height="142" />
+  </ContentLoader>
+)
+
+export default SkeletonLoader

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -28,6 +28,7 @@ import { compose } from "redux"
 import { connect } from "react-redux"
 import { connectRequest, requestAsync } from "redux-query"
 import { pathOr } from "ramda"
+import SkeletonLoader from "../../components/SkeletonLoader"
 
 type Props = {
   coursesIsLoading: ?boolean,
@@ -297,7 +298,7 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * This is a comparision method used to sort an array of Course Runs
+   * This is a comparison method used to sort an array of Course Runs
    * from earliest start date to latest start date.
    * @param {BaseCourseRun} courseRunA The first Course Run to compare.
    * @param {BaseCourseRun} courseRunB The second Course Run to compare.
@@ -487,17 +488,24 @@ export class CatalogPage extends React.Component<Props> {
    * Renders the entire catalog of course or program cards based on the catalog tab selected.
    */
   renderCatalog() {
-    if (
-      this.state.tabSelected === COURSES_TAB &&
-      this.state.filteredCourses.length > 0
-    ) {
+    const { filteredCourses, filteredPrograms, tabSelected } = this.state
+    if (this.props.coursesIsLoading || this.props.programsIsLoading) {
+      return (
+        <div id="catalog-grid">
+          <SkeletonLoader />
+          <SkeletonLoader />
+          <SkeletonLoader />
+        </div>
+      )
+    }
+    if (tabSelected === COURSES_TAB && filteredCourses.length > 0) {
       return this.renderCatalogRows(
-        this.state.filteredCourses,
+        filteredCourses,
         this.renderCourseCatalogCard.bind(this)
       )
-    } else if (this.state.tabSelected === PROGRAMS_TAB) {
+    } else if (tabSelected === PROGRAMS_TAB) {
       return this.renderCatalogRows(
-        this.state.filteredPrograms,
+        filteredPrograms,
         this.renderProgramCatalogCard.bind(this)
       )
     }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -28,7 +28,7 @@ import { compose } from "redux"
 import { connect } from "react-redux"
 import { connectRequest, requestAsync } from "redux-query"
 import { pathOr } from "ramda"
-import SkeletonLoader from "../../components/SkeletonLoader"
+import CourseLoader from "../../components/CourseLoader"
 
 type Props = {
   coursesIsLoading: ?boolean,
@@ -489,14 +489,12 @@ export class CatalogPage extends React.Component<Props> {
    */
   renderCatalog() {
     const { filteredCourses, filteredPrograms, tabSelected } = this.state
-    if (this.props.coursesIsLoading || this.props.programsIsLoading) {
-      return (
-        <div id="catalog-grid">
-          <SkeletonLoader />
-          <SkeletonLoader />
-          <SkeletonLoader />
-        </div>
-      )
+
+    if (
+      filteredCourses.length === 0 &&
+      (this.props.coursesIsLoading || this.props.programsIsLoading)
+    ) {
+      return courseLoaderGrid
     }
     if (tabSelected === COURSES_TAB && filteredCourses.length > 0) {
       return this.renderCatalogRows(
@@ -653,16 +651,7 @@ export class CatalogPage extends React.Component<Props> {
                     </CSSTransition>
                   </TransitionGroup>
                 </div>
-                <div
-                  className={`${
-                    this.state.isLoadingMoreItems ? "lds-ring" : "d-none"
-                  }`}
-                >
-                  <div></div>
-                  <div></div>
-                  <div></div>
-                  <div></div>
-                </div>
+                {this.state.isLoadingMoreItems ? courseLoaderGrid : null}
                 {/* span is used to detect when the learner has scrolled to the bottom of the catalog page. */}
                 <span ref={this.container}></span>
               </div>
@@ -673,6 +662,13 @@ export class CatalogPage extends React.Component<Props> {
     )
   }
 }
+const courseLoaderGrid = (
+  <div id="catalog-grid">
+    <CourseLoader />
+    <CourseLoader />
+    <CourseLoader />
+  </div>
+)
 
 const getNextCoursePage = page =>
   requestAsync({

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
         "build": "yarn workspaces foreach run build"
     },
     "version": "0.0.0",
-    "packageManager": "yarn@3.2.0"
+    "packageManager": "yarn@3.2.0",
+    "dependencies": {
+        "react-content-loader": "^6.2.1"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13644,6 +13644,8 @@ __metadata:
 "mitx-online-root@workspace:.":
   version: 0.0.0-use.local
   resolution: "mitx-online-root@workspace:."
+  dependencies:
+    react-content-loader: ^6.2.1
   languageName: unknown
   linkType: soft
 
@@ -16826,6 +16828,15 @@ __metadata:
   peerDependencies:
     react: ">=16.4.1"
   checksum: 303890eeaf9e18d59fca77f9c891bf3b52d2ec9ea88f0af9d19c160a1f101b447c5104ca46e2dd84c19de756d4797f1f054d041b888a3d57204d9145f4b1b532
+  languageName: node
+  linkType: hard
+
+"react-content-loader@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "react-content-loader@npm:6.2.1"
+  peerDependencies:
+    react: ">=16.0.0"
+  checksum: f777d408256a4218677e47f4cf3988d9fd8e556450e9b85ee1eb3952a5d5802573cea0df5eaf4dbc936c9522f355657de6f8ab0ecdf035d7dccdef15b45c9dae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2328

# Description (What does it do?)
Installs [react-content-loader](https://github.com/danilowoz/react-content-loader)
adds content loader for courses and programs in the catalog page

# Screenshots (if appropriate):
<img width="1449" alt="Screen Shot 2023-10-04 at 10 22 55 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/d6927f1b-9f07-4f74-bd22-260d0ff9285e">



# How can this be tested?
Go to catalog page while the courses are loading it should show the loader.