### PR TITLE
Course About Redesign - Accessibility issues on instructor bio

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -142,7 +142,7 @@
                                    $('#instructor-name-{{ member.id }}').focus();">
                     <span aria-hidden="true">&times;</span>
                   </button>
-                </div>Ï
+                </div>
                 <div class="modal-body">
                   <div class="row d-flex">
                     <div class="col col-instructor-photo">

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -75,7 +75,7 @@
                         <div class="member-card highlight-card" onClick="$('#instructor-modal-{{ member.id }}').modal('show');">
                           <img src="{% feature_img_src member.feature_image %}" alt="">
                           <div class="member-info">
-                            <h3 class="name">
+                            <h3 id="instructor-name-{{ member.id }}" class="name" role="button" tabindex="0">
                                 {{ member.instructor_name }}
                             </h3>
                             {% if member.instructor_title %}<h4 class="title">{{ member.instructor_title }}</h4>{% endif %}
@@ -137,10 +137,12 @@
               <div class="modal-content">
                 <div class="modal-header">
                   <h5 class="modal-title">{{ member.instructor_name }}</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close" onClick="$('#instructor-modal-{{ member.id }}').modal('hide');">
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close"
+                          onClick="$('#instructor-modal-{{ member.id }}').modal('hide');
+                                   $('#instructor-name-{{ member.id }}').focus();">
                     <span aria-hidden="true">&times;</span>
                   </button>
-                </div>
+                </div>Ï
                 <div class="modal-body">
                   <div class="row d-flex">
                     <div class="col col-instructor-photo">


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/2601

# Description (What does it do?)
<!--- Describe your changes in detail -->
Address accessibility issues on instructor section of course about page (new design)
 - make instructor name keyboard focusable
 - return focus on instructor name when modal closes

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Setup course/program about page for new design
- Add Faulty Members on course/program about page from CMS
- Go to course/program page
- Use screen reader to tab through the above page, you should now be able to tab to each instructor and open modal. 
- When instructor modal closes, the screen reader should now focus on instructor name.
