### PR TITLE
Product Page: Fix overflow on faculty info boxes

### DIFF
--- a/frontend/public/scss/product-faculty-members.scss
+++ b/frontend/public/scss/product-faculty-members.scss
@@ -27,6 +27,10 @@
       box-shadow: 0 1px 0 0 rgb(0 0 0 / 12%);
       display: flex;
 
+      @include media-breakpoint-down(sm) {
+        display: block;
+      }
+
       .member-info {
         margin-top: 7px;
         display: flow-root;
@@ -65,7 +69,6 @@
       @include media-breakpoint-down(sm) {
         display: block;
         float: none;
-        margin: 0 auto 10px;
       }
     }
   }

--- a/frontend/public/scss/product-faculty-members.scss
+++ b/frontend/public/scss/product-faculty-members.scss
@@ -19,16 +19,17 @@
 
     width: calc(50% - 44px);
     margin: 0 22px 24px;
+    min-width: min-content;
 
     .member-card {
       padding: 24px;
-      overflow: hidden;
       border-radius: 4px !important;
       box-shadow: 0 1px 0 0 rgb(0 0 0 / 12%);
+      display: flex;
 
       .member-info {
-        overflow: hidden;
         margin-top: 7px;
+        display: flow-root;
 
         @include media-breakpoint-down(md) {
           margin-top: 20px;
@@ -59,7 +60,7 @@
       width: 110px;
       border-radius: 50%;
       object-fit: cover;
-      margin-right: 24px;
+      margin: 0 24px 20px 0;
 
       @include media-breakpoint-down(sm) {
         display: block;


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2551

# Description (What does it do?)
Fix overflow on faculty info boxes for different browser width.

# Screenshots (if appropriate):
<img width="988" alt="Screen Shot 2023-10-05 at 9 07 55 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/dab89dd3-ec01-4253-ba61-1f9ba323875e">
<img width="1210" alt="Screen Shot 2023-10-05 at 9 08 06 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/3791d565-b4c5-4772-8b1a-3c7d03903a0e">
