### PR TITLE
Product Page: about section Show More toggle updates

### DIFF
--- a/cms/templatetags/expand.py
+++ b/cms/templatetags/expand.py
@@ -41,7 +41,7 @@ def expand(text):
         pre = str(expand_here[0])
         post = "".join([str(sib) for sib in expand_here[1].find_next_siblings()])
 
-        output = f'<!-- pre -->{pre}<!-- /pre --><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[1])}{post}</div><p class="expand_here_container"><a href="#" class="expand_here_link" data-expand-body="{container_uuid}">Show More</a></p>'
+        output = f'<!-- pre -->{pre}<!-- /pre --><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[1])}{post}</div><p class="expand_here_container"><a href="#" class="expand_here_link fade" data-expand-body="{container_uuid}">Show More</a></p>'
     elif len(text.split("\n\n")) > 1:
         (pre, post) = text.split("\n\n", maxsplit=1)
 

--- a/cms/templatetags/expand.py
+++ b/cms/templatetags/expand.py
@@ -41,7 +41,7 @@ def expand(text):
         pre = str(expand_here[0])
         post = "".join([str(sib) for sib in expand_here[1].find_next_siblings()])
 
-        output = f'<!-- pre -->{pre}<!-- /pre --><p class="expand_here_container"><a href="#" class="expand_here_link" data-expand-body="{container_uuid}">Show More</a></p><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[1])}{post}</div>'
+        output = f'<!-- pre -->{pre}<!-- /pre --><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[1])}{post}</div><p class="expand_here_container"><a href="#" class="expand_here_link" data-expand-body="{container_uuid}">Show More</a></p>'
     elif len(text.split("\n\n")) > 1:
         (pre, post) = text.split("\n\n", maxsplit=1)
 

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -41,6 +41,16 @@ body.new-design {
       div.expand_here_body.open {
         max-height: 400rem;
       }
+
+      a.expand_here_link {
+        opacity: 0;
+        transition: opacity 225ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+      }
+
+      a.expand_here_link.fade {
+        opacity: 1;
+        transition: opacity 300ms cubic-bezier(0.55, 0.085, 0.68, 0.53);
+      }
     }
 
     section.about-this-class {

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -16,7 +16,13 @@ const expandExpandBlock = (event: MouseEvent) => {
       if (elem && elem.classList && elem.classList.contains("open")) {
         event.srcElement.innerText = "Show Less"
       } else {
-        event.srcElement.innerText = "Show More"
+        event.srcElement.classList.remove("fade")
+        setTimeout(() => {
+          requestAnimationFrame(() => {
+            event.srcElement.innerText = "Show More"
+            event.srcElement.classList.add("fade")
+          })
+        }, 225) // timeout
       }
     }
   }

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -13,7 +13,7 @@ const expandExpandBlock = (event: MouseEvent) => {
     if (block) {
       const elem = document.querySelector(`div#exp${block}`)
       elem && elem.classList && elem.classList.toggle("open")
-      if (elem.classList.contains("open")) {
+      if (elem && elem.classList && elem.classList.contains("open")) {
         event.srcElement.innerText = "Show Less"
       } else {
         event.srcElement.innerText = "Show More"

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -6,13 +6,18 @@ import CourseProductDetailEnroll from "../components/CourseProductDetailEnroll"
 import ProgramProductDetailEnroll from "../components/ProgramProductDetailEnroll"
 
 const expandExpandBlock = (event: MouseEvent) => {
+  event.preventDefault()
   const blockTarget = event.target
-
   if (blockTarget instanceof HTMLElement) {
     const block = blockTarget.getAttribute("data-expand-body")
     if (block) {
       const elem = document.querySelector(`div#exp${block}`)
       elem && elem.classList && elem.classList.toggle("open")
+      if (elem.classList.contains("open")) {
+        event.srcElement.innerText = "Show Less"
+      } else {
+        event.srcElement.innerText = "Show More"
+      }
     }
   }
 }


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2595

# Description (What does it do?)
Update the Show more link to toggle text and appear at the bottom of the about text when expended.

# Screenshots (if appropriate):
<img width="873" alt="Screen Shot 2023-10-11 at 8 37 29 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/b0252361-e7d5-4135-8586-420ce723eb61">
<img width="886" alt="Screen Shot 2023-10-11 at 8 37 42 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/8ba0ad24-22df-40e4-8ecd-34a15ba26c36">
