### PR TITLE
Course Page: More enrollment dates updates

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -250,6 +250,12 @@ body.new-design {
               padding-left: 0;
               background-color: transparent;
             }
+            button.more-dates-link.enrolled {
+              color: $green-darker;
+              cursor: default;
+              text-decoration-line: none;
+
+            }
           }
         }
 

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -32,6 +32,12 @@ const getStartDateText = (run: BaseCourseRun, isArchived: boolean = false) => {
     : "Start Anytime"
 }
 
+const getStartDateForRun = (run: BaseCourseRun) => {
+  return run && !emptyOrNil(run.start_date) && !run.is_self_paced
+    ? formatPrettyDate(moment(new Date(run.start_date)))
+    : "Start Anytime"
+}
+
 export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProps> {
   state = {
     showMoreEnrollDates: false
@@ -60,7 +66,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               className="more-dates-link"
               onClick={() => this.setRunEnrollDialog(run)}
             >
-              {getStartDateText(run)}
+              {getStartDateForRun(run)}
             </button>
           ) : (
             <form action="/enrollments/" method="post">
@@ -71,7 +77,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               />
               <input type="hidden" name="run" value={run ? run.id : ""} />
               <button type="submit" className="more-dates-link">
-                {getStartDateText(run)}
+                {getStartDateForRun(run)}
               </button>
             </form>
           )}
@@ -87,10 +93,17 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     return !currentUser || !currentUser.id ? (
       <>
         <a href={routes.login} className="more-dates-link">
-          {getStartDateText(run)}
+          {getStartDateForRun(run)}
         </a>
       </>
     ) : null
+  }
+  renderEnrolledDateLink(run: EnrollmentFlaggedCourseRun) {
+    return (
+      <button className="more-dates-link enrolled">
+        {getStartDateText(run)} - Enrolled
+      </button>
+    )
   }
 
   render() {
@@ -115,9 +128,13 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     const moreEnrollableCourseRuns = courseRuns && courseRuns.length > 1
     if (moreEnrollableCourseRuns) {
       courseRuns.forEach((courseRun, index) => {
-        if (!courseRun.is_enrolled) {
+        if (courseRun.id !== run.id) {
           startDates.push(
-            <li key={index}>{this.renderEnrollNowDateLink(courseRun)}</li>
+            <li key={index}>
+              {courseRun.is_enrolled
+                ? this.renderEnrolledDateLink(courseRun)
+                : this.renderEnrollNowDateLink(courseRun)}
+            </li>
           )
         }
       })

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -145,10 +145,11 @@ export class CourseProductDetailEnroll extends React.Component<
   }
   getFirstUnexpiredRun = () => {
     const { courses, courseRuns } = this.props
-    const course = courses[0]
-    return course.next_run_id
-      ? courseRuns.find(elem => elem.id === course.next_run_id)
-      : courseRuns[0]
+    return courseRuns
+      ? courses && courses[0].next_run_id
+        ? courseRuns.find(elem => elem.id === courses[0].next_run_id)
+        : courseRuns[0]
+      : null
   }
 
   getCurrentCourseRun = (): EnrollmentFlaggedCourseRun => {
@@ -514,7 +515,7 @@ export class CourseProductDetailEnroll extends React.Component<
       product = null
     if (courseRuns) {
       run = this.getFirstUnexpiredRun()
-      product = run.products ? run.products[0] : null
+      product = run && run.products ? run.products[0] : null
       this.updateDate(run)
       const thisScope = this
       courseRuns.map(courseRun => {

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -143,6 +143,13 @@ export class CourseProductDetailEnroll extends React.Component<
       currentCourseRun: courseRun
     })
   }
+  getFirstUnexpiredRun = () => {
+    const { courses, courseRuns } = this.props
+    const course = courses[0]
+    return course.next_run_id
+      ? courseRuns.find(elem => elem.id === course.next_run_id)
+      : courseRuns[0]
+  }
 
   getCurrentCourseRun = (): EnrollmentFlaggedCourseRun => {
     return this.state.currentCourseRun
@@ -402,7 +409,11 @@ export class CourseProductDetailEnroll extends React.Component<
     )
   }
 
-  renderEnrolledButton(run: EnrollmentFlaggedCourseRun, startDate: any) {
+  renderEnrolledButton(run: EnrollmentFlaggedCourseRun) {
+    const startDate =
+      run && !emptyOrNil(run.start_date)
+        ? moment(new Date(run.start_date))
+        : null
     const waitingForCourseToBeginMessage = moment().isBefore(startDate) ? (
       <p style={{ fontSize: "16px" }}>
         Enrolled and waiting for the course to begin.
@@ -499,17 +510,12 @@ export class CourseProductDetailEnroll extends React.Component<
     } = this.props
     const showNewDesign = checkFeatureFlag("mitxonline-new-product-page")
 
-    let run =
-      !this.getCurrentCourseRun() && !courseRuns
-        ? null
-        : !this.getCurrentCourseRun() && courseRuns
-          ? this.getFirstUnenrolledCourseRun()
-          : this.getCurrentCourseRun()
-
-    if (run) this.updateDate(run)
-
-    let product = run && run.products ? run.products[0] : null
+    let run,
+      product = null
     if (courseRuns) {
+      run = this.getFirstUnexpiredRun()
+      product = run.products ? run.products[0] : null
+      this.updateDate(run)
       const thisScope = this
       courseRuns.map(courseRun => {
         // $FlowFixMe
@@ -524,10 +530,6 @@ export class CourseProductDetailEnroll extends React.Component<
         })
       })
     }
-    const startDate =
-      run && !emptyOrNil(run.start_date)
-        ? moment(new Date(run.start_date))
-        : null
 
     return (
       <>
@@ -535,7 +537,7 @@ export class CourseProductDetailEnroll extends React.Component<
           // $FlowFixMe: isLoading null or undefined
           <Loader key="product_detail_enroll_loader" isLoading={isLoading}>
             <>
-              {this.renderEnrolledButton(run, startDate)}
+              {this.renderEnrolledButton(run)}
               {this.renderEnrollLoginButton()}
               {this.renderEnrollNowButton(run, product)}
 


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2621

# Description (What does it do?)
Updates the More Dates section of the course box.
1. Show enrollable runs that are already enrolled
2. Don't show "first unexpired run" that is already listed after the start-date-icon. This run can be enrolled through the big "Enroll Now" button.
3. Fix the regression with the "enroll now" button not switching to enrolled once the user enrolled in the "first unexpired run"

# Screenshots (if appropriate):
<img width="475" alt="Screen Shot 2023-10-11 at 2 17 09 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/7561685e-4fb7-4594-95d4-376ff282b3f7">
<img width="404" alt="Screen Shot 2023-10-11 at 2 17 52 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/3ac4aad4-ffb3-442c-97dc-0c43fedfc2ef">
<img width="395" alt="Screen Shot 2023-10-11 at 2 18 55 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/1ae6d51d-d23d-433b-bee5-a1539536571f">
<img width="437" alt="Screen Shot 2023-10-11 at 2 19 46 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/ad9e3241-9040-4771-bacc-f198788d1eac">
