### PR TITLE
Filter out not live programs

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -273,6 +273,8 @@ def create_run_enrollments(
         then the change_status of that program_enrollment is checked to ensure it equals None.
         """
         for program in run.course.programs:
+            if not program.live:
+                continue
             program_enrollment, _ = ProgramEnrollment.objects.get_or_create(
                 user=user,
                 program=program,


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/mitxonline/issues/1934

# Description (What does it do?)
When enrolling user in a course, enroll them also in associated LIVE programs only.

# How can this be tested?
Enroll you user in a course run that is a requirement in a program. If the program is not "live" the should be no program enrollment.
If you set  `program.live = True` then when you enroll in a course a program enrollment should be created.
