### PR TITLE
Course About Page: update font and styles

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -1,14 +1,23 @@
 // sass-lint:disable mixins-before-declarations
 
 body.new-design {
+  font-family: Inter;
+
+  h1, h2 {
+      font-family: Poppins;
+
+  }
+
   .product-page {
     margin-top: 1.5rem;
     background-color: white;
 
     section.course-description {
-      line-height: 46px;
       font-size: 20px;
-      color: #646669;
+      color: var(--GreyText, #6F7175);
+      font-style: normal;
+      font-weight: 500;
+      line-height: 38px;
     }
 
     #tab-bar {
@@ -31,6 +40,12 @@ body.new-design {
 
     section.about-richtext-container {
       margin: 2.5rem 0;
+      color: var(--Blue-Dark, #03152D);
+
+      font-size: 15px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 24px;
 
       div.expand_here_body {
         max-height: 0px;
@@ -158,6 +173,7 @@ body.new-design {
         }
 
         .btn-enrollment-button {
+          font-family: Poppins;
           height: 50px;
           line-height: 50px;
           width: 100%;
@@ -182,7 +198,7 @@ body.new-design {
           border: 1px solid #d1d1d1;
           border-left: none;
           border-right: none;
-          font-size: 14px;
+          font-size: 15px;
 
           .row {
             margin: 20px 0;

--- a/frontend/public/scss/top-app-bar.scss
+++ b/frontend/public/scss/top-app-bar.scss
@@ -338,6 +338,7 @@ header.site-header.new-design {
   padding: 0;
 
   .mitx-online-link {
+    font-family: Poppins;
     color: var(--Blue-Dark, #03152D);
     font-size: 18px;
     font-weight: 700;

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -202,7 +202,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
             <div className="enrollment-info-icon">
               <img src="/static/images/products/cost.png" alt="Cost" />
             </div>
-            <div className="enrollment-info-text font-weight-bold">Free</div>
+            <div className="enrollment-info-text"><b>Free</b></div>
           </div>
           <div className="row d-flex align-items-top">
             <div className="enrollment-info-icon">

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -202,7 +202,9 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
             <div className="enrollment-info-icon">
               <img src="/static/images/products/cost.png" alt="Cost" />
             </div>
-            <div className="enrollment-info-text"><b>Free</b></div>
+            <div className="enrollment-info-text">
+              <b>Free</b>
+            </div>
           </div>
           <div className="row d-flex align-items-top">
             <div className="enrollment-info-icon">

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     {% include "partials/gtm_head.html" %}
     <link rel="stylesheet" type="text/css"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700|Montserrat:300,400,500,600,700|Inter:400, 700|Poppins:600,700&display=swap"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700|Montserrat:300,400,500,600,700|Inter:400,700|Poppins:600,700&display=swap"
       media="all"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
       media="none" onload="if(media!='all') media='all'">


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2618
Fix https://github.com/mitodl/hq/issues/2647


# Description (What does it do?)
Following the designs here https://www.figma.com/file/Gs4zIhOFv5gVvafawwl6PF/MITx-Online?type=design&node-id=0%3A1&mode=dev.

Updated the font family for new-design styles.


# Screenshots (if appropriate):
Before:
<img width="1373" alt="Screen Shot 2023-10-20 at 9 12 52 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/ad7e71cf-cb45-4cbf-a5f6-51ade140a862">

After:
<img width="1399" alt="Screen Shot 2023-10-20 at 10 20 35 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/9091396b-d2bd-4803-b8d4-61f31402cbf3">

