### PR TITLE
Course About Page: tablet and mobile view adjustments

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -13,7 +13,7 @@
 {% if new_design %}
     <div id="main" class="product-page">
       <div class="container">
-        <div class="row d-flex flex-row align-items-center">
+        <div class="row d-flex flex-row align-center">
           <div class="col flex-grow-1" id="product-details">
             <div class="text">
               <h1>{{ page.title }}</h1>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -13,7 +13,7 @@
 {% if new_design %}
     <div id="main" class="product-page">
       <div class="container">
-        <div class="row d-flex flex-row">
+        <div class="row d-flex flex-row align-items-center">
           <div class="col flex-grow-1" id="product-details">
             <div class="text">
               <h1>{{ page.title }}</h1>

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -12,6 +12,11 @@ body.new-design {
     margin-top: 1.5rem;
     background-color: white;
 
+    .row.align-items-center {
+      justify-content: center;
+      align-items: center;
+    }
+
     section.course-description {
       font-size: 20px;
       color: var(--GreyText, #6F7175);
@@ -87,6 +92,7 @@ body.new-design {
       border: 1px solid #e4e9ef;
       padding: 2rem;
       clear: both;
+      margin-bottom: 1.5rem;
     }
 
     #product-info-box {

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -12,10 +12,12 @@ body.new-design {
     margin-top: 1.5rem;
     background-color: white;
 
-    .row.align-items-center {
-      justify-content: center;
-      align-items: center;
+    .row.align-center {
+      @include media-breakpoint-down(md) {
+          justify-content: center !important;
+      }
     }
+
 
     section.course-description {
       font-size: 20px;
@@ -92,7 +94,6 @@ body.new-design {
       border: 1px solid #e4e9ef;
       padding: 2rem;
       clear: both;
-      margin-bottom: 1.5rem;
     }
 
     #product-info-box {
@@ -103,6 +104,10 @@ body.new-design {
       max-width: 400px;
       height: auto;
       border-radius: 5px;
+
+      @include media-breakpoint-down(md) {
+          margin-top: 1.5rem;
+        }
 
       strong {
         font-weight: 600;


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2570
# Description (What does it do?)
Adds padding for before the Course Info Box.
Aligns the course info box to be in the middle for tablet and mobile view.

# Screenshots (if appropriate):
<img width="489" alt="Screen Shot 2023-10-23 at 10 31 37 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/1c208c6e-6176-457f-8c27-e7ba1f8ec899">
<img width="719" alt="Screen Shot 2023-10-23 at 10 30 59 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/0a667328-e2ff-4301-928e-2b5972b9ae63">
