### PR TITLE
New design for the instructor bio cards on the course about page

### DIFF
--- a/frontend/public/scss/product-faculty-members.scss
+++ b/frontend/public/scss/product-faculty-members.scss
@@ -11,6 +11,41 @@
   }
 }
 
+body.new-design {
+
+  .faculty-members {
+    li {
+      width: calc(50% - 20px);
+      margin: 0 10px 10px;
+      min-width: 275px;
+
+      img {
+        margin: 0 15px 0 0;
+      }
+    }
+    .member-card {
+      padding: 15px;
+
+      .member-info {
+        overflow: hidden;
+        margin: 0;
+
+        h3 {
+          font-size: 16px;
+          font-weight: 700;
+          line-height: normal;
+        }
+
+        h4 {
+          font-size: 13px;
+          font-weight: 400;
+          line-height: normal;
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}
 .faculty-members {
   li {
     @include media-breakpoint-down(md) {
@@ -26,10 +61,6 @@
       border-radius: 4px !important;
       box-shadow: 0 1px 0 0 rgb(0 0 0 / 12%);
       display: flex;
-
-      @include media-breakpoint-down(sm) {
-        display: block;
-      }
 
       .member-info {
         margin-top: 7px;

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -387,7 +387,6 @@ body.new-design {
         height: 130px;
         align-items: start;
         padding: 20px;
-        z-index: 9;
 
         @include media-breakpoint-down(sm) {
           background-image: none;
@@ -395,6 +394,7 @@ body.new-design {
           padding: 5px;
           background-color: transparent;
           height: 0;
+          z-index: 9;
         }
     
         h5 {


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2654

# Description (What does it do?)
Implement a new design for the instructor bio cards on the course about page.

# Screenshots (if appropriate):
<img width="876" alt="Screen Shot 2023-10-30 at 1 15 06 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/4ac175e4-0548-4c7a-9af9-9b9865abd71d">
<img width="1293" alt="Screen Shot 2023-10-30 at 1 15 23 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/87e9604e-0529-4490-9873-8008a883b2ea">
<img width="392" alt="Screen Shot 2023-10-30 at 1 16 24 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/8226636a-cc58-4297-9d64-5e468ba2cc63">


# How can this be tested?
Make sure you have created few instructors for a course in the cms. Go to the course about page and make sure that they follow the design in the issue.