### PR TITLE
Update header design and navigation

### DIFF
--- a/frontend/public/scss/top-app-bar.scss
+++ b/frontend/public/scss/top-app-bar.scss
@@ -279,8 +279,11 @@ header.site-header.new-design {
   display: block;
   font-size: 14px;
   line-height: 21px;
-  border-left: 1px solid $home-page-border-grey;
-  padding-left: 15px;
+
+  .top-user-menu {
+    border-left: 1px solid $home-page-border-grey;
+    padding-left: 15px;
+  }
 
   @include media-breakpoint-down(md) {
     display: none;
@@ -301,6 +304,9 @@ header.site-header.new-design {
         text-decoration: none;
         display: block;
 
+        &.top-nav-link {
+          padding: 13px 10px 13px 20px;
+        }
 
         &:hover {
           color: $primary;
@@ -376,52 +382,23 @@ header.site-header.new-design {
     display: block;
   }
 
-  ul {
-    display: flex;
-    list-style-type: none;
-    padding: 0;
-    margin: 0;
+  li.mobile-dropdown-item {
+    display: block;
+    padding: 10px 0;
+    margin: 0 auto;
+    max-width: 170px;
 
-    li {
-      font-size: 12px;
+    a {
+      color: white;
+      font-size: 18px;
       font-weight: 600;
-      padding: 0 0 0 8px;
+      line-height: 25px;
+      padding: 0;
+      margin-top: 5px;
 
-      a {
-        color: black;
-        text-decoration: none;
-        display: block;
-        border: 1px solid var(--BorderGrey, #DFE5EC);
-
-
-        &:hover {
-          color: $primary;
-        }
-
-        &.simple {
-          display: inline-flex;
-          padding: 8px 15px;
-          align-items: flex-start;
-          border-radius: 3px;
-        }
-
-        &.button {
-          transition: .25s;
-          background: #a31f34;
-          color: white;
-
-          @include media-breakpoint-up(md) {
-            background: $primary;
-            color: white;
-            box-shadow: inset 0 0 2px 0 rgba(255, 255, 255, 0.57);
-
-            &:hover {
-              background: black;
-            }
-          }
-        }
+      &:hover {
+        color: white;
       }
     }
   }
-
 }

--- a/frontend/public/scss/top-app-bar.scss
+++ b/frontend/public/scss/top-app-bar.scss
@@ -258,6 +258,7 @@ header.site-header {
 header.site-header.new-design {
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14);
   background-color: $white;
+  font-family: Inter;
 
   .navbar.top-navbar {
     display: flex;
@@ -280,9 +281,17 @@ header.site-header.new-design {
   font-size: 14px;
   line-height: 21px;
 
+  .top-nav-link {
+    padding: 13px 10px 13px 20px;
+    display: inline-block;
+    color: black;
+    text-decoration: none;
+  }
+
   .top-user-menu {
     border-left: 1px solid $home-page-border-grey;
     padding-left: 15px;
+    display: inline-block;
   }
 
   @include media-breakpoint-down(md) {
@@ -303,10 +312,6 @@ header.site-header.new-design {
         color: black;
         text-decoration: none;
         display: block;
-
-        &.top-nav-link {
-          padding: 13px 10px 13px 20px;
-        }
 
         &:hover {
           color: $primary;
@@ -382,10 +387,10 @@ header.site-header.new-design {
     display: block;
   }
 
-  li.mobile-dropdown-item {
+  li {
     display: block;
     padding: 10px 0;
-    margin: 0 auto;
+    margin: 0;
     max-width: 170px;
 
     a {

--- a/frontend/public/src/components/AnonymousMenu.js
+++ b/frontend/public/src/components/AnonymousMenu.js
@@ -18,6 +18,16 @@ const AnonymousMenu = ({ mobileView }: Props) => {
       <li>
         <MixedLink
           id={"login".concat(identifierPostfix)}
+          dest={routes.catalog}
+          className="top-nav-link"
+          aria-label="Catalog"
+        >
+          Catalog
+        </MixedLink>
+      </li>
+      <li>
+        <MixedLink
+          id={"login".concat(identifierPostfix)}
           dest={routes.login.begin}
           className="simple"
           aria-label="Sign In"
@@ -32,7 +42,7 @@ const AnonymousMenu = ({ mobileView }: Props) => {
           className="simple button"
           aria-label="Create Account"
         >
-          Create {newDesign && mobileView ? "" : "Account"}
+          Create Account
         </MixedLink>
       </li>
     </ul>

--- a/frontend/public/src/components/AnonymousMenu.js
+++ b/frontend/public/src/components/AnonymousMenu.js
@@ -18,7 +18,7 @@ const AnonymousMenu = ({ mobileView }: Props) => {
       {newDesign ? (
         <li>
           <MixedLink
-            id={"login".concat(identifierPostfix)}
+            id="catalog"
             dest={routes.catalog}
             className="top-nav-link"
             aria-label="Catalog"

--- a/frontend/public/src/components/AnonymousMenu.js
+++ b/frontend/public/src/components/AnonymousMenu.js
@@ -15,16 +15,18 @@ const AnonymousMenu = ({ mobileView }: Props) => {
   const newDesign = checkFeatureFlag("mitxonline-new-header")
   return (
     <ul>
-      <li>
-        <MixedLink
-          id={"login".concat(identifierPostfix)}
-          dest={routes.catalog}
-          className="top-nav-link"
-          aria-label="Catalog"
-        >
-          Catalog
-        </MixedLink>
-      </li>
+      {newDesign ?
+        <li>
+          <MixedLink
+            id={"login".concat(identifierPostfix)}
+            dest={routes.catalog}
+            className="top-nav-link"
+            aria-label="Catalog"
+          >
+            Catalog
+          </MixedLink>
+        </li> : null
+      }
       <li>
         <MixedLink
           id={"login".concat(identifierPostfix)}

--- a/frontend/public/src/components/AnonymousMenu.js
+++ b/frontend/public/src/components/AnonymousMenu.js
@@ -15,7 +15,7 @@ const AnonymousMenu = ({ mobileView }: Props) => {
   const newDesign = checkFeatureFlag("mitxonline-new-header")
   return (
     <ul>
-      {newDesign ?
+      {newDesign ? (
         <li>
           <MixedLink
             id={"login".concat(identifierPostfix)}
@@ -25,8 +25,8 @@ const AnonymousMenu = ({ mobileView }: Props) => {
           >
             Catalog
           </MixedLink>
-        </li> : null
-      }
+        </li>
+      ) : null}
       <li>
         <MixedLink
           id={"login".concat(identifierPostfix)}

--- a/frontend/public/src/components/AnonymousMenu.js
+++ b/frontend/public/src/components/AnonymousMenu.js
@@ -23,7 +23,9 @@ const AnonymousMenu = ({ mobileView }: Props) => {
             className="top-nav-link"
             aria-label="Catalog"
           >
-            Catalog
+            <span data-bs-target="#nav" data-bs-toggle="collapse">
+              Catalog
+            </span>
           </MixedLink>
         </li>
       ) : null}
@@ -34,7 +36,9 @@ const AnonymousMenu = ({ mobileView }: Props) => {
           className="simple"
           aria-label="Sign In"
         >
-          Sign In
+          <span data-bs-target="#nav" data-bs-toggle="collapse">
+            Sign In
+          </span>
         </MixedLink>
       </li>
       <li>
@@ -44,7 +48,9 @@ const AnonymousMenu = ({ mobileView }: Props) => {
           className="simple button"
           aria-label="Create Account"
         >
-          Create Account
+          <span data-bs-target="#nav" data-bs-toggle="collapse">
+            Create Account
+          </span>
         </MixedLink>
       </li>
     </ul>

--- a/frontend/public/src/components/TopBar.js
+++ b/frontend/public/src/components/TopBar.js
@@ -9,6 +9,7 @@ import type { Location } from "react-router"
 import NotificationContainer from "./NotificationContainer"
 
 import type { CurrentUser } from "../flow/authTypes"
+import MixedLink from "./MixedLink"
 
 type Props = {
   currentUser: CurrentUser,
@@ -53,7 +54,17 @@ const TopBar = ({ currentUser }: Props) => (
       >
         <div className="full-screen-top-menu">
           {currentUser.is_authenticated ? (
-            <UserMenu currentUser={currentUser} useScreenOverlay={false} />
+            <>
+              <MixedLink
+                id="catalog"
+                dest={routes.catalog}
+                className="top-nav-link"
+                aria-label="Catalog"
+              >
+                Catalog
+              </MixedLink>
+              <UserMenu currentUser={currentUser} useScreenOverlay={false} />
+            </>
           ) : (
             <AnonymousMenu mobileView={false} />
           )}

--- a/frontend/public/src/components/TopBar.js
+++ b/frontend/public/src/components/TopBar.js
@@ -32,45 +32,40 @@ const TopBar = ({ currentUser }: Props) => (
           MITx Online
         </a>
       </div>
-      {currentUser.is_authenticated ? (
-        <>
-          <button
-            className="navbar-toggler nav-opener collapsed"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#nav"
-            aria-controls="nav"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-          >
-            <span className="bar" />
-            <span className="bar" />
-            <span className="bar" />
-          </button>
-          <div
-            id="nav"
-            className={`${
-              currentUser.is_authenticated ? "" : "collapse"
-            } user-menu-overlay px-0 justify-content-end`}
-          >
-            <div className="full-screen-top-menu">
-              <UserMenu currentUser={currentUser} useScreenOverlay={false} />
-            </div>
-            <div className="mobile-menu">
-              <UserMenu currentUser={currentUser} useScreenOverlay={true} />
-            </div>
-          </div>
-        </>
-      ) : (
-        <div className="justify-content-end">
-          <div className="full-screen-top-menu">
+      <button
+        className="navbar-toggler nav-opener collapsed"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#nav"
+        aria-controls="nav"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span className="bar" />
+        <span className="bar" />
+        <span className="bar" />
+      </button>
+      <div
+        id="nav"
+        className={`${
+          currentUser.is_authenticated ? "" : "collapse"
+        } user-menu-overlay px-0 justify-content-end`}
+      >
+        <div className="full-screen-top-menu">
+          {currentUser.is_authenticated ? (
+            <UserMenu currentUser={currentUser} useScreenOverlay={false} />
+          ) : (
             <AnonymousMenu mobileView={false} />
-          </div>
-          <div className="mobile-auth-buttons">
-            <AnonymousMenu mobileView={true} />
-          </div>
+          )}
         </div>
-      )}
+        <div className="mobile-auth-buttons">
+          {currentUser.is_authenticated ? (
+            <UserMenu currentUser={currentUser} useScreenOverlay={true} />
+          ) : (
+            <AnonymousMenu mobileView={true} />
+          )}
+        </div>
+      </div>
     </nav>
   </header>
 )

--- a/frontend/public/src/components/UserMenu.js
+++ b/frontend/public/src/components/UserMenu.js
@@ -80,13 +80,15 @@ const UserMenu = ({ currentUser, useScreenOverlay }: Props) => {
             </span>
           </MixedLink>
         </li>
-        <li {...(menuChildProps.li || {})}>
-          <MixedLink dest={routes.catalog} aria-label="Catalog">
-            <span data-bs-target="#nav" data-bs-toggle="collapse">
-              Catalog
-            </span>
-          </MixedLink>
-        </li>
+        {showNewDesign && useScreenOverlay ? (
+          <li {...(menuChildProps.li || {})}>
+            <MixedLink dest={routes.catalog} aria-label="Catalog">
+              <span data-bs-target="#nav" data-bs-toggle="collapse">
+                Catalog
+              </span>
+            </MixedLink>
+          </li>
+        ) : null}
         <li {...(menuChildProps.li || {})}>
           <MixedLink dest={routes.dashboard} aria-label="Dashboard">
             <span data-bs-target="#nav" data-bs-toggle="collapse">

--- a/frontend/public/src/components/UserMenu.js
+++ b/frontend/public/src/components/UserMenu.js
@@ -81,6 +81,13 @@ const UserMenu = ({ currentUser, useScreenOverlay }: Props) => {
           </MixedLink>
         </li>
         <li {...(menuChildProps.li || {})}>
+          <MixedLink dest={routes.catalog} aria-label="Catalog">
+            <span data-bs-target="#nav" data-bs-toggle="collapse">
+              Catalog
+            </span>
+          </MixedLink>
+        </li>
+        <li {...(menuChildProps.li || {})}>
           <MixedLink dest={routes.dashboard} aria-label="Dashboard">
             <span data-bs-target="#nav" data-bs-toggle="collapse">
               Dashboard

--- a/frontend/public/src/components/UserMenu_test.js
+++ b/frontend/public/src/components/UserMenu_test.js
@@ -13,7 +13,7 @@ describe("UserMenu component", () => {
     const userMenu = shallow(
       <UserMenu currentUser={user} useScreenOverlay={false} />
     )
-    assert.lengthOf(userMenu.find("MixedLink"), 4)
+    assert.lengthOf(userMenu.find("MixedLink"), 5)
     assert.lengthOf(userMenu.find("a"), 1)
   })
 
@@ -22,7 +22,7 @@ describe("UserMenu component", () => {
       shallow(<UserMenu currentUser={user} useScreenOverlay={true} />).find(
         "ul li"
       ),
-      5
+      6
     )
   })
 

--- a/frontend/public/src/components/UserMenu_test.js
+++ b/frontend/public/src/components/UserMenu_test.js
@@ -13,7 +13,7 @@ describe("UserMenu component", () => {
     const userMenu = shallow(
       <UserMenu currentUser={user} useScreenOverlay={false} />
     )
-    assert.lengthOf(userMenu.find("MixedLink"), 5)
+    assert.lengthOf(userMenu.find("MixedLink"), 4)
     assert.lengthOf(userMenu.find("a"), 1)
   })
 
@@ -22,7 +22,7 @@ describe("UserMenu component", () => {
       shallow(<UserMenu currentUser={user} useScreenOverlay={true} />).find(
         "ul li"
       ),
-      6
+      5
     )
   })
 


### PR DESCRIPTION
# What are the relevant tickets?
Partially completes https://github.com/mitodl/hq/issues/2559

# Description (What does it do?)
1. Change the anonymous header to use hamburger menu
2. Add Catalog link to the anonymous desktop header
3. Adds Catalog link to the dropdown navigation




# How can this be tested?
Checkout the header in desktop, mobile, anonymous, authenticated views. Make sure the navigation works.

# Screenshots (if appropriate):
Mobile View:

<img width="390" alt="Screen Shot 2023-11-01 at 8 48 52 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/fa3cba59-48af-4453-bda7-249f1f6da968">

<img width="391" alt="Screen Shot 2023-11-01 at 8 11 48 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/ca8f7c3e-2077-4912-b3e2-0ea5119c3981">
<img width="391" alt="Screen Shot 2023-11-01 at 8 21 02 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/68b0f876-f0b2-4047-8b32-d30bb37f0221">
Desktop:

<img width="1160" alt="Screen Shot 2023-11-01 at 8 17 59 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/542e0a6c-4859-4dc2-9e4f-fc6facd898cf">
<img width="627" alt="Screen Shot 2023-11-01 at 8 20 15 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/1113e0e5-8c85-45d3-8754-87e44cdd5eed">

<img width="1161" alt="Screen Shot 2023-11-01 at 8 34 49 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/4b766a9f-0966-45fd-867b-cd6b6e794679">

