### PR TITLE
Fixing the mobile styling on the enrollment modal

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -588,8 +588,15 @@ body.new-design {
 
 @media screen and (max-width: 768px) {
   body.new-design {
-    div.certificate-pricing {
-      margin-bottom: 15px !important;
+    div.certificate-pricing-row {
+      div.certificate-pricing {
+        margin-bottom: 15px !important;
+      }
+
+      div.enroll-and-pay {
+        padding-left: 0px;
+        padding-right: 0px;
+      }
     }
 
     div.upgrade-options-row {
@@ -599,6 +606,7 @@ body.new-design {
         p {
           text-align: center;
         }
+        margin-bottom: 12px;
       }
     }
   }

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -344,7 +344,7 @@ body.new-design {
 
     select {
       display: flex;
-      width: 690px;
+      width: 100%;
       padding: 10px 10px;
       align-items: flex-start;
       gap: 10px;
@@ -582,6 +582,24 @@ body.new-design {
 
     a {
       font-weight: 400;
+    }
+  }
+}
+
+@media screen and (max-width: 768px) {
+  body.new-design {
+    div.certificate-pricing {
+      margin-bottom: 15px !important;
+    }
+
+    div.upgrade-options-row {
+      div {
+        width: 100%;
+        text-align: center;
+        p {
+          text-align: center;
+        }
+      }
     }
   }
 }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -357,8 +357,8 @@ export class CourseProductDetailEnroll extends React.Component<
               </div>
             </div>
 
-            <div className="row">
-              <div className="col-6">
+            <div className="row d-sm-flex flex-md-row flex-sm-column">
+              <div className="col-md-6 col-sm-12">
                 <ul>
                   <li> Certificate is signed by MIT faculty</li>
                   <li>
@@ -368,7 +368,7 @@ export class CourseProductDetailEnroll extends React.Component<
                   <li> Enhance your college &amp; earn a promotion</li>
                 </ul>
               </div>
-              <div className="col-6">
+              <div className="col-md-6 col-sm-12">
                 <ul>
                   <li>Highlight on your resume/CV</li>
                   <li>Share on your social channels &amp; LinkedIn</li>
@@ -380,8 +380,8 @@ export class CourseProductDetailEnroll extends React.Component<
               </div>
             </div>
 
-            <div className="row certificate-pricing-row">
-              <div className="col-6 certificate-pricing d-flex align-items-center">
+            <div className="row certificate-pricing-row d-sm-flex flex-md-row flex-sm-column">
+              <div className="col-md-6 col-sm-12 certificate-pricing d-flex align-items-center">
                 <div className="certificate-pricing-logo">
                   <img src="/static/images/certificates/certificate-logo.svg" />
                 </div>
@@ -402,7 +402,7 @@ export class CourseProductDetailEnroll extends React.Component<
                   ) : null}
                 </p>
               </div>
-              <div className="col-6 pr-0">
+              <div className="col-md-6 col-sm-12 pr-0">
                 <form action="/cart/add/" method="get" className="text-center">
                   <input type="hidden" name="product_id" value={product.id} />
                   <button type="submit" className="btn btn-upgrade">

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -402,7 +402,7 @@ export class CourseProductDetailEnroll extends React.Component<
                   ) : null}
                 </p>
               </div>
-              <div className="col-md-6 col-sm-12 pr-0">
+              <div className="col-md-6 col-sm-12 pr-0 enroll-and-pay">
                 <form action="/cart/add/" method="get" className="text-center">
                   <input type="hidden" name="product_id" value={product.id} />
                   <button type="submit" className="btn btn-upgrade">


### PR DESCRIPTION
# What are the relevant tickets?

mitodl/hq#2616

# Description (What does it do?)

In the mobile version of the upsell modal:
- The certificate upsell list should fall into a single column
- The certificate pricing and Enroll and Pay buttons should also become a single column
- The Need Financial Assistance and free options should appear stacked and centered

# Screenshots (if appropriate):

Regular kind:
![Screenshot 2023-11-02 at 7 29 35 AM](https://github.com/mitodl/mitxonline/assets/945611/f72284c2-0197-4662-8e02-0d9b2fdd88db)

Mobile:
![Screenshot 2023-11-02 at 7 29 55 AM](https://github.com/mitodl/mitxonline/assets/945611/c2323635-d058-40a8-aa76-2ff4ff6dac18)


# How can this be tested?

Grab a course with multiple course runs and a verified track and open the upsell modal, then switch your browser into responsive mode. The styling should work as expected. (There are no functional changes here but all the functionality should work as expected.)
