### PR TITLE
Fixing date to display if you're logged in

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -30,12 +30,6 @@ const getStartDateText = (run: BaseCourseRun, isArchived: boolean = false) => {
     : "Start Anytime"
 }
 
-const getStartDateForRun = (run: BaseCourseRun) => {
-  return run && !emptyOrNil(run.start_date) && !run.is_self_paced
-    ? formatPrettyDate(moment(new Date(run.start_date)))
-    : "Start Anytime"
-}
-
 export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProps> {
   state = {
     showMoreEnrollDates: false
@@ -50,9 +44,6 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     this.props.toggleUpgradeDialogVisibility()
   }
 
-  renderUnenrolledDateLink(run: EnrollmentFlaggedCourseRun) {
-    return <>{getStartDateForRun(run)}</>
-  }
   renderEnrolledDateLink(run: EnrollmentFlaggedCourseRun) {
     return (
       <button className="more-dates-link enrolled">
@@ -93,7 +84,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     enrollment.run.id === courseRun.id
                 ))
                 ? this.renderEnrolledDateLink(courseRun)
-                : this.renderUnenrolledDateLink(courseRun)}
+                : this.getStartDateText(courseRun)}
             </li>
           )
         }

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -84,7 +84,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     enrollment.run.id === courseRun.id
                 ))
                 ? this.renderEnrolledDateLink(courseRun)
-                : this.getStartDateText(courseRun)}
+                : getStartDateText(courseRun)}
             </li>
           )
         }

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -51,11 +51,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
   }
 
   renderUnenrolledDateLink(run: EnrollmentFlaggedCourseRun) {
-    const { currentUser } = this.props
-
-    return !currentUser || !currentUser.id ? (
-      <>{getStartDateForRun(run)}</>
-    ) : null
+    return <>{getStartDateForRun(run)}</>
   }
   renderEnrolledDateLink(run: EnrollmentFlaggedCourseRun) {
     return (

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -24,6 +24,7 @@ import type {
   LearnerRecordProgram,
   LearnerRecordShare
 } from "../flow/courseTypes"
+import { CoursePage } from "../flow/cmsTypes"
 
 const genCourseRunId = incrementer()
 const genEnrollmentId = incrementer()
@@ -33,6 +34,17 @@ const genProductId = incrementer()
 const genProgramId = incrementer()
 const genPartnerSchoolId = incrementer()
 const genProgramRequirementId = incrementer()
+
+export const makeCoursePage = (): CoursePage => ({
+  financial_assistance_form_url: casual.url,
+  feature_image_src:             casual.url,
+  live:                          true,
+  description:                   casual.text,
+  current_price:                 casual.integer(),
+  instructors:                   [],
+  length:                        casual.text,
+  effort:                        casual.text
+})
 
 export const makeCourseRun = (): CourseRun => ({
   title:            casual.text,
@@ -95,16 +107,7 @@ const makeCourseDetail = (): CourseDetail => ({
   feature_image_src: casual.url,
   departments:       [makeDepartment()],
   live:              true,
-  page:              {
-    financial_assistance_form_url: casual.url,
-    feature_image_src:             casual.url,
-    live:                          true,
-    description:                   casual.text,
-    current_price:                 casual.integer(),
-    instructors:                   [],
-    length:                        casual.text,
-    effort:                        casual.text
-  }
+  page:              makeCoursePage()
 })
 
 const makeRequirementRootNode = (
@@ -221,7 +224,7 @@ const makeDEDPSampleRequirementsTree = (
 
 export const makeCourseDetailWithRuns = (): CourseDetailWithRuns => {
   return {
-    ...makeCourseRun(),
+    ...makeCourseDetail(),
     courseruns: [makeCourseRun()]
   }
 }


### PR DESCRIPTION
# What are the relevant tickets?

https://github.com/mitodl/hq/issues/2902

# Description (What does it do?)

If you were logged in but not enrolled in a course, the More Dates link would work but not show anything. This fixes that - we were looking for you to be an anonymous user to display the link. 

# How can this be tested?

Log in and view a course with multiple course runs that you're not enrolled in. Clicking More Dates should show you the additional dates.
