### PR TITLE
Fix Program Share URLs

### DIFF
--- a/courses/urls/__init__.py
+++ b/courses/urls/__init__.py
@@ -17,10 +17,10 @@ urlpatterns = [
 ]
 
 urlpatterns += [
-    re_path("api/records/program/<pk>/share/", v1.get_learner_record_share),
-    re_path("api/records/program/<pk>/revoke/", v1.revoke_learner_record_share),
-    re_path("api/records/program/<pk>/", v1.get_learner_record),
-    re_path(
+    path("api/records/program/<pk>/share/", v1.get_learner_record_share),
+    path("api/records/program/<pk>/revoke/", v1.revoke_learner_record_share),
+    path("api/records/program/<pk>/", v1.get_learner_record),
+    path(
         "api/records/shared/<uuid>/",
         v1.get_learner_record_from_uuid,
         name="shared_learner_record_from_uuid",


### PR DESCRIPTION
# What are the relevant tickets?
fixes https://github.com/mitodl/hq/issues/2933

# Description (What does it do?)
Changes the URLs from re_path to path


# How can this be tested?
be enrolled in a local program, go to dashboard and click to go into the record. Record should load and you should be able to enable sharing (if everything else is correctly set up)

# Additional Context
I broke this during the API refactor.  Here is urls.py prior to that refactor: https://github.com/mitodl/mitxonline/blob/709b0e3a8d7c5dedb674009314ee4cad800154e9/courses/urls.py