### PR TITLE
Adds v2 of the courses API for the program page

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -11,15 +11,12 @@ from courses.constants import DEFAULT_COURSE_IMG_PATH
 from ecommerce.models import Product
 
 
-class CoursePageSerializer(serializers.ModelSerializer):
+class BaseCoursePageSerializer(serializers.ModelSerializer):
     """Course page model serializer"""
 
     feature_image_src = serializers.SerializerMethodField()
     page_url = serializers.SerializerMethodField()
-    financial_assistance_form_url = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
-    current_price = serializers.SerializerMethodField()
-    instructors = serializers.SerializerMethodField()
     effort = serializers.SerializerMethodField()
     length = serializers.SerializerMethodField()
 
@@ -33,6 +30,41 @@ class CoursePageSerializer(serializers.ModelSerializer):
 
     def get_page_url(self, instance):
         return instance.get_url()
+
+    def get_description(self, instance):
+        return bleach.clean(instance.description, tags=[], strip=True)
+
+    def get_effort(self, instance):
+        return (
+            bleach.clean(instance.effort, tags=[], strip=True)
+            if instance.effort
+            else None
+        )
+
+    def get_length(self, instance):
+        return (
+            bleach.clean(instance.length, tags=[], strip=True)
+            if instance.length
+            else None
+        )
+
+    class Meta:
+        model = models.CoursePage
+        fields = [
+            "feature_image_src",
+            "page_url",
+            "description",
+            "live",
+            "length",
+            "effort",
+        ]
+
+class CoursePageSerializer(BaseCoursePageSerializer):
+    """Course page model serializer"""
+
+    financial_assistance_form_url = serializers.SerializerMethodField()
+    instructors = serializers.SerializerMethodField()
+    current_price = serializers.SerializerMethodField()
 
     def get_financial_assistance_form_url(self, instance):
         """
@@ -84,9 +116,6 @@ class CoursePageSerializer(serializers.ModelSerializer):
             else ""
         )
 
-    def get_description(self, instance):
-        return bleach.clean(instance.description, tags=[], strip=True)
-
     def get_current_price(self, instance):
         relevant_product = (
             instance.product.active_products.filter().order_by("-price").first()
@@ -114,32 +143,12 @@ class CoursePageSerializer(serializers.ModelSerializer):
 
         return returnable_members
 
-    def get_effort(self, instance):
-        return (
-            bleach.clean(instance.effort, tags=[], strip=True)
-            if instance.effort
-            else None
-        )
-
-    def get_length(self, instance):
-        return (
-            bleach.clean(instance.length, tags=[], strip=True)
-            if instance.length
-            else None
-        )
-
     class Meta:
         model = models.CoursePage
-        fields = [
-            "feature_image_src",
-            "page_url",
+        fields = BaseCoursePageSerializer.Meta.fields + [
             "financial_assistance_form_url",
-            "description",
             "current_price",
             "instructors",
-            "live",
-            "length",
-            "effort",
         ]
 
 

--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -1,6 +1,5 @@
 """CMS app serializers"""
 import bleach
-from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from rest_framework import serializers
 
@@ -8,7 +7,6 @@ from cms import models
 from cms.api import get_wagtail_img_src
 from cms.models import FlexiblePricingRequestForm, ProgramPage
 from courses.constants import DEFAULT_COURSE_IMG_PATH
-from ecommerce.models import Product
 
 
 class BaseCoursePageSerializer(serializers.ModelSerializer):
@@ -58,6 +56,7 @@ class BaseCoursePageSerializer(serializers.ModelSerializer):
             "length",
             "effort",
         ]
+
 
 class CoursePageSerializer(BaseCoursePageSerializer):
     """Course page model serializer"""

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -84,7 +84,6 @@ class CourseRunSerializer(BaseCourseRunSerializer):
 
     def get_approved_flexible_price_exists(self, instance):
         if not self.context or not self.context.get("include_approved_financial_aid"):
-            log.info("get_approved_flexible_price_exists: skipping")
             return False
 
         # Get the User object if it exists.

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -1,0 +1,172 @@
+"""Courses v2 serializers"""
+
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+
+import logging
+
+from cms.serializers import BaseCoursePageSerializer
+from courses import models
+from courses.api import create_run_enrollments
+from courses.serializers.v1.base import (
+    BaseCourseSerializer,
+    BaseCourseRunEnrollmentSerializer,
+    BaseCourseRunSerializer,
+    ProductRelatedField,
+)
+from courses.serializers.v1.departments import DepartmentSerializer
+from flexiblepricing.api import is_courseware_flexible_price_approved
+from main import features
+from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
+
+
+log = logging.getLogger(__name__)
+
+
+class CourseSerializer(BaseCourseSerializer):
+    """Course model serializer"""
+
+    departments = DepartmentSerializer(many=True, read_only=True)
+    next_run_id = serializers.SerializerMethodField()
+    page = BaseCoursePageSerializer(read_only=True)
+    programs = serializers.SerializerMethodField()
+
+    def get_next_run_id(self, instance):
+        """Get next run id"""
+        run = instance.first_unexpired_run
+        return run.id if run is not None else None
+
+    def get_programs(self, instance):
+        if self.context.get("all_runs", False):
+            from courses.serializers.v1.base import BaseProgramSerializer
+
+            return BaseProgramSerializer(instance.programs, many=True).data
+
+        return None
+
+    class Meta:
+        model = models.Course
+        fields = [
+            "id",
+            "title",
+            "readable_id",
+            "next_run_id",
+            "departments",
+            "page",
+            "programs",
+        ]
+
+
+class CourseRunSerializer(BaseCourseRunSerializer):
+    """CourseRun model serializer"""
+
+    products = ProductRelatedField(many=True, read_only=True)
+    approved_flexible_price_exists = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.CourseRun
+        fields = BaseCourseRunSerializer.Meta.fields + [
+            "products",
+            "approved_flexible_price_exists",
+        ]
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if self.context and self.context.get("include_enrolled_flag"):
+            return {
+                **data,
+                **{
+                    "is_enrolled": getattr(instance, "user_enrollments", 0) > 0,
+                    "is_verified": getattr(instance, "verified_enrollments", 0) > 0,
+                },
+            }
+        return data
+
+    def get_approved_flexible_price_exists(self, instance):
+        if not self.context or not self.context.get("include_approved_financial_aid"):
+            log.info("get_approved_flexible_price_exists: skipping")
+            return False
+
+        # Get the User object if it exists.
+        user = self.context["request"].user if "request" in self.context else None
+
+        # Check for an approved flexible price record if the
+        # user exists and has an ID (not an Anonymous user).
+        # Otherwise return False.
+        flexible_price_exists = (
+            is_courseware_flexible_price_approved(
+                instance.course, self.context["request"].user
+            )
+            if user and user.id
+            else False
+        )
+        return flexible_price_exists
+
+
+class CourseWithCourseRunsSerializer(CourseSerializer):
+    """Course model serializer - also serializes child course runs"""
+
+    courseruns = serializers.SerializerMethodField(read_only=True)
+
+    def get_courseruns(self, instance):
+        context = {
+            "include_approved_financial_aid": self.context.get(
+                "include_approved_financial_aid", False
+            )
+        }
+
+        return CourseRunSerializer(
+            instance.courseruns.all(), many=True, read_only=True, context=context
+        ).data
+
+    class Meta:
+        model = models.Course
+        fields = CourseSerializer.Meta.fields + [
+            "courseruns",
+        ]
+
+
+class CourseRunWithCourseSerializer(CourseRunSerializer):
+    """
+    CourseRun model serializer - also serializes the parent Course.
+    """
+
+    course = CourseSerializer(read_only=True, context={"include_page_fields": True})
+
+    class Meta:
+        model = models.CourseRun
+        fields = CourseRunSerializer.Meta.fields + [
+            "course",
+        ]
+
+
+class CourseRunEnrollmentSerializer(BaseCourseRunEnrollmentSerializer):
+    """CourseRunEnrollment model serializer"""
+
+    run = CourseRunWithCourseSerializer(read_only=True)
+    run_id = serializers.IntegerField(write_only=True)
+    certificate = serializers.SerializerMethodField(read_only=True)
+    enrollment_mode = serializers.ChoiceField(
+        (EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE), read_only=True
+    )
+    approved_flexible_price_exists = serializers.SerializerMethodField()
+    grades = serializers.SerializerMethodField(read_only=True)
+
+    def create(self, validated_data):
+        user = self.context["user"]
+        run_id = validated_data["run_id"]
+        try:
+            run = models.CourseRun.objects.get(id=run_id)
+        except models.CourseRun.DoesNotExist:
+            raise ValidationError({"run_id": f"Invalid course run id: {run_id}"})
+        successful_enrollments, edx_request_success = create_run_enrollments(
+            user,
+            [run],
+            keep_failed_enrollments=features.is_enabled(features.IGNORE_EDX_FAILURES),
+        )
+        return successful_enrollments
+
+    class Meta(BaseCourseRunEnrollmentSerializer.Meta):
+        fields = BaseCourseRunEnrollmentSerializer.Meta.fields + [
+            "run_id",
+        ]

--- a/courses/urls/v2/urls.py
+++ b/courses/urls/v2/urls.py
@@ -6,5 +6,6 @@ from courses.views import v2
 app_name = "courses"
 router = routers.SimpleRouter()
 router.register(r"programs", v2.ProgramViewSet, basename="programs_api")
+router.register(r"courses", v2.CourseViewSet, basename="courses_api")
 
 urlpatterns = router.urls

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -121,12 +121,3 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
             added_context["include_approved_financial_aid"] = True
 
         return {**super().get_serializer_context(), **added_context}
-
-    def paginate_queryset(self, queryset):
-        """
-        Enable pagination if a 'page' parameter is included in the request,
-        otherwise, do not use pagination.
-        """
-        if self.paginator and self.request.query_params.get("page", None) is None:
-            return None
-        return super().paginate_queryset(queryset)

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -7,22 +7,16 @@ from rest_framework.pagination import PageNumberPagination
 import django_filters
 from django_filters.rest_framework import DjangoFilterBackend
 from mitol.common.utils import now_in_utc
-from django.db.models import Count, Prefetch, Q
+from django.db.models import Prefetch, Q
 
 from courses.models import (
     Course,
     CourseRun,
-    CourseRunEnrollment,
-    Department,
-    LearnerProgramRecordShare,
-    PartnerSchool,
     Program,
-    ProgramEnrollment,
 )
 from courses.serializers.v2.programs import ProgramSerializer
 from courses.serializers.v2.courses import (
     CourseWithCourseRunsSerializer,
-    CourseSerializer,
 )
 
 

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -6,17 +6,21 @@ import operator as op
 import pytest
 from django.urls import reverse
 from rest_framework import status
+from django.db import connection
+import logging
 
 from courses.conftest import course_catalog_data
 from courses.serializers.v2.programs import ProgramSerializer
-from courses.views.test_utils import (
-    num_queries_from_programs,
-)
+from courses.serializers.v2.courses import CourseWithCourseRunsSerializer
+from courses.views.test_utils import num_queries_from_programs, num_queries_from_course
 from courses.views.v2 import Pagination
 from fixtures.common import raise_nplusone
 from main.test_utils import assert_drf_json_equal, duplicate_queries_check
 
 pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("raise_nplusone")]
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("course_catalog_course_count", [100], indirect=True)
@@ -105,3 +109,84 @@ def test_delete_program(
         )
     duplicate_queries_check(context)
     assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+@pytest.mark.parametrize("course_catalog_course_count", [100], indirect=True)
+@pytest.mark.parametrize("course_catalog_program_count", [15], indirect=True)
+@pytest.mark.parametrize("include_finaid", [True, False])
+def test_get_courses(
+    user_drf_client,
+    mock_context,
+    django_assert_max_num_queries,
+    course_catalog_data,
+    include_finaid,
+):
+    """Test the view that handles requests for all Courses"""
+    courses, _, _ = course_catalog_data
+    courses_from_fixture = []
+    num_queries = 0
+
+    if include_finaid:
+        mock_context["include_approved_financial_aid"] = True
+
+    for course in courses:
+        courses_from_fixture.append(
+            CourseWithCourseRunsSerializer(instance=course, context=mock_context).data
+        )
+        num_queries += num_queries_from_course(course, "v1")
+    with django_assert_max_num_queries(num_queries) as context:
+        query_count_start = len(connection.queries)
+        resp = user_drf_client.get(
+            reverse("v2:courses_api-list"),
+            {"include_approved_financial_aid": include_finaid},
+        )
+        query_count_end = len(connection.queries)
+        logger.info(
+            f"test_get_course logged {query_count_end - query_count_start} queries"
+        )
+    #     This will become an assert rather than a warning in the future, for now this function is informational
+    duplicate_queries_check(context)
+    courses_data = resp.json()
+    assert len(courses_data) == len(courses_from_fixture)
+    """
+    Due to the number of relations in our current course endpoint, and the potential for re-ordering of those nested
+    objects, deepdiff has an ignore_order flag which I've added with an optional boolean argument to the assert_drf_json
+    function.
+    """
+    assert_drf_json_equal(courses_data, courses_from_fixture, ignore_order=True)
+
+
+@pytest.mark.parametrize("course_catalog_course_count", [1], indirect=True)
+@pytest.mark.parametrize("course_catalog_program_count", [1], indirect=True)
+@pytest.mark.parametrize("include_finaid", [True, False])
+def test_get_course(
+    user_drf_client,
+    course_catalog_data,
+    mock_context,
+    django_assert_max_num_queries,
+    include_finaid,
+):
+    """Test the view that handles a request for single Course"""
+    courses, _, _ = course_catalog_data
+    course = courses[0]
+    num_queries = num_queries_from_course(course, "v2")
+
+    if include_finaid:
+        mock_context["include_approved_financial_aid"] = True
+
+    with django_assert_max_num_queries(num_queries) as context:
+        query_count_start = len(connection.queries)
+        resp = user_drf_client.get(
+            reverse("v2:courses_api-detail", kwargs={"pk": course.id}),
+            {"include_approved_financial_aid": include_finaid},
+        )
+        query_count_end = len(connection.queries)
+        logger.info(
+            f"test_get_course logged {query_count_end - query_count_start} queries"
+        )
+    duplicate_queries_check(context)
+    course_data = resp.json()
+    course_from_fixture = dict(
+        CourseWithCourseRunsSerializer(instance=course, context=mock_context).data
+    )
+    assert_drf_json_equal(course_data, course_from_fixture, ignore_order=True)

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -138,7 +138,10 @@ def test_get_courses(
         query_count_start = len(connection.queries)
         resp = user_drf_client.get(
             reverse("v2:courses_api-list"),
-            {"include_approved_financial_aid": include_finaid},
+            {
+                "include_approved_financial_aid": include_finaid,
+                "page_size": len(courses_from_fixture),
+            },
         )
         query_count_end = len(connection.queries)
         logger.info(
@@ -146,7 +149,7 @@ def test_get_courses(
         )
     #     This will become an assert rather than a warning in the future, for now this function is informational
     duplicate_queries_check(context)
-    courses_data = resp.json()
+    courses_data = resp.json()["results"]
     assert len(courses_data) == len(courses_from_fixture)
     """
     Due to the number of relations in our current course endpoint, and the potential for re-ordering of those nested

--- a/flexiblepricing/api.py
+++ b/flexiblepricing/api.py
@@ -109,39 +109,21 @@ def get_ordered_eligible_coursewares(courseware):
     Returns the courseware(s) eligible for a flexible pricing tier in order
     (program first, then course)
     """
-    query_count_start = len(connection.queries)
-
     if isinstance(courseware, CourseRun):
         # recurse using the course run's course ;-)
-        retval = get_ordered_eligible_coursewares(courseware.course)
-        log.info(
-            f"get_ordered_eligible_courseware query count (but we recursed): {len(connection.queries) - query_count_start}"
-        )
-        return retval
+        return get_ordered_eligible_coursewares(courseware.course)
     if isinstance(courseware, Course) and len(courseware.programs) > 0:
         program_relations = []
 
         for program in courseware.programs:
             program_relations += program.related_programs
 
-        retval = courseware.programs + [courseware] + program_relations
-        log.info(
-            f"get_ordered_eligible_courseware query count (party time 1): {len(connection.queries) - query_count_start}"
-        )
-        return retval
+        return courseware.programs + [courseware] + program_relations
     if isinstance(courseware, ProgramRun) and courseware.program is not None:
-        retval = [courseware.program] + [
+        return [courseware.program] + [
             program_tuple[0] for program_tuple in courseware.program.related_programs
         ]
-        log.info(
-            f"get_ordered_eligible_courseware query count (party time 2): {len(connection.queries) - query_count_start}"
-        )
-        return retval
-    retval = [courseware]
-    log.info(
-        f"get_ordered_eligible_courseware query count (bottom): {len(connection.queries) - query_count_start}"
-    )
-    return retval
+    return [courseware]
 
 
 def determine_tier_courseware(courseware, income):
@@ -322,10 +304,7 @@ def is_courseware_flexible_price_approved(course_run, user):
     if isinstance(user, AnonymousUser):
         return False
 
-    query_count = 0
-
     for eligible_courseware in get_ordered_eligible_coursewares(course_run):
-        query_count_start = len(connection.queries)
         content_type = ContentType.objects.get_for_model(eligible_courseware)
         flexible_price = FlexiblePrice.objects.filter(
             courseware_content_type=content_type,
@@ -333,22 +312,14 @@ def is_courseware_flexible_price_approved(course_run, user):
             user=user,
         ).first()
 
-        query_count += len(connection.queries) - query_count_start
-
         if (
             flexible_price
             and flexible_price.tier.current
             and flexible_price.status
             in (FlexiblePriceStatus.APPROVED, FlexiblePriceStatus.AUTO_APPROVED)
         ):
-            log.info(
-                f"is_courseware_flexible_price_approved: terminating on true, {query_count} queries"
-            )
             return True
 
-    log.info(
-        f"is_courseware_flexible_price_approved: terminating on false, {query_count} queries"
-    )
     return False
 
 


### PR DESCRIPTION
# What are the relevant tickets?

mitodl/hq#2798

# Description (What does it do?)

Adds a refactored courses API to the app. This API:
* Allows for filtering on specific course IDs (numeric IDs)
* By default excludes the approved financial assistance check
* Uses a cut down version of the CoursePageSerializer (named aptly `BaseCoursePageSerializer`)

With these changes, the `/api/v2/courses` page runs ~600 queries (using the normal test case) versus v1's ~2000 queries. It also contains less data. 

The v2 API is intended to be used by the catalog; the course product pages should continue to use the v1 API so that financial assistance, instructors, and pricing data is available.

# How can this be tested?

Compare loading a course (or courses) in the v1 api versus the v2 one: `/api/courses` vs `/api/v2/courses` optionally with a PK at the end. They should be largely the same but the v2 should not include financial assistance page info, instructors, and pricing data in the page, and the approved financial assistance key should always be False. 

Load multiple courses by appending `?id=<IDs separated by commas>` - i.e. `/api/v2/courses/?id=1,3,5,7`. You should just get back those courses. 
