### PR TITLE
Adding a test for archived courses

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -94,7 +94,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
       <>
         <div className="enrollment-info-box componentized">
           {isArchived ? (
-            <div className="row d-flex align-self-stretch callout callout-warning">
+            <div className="row d-flex align-self-stretch callout callout-warning course-archived-message">
               <i className="material-symbols-outlined warning">error</i>
               <p>
                 This course is no longer active, but you can still access
@@ -102,7 +102,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               </p>
             </div>
           ) : null}
-          <div className="row d-flex align-items-center">
+          <div className="row d-flex align-items-center course-timing-message">
             <div className="enrollment-info-icon">
               <img
                 src="/static/images/products/start-date.png"
@@ -127,7 +127,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
             ) : null}
           </div>
           {course && course.page ? (
-            <div className="row d-flex align-items-top">
+            <div className="row d-flex align-items-top course-effort-message">
               <div className="enrollment-info-icon">
                 <img
                   src="/static/images/products/effort.png"
@@ -149,7 +149,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               </div>
             </div>
           ) : null}
-          <div className="row d-flex align-items-center">
+          <div className="row d-flex align-items-center course-pricing-message">
             <div className="enrollment-info-icon">
               <img src="/static/images/products/cost.png" alt="Cost" />
             </div>
@@ -157,7 +157,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               <b>Free</b>
             </div>
           </div>
-          <div className="row d-flex align-items-top">
+          <div className="row d-flex align-items-top course-certificate-message">
             <div className="enrollment-info-icon">
               <img
                 src="/static/images/products/certificate.png"

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -620,4 +620,57 @@ describe("CourseProductDetailEnroll", () => {
     const enrolledItem = infobox.find(".more-dates-link.enrolled")
     assert.isTrue(enrolledItem.exists())
   })
+
+  it("CourseInfoBox renders the archived message if the course is archived", async () => {
+    const courseRun = {
+      ...makeCourseRunDetail(),
+      is_self_paced:    true,
+      enrollment_end:   null,
+      enrollment_start: moment()
+        .subtract(1, "years")
+        .toISOString(),
+      start_date: moment()
+        .subtract(10, "months")
+        .toISOString(),
+      end_date: moment()
+        .subtract(7, "months")
+        .toISOString(),
+      upgrade_deadline: null
+    }
+    const course = {
+      ...makeCourseDetailWithRuns(),
+      courseruns: [courseRun]
+    }
+
+    console.log(course)
+
+    const entities = {
+      currentUser: currentUser,
+      enrollments: [],
+      courseRuns:  [courseRun],
+      courses:     [course]
+    }
+
+    const { inner } = await renderPage({
+      entities: entities
+    })
+
+    assert.isTrue(inner.exists())
+    const infobox = inner.find("CourseInfoBox").dive()
+    assert.isTrue(infobox.exists())
+
+    const archivedMessage = infobox.find("div.course-archived-message")
+    assert.isTrue(archivedMessage.exists())
+
+    const contentAvailabilityMessage = infobox.find(
+      "div.course-timing-message div.enrollment-info-text"
+    )
+    assert.isTrue(contentAvailabilityMessage.exists())
+    assert.isTrue(
+      contentAvailabilityMessage
+        .first()
+        .text()
+        .includes("Course content available anytime")
+    )
+  })
 })


### PR DESCRIPTION
# What are the relevant tickets?

mitodl/hq#2912

# Description (What does it do?)

After some investigation into the ticket noted, the archived message was in fact working properly - this just adds an automated test for that case. 

This also adds a few classes to the parts of the course infobox so it's easier to write tests for them.

# How can this be tested?

Run the automated test, which should pass.

You should additionally see new class names in the course infobox for the various sections of the box:
```
course-archived-message (if visible)
course-timing-message
course-effort-message
course-pricing-message
course-certificate-message
```

# Additional Context

The rules for this are:

A course is archived (and displays the yellow archived callout) if:
- The `enrollment_end` date is unset, or set in the future
- The `end_date` is set
