### PR TITLE
Change Catalog to use v2 API endpoint for courses

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -8,7 +8,7 @@ import {
   coursesNextPageSelector,
   coursesQuery,
   coursesQueryKey
-} from "../../lib/queries/courses"
+} from "../../lib/queries/catalogCourses"
 
 import {
   programsSelector,

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -713,7 +713,7 @@ describe("CatalogPage", function() {
 
     sinon.assert.calledWith(
       helper.handleRequestStub,
-      "/api/courses/?page=2&live=true&page__live=true&courserun_is_enrollable=true",
+      "/api/v2/courses/?page=2&live=true&page__live=true&courserun_is_enrollable=true",
       "GET"
     )
 

--- a/frontend/public/src/lib/queries/catalogCourses.js
+++ b/frontend/public/src/lib/queries/catalogCourses.js
@@ -1,0 +1,24 @@
+import { pathOr } from "ramda"
+
+import { nextState } from "./util"
+
+export const coursesSelector = pathOr(null, ["entities", "courses", "results"])
+
+export const coursesNextPageSelector = pathOr(null, [
+  "entities",
+  "courses",
+  "next"
+])
+
+export const coursesQueryKey = "courses"
+
+export const coursesQuery = page => ({
+  queryKey:  coursesQueryKey,
+  url:       `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
+  transform: json => ({
+    courses: json
+  }),
+  update: {
+    courses: nextState
+  }
+})


### PR DESCRIPTION
# What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/2798

# Description (What does it do?)
Since we don't want to change other pages, I've added this to a new query under catalogCourses (open to changing this name, but it made the most sense to me).


# How can this be tested?
Load up and load /catalog... careful, you might experience whiplash it's so fast now (kidding... but it's a major improvement.)

![Screenshot_2023-11-08_11-23-06](https://github.com/mitodl/mitxonline/assets/7756053/e8be2b8e-efe1-4663-a2c3-08df466ba5cd)
![image](https://github.com/mitodl/mitxonline/assets/7756053/a450ba1a-b8dc-4b2c-acc1-8635d6c22f2a)



