### PR TITLE
Updated v1 course API to only pull live programs; added tests

### DIFF
--- a/courses/serializers/v1/courses.py
+++ b/courses/serializers/v1/courses.py
@@ -33,7 +33,9 @@ class CourseSerializer(BaseCourseSerializer):
         if self.context.get("all_runs", False):
             from courses.serializers.v1.base import BaseProgramSerializer
 
-            return BaseProgramSerializer(instance.programs, many=True).data
+            return BaseProgramSerializer(
+                [program for program in instance.programs if program.live], many=True
+            ).data
 
         return None
 

--- a/courses/serializers/v1/courses.py
+++ b/courses/serializers/v1/courses.py
@@ -33,9 +33,15 @@ class CourseSerializer(BaseCourseSerializer):
         if self.context.get("all_runs", False):
             from courses.serializers.v1.base import BaseProgramSerializer
 
-            return BaseProgramSerializer(
-                [program for program in instance.programs if program.live], many=True
-            ).data
+            programs = (
+                models.Program.objects.select_related("page")
+                .filter(pk__in=[program.id for program in instance.programs])
+                .filter(live=True)
+                .filter(page__live=True)
+                .all()
+            )
+
+            return BaseProgramSerializer(programs, many=True).data
 
         return None
 

--- a/courses/views/v1/views_test.py
+++ b/courses/views/v1/views_test.py
@@ -200,12 +200,14 @@ def test_get_course(
 @pytest.mark.parametrize("course_catalog_course_count", [1], indirect=True)
 @pytest.mark.parametrize("course_catalog_program_count", [1], indirect=True)
 @pytest.mark.parametrize("program_is_live", [True, False])
+@pytest.mark.parametrize("program_page_is_live", [True, False])
 def test_get_course_by_readable_id(
     user_drf_client,
     course_catalog_data,
     mock_context,
     django_assert_max_num_queries,
     program_is_live,
+    program_page_is_live,
 ):
     """Test the view that handles a request for single Course"""
     courses, _, _ = course_catalog_data
@@ -214,6 +216,10 @@ def test_get_course_by_readable_id(
     if not program_is_live:
         course.programs[0].live = False
         course.programs[0].save()
+
+    if not program_page_is_live:
+        course.programs[0].page.live = False
+        course.programs[0].page.save()
 
     num_queries = num_queries_from_course(course, "v1")
     with django_assert_max_num_queries(num_queries) as context:
@@ -234,7 +240,7 @@ def test_get_course_by_readable_id(
     )
     assert_drf_json_equal(course_data, [course_from_fixture], ignore_order=True)
 
-    if program_is_live:
+    if program_is_live and program_page_is_live:
         assert len(course_data[0]["programs"]) == 1
     else:
         assert course_data[0]["programs"] == []

--- a/courses/views/v1/views_test.py
+++ b/courses/views/v1/views_test.py
@@ -199,6 +199,49 @@ def test_get_course(
 
 @pytest.mark.parametrize("course_catalog_course_count", [1], indirect=True)
 @pytest.mark.parametrize("course_catalog_program_count", [1], indirect=True)
+@pytest.mark.parametrize("program_is_live", [True, False])
+def test_get_course_by_readable_id(
+    user_drf_client,
+    course_catalog_data,
+    mock_context,
+    django_assert_max_num_queries,
+    program_is_live,
+):
+    """Test the view that handles a request for single Course"""
+    courses, _, _ = course_catalog_data
+    course = courses[0]
+
+    if not program_is_live:
+        course.programs[0].live = False
+        course.programs[0].save()
+
+    num_queries = num_queries_from_course(course, "v1")
+    with django_assert_max_num_queries(num_queries) as context:
+        resp = user_drf_client.get(
+            reverse("v1:courses_api-list"),
+            {"readable_id": course.readable_id, "live": True},
+        )
+    duplicate_queries_check(context)
+    course_data = resp.json()
+    course_from_fixture = dict(
+        CourseWithCourseRunsSerializer(
+            instance=course,
+            context={
+                **mock_context,
+                "all_runs": True,
+            },
+        ).data
+    )
+    assert_drf_json_equal(course_data, [course_from_fixture], ignore_order=True)
+
+    if program_is_live:
+        assert len(course_data[0]["programs"]) == 1
+    else:
+        assert course_data[0]["programs"] == []
+
+
+@pytest.mark.parametrize("course_catalog_course_count", [1], indirect=True)
+@pytest.mark.parametrize("course_catalog_program_count", [1], indirect=True)
 def test_create_course(
     user_drf_client,
     course_catalog_data,


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#2916

# Description (What does it do?)

Updates the courses API to filter programs by Live - if the program isn't live, then the course's programs list shouldn't have it. 

Also added a test for the course API by readable id - there didn't seem to be one, and the new tests also checks for program data to be included (or not) appropriately. 

# How can this be tested?

Automated tests should pass.

Load a course page for a course that's in a program. You should see the program in the list in the course infobox. 

Turn off the program by going to Django Admin and unchecking the Live box, then reload the course page. You should no longer see the program in the list. 
