### PR TITLE
Add page__live filter to programs API and update url in catalog page query

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -184,11 +184,12 @@ class ProgramPageSerializer(serializers.ModelSerializer):
             .live()
             .first()
         )
+        page_children = instance.get_children()
         if (financial_assistance_page is None) and (
-            instance.get_children() is not None
+            page_children is not None
         ):
             financial_assistance_page = (
-                instance.get_children().type(FlexiblePricingRequestForm).live().first()
+                page_children.type(FlexiblePricingRequestForm).live().first()
             )
         if (financial_assistance_page is None) & (
             len(instance.program.related_programs) > 0

--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -185,9 +185,7 @@ class ProgramPageSerializer(serializers.ModelSerializer):
             .first()
         )
         page_children = instance.get_children()
-        if (financial_assistance_page is None) and (
-            page_children is not None
-        ):
+        if (financial_assistance_page is None) and (page_children is not None):
             financial_assistance_page = (
                 page_children.type(FlexiblePricingRequestForm).live().first()
             )

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -37,7 +37,7 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProgramSerializer
     pagination_class = Pagination
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["id", "live", "readable_id"]
+    filterset_fields = ["id", "live", "readable_id", "page__live"]
     queryset = Program.objects.filter().prefetch_related("departments")
 
 

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -905,7 +905,7 @@ describe("CatalogPage", function() {
 
     sinon.assert.calledWith(
       helper.handleRequestStub,
-      "/api/v2/programs/?page=2&live=true",
+      "/api/v2/programs/?page=2&live=true&page__live=true",
       "GET"
     )
 

--- a/frontend/public/src/lib/queries/programs.js
+++ b/frontend/public/src/lib/queries/programs.js
@@ -18,7 +18,7 @@ export const programsQueryKey = "programs"
 
 export const programsQuery = page => ({
   queryKey:  programsQueryKey,
-  url:       `/api/v2/programs/?page=${page}&live=true`,
+  url:       `/api/v2/programs/?page=${page}&live=true&page__live=true`,
   transform: json => ({
     programs: json
   }),


### PR DESCRIPTION
# What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/2907

# Description (What does it do?)
updates programs to have a  page__live query


# How can this be tested?
Have a live program with no live associated page, should not see it on catalog page.
