### PR TITLE
Fixes start date formatting in CourseInfoBox, refactors date display for reuse

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -75,7 +75,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     enrollment.run.id === courseRun.id
                 ))
                 ? this.renderEnrolledDateLink(courseRun)
-                : getStartDateText(courseRun, false, true)}
+                : getStartDateText(courseRun, true)}
             </li>
           )
         }
@@ -101,7 +101,9 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               />
             </div>
             <div className="enrollment-info-text">
-              {getStartDateText(run, isArchived)}
+              {isArchived
+                ? "Course content available anytime"
+                : getStartDateText(run)}
             </div>
             {!isArchived && moreEnrollableCourseRuns ? (
               <>

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -3,7 +3,8 @@ import {
   formatPrettyDate,
   emptyOrNil,
   getFlexiblePriceForProduct,
-  formatLocalePrice
+  formatLocalePrice,
+  getStartDateText
 } from "../lib/util"
 import moment from "moment-timezone"
 
@@ -18,16 +19,6 @@ type CourseInfoBoxProps = {
   currentUser: CurrentUser,
   toggleUpgradeDialogVisibility: () => Promise<any>,
   setCurrentCourseRun: (run: EnrollmentFlaggedCourseRun) => Promise<any>
-}
-
-const getStartDateText = (run: BaseCourseRun, isArchived: boolean = false) => {
-  if (isArchived) {
-    return "Course content available anytime"
-  }
-  return run && !emptyOrNil(run.start_date) && !run.is_self_paced
-    ? (run.start_date > moment() ? "Starts: " : "Started: ") +
-        formatPrettyDate(moment(new Date(run.start_date)))
-    : "Start Anytime"
 }
 
 export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProps> {
@@ -84,7 +75,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     enrollment.run.id === courseRun.id
                 ))
                 ? this.renderEnrolledDateLink(courseRun)
-                : getStartDateText(courseRun)}
+                : getStartDateText(courseRun, false, true)}
             </li>
           )
         }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -1,7 +1,9 @@
 import React from "react"
 import { CSSTransition, TransitionGroup } from "react-transition-group"
 import moment from "moment"
-import { parseDateString, formatPrettyDate } from "../../lib/util"
+import {
+  getStartDateText
+} from "../../lib/util"
 
 import {
   coursesSelector,
@@ -299,55 +301,12 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * This is a comparison method used to sort an array of Course Runs
-   * from earliest start date to latest start date.
-   * @param {BaseCourseRun} courseRunA The first Course Run to compare.
-   * @param {BaseCourseRun} courseRunB The second Course Run to compare.
-   */
-  compareCourseRunStartDates(
-    courseRunA: BaseCourseRun,
-    courseRunB: BaseCourseRun
-  ) {
-    if (moment(courseRunA.start_date).isBefore(courseRunB.start_date)) {
-      return -1
-    }
-    if (moment(courseRunA.start_date).isAfter(courseRunB.start_date)) {
-      return 1
-    }
-    // CourseRunA and CourseRunB share the same start date.
-    return 0
-  }
-
-  /**
    * Returns the text to be displayed on a course catalog card's tag.
-   * This text will either be "Start Anytime" or "Start Date: <most recent, future, start date for the course>".
-   * If the Course has at least one associated Course Run which is not self-paced, and
-   * Course Run start date is in the future, then return "Start Date: <most recent, future, start date for the course>".
-   * If the Course has at least one associated Course Run which is not self-paced, and
-   * Course Run start date is in the past, then return "Start Anytime".
-   * If the course only has Course Runs which are self-paced, display "Start Anytime".
+   * The rules for this are in the description of getStartDateText.
    * @param {CourseDetailWithRuns} course The course being evaluated.
    */
   renderCatalogCardTagForCourse(course: CourseDetailWithRuns) {
-    const nonSelfPacedCourseRuns = course.courseruns.filter(
-      courseRun => !courseRun.is_self_paced
-    )
-    if (nonSelfPacedCourseRuns.length > 0) {
-      const futureStartDateCourseRuns = nonSelfPacedCourseRuns.filter(
-        courseRun => moment(courseRun.start_date).isAfter(moment())
-      )
-      if (futureStartDateCourseRuns.length > 0) {
-        const startDate = parseDateString(
-          futureStartDateCourseRuns.sort(this.compareCourseRunStartDates)[0]
-            .start_date
-        )
-        return `Start Date: ${formatPrettyDate(startDate)}`
-      } else {
-        return "Start Anytime"
-      }
-    } else {
-      return "Start Anytime"
-    }
+    return getStartDateText(course)
   }
 
   /**

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -299,15 +299,6 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * Returns the text to be displayed on a course catalog card's tag.
-   * The rules for this are in the description of getStartDateText.
-   * @param {CourseDetailWithRuns} course The course being evaluated.
-   */
-  renderCatalogCardTagForCourse(course: CourseDetailWithRuns) {
-    return getStartDateText(course)
-  }
-
-  /**
    * Returns a filtered array of Course Runs which are live, define a start date,
    * enrollment start date is before the current date and time, and
    * enrollment end date is not defined or is after the current date and time.

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -1,9 +1,7 @@
 import React from "react"
 import { CSSTransition, TransitionGroup } from "react-transition-group"
 import moment from "moment"
-import {
-  getStartDateText
-} from "../../lib/util"
+import { getStartDateText } from "../../lib/util"
 
 import {
   coursesSelector,
@@ -301,15 +299,6 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * Returns the text to be displayed on a course catalog card's tag.
-   * The rules for this are in the description of getStartDateText.
-   * @param {CourseDetailWithRuns} course The course being evaluated.
-   */
-  renderCatalogCardTagForCourse(course: CourseDetailWithRuns) {
-    return getStartDateText(course)
-  }
-
-  /**
    * Returns a filtered array of Course Runs which are live, define a start date,
    * enrollment start date is before the current date and time, and
    * enrollment end date is not defined or is after the current date and time.
@@ -395,7 +384,7 @@ export class CatalogPage extends React.Component<Props> {
           />
           <div className="catalog-item-description">
             <div className="start-date-description">
-              {this.renderCatalogCardTagForCourse(course)}
+              {getStartDateText(course)}
             </div>
             <div className="item-title">{course.title}</div>
           </div>

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -299,6 +299,15 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
+   * Returns the text to be displayed on a course catalog card's tag.
+   * The rules for this are in the description of getStartDateText.
+   * @param {CourseDetailWithRuns} course The course being evaluated.
+   */
+  renderCatalogCardTagForCourse(course: CourseDetailWithRuns) {
+    return getStartDateText(course)
+  }
+
+  /**
    * Returns a filtered array of Course Runs which are live, define a start date,
    * enrollment start date is before the current date and time, and
    * enrollment end date is not defined or is after the current date and time.

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -4,7 +4,6 @@ import { expect } from "chai"
 import moment from "moment-timezone"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import CatalogPage, { CatalogPage as InnerCatalogPage } from "./CatalogPage"
-import { formatPrettyDate } from "../../lib/util"
 import sinon from "sinon"
 
 const displayedCourse = {
@@ -484,86 +483,6 @@ describe("CatalogPage", function() {
       .instance()
       .validateCoursesCourseRuns(courseRuns)
     expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-  })
-
-  it("renders catalog course card with Start Anytime label if non-self paced course runs exist and all course runs start date in the past", async () => {
-    const course = JSON.parse(JSON.stringify(displayedCourse))
-    const { inner } = await renderPage()
-    let catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    expect(catalogCardTagForCourse).equals("Start Anytime")
-    course.courseruns[0].start_date = moment().add(2, "M")
-    catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    expect(catalogCardTagForCourse).equals(
-      `Start Date: ${formatPrettyDate(course.courseruns[0].start_date)}`
-    )
-  })
-
-  it("renders catalog course card with start date label if non-self paced course runs exist and all course runs start in the future", async () => {
-    const course = JSON.parse(JSON.stringify(displayedCourse))
-    const { inner } = await renderPage()
-    let catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    expect(catalogCardTagForCourse).equals("Start Anytime")
-    course.courseruns[0].start_date = moment().add(2, "M")
-    catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    expect(catalogCardTagForCourse).equals(
-      `Start Date: ${formatPrettyDate(course.courseruns[0].start_date)}`
-    )
-  })
-
-  it("renders catalog course card with closest future start date label if non-self paced course runs exist and a course run start date is in the future", async () => {
-    const course = JSON.parse(JSON.stringify(displayedCourse))
-    // Associate a second course run with the course
-    course.courseruns.push(
-      JSON.parse(JSON.stringify(displayedCourse.courseruns[0]))
-    )
-    course.courseruns.push(
-      JSON.parse(JSON.stringify(displayedCourse.courseruns[0]))
-    )
-    course.courseruns.push(
-      JSON.parse(JSON.stringify(displayedCourse.courseruns[0]))
-    )
-    const { inner } = await renderPage()
-    let catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    expect(catalogCardTagForCourse).equals("Start Anytime")
-
-    // Update the start dates of each associated course run to be in the future.
-    course.courseruns[0].start_date = moment().add(2, "M")
-    course.courseruns[1].start_date = moment().add(3, "d")
-    course.courseruns[2].start_date = moment().add(2, "d")
-    course.courseruns[3].is_self_paced = true
-    catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    // Expect the closest future start date
-    expect(catalogCardTagForCourse).equals(
-      `Start Date: ${formatPrettyDate(course.courseruns[2].start_date)}`
-    )
-  })
-
-  it("renders catalog course card with Start Anytime if only self paced course runs exist, even if start date is in the future", async () => {
-    const course = JSON.parse(JSON.stringify(displayedCourse))
-    const { inner } = await renderPage()
-    let catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    expect(catalogCardTagForCourse).equals("Start Anytime")
-
-    course.courseruns[0].start_date = moment().add(2, "M")
-    course.courseruns[0].is_self_paced = true
-    catalogCardTagForCourse = inner
-      .instance()
-      .renderCatalogCardTagForCourse(course)
-    expect(catalogCardTagForCourse).equals("Start Anytime")
   })
 
   it("renders catalog courses based on selected department", async () => {

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -306,28 +306,43 @@ export const compareCourseRunStartDates = (
 }
 
 /**
+ * This is a comparison method used to sort an array of Course Runs
+ * from latest start date to earliest start date.
+ * @param {BaseCourseRun} courseRunA The first Course Run to compare.
+ * @param {BaseCourseRun} courseRunB The second Course Run to compare.
+ */
+export const reverseCompareCourseRunStartDates = (
+  courseRunA: BaseCourseRun,
+  courseRunB: BaseCourseRun
+) => {
+  if (moment(courseRunA.start_date).isBefore(courseRunB.start_date)) {
+    return 1
+  }
+  if (moment(courseRunA.start_date).isAfter(courseRunB.start_date)) {
+    return -1
+  }
+  // CourseRunA and CourseRunB share the same start date.
+  return 0
+}
+
+/**
  * Returns the text to be displayed on a course catalog card's tag.
  * This text will either be "Start Anytime" or "Start Date: <most recent, future, start date for the course>".
  * If the Course has at least one associated Course Run which is not self-paced, and
  * Course Run start date is in the future, then return "Start Date: <most recent, future, start date for the course>".
  * If the Course has at least one associated Course Run which is not self-paced, and
- * Course Run start date is in the past, then return "Start Anytime".
+ * Course Run start date is in the past, and showPast is not true, then return "Start Anytime".
+ * If the Course has at least one associated Course Run which is not self-paced, and
+ * Course Run start date is in the past, and showPast is true, then return "Start Date: <most recent start date for the course>".
  * If the course only has Course Runs which are self-paced, display "Start Anytime".
- * If the isArchived flag is set, display "Course content available anytime".
- * @param {CourseDetailWithRuns} course The course being evaluated.
- * @param {isArchived} boolean Whether the course is archived or not.
+ * @param {CourseDetailWithRuns|BaseCourseRun} course The course being evaluated, or an individual course run to display the start text for.
  * @param {showPast} boolean Render start dates for course start dates that are in the past.
  */
 
 export const getStartDateText = (
   courseware: BaseCourseRun | CourseDetailWithRuns,
-  isArchived: boolean = false,
   showPast: boolean = false
 ) => {
-  if (isArchived) {
-    return "Course content available anytime"
-  }
-
   const nonSelfPacedCourseRuns = courseware.courseruns
     ? courseware.courseruns.filter(courseRun => !courseRun.is_self_paced)
     : courseware.is_self_paced
@@ -344,9 +359,12 @@ export const getStartDateText = (
       )
       return `Start Date: ${formatPrettyDate(startDate)}`
     } else {
-      if (showPast && nonSelfPacedCourseRuns.length > 0) {
+      if (showPast) {
         return `Start Date: ${formatPrettyDate(
-          parseDateString(nonSelfPacedCourseRuns[0].start_date)
+          parseDateString(
+            nonSelfPacedCourseRuns.sort(reverseCompareCourseRunStartDates)[0]
+              .start_date
+          )
         )}`
       }
       return "Start Anytime"

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -336,7 +336,7 @@ export const reverseCompareCourseRunStartDates = (
  * Course Run start date is in the past, and showPast is true, then return "Start Date: <most recent start date for the course>".
  * If the course only has Course Runs which are self-paced, display "Start Anytime".
  * @param {CourseDetailWithRuns|BaseCourseRun} course The course being evaluated, or an individual course run to display the start text for.
- * @param {showPast} boolean Render start dates for course start dates that are in the past.
+ * @param {showPast} boolean If the start date for the course is in the past, and showPast is true, then render the most recent start date for the course.
  */
 
 export const getStartDateText = (

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -26,7 +26,8 @@ import {
   isErrorResponse,
   isUnauthorizedResponse,
   formatLocalePrice,
-  intCheckFeatureFlag
+  intCheckFeatureFlag,
+  getStartDateText
 } from "./util"
 
 describe("utility functions", () => {
@@ -332,6 +333,74 @@ describe("utility functions", () => {
       )
       assert.isTrue(
         intCheckFeatureFlag("flagtwo", "anonymousUser", document, SETTINGS)
+      )
+    })
+  })
+
+  describe("getStartDateText", () => {
+    it("displays the Start Date text when the course run is in the future", () => {
+      const courseRun = {
+        start_date: moment().add(1, "days")
+      }
+      assert.isTrue(getStartDateText(courseRun).includes("Start Date:"))
+    })
+
+    it("displays the Start Date text when the course has a course run in the future", () => {
+      const course = {
+        courseruns: [
+          {
+            start_date: moment().add(1, "days")
+          }
+        ]
+      }
+      assert.isTrue(getStartDateText(course).includes("Start Date:"))
+    })
+
+    it("displays the Start Anytime text when the course run start date is in the past", () => {
+      const courseRun = {
+        start_date: moment().subtract(1, "months")
+      }
+      assert.isTrue(getStartDateText(courseRun).includes("Start Anytime"))
+    })
+
+    it("displays the Start Anytime text when the course has a course run start date is in the past", () => {
+      const course = {
+        courseruns: [
+          {
+            start_date: moment().subtract(1, "months")
+          }
+        ]
+      }
+      assert.isTrue(getStartDateText(course).includes("Start Anytime"))
+    })
+
+    it("displays the Start Anytime text when the course run is in the past but is Self-Paced", () => {
+      const courseRun = {
+        start_date:    moment().add(1, "days"),
+        is_self_paced: true
+      }
+      assert.isTrue(getStartDateText(courseRun).includes("Start Anytime"))
+    })
+
+    it("displays the Start Date text when the course run is completely in the past but showPast is true", () => {
+      const courseRun = {
+        start_date: moment().subtract(3, "months"),
+        end_date:   moment().subtract(2, "months")
+      }
+      assert.isTrue(
+        getStartDateText(courseRun, false, true).includes("Start Date")
+      )
+    })
+
+    it("displays the archived course message when isArchive flag is true", () => {
+      const courseRun = {
+        start_date: moment().subtract(3, "months"),
+        end_date:   moment().subtract(2, "months")
+      }
+      assert.isTrue(
+        getStartDateText(courseRun, true).includes(
+          "Course content available anytime"
+        )
       )
     })
   })

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -357,7 +357,8 @@ describe("utility functions", () => {
               start_date:
                 datePosition === "future"
                   ? moment().add(1, "days")
-                  : moment().subtract(1, "days")
+                  : moment().subtract(1, "days"),
+              is_self_paced: false
             }
           ]
         }


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#2984

# Description (What does it do?)

Ferdi noticed that the start date on a course in the future displayed as "Started: <future date>" in the course info box. This fixes that display - it should display "Start Date" now - and refactors out the date display code from the CatalogPage so that it is reusable elsewhere (but still takes into account the cases that the CourseInfoBox has, like archived courses and the More Dates display). 

# How can this be tested?

Automated tests should pass.

In the Course Info Box for a course with a valid future start date that isn't self-paced, it should display "Start Date:" and then the start date of the course.

In the Course Info Box for a course with a valid past start date that isn't self-paced, it should display "Start Anytime" and then the start date of the course.

In the Course Info Box for a course with a valid start date that _is_ self-paced, it should display "Start Anytime" and then the start date of the course.

In the Course Info Box for a course with multiple course runs, selecting More Dates should show "Start Date:" and the dates for each course run even if they are in the past.
