### PR TITLE
Headings for required courses start date

### DIFF
--- a/cms/templates/course_list_card.html
+++ b/cms/templates/course_list_card.html
@@ -4,9 +4,9 @@
         <div class="program-course-card">
         <img src="{{card.featured_image}}" alt="">
         <div class="program-course-card-info">
-            <h4 class="startdate">
+            <div class="start-date">
             {{card.start_descriptor}}
-            </h4>
+            </div>
             <h3 class="title">{{card.course.title}}</h3>
         </div>
         </div>

--- a/frontend/public/scss/product-page/program-courses.scss
+++ b/frontend/public/scss/product-page/program-courses.scss
@@ -80,10 +80,11 @@ body.new-design {
                         margin-top: 20px;
                     }
 
-                    h4 {
+                    .start-date {
                         font-weight: 400;
                         font-size: 12px;
                         color: #6f7175;
+                        margin-bottom: 0.5rem
                     }
 
                     h3 {


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2644

# Description (What does it do?)
Change the start time label to div instead of h4.

# Screenshots (if appropriate):
<img width="336" alt="Screen Shot 2023-11-15 at 10 24 59 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/ee0a68f6-fa49-4ff4-a1fd-ebcea4e28adf">


# How can this be tested?
Make sure that the design looks the same as before and nothing is broken.