### PR TITLE
Product Page: Display none for hidden text

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -94,7 +94,7 @@ body.new-design {
       }
 
       .hide {
-        transition: opacity 200ms, display 200ms;
+        //transition: opacity 200ms, display 200ms;
         display: none;
         opacity: 0;
       }

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -93,6 +93,12 @@ body.new-design {
         max-height: 400rem;
       }
 
+      .hide {
+        transition: opacity 200ms, display 200ms;
+        display: none;
+        opacity: 0;
+      }
+
       a.expand_here_link {
         opacity: 0;
         transition: opacity 225ms cubic-bezier(0.25, 0.46, 0.45, 0.94);

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -15,12 +15,14 @@ const expandExpandBlock = (event: MouseEvent) => {
       elem && elem.classList && elem.classList.toggle("open")
       if (elem && elem.classList && elem.classList.contains("open")) {
         event.srcElement.innerText = "Show Less"
+        elem.classList.remove("hide")
       } else {
         event.srcElement.classList.remove("fade")
         setTimeout(() => {
           requestAnimationFrame(() => {
             event.srcElement.innerText = "Show More"
             event.srcElement.classList.add("fade")
+            elem.classList.add("hide")
           })
         }, 225) // timeout
       }

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -22,7 +22,7 @@ const expandExpandBlock = (event: MouseEvent) => {
           requestAnimationFrame(() => {
             event.srcElement.innerText = "Show More"
             event.srcElement.classList.add("fade")
-            elem.classList.add("hide")
+            elem && elem.classList && elem.classList.add("hide")
           })
         }, 225) // timeout
       }


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2596


# Description (What does it do?)
Sets display none for hidden text on the page

# Screenshots (if appropriate):
<img width="851" alt="Screen Shot 2023-11-15 at 1 56 27 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/43851cb2-a0f1-4381-9759-ba405a517b11">
<img width="857" alt="Screen Shot 2023-11-15 at 1 56 36 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/ba14b8f2-d3ba-4417-8873-534dcc905532">


# How can this be tested?
Use voiceover to make sure the it doesn't read text that is not visible on the page.