### PR TITLE
Departments v2 endpoint - now with more course and program counts

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -1,4 +1,5 @@
 """Factories for creating course data in tests"""
+import string
 from types import SimpleNamespace
 
 import factory
@@ -16,6 +17,7 @@ from courses.models import (
     CourseRunCertificate,
     CourseRunEnrollment,
     CourseRunGrade,
+    Department,
     LearnerProgramRecordShare,
     PartnerSchool,
     Program,
@@ -30,6 +32,13 @@ from users.factories import UserFactory
 FAKE = faker.Factory.create()
 
 
+class DepartmentFactory(DjangoModelFactory):
+    name = fuzzy.FuzzyText(length=6, chars=string.ascii_letters, prefix="Testing-", suffix=" Department")
+
+    class Meta:
+        model = Department
+
+
 class ProgramFactory(DjangoModelFactory):
     """Factory for Programs"""
 
@@ -40,6 +49,12 @@ class ProgramFactory(DjangoModelFactory):
     live = True
 
     page = factory.RelatedFactory("cms.factories.ProgramPageFactory", "program")
+
+    @factory.post_generation
+    def departments(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+        self.departments.add(*extracted)
 
     class Meta:
         model = Program
@@ -61,8 +76,15 @@ class CourseFactory(DjangoModelFactory):
     title = fuzzy.FuzzyText(prefix="Course ")
     readable_id = factory.Sequence("course-{0}".format)
     live = True
+    departments = factory.SubFactory(DepartmentFactory)
 
     page = factory.RelatedFactory("cms.factories.CoursePageFactory", "course")
+
+    @factory.post_generation
+    def departments(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+        self.departments.add(*extracted)
 
     class Meta:
         model = Course

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -33,7 +33,7 @@ FAKE = faker.Factory.create()
 
 
 class DepartmentFactory(DjangoModelFactory):
-    name = fuzzy.FuzzyText(length=6, chars=string.ascii_letters, prefix="Testing-", suffix=" Department")
+    name = factory.Sequence(lambda x: f"Testing - {x} Department")
 
     class Meta:
         model = Department

--- a/courses/serializers/v2/departments.py
+++ b/courses/serializers/v2/departments.py
@@ -27,12 +27,19 @@ class DepartmentWithCountSerializer(DepartmentSerializer):
             & Q(live=True)
             & Q(start_date__isnull=False)
             & Q(enrollment_start__lt=now)
-            & (Q(enrollment_end=None) | Q(enrollment_end__gt=now))).values_list("id", flat=True)
+            & (Q(enrollment_end=None) | Q(enrollment_end__gt=now))
+        ).values_list("id", flat=True)
 
-        return related_courses.filter(courseruns__id__in=relevant_courseruns).distinct().count()
+        return (
+            related_courses.filter(courseruns__id__in=relevant_courseruns)
+            .distinct()
+            .count()
+        )
 
     def get_programs(self, instance):
-        return instance.program_set.filter(live=True, page__live=True).distinct().count()
+        return (
+            instance.program_set.filter(live=True, page__live=True).distinct().count()
+        )
 
     class Meta:
         model = Department

--- a/courses/serializers/v2/departments.py
+++ b/courses/serializers/v2/departments.py
@@ -14,7 +14,7 @@ class DepartmentSerializer(serializers.ModelSerializer):
 
 
 class DepartmentWithCountSerializer(DepartmentSerializer):
-    """CourseRun model serializer that includes the number of courses and programs associated with each departments"""
+    """Department model serializer that includes the number of courses and programs associated with each"""
 
     courses = serializers.SerializerMethodField()
     programs = serializers.SerializerMethodField()

--- a/courses/serializers/v2/departments.py
+++ b/courses/serializers/v2/departments.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+
+from courses import models
+
+
+class DepartmentSerializer(serializers.ModelSerializer):
+    """Department model serializer"""
+
+    class Meta:
+        model = models.Department
+        fields = ["id", "name"]
+
+
+class DepartmentWithCountSerializer(DepartmentSerializer):
+    """CourseRun model serializer that includes the number of courses and programs associated with each departments"""
+
+    courses = serializers.IntegerField()
+    programs = serializers.IntegerField()
+
+    class Meta:
+        model = models.Department
+        fields = DepartmentSerializer.Meta.fields + [
+            "courses",
+            "programs",
+        ]

--- a/courses/serializers/v2/departments.py
+++ b/courses/serializers/v2/departments.py
@@ -1,24 +1,41 @@
+from django.db.models import Prefetch, Q, Count
+from mitol.common.utils import now_in_utc
 from rest_framework import serializers
 
-from courses import models
+from courses.models import CourseRun, Department
 
 
 class DepartmentSerializer(serializers.ModelSerializer):
     """Department model serializer"""
 
     class Meta:
-        model = models.Department
+        model = Department
         fields = ["id", "name"]
 
 
 class DepartmentWithCountSerializer(DepartmentSerializer):
     """CourseRun model serializer that includes the number of courses and programs associated with each departments"""
 
-    courses = serializers.IntegerField()
-    programs = serializers.IntegerField()
+    courses = serializers.SerializerMethodField()
+    programs = serializers.SerializerMethodField()
+
+    def get_courses(self, instance):
+        now = now_in_utc()
+        related_courses = instance.course_set.filter(live=True, page__live=True)
+        relevant_courseruns = CourseRun.objects.filter(
+            Q(course__in=related_courses)
+            & Q(live=True)
+            & Q(start_date__isnull=False)
+            & Q(enrollment_start__lt=now)
+            & (Q(enrollment_end=None) | Q(enrollment_end__gt=now))).values_list("id", flat=True)
+
+        return related_courses.filter(courseruns__id__in=relevant_courseruns).distinct().count()
+
+    def get_programs(self, instance):
+        return instance.program_set.filter(live=True, page__live=True).distinct().count()
 
     class Meta:
-        model = models.Department
+        model = Department
         fields = DepartmentSerializer.Meta.fields + [
             "courses",
             "programs",

--- a/courses/serializers/v2/departments_test.py
+++ b/courses/serializers/v2/departments_test.py
@@ -1,0 +1,79 @@
+from datetime import timedelta
+
+import pytest
+
+from courses.factories import (
+    CourseFactory,
+    CourseRunFactory,
+    ProgramFactory,
+    DepartmentFactory,
+)
+from courses.serializers.v2.departments import DepartmentSerializer, DepartmentWithCountSerializer
+
+from main.test_utils import assert_drf_json_equal
+
+
+def test_serialize_department(mock_context):
+    department = DepartmentFactory.create()
+    data = DepartmentSerializer(instance=department, context=mock_context).data
+
+    assert_drf_json_equal(data, {"id": department.id, "name": department.name})
+
+
+# Should return 0 when there are no courses or programs at all, or when there are, but none are relevant
+def test_serialize_department_with_courses_and_programs__no_related(mock_context):
+    department = DepartmentFactory.create()
+    data = DepartmentWithCountSerializer(instance=department, context=mock_context).data
+    assert_drf_json_equal(data, {"id": department.id, "name": department.name, "courses": 0, "programs": 0})
+
+    course = CourseFactory.create()
+    CourseRunFactory.create(course=course, in_future=True)
+    ProgramFactory.create()
+    data = DepartmentWithCountSerializer(instance=department, context=mock_context).data
+    assert_drf_json_equal(data, {"id": department.id, "name": department.name, "courses": 0, "programs": 0})
+
+
+@pytest.mark.parametrize(
+    "valid_courses,valid_programs,invalid_courses,invalid_programs",
+    [(0, 0, 0, 0), (1, 1, 0, 0), (0, 0, 1, 1), (2, 2, 0, 0), (2, 2, 1, 1)]
+)
+def test_serialize_department_with_courses_and_programs__with_multiples(
+    mock_context,
+    valid_courses,
+    valid_programs,
+    invalid_courses,
+    invalid_programs,
+):
+    department = DepartmentFactory.create()
+    valid_courses_list = []
+    valid_programs_list = []
+
+    invalid_courses_list = []
+    invalid_programs_list = []
+
+    vc = valid_courses
+    while vc > 0:
+        course = CourseFactory.create(departments=[department])
+        # Each course has 2 course runs that are possible matches to make sure it is not returned twice.
+        CourseRunFactory.create(course=course, in_future=True)
+        CourseRunFactory.create(course=course, in_progress=True)
+        valid_courses_list += [course]
+        vc -= 1
+    vp = valid_programs
+    while vp > 0:
+        valid_programs_list += [ProgramFactory.create(departments=[department])]
+        vp -= 1
+    while invalid_courses > 0:
+        invalid_courses_list += [CourseFactory.create()]
+        invalid_courses -= 1
+    while invalid_programs > 0:
+        invalid_programs_list += [ProgramFactory.create()]
+        invalid_programs -= 1
+    data = DepartmentWithCountSerializer(instance=department, context=mock_context).data
+    assert_drf_json_equal(data,
+                          {
+                              "id": department.id,
+                              "name": department.name,
+                              "courses": valid_courses,
+                              "programs": valid_programs,
+                          })

--- a/courses/serializers/v2/departments_test.py
+++ b/courses/serializers/v2/departments_test.py
@@ -8,7 +8,10 @@ from courses.factories import (
     ProgramFactory,
     DepartmentFactory,
 )
-from courses.serializers.v2.departments import DepartmentSerializer, DepartmentWithCountSerializer
+from courses.serializers.v2.departments import (
+    DepartmentSerializer,
+    DepartmentWithCountSerializer,
+)
 
 from main.test_utils import assert_drf_json_equal
 
@@ -24,18 +27,24 @@ def test_serialize_department(mock_context):
 def test_serialize_department_with_courses_and_programs__no_related(mock_context):
     department = DepartmentFactory.create()
     data = DepartmentWithCountSerializer(instance=department, context=mock_context).data
-    assert_drf_json_equal(data, {"id": department.id, "name": department.name, "courses": 0, "programs": 0})
+    assert_drf_json_equal(
+        data,
+        {"id": department.id, "name": department.name, "courses": 0, "programs": 0},
+    )
 
     course = CourseFactory.create()
     CourseRunFactory.create(course=course, in_future=True)
     ProgramFactory.create()
     data = DepartmentWithCountSerializer(instance=department, context=mock_context).data
-    assert_drf_json_equal(data, {"id": department.id, "name": department.name, "courses": 0, "programs": 0})
+    assert_drf_json_equal(
+        data,
+        {"id": department.id, "name": department.name, "courses": 0, "programs": 0},
+    )
 
 
 @pytest.mark.parametrize(
     "valid_courses,valid_programs,invalid_courses,invalid_programs",
-    [(0, 0, 0, 0), (1, 1, 0, 0), (0, 0, 1, 1), (2, 2, 0, 0), (2, 2, 1, 1)]
+    [(0, 0, 0, 0), (1, 1, 0, 0), (0, 0, 1, 1), (2, 2, 0, 0), (2, 2, 1, 1)],
 )
 def test_serialize_department_with_courses_and_programs__with_multiples(
     mock_context,
@@ -70,10 +79,12 @@ def test_serialize_department_with_courses_and_programs__with_multiples(
         invalid_programs_list += [ProgramFactory.create()]
         invalid_programs -= 1
     data = DepartmentWithCountSerializer(instance=department, context=mock_context).data
-    assert_drf_json_equal(data,
-                          {
-                              "id": department.id,
-                              "name": department.name,
-                              "courses": valid_courses,
-                              "programs": valid_programs,
-                          })
+    assert_drf_json_equal(
+        data,
+        {
+            "id": department.id,
+            "name": department.name,
+            "courses": valid_courses,
+            "programs": valid_programs,
+        },
+    )

--- a/courses/urls/v2/urls.py
+++ b/courses/urls/v2/urls.py
@@ -7,5 +7,6 @@ app_name = "courses"
 router = routers.SimpleRouter()
 router.register(r"programs", v2.ProgramViewSet, basename="programs_api")
 router.register(r"courses", v2.CourseViewSet, basename="courses_api")
+router.register(r"departments", v2.DepartmentViewSet, basename="departments_api")
 
 urlpatterns = router.urls

--- a/courses/views/test_utils.py
+++ b/courses/views/test_utils.py
@@ -70,3 +70,17 @@ def num_queries_from_programs(programs, version="v1"):
         if version == "v2":
             num_queries += 6 + (12 * num_courses) + 1
     return num_queries
+
+
+def num_queries_from_department(num_departments, version="v2"):
+    """
+    v2 only as this was not in use prior
+    each department gets a course query, a program query and there are 3 overall queries - s
+        - site
+        - department count
+        - department IDs
+    Args:
+        num_departments (int): Number of department objects
+        version (str): version string (v2)
+    """
+    return (num_departments * 2) + 3

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -132,4 +132,4 @@ class DepartmentViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = []
 
     def get_queryset(self):
-        return Department.objects.all()
+        return Department.objects.all().order_by("name")


### PR DESCRIPTION
# What are the relevant tickets?
Updates
https://github.com/mitodl/hq/issues/2992
https://github.com/mitodl/hq/issues/2911
https://github.com/mitodl/hq/issues/2910
https://github.com/mitodl/hq/issues/2823

# Description (What does it do?)
This update to teh Departments endpoint:
- Makes the course and department counts accurate
- Moves the logic to the serializer rather than the view
- adds serializer tests
- adds view tests

# How can this be tested?
Run tests
Add departments to your local. The count in the catalog page should match the API output.
Also, double check my "math" on that logic.
