### PR TITLE
Fixes financial assistance form URL for programs that don't have their own

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -196,9 +196,16 @@ class ProgramPageSerializer(serializers.ModelSerializer):
                 FlexiblePricingRequestForm.objects.filter(
                     selected_program__in=instance.program.related_programs
                 )
+                .select_related("selected_program")
                 .live()
                 .first()
             )
+
+            program_page = ProgramPage.objects.filter(
+                program=financial_assistance_page.selected_program
+            ).get()
+            return f"{program_page.get_url()}{financial_assistance_page.slug}/"
+
         return (
             f"{instance.get_url()}{financial_assistance_page.slug}/"
             if financial_assistance_page

--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -369,7 +369,7 @@ def test_serialize_program_page__with_related_financial_form(
         {
             "feature_image_src": fake_image_src,
             "page_url": program_page.url,
-            "financial_assistance_form_url": f"{program_page.get_url()}{financial_assistance_form.slug}/",
+            "financial_assistance_form_url": f"{other_program_page.get_url()}{financial_assistance_form.slug}/",
             "description": bleach.clean(program_page.description, tags=[], strip=True),
             "live": True,
             "length": program_page.length,


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#2994

# Description (What does it do?)

If a program does not have its own financial assistance form, but is related to a program that does have one, the serializer looks for the appropriate financial assistance form URL for the related program. This works, but it was also putting the program it was asked for (that doesn't have a FA form)'s URL slug in the URL, which caused a broken link. This instead gets the program page that the financial assistance form belongs to and constructs the URL with that instead. 

# How can this be tested?

Create two programs in the system, including CMS pages. Create a financial assistance form for just one of those programs. Then, add a RelatedProgram record that ties the two programs together.

View the CMS page for the program with the FA form. The link to financial assistance should be visible and should go to the correct page. 

View the CMS page for the other program that does not have a FA form. The financial assistance link should be visible and it should go to the correct page; that is, it should go to the FA form for the first program. 
