### PR TITLE
Reoder product info for mobile view

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -14,8 +14,9 @@
     <div id="main" class="product-page">
       <div class="container">
         <div class="row d-flex flex-row align-center">
-          <div class="col flex-grow-1" id="product-details">
-            <div class="text">
+        <div class="col d-block d-md-none">
+        {# Mobile only #}
+          <div class="text">
             <nav aria-label="breadcrumb">
               <ol class="breadcrumb">
                 <li class="breadcrumb-item">
@@ -33,10 +34,38 @@
             {% endif %}
               <h1>{{ page.title }}</h1>
               {# Description field contents are already rendered wrapped in a <p> tag #}
-              
+
               <section class="course-description">
                 {{ page.description | richtext }}
               </section>
+        </div>
+        </div>
+          <div class="col order-md-1 order-2 flex-grow-1" id="product-details">
+            <div class="text">
+              <div class="d-none d-md-block">
+                {# Non-Mobile only #}
+                <nav aria-label="breadcrumb">
+                  <ol class="breadcrumb">
+                    <li class="breadcrumb-item">
+                      <a href="/catalog">
+                        <img alt="breadcrumb-arrow" src="/static/images/breadcrumb-arrow.svg"/>Catalog
+                      </a>
+                    </li>
+                    <li class="breadcrumb-item" aria-current="page">{% if page.is_program_page %}Program{% else %}Course{% endif %}</li>
+                  </ol>
+                </nav>
+                {% if page.is_program_page %}
+                    <div class="mb-2">
+                        <span class="badge-program-type">{{ page.product.program_type }}</span>
+                    </div>
+                {% endif %}
+                  <h1>{{ page.title }}</h1>
+                  {# Description field contents are already rendered wrapped in a <p> tag #}
+
+                  <section class="course-description">
+                    {{ page.description | richtext }}
+                  </section>
+                </div>
 
               <nav id="tab-bar">
                 <ul class="nav">

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -14,9 +14,9 @@
     <div id="main" class="product-page">
       <div class="container">
         <div class="row d-flex flex-row align-center">
-        <div class="col d-block d-md-none">
-        {# Mobile only #}
-          <div class="text">
+          <div class="col d-block d-md-none flex-none">
+          {# Mobile only #}
+            <div class="text">
             <nav aria-label="breadcrumb">
               <ol class="breadcrumb">
                 <li class="breadcrumb-item">
@@ -39,7 +39,7 @@
                 {{ page.description | richtext }}
               </section>
         </div>
-        </div>
+          </div>
           <div class="col order-md-1 order-2 flex-grow-1" id="product-details">
             <div class="text">
               <div class="d-none d-md-block">
@@ -144,7 +144,7 @@
         
             </div>
           </div>
-          <div class="col" id="product-info-box">
+          <div class="col order-md-2 order-1" id="product-info-box">
             <div class="px-4 py-2 border align-items-center justify-items-top d-flex flex-column">
               <div class="hero-media">
                 {% if page.video_url %}

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -23,6 +23,9 @@ body.new-design {
           justify-content: center !important;
       }
     }
+    .col.flex-none {
+      flex: none;
+    }
 
     .breadcrumb-item {
       color: var(--GreyText, #6F7175);


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2567

# Description (What does it do?)

Reoder product info for mobile view
# Screenshots (if appropriate):
<img width="1290" alt="Screen Shot 2023-11-17 at 8 46 26 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/22b8a21b-0fa8-431e-b7b7-138a393cf30f">
<img width="296" alt="Screen Shot 2023-11-17 at 8 46 45 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/53762bf2-eb3d-4aed-a4d3-31581b35e3fd">


# How can this be tested?
Go to product page make sure that Desktop and tablet view look the same as before. Go to mobile view and make sure that the Product Info Box goes right after product description.