### PR TITLE
Adding "text-break" so the browser will break long words into lines if it has to

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -31,7 +31,7 @@
                     <span class="badge-program-type">{{ page.product.program_type }}</span>
                 </div>
             {% endif %}
-              <h1>{{ page.title }}</h1>
+              <h1 class="text-break">{{ page.title }}</h1>
               {# Description field contents are already rendered wrapped in a <p> tag #}
               
               <section class="course-description">


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#2359

# Description (What does it do?)

Adds the `text-break` class to the course/program title's `h1` tag. This should tell the browser to break very long words if it has to - it should still break on spaces for words that aren't larger than the bounding box they're in. 

# Screenshots (if appropriate):

Really long word:
![image](https://github.com/mitodl/mitxonline/assets/945611/bb61d64d-a59e-4c37-974d-f7890de5e346)


Three long words with spaces:
![image](https://github.com/mitodl/mitxonline/assets/945611/63092422-92f2-48bc-a2c2-0360c9bc9b78)


# How can this be tested?

Update a course to have a really long string in it, then view the page. The browser should break it up and you should still see the course info box in the right location.

# Additional Context

This may not happen very often - you need a word long enough to extend past the bounding box of that column - but it was a pretty straightforward fix. 