### PR TITLE
Updates the onclick for the instructor name to activate on keyup, fixes an issue with financial assistance page serialization

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -201,6 +201,9 @@ class ProgramPageSerializer(serializers.ModelSerializer):
                 .first()
             )
 
+            if financial_assistance_page is None:
+                return ""
+
             program_page = ProgramPage.objects.filter(
                 program=financial_assistance_page.selected_program
             ).get()

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -90,7 +90,7 @@
                         <div class="member-card highlight-card" onClick="$('#instructor-modal-{{ member.id }}').modal('show');">
                           <img src="{% feature_img_src member.feature_image %}" alt="">
                           <div class="member-info">
-                            <h3 id="instructor-name-{{ member.id }}" class="name" role="button" tabindex="0">
+                            <h3 id="instructor-name-{{ member.id }}" class="name" role="button" tabindex="0" onClick="$('#instructor-modal-{{ member.id }}').modal('show');" onKeyUp="if (event.code === 'Enter') { $('#instructor-modal-{{ member.id }}').modal('show'); }">
                                 {{ member.instructor_name }}
                             </h3>
                             {% if member.instructor_title %}<h4 class="title">{{ member.instructor_title }}</h4>{% endif %}
@@ -148,7 +148,7 @@
 
           {% if instructors %}
           {% for member in instructors %}
-          <div class="modal instructor-modal" tabindex="-1" id="instructor-modal-{{ member.id }}">
+          <div class="modal instructor-modal" tabindex="-1" id="instructor-modal-{{ member.id }}" data-keyboard="true">
             <div class="modal-dialog modal-dialog-centered">
               <div class="modal-content">
                 <div class="modal-header">


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#2752

# Description (What does it do?)

This does two things:
1. There was no way to open the instructor cards by keyboard. You could tab down to an instructor name but you could not hit Enter to open the modal. Further, when the modal was open, you could not close it via the Escape key. 
2. In testing, I found an issue where if the program doesn't have a financial assistance form, and it has a related program that _also_ doesn't have a FA form, the serializer will fail. 

# How can this be tested?

Instructor cards: Open a product page and use the tab key to select the instructor name. Hit Enter, and the modal should open. Hit Escape and the modal should close. 

Program FA: Create two programs that are related to each other but do not create financial assistance forms for either. The program API should continue to work. 
