### PR TITLE
Accessibility: Make label visible to screen reader

### DIFF
--- a/frontend/public/scss/home-page/home-page-contact-row.scss
+++ b/frontend/public/scss/home-page/home-page-contact-row.scss
@@ -121,6 +121,10 @@ body.new-design {
               width:1px;
               height:1px;
               overflow:hidden;
+
+              .hs-form-required {
+                display: none;
+              }
             }
             .input {
               .hs-input {

--- a/frontend/public/scss/home-page/home-page-contact-row.scss
+++ b/frontend/public/scss/home-page/home-page-contact-row.scss
@@ -109,6 +109,7 @@ body.new-design {
           margin-top: 20px;
           margin-bottom: 40px;
           flex-wrap: wrap;
+          align-items: flex-end;
           .hs_email {
             order: 1;
             width: 70%;
@@ -117,7 +118,7 @@ body.new-design {
               max-width: 100%;
             }
             label {
-              display: none;
+              font-size: 12px;
             }
             .input {
               .hs-input {

--- a/frontend/public/scss/home-page/home-page-contact-row.scss
+++ b/frontend/public/scss/home-page/home-page-contact-row.scss
@@ -109,7 +109,6 @@ body.new-design {
           margin-top: 20px;
           margin-bottom: 40px;
           flex-wrap: wrap;
-          align-items: flex-end;
           .hs_email {
             order: 1;
             width: 70%;
@@ -118,7 +117,10 @@ body.new-design {
               max-width: 100%;
             }
             label {
-              font-size: 12px;
+              position:absolute;
+              width:1px;
+              height:1px;
+              overflow:hidden;
             }
             .input {
               .hs-input {


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2486
# Description (What does it do?)
Make Email input label visible to screen reader

# Screenshots (if appropriate):
<img width="1476" alt="Screen Shot 2023-11-21 at 11 03 21 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/025cfc2c-838d-467f-ab84-20a429552289">


# How can this be tested?
Use voiceover to to read the Signup section at the bottom of the home page. It should read the "Email*" label.

