### PR TITLE
Announce course count change

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -578,7 +578,7 @@ export class CatalogPage extends React.Component<Props> {
                     </TransitionGroup>
                   </div>
                   <div className="col catalog-page-item-count d-none d-sm-block">
-                    <div className="catalog-count-animation">
+                    <div className="catalog-count-animation" role="status" aria-atomic="true">
                       <TransitionGroup id="count-animation-grid">
                         <CSSTransition
                           key={this.state.tabSelected}

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -578,7 +578,11 @@ export class CatalogPage extends React.Component<Props> {
                     </TransitionGroup>
                   </div>
                   <div className="col catalog-page-item-count d-none d-sm-block">
-                    <div className="catalog-count-animation" role="status" aria-atomic="true">
+                    <div
+                      className="catalog-count-animation"
+                      role="status"
+                      aria-atomic="true"
+                    >
                       <TransitionGroup id="count-animation-grid">
                         <CSSTransition
                           key={this.state.tabSelected}


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2494

# Description (What does it do?)
Adds `role="status" aria-atomic="true"` to the course count div.

# How can this be tested?
Use voiceover to navigate the page click the department filters, when the course count updates it should announce the update.