### PR TITLE
Updates CSS to add hover states on the program course cards

### DIFF
--- a/frontend/public/scss/product-page/program-courses.scss
+++ b/frontend/public/scss/product-page/program-courses.scss
@@ -87,8 +87,9 @@ body.new-design {
                     .start-date {
                         font-weight: 400;
                         font-size: 12px;
-                        color: #6f7175;
-                        margin-bottom: 0.5rem
+                        color: rgba(112, 114, 117, 0.5);
+                        margin-bottom: 0.5rem;
+                        transition: $product-page-hover-time;
                     }
 
                     h3 {
@@ -96,19 +97,24 @@ body.new-design {
                         font-weight: 600;
                         line-height: 16px;
                         color: rgba(3, 21, 45, 0.5);
-                        transition: .25s;
+                        transition: $product-page-hover-time;
                     }
                 }
 
                 &:hover {
+                    .start-date {
+                        color: rgba(112, 114, 117, 1);
+                        transition: $product-page-hover-time;
+                    }
+
                     h3 {
                         color: rgba(3, 21, 45, 1);
-                        transition: .25s;
+                        transition: $product-page-hover-time;
                     }
 
                     img {
                         opacity: 1;
-                        transition: .25s;
+                        transition: $product-page-hover-time;
                     }
                 }
             }

--- a/frontend/public/scss/product-page/program-courses.scss
+++ b/frontend/public/scss/product-page/program-courses.scss
@@ -57,6 +57,7 @@ body.new-design {
                 max-width: 262px;
                 max-height: 259px;
                 height: 259px;
+                transition: .25s;
 
                 img {
                     max-width: 262px;
@@ -64,7 +65,10 @@ body.new-design {
                     height: 171px;
                     object-fit: cover;
                     object-position: center;
-
+                    background: rgba(0, 0, 0, 0.50);
+                    opacity: 0.5;
+                    transition: .25s;
+              
                     @include media-breakpoint-down(sm) {
                         display: block;
                         float: none;
@@ -91,13 +95,20 @@ body.new-design {
                         font-size: 14px;
                         font-weight: 600;
                         line-height: 16px;
-                        color: rgba(3, 21, 45, 0.85);
+                        color: rgba(3, 21, 45, 0.5);
+                        transition: .25s;
                     }
                 }
 
                 &:hover {
                     h3 {
-                        color: $brand-button-bg;
+                        color: rgba(3, 21, 45, 1);
+                        transition: .25s;
+                    }
+
+                    img {
+                        opacity: 1;
+                        transition: .25s;
                     }
                 }
             }

--- a/frontend/public/scss/variables.scss
+++ b/frontend/public/scss/variables.scss
@@ -56,3 +56,5 @@ $home-page-linkedin-blue: #0A66C2;
 $home-page-twitter-blue: #00A5E3;
 $home-page-border-purple: #491EA4;
 $home-page-subheader-light-blue: #03ADD2;
+
+$product-page-hover-time: 0.5s;


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#2986

# Description (What does it do?)

The program course cards should default to a "dimmed" mode, and then undim on hover. This adds the CSS to support that. See the [relevant Figma link](https://www.figma.com/proto/Gs4zIhOFv5gVvafawwl6PF/MITx-Online?page-id=0%3A1&type=design&node-id=1373-5892&viewport=-17610%2C515%2C0.97&t=8L3q92hSlGEYTV7H-1&scaling=min-zoom&mode=design). 

# Screenshots (if appropriate):

https://github.com/mitodl/mitxonline/assets/945611/96cf69ae-6bb1-49ed-957f-25481cb3b098

# How can this be tested?

Load the program page for a program with courses. The course cards should be dimmed, and hovering over them should bring the opacity of the image and the text to 1.

# Additional Context

We were using the red button background (ala the Enroll Now button) for the course title text - in Figma it isn't like this. 
