### PR TITLE
Mobile redesign: add course and program counts

### DIFF
--- a/frontend/public/scss/catalog.scss
+++ b/frontend/public/scss/catalog.scss
@@ -272,7 +272,6 @@
                 #tabs {
                     align-items: flex-start;
                     font-size: 16px;
-                    font-weight: 700;
                     flex-direction: row;
                     flex-wrap: nowrap;
         

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -579,7 +579,10 @@ export class CatalogPage extends React.Component<Props> {
                               }
                               tabIndex="0"
                             >
-                              Courses
+                              <strong>Courses</strong>{" "}
+                              <div className="d-inline-block d-sm-none">
+                                ({this.state.filteredCourses.length})
+                              </div>
                             </button>
                           </div>
                           <div
@@ -598,7 +601,10 @@ export class CatalogPage extends React.Component<Props> {
                                 this.changeSelectedTab(PROGRAMS_TAB)
                               }
                             >
-                              Programs
+                              <strong>Programs</strong>{" "}
+                              <div className="d-inline-block d-sm-none">
+                                ({this.state.filteredPrograms.length})
+                              </div>
                             </button>
                           </div>
                         </div>


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2509

# Description (What does it do?)
Add course and program counts to mobile view of the Catalog page

# Screenshots (if appropriate):
<img width="489" alt="Screen Shot 2023-11-29 at 2 15 23 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/c36a8cdb-6c9e-4a89-b494-0f9bf36f1dfd">


# How can this be tested?
Go to the Catalog page and view it in a mobile mode.