### PR TITLE
Fixes card sizing on the program tab in the catalog

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -427,21 +427,23 @@ export class CatalogPage extends React.Component<Props> {
    */
   renderProgramCatalogCard(program: Program) {
     return (
-      <a href={program.page.page_url} key={program.id}>
-        <div className="col catalog-item">
-          <div className="program-image-and-badge">
-            <img
-              src={program?.page?.feature_image_src}
-              key={program.id + program?.page?.feature_image_src}
-              alt=""
-            />
-            <div className="program-type-badge">{program.program_type}</div>
+      <li>
+        <a href={program.page.page_url} key={program.id}>
+          <div className="col catalog-item">
+            <div className="program-image-and-badge">
+              <img
+                src={program?.page?.feature_image_src}
+                key={program.id + program?.page?.feature_image_src}
+                alt=""
+              />
+              <div className="program-type-badge">{program.program_type}</div>
+            </div>
+            <div className="catalog-item-description">
+              <div className="item-title">{program.title}</div>
+            </div>
           </div>
-          <div className="catalog-item-description">
-            <div className="item-title">{program.title}</div>
-          </div>
-        </div>
-      </a>
+        </a>
+      </li>
     )
   }
 


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#3104

# Description (What does it do?)

@JenniWhitman noticed the card sizing on the program tab of the catalog was variable (unlike the courses tab) where they should match the courses tab. Upon investigation, it seemed that the program cards were missing `li` tags - they're in a `ul`, like the course cards, but they just weren't being put in list items. This adds that markup.

# Screenshots (if appropriate):

Before:
![Screenshot 2023-12-04 at 7 32 50 AM](https://github.com/mitodl/mitxonline/assets/945611/dd971971-a760-49ef-8508-47efa547de69)

After:
![Screenshot 2023-12-04 at 7 32 14 AM](https://github.com/mitodl/mitxonline/assets/945611/59866355-1954-488d-9da7-8dda5ddd0be0)


# How can this be tested?

Make sure you have some programs with long titles and some with short titles (to make it super obvious), then load the catalog page and hit the Programs tab. 
