### PR TITLE
Make department sidebar sticky on mobile

### DIFF
--- a/frontend/public/scss/layout.scss
+++ b/frontend/public/scss/layout.scss
@@ -47,11 +47,12 @@ body {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
+  position: relative;
 
   .main-panel {
     flex: 1;
     min-height: calc(100vh - 351px);
-    position: relative;
+    position: static;
 
     // TODO: temporary fix for home page iamge size, please remove it after home page design
     p {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -514,7 +514,11 @@ export class CatalogPage extends React.Component<Props> {
       )
     )
     return (
-      <nav id="department-sidebar" aria-label="department filters">
+      <nav
+        className="sticky-top"
+        id="department-sidebar"
+        aria-label="department filters"
+      >
         <ul id="department-sidebar-link-list">{departmentSideBarListItems}</ul>
       </nav>
     )


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2531

# Description (What does it do?)
Make department sidebar stay on the page when scrolling down on mobile



# How can this be tested?
Go to Catalog on mobile, scroll down to the bottom of the page, click the department filter button, a nav menu will open up. You should be able to see the list of the departments.