### PR TITLE
Fixes course run selection code and standardizes it

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -6,6 +6,7 @@ import {
   formatLocalePrice,
   getStartDateText
 } from "../lib/util"
+import { getFirstRelevantRun } from "../lib/courseApi"
 import moment from "moment-timezone"
 
 import type { BaseCourseRun } from "../flow/courseTypes"
@@ -52,10 +53,20 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
     const course = courses[0]
 
+    const testRun = getFirstRelevantRun(courses, courseRuns)
+    console.log(
+      "qq infobox btw new thingy says this is the relevant run",
+      testRun
+    )
+
+    console.log("qq infobox thinks it has these courseruns", courseRuns)
+
     const run = course.next_run_id
       ? course.courseruns.find(elem => elem.id === course.next_run_id)
       : course.courseruns[0]
     const product = run && run.products.length > 0 && run.products[0]
+
+    console.log("qq the infobox thinks this one is the right courserun", run)
 
     const isArchived =
       moment().isAfter(run.end_date) &&

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -53,17 +53,16 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
     const course = courses[0]
 
-    const testRun = getFirstRelevantRun(courses, courseRuns)
+    console.log("qq infobox thinks it has these courseruns", courseRuns)
+    console.log("qq and infobox thinks this is the course", course)
+
+    const testRun = getFirstRelevantRun(course, courseRuns)
     console.log(
       "qq infobox btw new thingy says this is the relevant run",
       testRun
     )
 
-    console.log("qq infobox thinks it has these courseruns", courseRuns)
-
-    const run = course.next_run_id
-      ? course.courseruns.find(elem => elem.id === course.next_run_id)
-      : course.courseruns[0]
+    const run = getFirstRelevantRun(course, courseRuns)
     const product = run && run.products.length > 0 && run.products[0]
 
     console.log("qq the infobox thinks this one is the right courserun", run)

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -52,20 +52,8 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     }
 
     const course = courses[0]
-
-    console.log("qq infobox thinks it has these courseruns", courseRuns)
-    console.log("qq and infobox thinks this is the course", course)
-
-    const testRun = getFirstRelevantRun(course, courseRuns)
-    console.log(
-      "qq infobox btw new thingy says this is the relevant run",
-      testRun
-    )
-
     const run = getFirstRelevantRun(course, courseRuns)
     const product = run && run.products.length > 0 && run.products[0]
-
-    console.log("qq the infobox thinks this one is the right courserun", run)
 
     const isArchived =
       moment().isAfter(run.end_date) &&

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -298,6 +298,7 @@ export class CourseProductDetailEnroll extends React.Component<
   }
 
   updateDate(run: EnrollmentFlaggedCourseRun) {
+    // for original design - not used in course infobox design
     let date = emptyOrNil(run.start_date)
       ? undefined
       : moment(new Date(run.start_date))
@@ -633,13 +634,22 @@ export class CourseProductDetailEnroll extends React.Component<
     let run,
       product = null
 
+    console.log("qq we think we have these course runs", courseRuns)
+
     if (courseRuns) {
       run = this.getFirstUnexpiredRun()
+
+      console.log("qq so for now we have this run", run)
 
       if (run) {
         product = run && run.products ? run.products[0] : null
         this.updateDate(run)
       }
+
+      console.log(
+        "qq we did some product searching and now we have this run",
+        run
+      )
     }
 
     return (

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -634,22 +634,13 @@ export class CourseProductDetailEnroll extends React.Component<
     let run,
       product = null
 
-    console.log("qq we think we have these course runs", courseRuns)
-
     if (courseRuns) {
       run = this.getFirstUnexpiredRun()
-
-      console.log("qq so for now we have this run", run)
 
       if (run) {
         product = run && run.products ? run.products[0] : null
         this.updateDate(run)
       }
-
-      console.log(
-        "qq we did some product searching and now we have this run",
-        run
-      )
     }
 
     return (

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -592,14 +592,17 @@ describe("CourseProductDetailEnroll", () => {
 
   it("CourseInfoBox renders a date selector with Enrolled text if the user is enrolled in one", async () => {
     const secondCourseRun = makeCourseRunDetail()
-    const enrollment = {
+    const enrollmentOne = {
       ...makeCourseRunEnrollment(),
       run: secondCourseRun
     }
-
+    const enrollmentTwo = {
+      ...makeCourseRunEnrollment(),
+      run: courseRun
+    }
     const entities = {
       currentUser: currentUser,
-      enrollments: [enrollment],
+      enrollments: [enrollmentOne, enrollmentTwo],
       courseRuns:  [courseRun, secondCourseRun]
     }
 
@@ -618,6 +621,7 @@ describe("CourseProductDetailEnroll", () => {
     assert.isTrue(selectorBar.exists())
 
     const enrolledItem = infobox.find(".more-dates-link.enrolled")
+
     assert.isTrue(enrolledItem.exists())
   })
 
@@ -641,8 +645,6 @@ describe("CourseProductDetailEnroll", () => {
       ...makeCourseDetailWithRuns(),
       courseruns: [courseRun]
     }
-
-    console.log(course)
 
     const entities = {
       currentUser: currentUser,

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -401,7 +401,7 @@ export class CatalogPage extends React.Component<Props> {
    */
   renderCourseCatalogCard(course: CourseDetailWithRuns) {
     return (
-      <li>
+      <li key={`course-card-${course.id}`}>
         <a href={course.page.page_url} key={course.id}>
           <div className="col catalog-item">
             <img
@@ -427,7 +427,7 @@ export class CatalogPage extends React.Component<Props> {
    */
   renderProgramCatalogCard(program: Program) {
     return (
-      <li>
+      <li key={`program-card-${program.id}`}>
         <a href={program.page.page_url} key={program.id}>
           <div className="col catalog-item">
             <div className="program-image-and-badge">

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -65,19 +65,7 @@ export const makeCourseRun = (): CourseRun => ({
 })
 
 export const makeCourseRunWithProduct = (): CourseRun => ({
-  title:            casual.text,
-  start_date:       casual.moment.add(2, "M").format(),
-  end_date:         casual.moment.add(4, "M").format(),
-  enrollment_start: casual.moment.add(-1, "M").format(),
-  enrollment_end:   casual.moment.add(3, "M").format(),
-  upgrade_deadline: casual.moment.add(4, "M").format(),
-  courseware_url:   casual.url,
-  courseware_id:    casual.word.concat(genCoursewareId.next().value),
-  run_tag:          casual.word.concat(genRunTagNumber.next().value),
-  // $FlowFixMe
-  id:               genCourseRunId.next().value,
-  course_number:    casual.word,
-  is_upgradable:    true,
+  ...makeCourseRun(),
   products:         [
     {
       description:            casual.text,
@@ -225,7 +213,7 @@ const makeDEDPSampleRequirementsTree = (
 export const makeCourseDetailWithRuns = (): CourseDetailWithRuns => {
   return {
     ...makeCourseDetail(),
-    courseruns: [makeCourseRun()]
+    courseruns: [makeCourseRunWithProduct()]
   }
 }
 

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -65,7 +65,19 @@ export const makeCourseRun = (): CourseRun => ({
 })
 
 export const makeCourseRunWithProduct = (): CourseRun => ({
-  ...makeCourseRun(),
+  title:            casual.text,
+  start_date:       casual.moment.add(2, "M").format(),
+  end_date:         casual.moment.add(4, "M").format(),
+  enrollment_start: casual.moment.add(-1, "M").format(),
+  enrollment_end:   casual.moment.add(3, "M").format(),
+  upgrade_deadline: casual.moment.add(4, "M").format(),
+  courseware_url:   casual.url,
+  courseware_id:    casual.word.concat(genCoursewareId.next().value),
+  run_tag:          casual.word.concat(genRunTagNumber.next().value),
+  // $FlowFixMe
+  id:               genCourseRunId.next().value,
+  course_number:    casual.word,
+  is_upgradable:    true,
   products:         [
     {
       description:            casual.text,
@@ -213,7 +225,7 @@ const makeDEDPSampleRequirementsTree = (
 export const makeCourseDetailWithRuns = (): CourseDetailWithRuns => {
   return {
     ...makeCourseDetail(),
-    courseruns: [makeCourseRunWithProduct()]
+    courseruns: [makeCourseRun()]
   }
 }
 

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -6,7 +6,8 @@ import {
   isFinancialAssistanceAvailable,
   learnerProgramIsCompleted,
   extractCoursesFromNode,
-  walkNodes
+  walkNodes,
+  getFirstRelevantRun
 } from "./courseApi"
 import { assert } from "chai"
 import moment from "moment"
@@ -18,7 +19,9 @@ import {
   makeProgramWithOnlyRequirements,
   makeProgramWithOnlyElectives,
   makeProgramWithNoElectivesOrRequirements,
-  makeProgram
+  makeProgram,
+  makeCourseDetailWithRuns,
+  makeCourseDetail
 } from "../factories/course"
 import { makeUser } from "../factories/user"
 
@@ -32,11 +35,17 @@ describe("Course API", () => {
     farPast = moment()
       .add(-50, "days")
       .toISOString(),
+    farFarPast = moment()
+      .add(-100, "days")
+      .toISOString(),
     future = moment()
       .add(10, "days")
       .toISOString(),
     farFuture = moment()
       .add(50, "days")
+      .toISOString(),
+    farFarFuture = moment()
+      .add(100, "days")
       .toISOString(),
     exampleUrl = "http://example.com"
   let courseRun: CourseRunDetail, user: LoggedInUser
@@ -312,6 +321,131 @@ describe("Course API", () => {
         const learnerRecord = makeLearnerRecord(false)
         const result = walkNodes(node, learnerRecord)
         assert.equal(result, expResult)
+      })
+    })
+  })
+
+  describe("getFirstRelevantRun", () => {
+    it("returns null if there aren't any supplied course runs", () => {
+      const course = makeCourseDetailWithRuns()
+      const result = getFirstRelevantRun(course, [])
+      assert.equal(result, null)
+    })
+
+    it("returns null if there aren't course runs in the course", () => {
+      const testCourse = {
+        ...makeCourseDetailWithRuns(),
+        courseruns: []
+      }
+      const result = getFirstRelevantRun(testCourse, [makeCourseRunDetail()])
+      assert.equal(result, null)
+    })
+    ;[
+      ["in order", true],
+      ["out of order", false]
+    ].forEach(([isInOrderDesc, isInOrder]) => {
+      it(`returns the first run that is in the future and runs are ${isInOrderDesc}`, () => {
+        const runs = [
+          {
+            ...makeCourseRunDetail(),
+            start_date:       future,
+            enrollment_start: future,
+            end_date:         farFuture,
+            enrollment_end:   farFuture
+          },
+          {
+            ...makeCourseRunDetail(),
+            start_date:       farFuture,
+            enrollment_start: farFuture,
+            end_date:         farFarFuture,
+            enrollment_end:   farFarFuture
+          }
+        ]
+
+        if (!isInOrder) {
+          runs.reverse()
+        }
+
+        const testCourse = {
+          ...makeCourseDetailWithRuns(),
+          next_run_id: null,
+          courseruns:  runs
+        }
+
+        const result = getFirstRelevantRun(testCourse, runs)
+        assert.equal(result, isInOrder ? runs[0] : runs[1])
+      })
+    })
+    ;[
+      ["in order", true],
+      ["out of order", false]
+    ].forEach(([isInOrderDesc, isInOrder]) => {
+      it(`returns the first run that is in the future and runs are ${isInOrderDesc}`, () => {
+        const runs = [
+          {
+            ...makeCourseRunDetail(),
+            start_date:       future,
+            enrollment_start: future,
+            end_date:         farFuture,
+            enrollment_end:   farFuture
+          },
+          {
+            ...makeCourseRunDetail(),
+            start_date:       farPast,
+            enrollment_start: farPast,
+            end_date:         past,
+            enrollment_end:   past
+          }
+        ]
+
+        if (!isInOrder) {
+          runs.reverse()
+        }
+
+        const testCourse = {
+          ...makeCourseDetailWithRuns(),
+          next_run_id: null,
+          courseruns:  runs
+        }
+
+        const result = getFirstRelevantRun(testCourse, runs)
+        assert.equal(result, isInOrder ? runs[0] : runs[1])
+      })
+    })
+    ;[
+      ["in order", true],
+      ["out of order", false]
+    ].forEach(([isInOrderDesc, isInOrder]) => {
+      it(`returns the most recent run that is in the past if all runs are done and runs are ${isInOrderDesc}`, () => {
+        const runs = [
+          {
+            ...makeCourseRunDetail(),
+            start_date:       farPast,
+            enrollment_start: farPast,
+            end_date:         past,
+            enrollment_end:   past
+          },
+          {
+            ...makeCourseRunDetail(),
+            start_date:       farFarPast,
+            enrollment_start: farFarPast,
+            end_date:         farPast,
+            enrollment_end:   farPast
+          }
+        ]
+
+        if (!isInOrder) {
+          runs.reverse()
+        }
+
+        const testCourse = {
+          ...makeCourseDetailWithRuns(),
+          next_run_id: null,
+          courseruns:  runs
+        }
+
+        const result = getFirstRelevantRun(testCourse, runs)
+        assert.equal(result, isInOrder ? runs[0] : runs[1])
       })
     })
   })

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -20,8 +20,7 @@ import {
   makeProgramWithOnlyElectives,
   makeProgramWithNoElectivesOrRequirements,
   makeProgram,
-  makeCourseDetailWithRuns,
-  makeCourseDetail
+  makeCourseDetailWithRuns
 } from "../factories/course"
 import { makeUser } from "../factories/user"
 


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#3083

# Description (What does it do?)

The issue in 3083 is that the course run selection was selecting two different courses - the Enroll button code used one method and the infobox uses a separate one, which ended up selecting a non-archived course where it should have grabbed the archived one. This reworks that code to ensure it selects the most recent course run if they're all expired (and thus fixes the issue) and moves the selection into a utility function so it's only in one place. 

In addition, I [fixed an issue](https://github.com/mitodl/mitxonline/pull/2013) this (12/4) morning and forgot to add `key`s to the `li` tags - this fixes that too, for both course cards and program cards (neither had that).

# How can this be tested?

Set up two courses:
- One entirely in the past, with an enrollment end date and an end date in the past.
- One in the past, but with open-ended enrollment (i.e. end date in the past but no enrollment end date)

You should see the "archived course" message in the Info Box for the course. 

All other course run date scenarios should work as before - if you have one that's currently open or in the future, it should select it appropriately, etc.

# Additional Context

I found some weirdness with products and unupgradeable courseruns - that has been captured here: https://github.com/mitodl/hq/issues/3109