### PR TITLE
Accessibility: tabbing through featured products improvement

### DIFF
--- a/frontend/public/scss/home-page/featured-product-cards.scss
+++ b/frontend/public/scss/home-page/featured-product-cards.scss
@@ -210,7 +210,7 @@
               p.date {
                 color: $home-page-grey-text;
                 font-size: 12px;
-                margin-bottom: 5px;
+                margin-bottom: 7px;
                 overflow: hidden;
                 align-self: stretch;
                 text-overflow: ellipsis;
@@ -218,7 +218,6 @@
               }
 
               h2.featured-product-card-title {
-                height: 38px;
                 align-self: stretch;
                 color: $home-page-header-blue;
                 font-size: 0.875rem;
@@ -229,9 +228,6 @@
                 -webkit-box-orient: vertical;
                 overflow: hidden;
                 line-height: 18px;
-              }
-              h2.featured-product-card-title.program-title {
-                height: 57.953px;
               }
             }
           }

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -60,4 +60,5 @@ $(document).ready(function() {
     slidesToShow:   4,
     slidesToScroll: 4
   })
+  $(".slick-slide").removeAttr("tabindex")
 })

--- a/main/templates/partials/featured_product_card.html
+++ b/main/templates/partials/featured_product_card.html
@@ -6,18 +6,18 @@
       <div class="badge badge-program-type{% if not product.program_type %}-none{% endif %}">{% if product.program_type %}{{ product.program_type }}{% endif %}</div>
     </div>
     <div class="featured-product-info">
-      {% if product.start_date and not product.is_self_paced and not product.is_program %}
-      <p class="date">
-        Starts {{ product.start_date | date:"F j, Y" }}
-      </p>
-      {% elif not product.is_program %}
-        <p class="date">
-          Start Anytime
-        </p>
-      {% endif %}
       <h2 class="featured-product-card-title card-title{% if product.is_program %} program-title{% endif %}">
+          {% if product.start_date and not product.is_self_paced and not product.is_program %}
+          <p class="date">
+            Starts {{ product.start_date | date:"F j, Y" }}
+          </p>
+          {% elif not product.is_program %}
+            <p class="date">
+              Start Anytime
+            </p>
+          {% endif %}
           {{ product.title }}
       </h2>
     </div>
-    </div>
+  </div>
   </a>


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2453
# Description (What does it do?)
Removes the duplicate selection of the featured products in the carousel.
Groups the title and the start time into a header for better readability.

# Screenshots (if appropriate):
<img width="1449" alt="Screen Shot 2023-12-04 at 3 01 20 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/d8cdc0ad-c5db-4464-8d00-7e2e368d038b">


# How can this be tested?
Use screen reader to read the featured products in the carousel. 
Tab through the products in the carousel each tab will move the selection to the next product.