### PR TITLE
Fixes the keyboard trap issue with instructor modals

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -115,11 +115,11 @@
                   <ul class="faculty-members card-listing">
                     {% if instructors %}
                     {% for member in instructors %}
-                      <li>
-                        <div class="member-card highlight-card" onClick="$('#instructor-modal-{{ member.id }}').modal('show');">
-                          <img src="{% feature_img_src member.feature_image %}" alt="">
+                      <li class="member-card-container">
+                        <div class="member-card highlight-card">
+                          <img tabindex="0" src="{% feature_img_src member.feature_image %}" alt="Featured image for {{ member.instructor_name }}" data-instructor-id="{{ member.id }}">
                           <div class="member-info">
-                            <h3 id="instructor-name-{{ member.id }}" class="name" role="button" tabindex="0" onClick="$('#instructor-modal-{{ member.id }}').modal('show');" onKeyUp="if (event.code === 'Enter') { $('#instructor-modal-{{ member.id }}').modal('show'); }">
+                            <h3 id="instructor-name-{{ member.id }}" data-instructor-id="{{ member.id }}" class="name instructor-name" role="button" tabindex="0">
                                 {{ member.instructor_name }}
                             </h3>
                             {% if member.instructor_title %}<h4 class="title">{{ member.instructor_title }}</h4>{% endif %}
@@ -182,9 +182,7 @@
               <div class="modal-content">
                 <div class="modal-header">
                   <h5 class="modal-title">{{ member.instructor_name }}</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close"
-                          onClick="$('#instructor-modal-{{ member.id }}').modal('hide');
-                                   $('#instructor-name-{{ member.id }}').focus();">
+                  <button type="button" class="close" data-close-instructor-id="{{ member.id }}" aria-label="Close">
                     <span aria-hidden="true">
                         <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.1239L8.94245 0.181446C9.18438 -0.0604821 9.57662 -0.0604821 9.81855 0.181446C10.0605 0.423375 10.0605 0.815619 9.81855 1.05755L5.8761 5L9.81855 8.94245C10.0605 9.18438 10.0605 9.57662 9.81855 9.81855C9.57662 10.0605 9.18438 10.0605 8.94245 9.81855L5 5.8761L1.05755 9.81855C0.815619 10.0605 0.423375 10.0605 0.181446 9.81855C-0.0604821 9.57662 -0.0604821 9.18438 0.181446 8.94245L4.1239 5L0.181446 1.05755C-0.0604821 0.815619 -0.0604821 0.423375 0.181446 0.181446C0.423375 -0.0604821 0.815619 -0.0604821 1.05755 0.181446L5 4.1239Z" fill="#03152D"/>

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -1,4 +1,5 @@
 // @flow
+/* global $:false */
 import React from "react"
 import { checkFeatureFlag } from "../lib/util"
 
@@ -30,6 +31,61 @@ const expandExpandBlock = (event: MouseEvent) => {
   }
 }
 
+const closeInstructorModal = (event: MouseEvent | KeyboardEvent) => {
+  event.preventDefault()
+  event.stopImmediatePropagation()
+
+  const instructorId = event.target.getAttribute("data-close-instructor-id")
+
+  if (
+    (instructorId && event.keyCode && event.keyCode === 13) ||
+    event.type === "click"
+  ) {
+    const modal = document.getElementById(`instructor-modal-${instructorId}`)
+    if (modal) {
+      $(modal)
+        .off("hidden.bs.modal")
+        .on("hidden.bs.modal", () => {
+          console.log("i'm in the hidden.bs.modal event")
+          document
+            .querySelector(
+              `li.member-card-container img[data-instructor-id='${instructorId}']`
+            )
+            .focus()
+        })
+
+      $(modal).modal("hide")
+      // document.querySelector(`div[data-instructor-id='${instructorId}'] h3`).focus()
+    }
+  }
+}
+
+const openInstructorModal = (event: MouseEvent | KeyboardEvent) => {
+  event.preventDefault()
+  event.stopImmediatePropagation()
+
+  const instructorId = event.target.getAttribute("data-instructor-id")
+
+  if (
+    (instructorId && event.keyCode && event.keyCode === 13) ||
+    event.type === "click"
+  ) {
+    const modal = document.getElementById(`instructor-modal-${instructorId}`)
+    if (modal) {
+      $(modal).modal("show")
+
+      document
+        .querySelectorAll(`div#instructor-modal-${instructorId} button.close`)
+        .forEach(button => {
+          button.removeEventListener("keyup", closeInstructorModal)
+          button.addEventListener("keyup", closeInstructorModal)
+          button.removeEventListener("click", closeInstructorModal)
+          button.addEventListener("click", closeInstructorModal)
+        })
+    }
+  }
+}
+
 type Props = {
   courseId: ?string,
   programId: ?string,
@@ -49,6 +105,13 @@ export class ProductDetailEnrollApp extends React.Component<Props> {
       document.querySelectorAll("a.expand_here_link").forEach(link => {
         link.removeEventListener("click", expandExpandBlock)
         link.addEventListener("click", expandExpandBlock)
+      })
+
+      document.querySelectorAll("h3.instructor-name").forEach(link => {
+        link.removeEventListener("click", openInstructorModal)
+        link.addEventListener("click", openInstructorModal)
+        link.removeEventListener("keyup", openInstructorModal)
+        link.addEventListener("keyup", openInstructorModal)
       })
     }
 

--- a/frontend/public/src/containers/ProductDetailEnrollApp.js
+++ b/frontend/public/src/containers/ProductDetailEnrollApp.js
@@ -35,27 +35,32 @@ const closeInstructorModal = (event: MouseEvent | KeyboardEvent) => {
   event.preventDefault()
   event.stopImmediatePropagation()
 
-  const instructorId = event.target.getAttribute("data-close-instructor-id")
+  const target = event.target
 
-  if (
-    (instructorId && event.keyCode && event.keyCode === 13) ||
-    event.type === "click"
-  ) {
-    const modal = document.getElementById(`instructor-modal-${instructorId}`)
-    if (modal) {
-      $(modal)
-        .off("hidden.bs.modal")
-        .on("hidden.bs.modal", () => {
-          console.log("i'm in the hidden.bs.modal event")
-          document
-            .querySelector(
+  if (target instanceof HTMLElement) {
+    const instructorId: string =
+      target.getAttribute("data-close-instructor-id") || ""
+
+    if (
+      instructorId &&
+      ((event.keyCode && event.keyCode === 13) || event.type === "click")
+    ) {
+      const modal = document.getElementById(`instructor-modal-${instructorId}`)
+      if (modal) {
+        // $FlowFixMe
+        $(modal)
+          .off("hidden.bs.modal")
+          .on("hidden.bs.modal", () => {
+            const instructorImg = document.querySelector(
               `li.member-card-container img[data-instructor-id='${instructorId}']`
             )
-            .focus()
-        })
 
-      $(modal).modal("hide")
-      // document.querySelector(`div[data-instructor-id='${instructorId}'] h3`).focus()
+            if (instructorImg) instructorImg.focus()
+          })
+
+        // $FlowFixMe
+        $(modal).modal("hide")
+      }
     }
   }
 }
@@ -64,24 +69,29 @@ const openInstructorModal = (event: MouseEvent | KeyboardEvent) => {
   event.preventDefault()
   event.stopImmediatePropagation()
 
-  const instructorId = event.target.getAttribute("data-instructor-id")
+  const target = event.target
 
-  if (
-    (instructorId && event.keyCode && event.keyCode === 13) ||
-    event.type === "click"
-  ) {
-    const modal = document.getElementById(`instructor-modal-${instructorId}`)
-    if (modal) {
-      $(modal).modal("show")
+  if (target instanceof HTMLElement) {
+    const instructorId: string = target.getAttribute("data-instructor-id") || ""
 
-      document
-        .querySelectorAll(`div#instructor-modal-${instructorId} button.close`)
-        .forEach(button => {
-          button.removeEventListener("keyup", closeInstructorModal)
-          button.addEventListener("keyup", closeInstructorModal)
-          button.removeEventListener("click", closeInstructorModal)
-          button.addEventListener("click", closeInstructorModal)
-        })
+    if (
+      instructorId &&
+      ((event.keyCode && event.keyCode === 13) || event.type === "click")
+    ) {
+      const modal = document.getElementById(`instructor-modal-${instructorId}`)
+      if (modal) {
+        // $FlowFixMe
+        $(modal).modal("show")
+
+        document
+          .querySelectorAll(`div#instructor-modal-${instructorId} button.close`)
+          .forEach(button => {
+            button.removeEventListener("keyup", closeInstructorModal)
+            button.addEventListener("keyup", closeInstructorModal)
+            button.removeEventListener("click", closeInstructorModal)
+            button.addEventListener("click", closeInstructorModal)
+          })
+      }
     }
   }
 }


### PR DESCRIPTION

# What are the relevant tickets?

Closes mitodl/hq#3077

# Description (What does it do?)

- Moves the instructor modal code into the ProductDetailEnrollApp (eliminating inline JS calls)
- Adds taborder to the instructor image so it can be focused upon
- When the modal is popped, set focus to the close button
- When the modal closes, set focus to the instructor's featured image

This sets the focus to the featured image because otherwise there ends up being a stray keyup that re-toggles the modal to open again if focus is set to the h3.

# How can this be tested?

Navigate to a course page that has instructors on it. You should be able to tab down to the instructor name, hit Enter, and pop the modal. The focus should be on the Close button so hitting Enter again should close, or you can tab around. The modal should close but not reopen.

Similarly, navigation should work as expected with a screen reader turned on.
