### PR TITLE
add styles to the navbar on product page

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -67,16 +67,15 @@
                   </section>
                 </div>
 
-            <div data-bs-spy="scroll" data-bs-target="#tab-bar" tabindex="0" data-bs-offset=100 class="scroll-spy-content">
               {# Non-Mobile only #}
               <nav id="tab-bar" class="sticky-top d-none d-md-block">
                 <ul class="nav">
-                  {% if page.about %}<li class="nav-item"><a href="#about-this-class">About</a></li>{% endif %}
-                  {% if page.is_program_page %}<li class="nav-item"><a href="#program-courses">Courses</a></li>{% endif %}
-                  {% if page.what_you_learn %}<li class="nav-item"><a href="#what-youll-learn">What you'll learn</a></li>{% endif %}
-                  {% if page.prerequisites %}<li class="nav-item"><a href="#prerequisites">Prerequisites</a></li>{% endif %}
-                  {% if instructors %}<li class="nav-item"><a href="#instructors">Instructors</a></li>{% endif %}
-                  {% if page.faq_url %}<li class="nav-item"><a href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
+                  {% if page.about %}<li class="nav-item"><a class="nav-link" href="#about-this-class">About</a></li>{% endif %}
+                  {% if page.is_program_page %}<li class="nav-item"><a class="nav-link" href="#program-courses">Courses</a></li>{% endif %}
+                  {% if page.what_you_learn %}<li class="nav-item"><a class="nav-link" href="#what-youll-learn">What you'll learn</a></li>{% endif %}
+                  {% if page.prerequisites %}<li class="nav-item"><a class="nav-link" href="#prerequisites">Prerequisites</a></li>{% endif %}
+                  {% if instructors %}<li class="nav-item"><a class="nav-link" href="#instructors">Instructors</a></li>{% endif %}
+                  {% if page.faq_url %}<li class="nav-item"><a class="nav-link" href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
                 </ul>
               </nav>
               {# Mobile only #}
@@ -93,7 +92,7 @@
                       </ul>
                     </div>
                 </nav>
-
+            <div class="scroll-spy-content">
               {% if page.about %}<section class="about-this-class about-richtext-container" id="about-this-class">
                 {{ page.about | richtext | expand }}
               </section>{% endif %}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -71,12 +71,12 @@
               {# Non-Mobile only #}
               <nav id="tab-bar" class="sticky-top d-none d-md-block">
                 <ul class="nav">
-                  {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
-                  {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
-                  {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
-                  {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}
-                  {% if instructors %}<a href="#instructors"><li class="nav-item">Instructors</li></a>{% endif %}
-                  {% if page.faq_url %}<a href="{{page.faq_url}}" target="_blank"><li class="nav-item">FAQs</li></a>{% endif %}
+                  {% if page.about %}<li class="nav-item"><a href="#about-this-class">About</a></li>{% endif %}
+                  {% if page.is_program_page %}<li class="nav-item"><a href="#program-courses">Courses</a></li>{% endif %}
+                  {% if page.what_you_learn %}<li class="nav-item"><a href="#what-youll-learn">What you'll learn</a></li>{% endif %}
+                  {% if page.prerequisites %}<li class="nav-item"><a href="#prerequisites">Prerequisites</a></li>{% endif %}
+                  {% if instructors %}<li class="nav-item"><a href="#instructors">Instructors</a></li>{% endif %}
+                  {% if page.faq_url %}<li class="nav-item"><a href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
                 </ul>
               </nav>
               {# Mobile only #}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 {% if new_design %}
-    <div id="main" class="product-page">
+    <div id="main" class="product-page" data-spy="scroll" data-target="#tab-bar" data-offset="50">
       <div class="container">
         <div class="row d-flex flex-row align-center">
           <div class="col d-block d-md-none flex-none">
@@ -67,9 +67,9 @@
                   </section>
                 </div>
 
-              <nav id="tab-bar">
+              <nav id="tab-bar" class="sticky-top">
                 <ul class="nav">
-                  {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
+                  {% if page.about %}<a href="#about-this-class"><li class="nav-item active">About</li></a>{% endif %}
                   {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
                   {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
                   {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -66,18 +66,34 @@
                     {{ page.description | richtext }}
                   </section>
                 </div>
-                <nav id="tab-bar-wrapper" class="sticky-top">
-                  <ul id="tab-bar" class="nav">
-                      {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
-                      {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
-                      {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
-                      {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}
-                      {% if instructors %}<a href="#instructors"><li class="nav-item">Instructors</li></a>{% endif %}
-                      {% if page.faq_url %}<a href="{{page.faq_url}}" target="_blank"><li class="nav-item">FAQs</li></a>{% endif %}
-                  </ul>
+
+            <div data-bs-spy="scroll" data-bs-target="#tab-bar-wrapper" tabindex="0" data-bs-offset="100px" class="scroll-spy-content">
+              {# Non-Mobile only #}
+              <nav id="tab-bar" class="sticky-top d-none d-md-block">
+                <ul class="nav">
+                  {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
+                  {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
+                  {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
+                  {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}
+                  {% if instructors %}<a href="#instructors"><li class="nav-item">Instructors</li></a>{% endif %}
+                  {% if page.faq_url %}<a href="{{page.faq_url}}" target="_blank"><li class="nav-item">FAQs</li></a>{% endif %}
+                </ul>
+              </nav>
+              {# Mobile only #}
+                <nav id="tab-bar" class="sticky-top d-block d-md-none">
+                  <div class="nav-item dropdown mobile-nav-dropdown">
+                      <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">About</a>
+                      <ul class="dropdown-menu">
+                        {% if page.about %}<li><a class="dropdown-item" href="#about-this-class">About</a></li>{% endif %}
+                        {% if page.is_program_page %}<li><a class="dropdown-item" href="#program-courses">Courses</a></li>{% endif %}
+                          {% if page.what_you_learn %}<li><a class="dropdown-item" href="#what-youll-learn">What you'll learn</a></li>{% endif %}
+                          {% if page.prerequisites %}<li><a class="dropdown-item" href="#prerequisites">Prerequisites</a></li>{% endif %}
+                          {% if instructors %}<li><a class="dropdown-item" href="#instructors">Instructors</a></li>{% endif %}
+                          {% if page.faq_url %}<li><a class="dropdown-item" href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
+                      </ul>
+                    </div>
                 </nav>
 
-            <div data-bs-spy="scroll" data-bs-target="#tab-bar-wrapper" tabindex="0" data-bs-offset="100" class="scroll-spy-content">
               {% if page.about %}<section class="about-this-class about-richtext-container" id="about-this-class">
                 {{ page.about | richtext | expand }}
               </section>{% endif %}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -67,7 +67,7 @@
                   </section>
                 </div>
 
-            <div data-bs-spy="scroll" data-bs-target="#tab-bar-wrapper" tabindex="0" data-bs-offset="100px" class="scroll-spy-content">
+            <div data-bs-spy="scroll" data-bs-target="#tab-bar" tabindex="0" data-bs-offset=100 class="scroll-spy-content">
               {# Non-Mobile only #}
               <nav id="tab-bar" class="sticky-top d-none d-md-block">
                 <ul class="nav">
@@ -81,15 +81,15 @@
               </nav>
               {# Mobile only #}
                 <nav id="tab-bar" class="sticky-top d-block d-md-none">
-                  <div class="nav-item dropdown mobile-nav-dropdown">
-                      <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">About</a>
+                  <div class="nav dropdown">
+                      <a class="dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">About</a>
                       <ul class="dropdown-menu">
-                        {% if page.about %}<li><a class="dropdown-item" href="#about-this-class">About</a></li>{% endif %}
-                        {% if page.is_program_page %}<li><a class="dropdown-item" href="#program-courses">Courses</a></li>{% endif %}
-                          {% if page.what_you_learn %}<li><a class="dropdown-item" href="#what-youll-learn">What you'll learn</a></li>{% endif %}
-                          {% if page.prerequisites %}<li><a class="dropdown-item" href="#prerequisites">Prerequisites</a></li>{% endif %}
-                          {% if instructors %}<li><a class="dropdown-item" href="#instructors">Instructors</a></li>{% endif %}
-                          {% if page.faq_url %}<li><a class="dropdown-item" href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
+                        {% if page.about %}<li class="nav-item"><a class="nav-link dropdown-item" href="#about-this-class">About</a></li>{% endif %}
+                        {% if page.is_program_page %}<li><a class="nav-link dropdown-item" href="#program-courses">Courses</a></li>{% endif %}
+                        {% if page.what_you_learn %}<li class="nav-item"><a class="nav-link dropdown-item" href="#what-youll-learn">What you'll learn</a></li>{% endif %}
+                        {% if page.prerequisites %}<li><a class="nav-link dropdown-item" href="#prerequisites">Prerequisites</a></li>{% endif %}
+                        {% if instructors %}<li><a class="nav-link dropdown-item" href="#instructors">Instructors</a></li>{% endif %}
+                        {% if page.faq_url %}<li><a class="nav-link dropdown-item" href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
                       </ul>
                     </div>
                 </nav>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -84,11 +84,11 @@
                       <a class="dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">About</a>
                       <ul class="dropdown-menu">
                         {% if page.about %}<li class="nav-item"><a class="nav-link dropdown-item" href="#about-this-class">About</a></li>{% endif %}
-                        {% if page.is_program_page %}<li><a class="nav-link dropdown-item" href="#program-courses">Courses</a></li>{% endif %}
+                        {% if page.is_program_page %}<li class="nav-item"><a class="nav-link dropdown-item" href="#program-courses">Courses</a></li>{% endif %}
                         {% if page.what_you_learn %}<li class="nav-item"><a class="nav-link dropdown-item" href="#what-youll-learn">What you'll learn</a></li>{% endif %}
-                        {% if page.prerequisites %}<li><a class="nav-link dropdown-item" href="#prerequisites">Prerequisites</a></li>{% endif %}
-                        {% if instructors %}<li><a class="nav-link dropdown-item" href="#instructors">Instructors</a></li>{% endif %}
-                        {% if page.faq_url %}<li><a class="nav-link dropdown-item" href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
+                        {% if page.prerequisites %}<li class="nav-item"><a class="nav-link dropdown-item" href="#prerequisites">Prerequisites</a></li>{% endif %}
+                        {% if instructors %}<li class="nav-item"><a class="nav-link dropdown-item" href="#instructors">Instructors</a></li>{% endif %}
+                        {% if page.faq_url %}<li class="nav-item"><a class="nav-link dropdown-item" href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
                       </ul>
                     </div>
                 </nav>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -69,12 +69,12 @@
 
               <nav id="tab-bar">
                 <ul class="nav">
-                  {% if page.about %}<li class="nav-item"><a href="#about-this-class">About</a></li>{% endif %}
-                  {% if page.is_program_page %}<li class="nav-item"><a href="#program-courses">Courses</a></li>{% endif %}
-                  {% if page.what_you_learn %}<li class="nav-item"><a href="#what-youll-learn">What you'll learn</a></li>{% endif %}
-                  {% if page.prerequisites %}<li class="nav-item"><a href="#prerequisites">Prerequisites</a></li>{% endif %}
-                  {% if instructors %}<li class="nav-item"><a href="#instructors">Instructors</a></li>{% endif %}
-                  {% if page.faq_url %}<li class="nav-item"><a href="{{page.faq_url}}" target="_blank">FAQs</a></li>{% endif %}
+                  {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
+                  {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
+                  {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
+                  {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}
+                  {% if instructors %}<a href="#instructors"><li class="nav-item">Instructors</li></a>{% endif %}
+                  {% if page.faq_url %}<a href="{{page.faq_url}}" target="_blank"><li class="nav-item">FAQs</li></a>{% endif %}
                 </ul>
               </nav>
 

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 {% if new_design %}
-    <div id="main" class="product-page" data-spy="scroll" data-target="#tab-bar" data-offset="50">
+    <div id="main" class="product-page">
       <div class="container">
         <div class="row d-flex flex-row align-center">
           <div class="col d-block d-md-none flex-none">
@@ -67,17 +67,16 @@
                   </section>
                 </div>
 
-              <nav id="tab-bar" class="sticky-top">
-                <ul class="nav">
-                  {% if page.about %}<a href="#about-this-class"><li class="nav-item active">About</li></a>{% endif %}
+              <ul id="tab-bar" class="nav sticky-top">
+                  {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
                   {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
                   {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
                   {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}
                   {% if instructors %}<a href="#instructors"><li class="nav-item">Instructors</li></a>{% endif %}
                   {% if page.faq_url %}<a href="{{page.faq_url}}" target="_blank"><li class="nav-item">FAQs</li></a>{% endif %}
-                </ul>
-              </nav>
+              </ul>
 
+            <div data-bs-spy="scroll" data-bs-target="#tab-bar" tabindex="0" data-bs-offset="0" class="scroll-spy-content">
               {% if page.about %}<section class="about-this-class about-richtext-container" id="about-this-class">
                 {{ page.about | richtext | expand }}
               </section>{% endif %}
@@ -133,6 +132,7 @@
                 </div>
               </section>
               {% endif %}
+            </div>
 
               <section class="ofac-message border">
                 <div class="container">

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -66,17 +66,18 @@
                     {{ page.description | richtext }}
                   </section>
                 </div>
+                <nav id="tab-bar-wrapper" class="sticky-top">
+                  <ul id="tab-bar" class="nav">
+                      {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
+                      {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
+                      {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
+                      {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}
+                      {% if instructors %}<a href="#instructors"><li class="nav-item">Instructors</li></a>{% endif %}
+                      {% if page.faq_url %}<a href="{{page.faq_url}}" target="_blank"><li class="nav-item">FAQs</li></a>{% endif %}
+                  </ul>
+                </nav>
 
-              <ul id="tab-bar" class="nav sticky-top">
-                  {% if page.about %}<a href="#about-this-class"><li class="nav-item">About</li></a>{% endif %}
-                  {% if page.is_program_page %}<a href="#program-courses"><li class="nav-item">Courses</li></a>{% endif %}
-                  {% if page.what_you_learn %}<a href="#what-youll-learn"><li class="nav-item">What you'll learn</li></a>{% endif %}
-                  {% if page.prerequisites %}<a href="#prerequisites"><li class="nav-item">Prerequisites</li></a>{% endif %}
-                  {% if instructors %}<a href="#instructors"><li class="nav-item">Instructors</li></a>{% endif %}
-                  {% if page.faq_url %}<a href="{{page.faq_url}}" target="_blank"><li class="nav-item">FAQs</li></a>{% endif %}
-              </ul>
-
-            <div data-bs-spy="scroll" data-bs-target="#tab-bar" tabindex="0" data-bs-offset="0" class="scroll-spy-content">
+            <div data-bs-spy="scroll" data-bs-target="#tab-bar-wrapper" tabindex="0" data-bs-offset="100" class="scroll-spy-content">
               {% if page.about %}<section class="about-this-class about-richtext-container" id="about-this-class">
                 {{ page.about | richtext | expand }}
               </section>{% endif %}

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -75,7 +75,6 @@ body.new-design {
       }
 
       li.nav-item {
-        padding: 16px 0;
         a {
           color: #2A6D87;
           text-decoration: none;
@@ -93,8 +92,7 @@ body.new-design {
       }
     }
     .scroll-spy-content {
-      height: fit-content;
-      position: relative;
+
       a:hover {
         color: #061e2d;
       }

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -64,13 +64,15 @@ body.new-design {
       margin: 2em 0;
       border-bottom: 1px solid #DFE5EC;
       background-color: #EFF3F6;
+      box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.1);
 
       @include media-breakpoint-down(md) {
         padding: 15px;
+        margin: 0 -15px;
       }
 
       a {
-        color: #35607a;
+        color: black;
         text-decoration: none;
 
         li.nav-item {
@@ -97,8 +99,13 @@ body.new-design {
       a:hover {
         color: #061e2d;
       }
+      .dropdown-menu {
+        box-shadow: 0 5px 3px 0 rgba(0, 0, 0, 0.1);
+        border: 1px solid #DFE5EC;
+        margin: -2px 0 0 0;
+      }
       .dropdown-toggle {
-        border: 1px solid black;
+        border: 1px solid #DFE5EC;
         padding: 10px 15px;
         background-color: white;
         width: 100%;
@@ -112,7 +119,7 @@ body.new-design {
         width: 100%;
       }
       .dropdown-item.active {
-        background-color: #EFF3F6;
+        background-color: #8c8a8a42;
         color: #061e2d;
       }
 

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -60,10 +60,14 @@ body.new-design {
     }
 
     #tab-bar {
-      background-color: #edf2f4;
       padding: 0;
       margin: 2em 0;
       border-bottom: 1px solid #DFE5EC;
+      background-color: #EFF3F6;
+
+      @include media-breakpoint-down(md) {
+        padding: 15px;
+      }
 
       a {
         color: #35607a;
@@ -93,15 +97,25 @@ body.new-design {
       a:hover {
         color: #061e2d;
       }
-      .mobile-nav-dropdown {
-        padding: 15px 18px;
-
-        .dropdown-toggle {
-          border: 1px solid black;
-          padding: 5px;
-          background-color: white;
-        }
+      .dropdown-toggle {
+        border: 1px solid black;
+        padding: 10px 15px;
+        background-color: white;
+        width: 100%;
+        color: #03152D;
+        text-align: left;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
       }
+      .dropdown-menu.show {
+        width: 100%;
+      }
+      .dropdown-item.active {
+        background-color: #EFF3F6;
+        color: #061e2d;
+      }
+
     }
 
     section.about-richtext-container {

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -74,15 +74,24 @@ body.new-design {
           font-size: 16px;
           line-height: 19px;
         }
-        li.nav-item.active {
+      }
+
+      a.active {
+        li.nav-item {
           color: $primary;
           border-bottom: 1px solid $primary;
         }
       }
+
       a:hover {
         color: #061e2d;
       }
 
+    }
+    .scroll-spy-content {
+      height: fit-content;
+      overflow-y: scroll;
+      position: relative;
     }
 
     section.about-richtext-container {

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -64,33 +64,32 @@ body.new-design {
       margin: 2em 0;
       border-bottom: 1px solid #DFE5EC;
       background-color: #EFF3F6;
-      box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.1);
 
       @include media-breakpoint-down(md) {
         padding: 15px;
         margin: 0 -15px;
+        box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.1);
+        a {
+          color: black;
+        }
       }
 
-      a {
-        color: black;
-        text-decoration: none;
-
-        li.nav-item {
+      li.nav-item {
+        padding: 16px 0;
+        a {
+          color: #2A6D87;
+          text-decoration: none;
           padding: 18px 20px;
           font-size: 16px;
           line-height: 19px;
         }
-      }
-
-      a.active {
-        li.nav-item {
+        a.active, a.active:hover {
           color: $primary;
           border-bottom: 1px solid $primary;
         }
-      }
-
-      a:hover {
-        color: #061e2d;
+        a:hover {
+          color: #061e2d;
+        }
       }
     }
     .scroll-spy-content {

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -61,19 +61,22 @@ body.new-design {
 
     #tab-bar {
       background-color: #edf2f4;
-      padding: 15px 19px;
+      padding: 0;
       margin: 2em 0;
+      border-bottom: 1px solid #DFE5EC;
 
-      ul li.nav-item {
-        padding: 0;
-        padding-right: 40px;
+      a {
         color: #35607a;
-        font-weight: normal;
+        text-decoration: none;
 
-        a {
-          color: #35607a;
-          text-decoration: none;
+        li.nav-item {
+          padding: 18px 20px;
+          font-size: 16px;
+          line-height: 19px;
         }
+      }
+      a:hover {
+        color: #061e2d;
       }
     }
 

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -90,7 +90,6 @@ body.new-design {
     }
     .scroll-spy-content {
       height: fit-content;
-      overflow-y: scroll;
       position: relative;
     }
 

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -61,7 +61,6 @@ body.new-design {
 
     #tab-bar {
       padding: 0;
-      margin: 2em 0;
       border-bottom: 1px solid #DFE5EC;
       background-color: #EFF3F6;
 
@@ -69,9 +68,6 @@ body.new-design {
         padding: 15px;
         margin: 0 -15px;
         box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.1);
-        a {
-          color: black;
-        }
       }
 
       li.nav-item {
@@ -89,12 +85,11 @@ body.new-design {
         a:hover {
           color: #061e2d;
         }
-      }
-    }
-    .scroll-spy-content {
-
-      a:hover {
-        color: #061e2d;
+        a.nav-link.dropdown-item {
+        color: black;
+        text-decoration: none;
+        border-bottom: none;
+        }
       }
       .dropdown-menu {
         box-shadow: 0 5px 3px 0 rgba(0, 0, 0, 0.1);
@@ -111,6 +106,7 @@ body.new-design {
         display: flex;
         justify-content: space-between;
         align-items: center;
+        text-decoration: none;
       }
       .dropdown-menu.show {
         width: 100%;
@@ -119,7 +115,6 @@ body.new-design {
         background-color: #8c8a8a42;
         color: #061e2d;
       }
-
     }
 
     section.about-richtext-container {
@@ -160,7 +155,7 @@ body.new-design {
 
     section.about-this-class {
       color: #000;
-      /* TODO: this requires a different font and colors */    
+      /* TODO: this requires a different font and colors */
       h2, h3, h4, h5, h6 {
         font-size: smaller;
       }
@@ -218,32 +213,32 @@ body.new-design {
             height: 64px;
             border: none;
             border-radius: 50%;
-    
+
             &:hover {
               opacity: 0.6;
             }
           }
-    
+
           .vjs-poster {
             height: fit-content;
           }
         }
-    
+
         .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
           top: 0.3em;
         }
-    
+
         .vjs-youtube {
-    
+
           .vjs-big-play-button {
             display: none;
           }
         }
-    
+
         .video-holder {
           background: $sirocco;
           margin-top: 10px;
-    
+
           img {
             display: block;
             width: 100%;
@@ -331,7 +326,7 @@ body.new-design {
           .enrollment-info-icon {
             max-width: 20px;
             margin-right: 12px;
-            
+
             img {
               max-width: 20px;
             }
@@ -418,7 +413,7 @@ body.new-design {
       }
     }
 
-    ul { 
+    ul {
       padding: 0;
     }
 
@@ -438,7 +433,7 @@ body.new-design {
 
     label {
      font-weight: bold;
-     line-height: 24px; /* 160% */      
+     line-height: 24px; /* 160% */
     }
 
     select {
@@ -454,7 +449,7 @@ body.new-design {
     }
   }
 
-  div.certificate-pricing-row { 
+  div.certificate-pricing-row {
     border-radius: 5px;
     border: 1px solid var(--BorderGrey, #DFE5EC);
     background: rgba(3, 21, 45, 0.05);
@@ -501,9 +496,9 @@ body.new-design {
     padding: 0px;
     justify-content: space-between;
     align-items: center;
-    align-self: stretch; 
+    align-self: stretch;
 
-    // border-bottom: 1px solid var(--BorderGrey, #DFE5EC); 
+    // border-bottom: 1px solid var(--BorderGrey, #DFE5EC);
     border: none;
 
     div {
@@ -523,7 +518,7 @@ body.new-design {
 
   div.upsell-messaging-header {
     margin: 20px 1px;
-    
+
     div {
       font-weight: 700;
     }
@@ -566,11 +561,11 @@ body.new-design {
           height: 0;
           z-index: 9;
         }
-    
+
         h5 {
           margin-left: -9999px;
         }
-    
+
         button.close {
           border: 0;
           border-radius: 100%;
@@ -584,7 +579,7 @@ body.new-design {
           }
         }
       }
-    
+
       .modal-body {
         padding-left: 50px;
         padding-right: 50px;

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -74,10 +74,15 @@ body.new-design {
           font-size: 16px;
           line-height: 19px;
         }
+        li.nav-item.active {
+          color: $primary;
+          border-bottom: 1px solid $primary;
+        }
       }
       a:hover {
         color: #061e2d;
       }
+
     }
 
     section.about-richtext-container {

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -86,11 +86,22 @@ body.new-design {
       a:hover {
         color: #061e2d;
       }
-
     }
     .scroll-spy-content {
       height: fit-content;
       position: relative;
+      a:hover {
+        color: #061e2d;
+      }
+      .mobile-nav-dropdown {
+        padding: 15px 18px;
+
+        .dropdown-toggle {
+          border: 1px solid black;
+          padding: 5px;
+          background-color: white;
+        }
+      }
     }
 
     section.about-richtext-container {

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -210,12 +210,10 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
 
             <ul>
               {course.programs.map(elem => (
-                <>
-                  <li>
-                    {" "}
-                    <a href={`/programs/${elem.readable_id}/`}>{elem.title}</a>
-                  </li>
-                </>
+                <li key={elem.readable_id}>
+                  {" "}
+                  <a href={`/programs/${elem.readable_id}/`}>{elem.title}</a>
+                </li>
               ))}
             </ul>
           </div>

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -63,7 +63,4 @@ $(document).ready(function() {
   $(".slick-slide").removeAttr("tabindex")
 
   $('body').scrollspy({ target: '#tab-bar' })
-  $('[data-spy="scroll"]').on('activate.bs.scrollspy', function () {
-    console.log("here")
-  })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -68,10 +68,15 @@ $(document).ready(function() {
     rootMargin:   "0px 0px 0px 0px"
   })
   $(".nav .nav-link").on("click", function() {
-    $(".nav")
-      .find(".active")
-      .removeClass("active")
-    $(this).addClass("active")
     $(".nav .dropdown-toggle").text($(this).text())
+    const self = this
+    setTimeout(
+      function() {
+        $(".nav")
+          .find(".active")
+          .removeClass("active")
+        $(self).addClass("active")
+      },
+      300)
   })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -70,13 +70,11 @@ $(document).ready(function() {
   $(".nav .nav-link").on("click", function() {
     $(".nav .dropdown-toggle").text($(this).text())
     const self = this
-    setTimeout(
-      function() {
-        $(".nav")
-          .find(".active")
-          .removeClass("active")
-        $(self).addClass("active")
-      },
-      300)
+    setTimeout(function() {
+      $(".nav")
+        .find(".active")
+        .removeClass("active")
+      $(self).addClass("active")
+    }, 300)
   })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -62,5 +62,5 @@ $(document).ready(function() {
   })
   $(".slick-slide").removeAttr("tabindex")
 
-  $('body').scrollspy({ target: '#tab-bar' })
+  $("body").scrollspy({ target: "#tab-bar" })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -61,4 +61,9 @@ $(document).ready(function() {
     slidesToScroll: 4
   })
   $(".slick-slide").removeAttr("tabindex")
+
+  $('body').scrollspy({ target: '#tab-bar' })
+  $('[data-spy="scroll"]').on('activate.bs.scrollspy', function () {
+    console.log("here")
+  })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -62,7 +62,11 @@ $(document).ready(function() {
   })
   $(".slick-slide").removeAttr("tabindex")
 
-  $("body").scrollspy({ target: "#tab-bar", offset: 100})
+  $("body").scrollspy({
+    target:       "#tab-bar",
+    smoothScroll: true,
+    rootMargin:   "0px 0px 0px 0px"
+  })
   $(".nav .nav-link").on("click", function() {
     $(".nav")
       .find(".active")

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -63,4 +63,9 @@ $(document).ready(function() {
   $(".slick-slide").removeAttr("tabindex")
 
   $("body").scrollspy({ target: "#tab-bar" })
+  $(".nav .nav-link").on("click", function() {
+    $(".nav").find(".active").removeClass("active")
+    $(this).addClass("active")
+    $(".nav .dropdown-toggle").text($(this).text())
+  })
 })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -64,7 +64,9 @@ $(document).ready(function() {
 
   $("body").scrollspy({ target: "#tab-bar" })
   $(".nav .nav-link").on("click", function() {
-    $(".nav").find(".active").removeClass("active")
+    $(".nav")
+      .find(".active")
+      .removeClass("active")
     $(this).addClass("active")
     $(".nav .dropdown-toggle").text($(this).text())
   })

--- a/frontend/public/src/entry/django.js
+++ b/frontend/public/src/entry/django.js
@@ -62,7 +62,7 @@ $(document).ready(function() {
   })
   $(".slick-slide").removeAttr("tabindex")
 
-  $("body").scrollspy({ target: "#tab-bar" })
+  $("body").scrollspy({ target: "#tab-bar", offset: 100})
   $(".nav .nav-link").on("click", function() {
     $(".nav")
       .find(".active")

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -29,7 +29,7 @@
     {% endblock %}
     {% endspaceless %}
   </head>
-  <body class="{% block bodyclass %}{% endblock %}">
+  <body class="{% block bodyclass %}{% endblock %}" data-bs-spy="scroll" data-bs-target="#tab-bar" data-bs-offset="0" tabindex="0" data-bs-smooth-scroll="true">
   <div class="main-panel">
     <a href="#main" class="visually-hidden visually-hidden-focusable">Skip to main content</a>
     {% include "partials/gtm_body.html" %}

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -29,7 +29,7 @@
     {% endblock %}
     {% endspaceless %}
   </head>
-  <body class="{% block bodyclass %}{% endblock %}" data-bs-spy="scroll" data-bs-target="#tab-bar" data-bs-offset="0" tabindex="0" data-bs-smooth-scroll="true">
+  <body class="{% block bodyclass %}{% endblock %}" tabindex="0">
   <div class="main-panel">
     <a href="#main" class="visually-hidden visually-hidden-focusable">Skip to main content</a>
     {% include "partials/gtm_body.html" %}


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2973
Fix https://github.com/mitodl/hq/issues/2769
Fix https://github.com/mitodl/hq/issues/2838

# Description (What does it do?)
Updates the style for  the navbar on product page:
1. The links hover over the whole tab rather than just the words.
2. Adjusted some of styles to match the figma design
3. Active tab is changes color
4. Navbar is fixed at top of page

# Screenshots (if appropriate):
<img width="1410" alt="Screen Shot 2023-12-06 at 2 50 19 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/595e4585-0e7e-479e-9d2e-3afcb56f49c6">
<img width="387" alt="Screen Shot 2023-12-06 at 2 55 18 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/d11deaff-a33f-411b-85c7-58c245bf48e0">


# How can this be tested?
Look at the design in the issue. Go to product page and hover over the navbar. It should be visible that the menu is clickable.
When you select a tab it should scroll to the location on the page. The active tab changes based on the position of the scroll.
