### PR TITLE
Filter out courseruns that can't be upgraded when displaying the upsell dialog

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -240,16 +240,18 @@ export class CourseProductDetailEnroll extends React.Component<
           className="form-control"
         >
           {courseRuns &&
-            courseRuns.map((elem: EnrollmentFlaggedCourseRun) => (
-              <option
-                selected={run.id === elem.id}
-                value={elem.id}
-                key={`courserun-selection-${elem.id}`}
-              >
-                {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
-                {formatPrettyDate(moment(new Date(elem.end_date)))}
-              </option>
-            ))}
+            courseRuns
+              .filter((elem: EnrollmentFlaggedCourseRun) => elem.is_upgradable)
+              .map((elem: EnrollmentFlaggedCourseRun) => (
+                <option
+                  selected={run.id === elem.id}
+                  value={elem.id}
+                  key={`courserun-selection-${elem.id}`}
+                >
+                  {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
+                  {formatPrettyDate(moment(new Date(elem.end_date)))}
+                </option>
+              ))}
         </select>
       </>
     )
@@ -322,6 +324,9 @@ export class CourseProductDetailEnroll extends React.Component<
         ) : null
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
+    const upgradableCourseRuns = courseRuns.filter(
+      (run: EnrollmentFlaggedCourseRun) => run.is_upgradable
+    )
 
     return product ? (
       showNewDesign ? (
@@ -336,7 +341,7 @@ export class CourseProductDetailEnroll extends React.Component<
             {run.title}
           </ModalHeader>
           <ModalBody>
-            {courseRuns ? (
+            {upgradableCourseRuns.length > 1 ? (
               <div className="row date-selector-button-bar">
                 <div className="col-12">
                   <div>{this.renderRunSelectorButtons(run)}</div>

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -324,9 +324,11 @@ export class CourseProductDetailEnroll extends React.Component<
         ) : null
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run.products ? run.products[0] : null
-    const upgradableCourseRuns = courseRuns.filter(
-      (run: EnrollmentFlaggedCourseRun) => run.is_upgradable
-    )
+    const upgradableCourseRuns = courseRuns
+      ? courseRuns.filter(
+        (run: EnrollmentFlaggedCourseRun) => run.is_upgradable
+      )
+      : []
 
     return product ? (
       showNewDesign ? (

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -464,7 +464,7 @@ describe("CourseProductDetailEnroll", () => {
     )
   })
   ;[
-    ["shows", "one", false],
+    ["does not show", "one", false],
     ["shows", "multiple", true]
   ].forEach(([showsQualifier, runsQualifier, multiples]) => {
     it(`${showsQualifier} the course run selector for a course with ${runsQualifier} active run${
@@ -474,6 +474,7 @@ describe("CourseProductDetailEnroll", () => {
         {
           id:                     1,
           price:                  10,
+          is_upgradable:          true,
           product_flexible_price: {
             amount:        10,
             discount_type: DISCOUNT_TYPE_PERCENT_OFF
@@ -516,13 +517,13 @@ describe("CourseProductDetailEnroll", () => {
       assert.isTrue(upgradeForm.exists())
 
       const selectorControl = modal.find(".date-selector-button-bar").at(0)
-      assert.isTrue(selectorControl.exists())
 
-      const selectorControlItems = selectorControl.find("option")
       if (multiples) {
+        assert.isTrue(selectorControl.exists())
+        const selectorControlItems = selectorControl.find("option")
         assert.isTrue(selectorControlItems.length === 2)
       } else {
-        assert.isTrue(selectorControlItems.length === 1)
+        assert.isFalse(selectorControl.exists())
       }
     })
   })


### PR DESCRIPTION
# What are the relevant tickets?

Partial fix for mitodl/hq#3109

# Description (What does it do?)

If there are two active course runs, both with products but one of which is ineligible for upgrade, the upsell dialog will allow you to upgrade that particular course run where you shouldn't be able to. This adds some filtering to keep that from happening. 

# How can this be tested?

Set up two course runs that overlap. Both should have products and allow for upgrading, but the one that starts the latest should have an upgrade deadline in the past. (So, if you have ones that has both start dates as 2023-11-01 and one that has both start dates as 2023-11-15, the 2023-11-15 one should be the one with the upgrade deadline set in the past.) 

- On main, you should be able to upgrade, and you should be able to select the second course run and upgrade it.
- In this branch, you should be able to upgrade but you won't see the selector at all. 

If you add a _third_ course run that overlaps and is eligible for upgrade, you should see two course runs but not the ineligible one. 