### PR TITLE
Certificates use product title

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -439,9 +439,13 @@ class CertificatePage(CourseProgramChildPage):
             is_program_certificate = False
             if isinstance(self.certificate, ProgramCertificate):
                 is_program_certificate = True
+                product_name = self.parent.program.title
+            else:
+                product_name = self.parent.course.title
 
             context = {
                 "uuid": self.certificate.uuid,
+                "product_name": product_name,
                 "certificate_user": self.certificate.user,
                 "learner_name": self.certificate.user.get_full_name(),
                 "start_date": start_date,
@@ -458,7 +462,7 @@ class CertificatePage(CourseProgramChildPage):
             "share_image_width": "1665",
             "share_image_height": "1291",
             "share_text": "I just earned a certificate in {} from {}".format(
-                self.product_name, settings.SITE_NAME
+                product_name, settings.SITE_NAME
             ),
             **super().get_context(request, *args, **kwargs),
             **preview_context,

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static wagtailimages_tags %}
 
-{% block title %}{{ site_name }} | Certificate for: {{ page.product_name }}{% endblock %}
+{% block title %}{{ site_name }} | Certificate for: {{ product_name }}{% endblock %}
 
 {% block seohead %}
     {{ block.super }}
@@ -9,8 +9,8 @@
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@MITxonedX" />
-    <meta property="og:title" content="{{ site_name }} | Certificate for: {{ page.product_name }}" />
-    <meta property="og:description" content="Certificate for {{ page.product_name }} awarded by {{ site_name }}." />
+    <meta property="og:title" content="{{ site_name }} | Certificate for: {{ product_name }}" />
+    <meta property="og:description" content="Certificate for {{ product_name }} awarded by {{ site_name }}." />
     <meta property="og:url" content="{{ request.build_absolute_uri }}" />
     <meta property="og:image:width" content="{{ share_image_width }}" />
     <meta property="og:image:height" content="{{ share_image_height }}" />
@@ -36,7 +36,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://www.linkedin.com/profile/add?startTask={{ page.product_name|urlencode }}" target="_blank">
+                            <a href="https://www.linkedin.com/profile/add?startTask={{ product_name|urlencode }}" target="_blank">
                                 <img src="{% static 'images/certificates/icon-linkedin.svg' %}" alt="Share to LinkedIn">
                             </a>
                         </li>
@@ -47,7 +47,7 @@
                         </li>
                     </ul>
                         <h2>Congratulations, {{ learner_name }}!</h2>
-                        <p>You have successfully completed {{ page.product_name }}. Share your accomplishment with your friends, family and colleagues. </p>
+                        <p>You have successfully completed {{ product_name }}. Share your accomplishment with your friends, family and colleagues. </p>
                     </div>
                 </div>
             </div>
@@ -67,7 +67,7 @@
                     <span class="certify-text">This is to certify that</span>
                     <span class="certify-name">{{ learner_name }}</span>
                     <span class="success-text">has successfully completed {% if is_program_certificate %}all courses and received passing grades to earn a MicroMasters program certificate in{% endif %}</span>
-                    <span class="degree-text">{{ page.product_name }}</span>
+                    <span class="degree-text">{{ product_name }}</span>
                     {% if is_program_certificate %}
                         <span class="success-text">a program of study offered by MITx, an online learning initiative of the Massachusetts Institute of Technology<br></span>
                     {% endif %}


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2696
Fix https://github.com/mitodl/mitxonline/issues/2003

# Description (What does it do?)
Updates the program and course certificate to use the title of the product.

# Screenshots (if appropriate):
<img width="1084" alt="Screen Shot 2023-12-11 at 12 26 20 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/336e7e53-eae4-4dac-a2ef-1d68e7562953">


# How can this be tested?
Create a course certificate, create a course certificate page in wagtail. 
View the certificate. Make sure it looks as expected.

Repeat the same with a program certificate. 