### PR TITLE
Updating the program enrollment  dialog text

### DIFF
--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -238,9 +238,10 @@ export class ProgramProductDetailEnroll extends React.Component<
           <div className="row">
             <div className="col-12">
               <p>
-                Thank you for choosing an MITx online program. To complete your enrollment in
-                this program, you must choose a course to start with. You can enroll now for
-                free, but you will need to pay for a certificate in order to earn the program credential.
+                Thank you for choosing an MITx online program. To complete your
+                enrollment in this program, you must choose a course to start
+                with. You can enroll now for free, but you will need to pay for
+                a certificate in order to earn the program credential.
               </p>
             </div>
           </div>

--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -238,9 +238,9 @@ export class ProgramProductDetailEnroll extends React.Component<
           <div className="row">
             <div className="col-12">
               <p>
-                Thank you for choosing an MITx online course. By paying for this
-                course, you're joining the most engaged and motivated learners
-                on your path to a certificate from MITx.
+                Thank you for choosing an MITx online program. To complete your enrollment in
+                this program, you must choose a course to start with. You can enroll now for
+                free, but you will need to pay for a certificate in order to earn the program credential.
               </p>
             </div>
           </div>


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2651

# Description (What does it do?)
Go to program page and open the enrollment dialog.

The button area is not added here because it is dependent on the course run selected, whether the course run has price info, finaid info etc...

# Screenshots (if appropriate):
<img width="815" alt="Screen Shot 2023-12-11 at 7 20 47 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/e6e1bda2-90ac-4683-90bc-78a2d0e54fcb">
