### PR TITLE
Prevent department selection when loading courses

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -287,6 +287,9 @@ export class CatalogPage extends React.Component<Props> {
    * @param {string} selectedDepartment The department name to set selectedDepartment to and filter courses by.
    */
   changeSelectedDepartment = (selectedDepartment: string) => {
+    if (this.props.coursesIsLoading) {
+      return
+    }
     this.setState({ selectedDepartment: selectedDepartment })
     this.setState({
       filteredCourses: this.filteredCoursesBasedOnCourseRunCriteria(

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -487,6 +487,28 @@ describe("CatalogPage", function() {
       .validateCoursesCourseRuns(courseRuns)
     expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
   })
+  it("does not filter courses if not loaded", async () => {
+    const { inner } = await renderPage({
+      queries: {
+        courses: {
+          isPending: true,
+          status:    200
+        },
+        entities: {
+          departments: [
+            {
+              name:     "History",
+              courses:  2,
+              programs: 1
+            }
+          ]
+        }
+      }
+    })
+    expect(inner.state().selectedDepartment).equals("All Departments")
+    inner.instance().changeSelectedDepartment("History", "courses")
+    expect(inner.state().selectedDepartment).equals("All Departments")
+  })
 
   it("renders catalog courses based on selected department", async () => {
     const course1 = JSON.parse(JSON.stringify(displayedCourse))


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2909

# Description (What does it do?)
Prevent department selection when loading courses

# How can this be tested?
Make sure you can't select a tab while courses are loading.