### PR TITLE
Remove role menu

### DIFF
--- a/frontend/public/src/components/UserMenu.js
+++ b/frontend/public/src/components/UserMenu.js
@@ -77,7 +77,6 @@ const UserMenu = ({ currentUser, useScreenOverlay }: Props) => {
         aria-haspopup="true"
         aria-expanded="false"
         type="button"
-        role="menu"
       >
         {currentUser.name}
       </button>


### PR DESCRIPTION
# What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2988

# Description (What does it do?)

Removes role="menu" from user menu.


# How can this be tested?
using a screen reader navigate to the user menu dropdown, you should be able to toggle the user dropdown and have the reader announce it to you.