### PR TITLE
Check to make sure the end date and upgrade deadline haven't passed before grabbing your audit enrollment

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -145,13 +145,18 @@ export class CourseProductDetailEnroll extends React.Component<
     // Find an existing enrollment - the default should be the audit enrollment
     // already have, so you can just upgrade in place. If you don't, you get the
     // current run (which should be the first available one).
+    // This was changed to also make sure the run you're enrolled in is upgradeable.
     const { enrollments } = this.props
 
     if (enrollments) {
       const firstAuditEnrollment = enrollments.find(
         (enrollment: RunEnrollment) =>
           enrollment.run.course.id === run.course.id &&
-          enrollment.enrollment_mode === "audit"
+          enrollment.enrollment_mode === "audit" &&
+          enrollment.run.enrollment_end !== null &&
+          enrollment.run.enrollment_end > moment.now() &&
+          (enrollment.run.upgrade_deadline === null ||
+            enrollment.run.upgrade_deadline > moment.now())
       )
 
       if (firstAuditEnrollment) {


### PR DESCRIPTION
# What are the relevant tickets?

Closes mitodl/hq#3295

# Description (What does it do?)

If you have an existing enrollment in a course that is upgradeable, the enroll now button component will try to funnel you into upgrading that enrollment. However, it did this funneling even if the run's deadline had passed. This fixes that by adding some checks to make sure the course run is actually eligible for upgrade. 

# How can this be tested?

Set up two course runs (and related course, if necessary). One should be fully in the past and one should be eligible for enrollment and upgrade now. The course runs must have products and the course must have a CMS page. Create an audit enrollment in the past course run, then load the course page. You should see the normal messaging - current upgrade deadline and price, Enroll Now button - and clicking Enroll Now should prompt you to upgrade into the new course.
