### PR TITLE
When resolving the current run, make sure it's also enrollable

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -86,7 +86,7 @@ export class CourseProductDetailEnroll extends React.Component<
   resolveFirstEnrollableRun() {
     const { courseRuns } = this.props
 
-    const enrollableRun = courseRuns
+    const enrollableRun = courseRuns && courseRuns
       .sort((a: EnrollmentFlaggedCourseRun, b: EnrollmentFlaggedCourseRun) => {
         if (moment(a.enrollment_start).isBefore(moment(b.enrollment_start))) {
           return -1
@@ -107,7 +107,7 @@ export class CourseProductDetailEnroll extends React.Component<
         )
       })
 
-    return enrollableRun
+    return enrollableRun || courseRuns[0]
   }
 
   resolveCurrentRun() {

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -362,7 +362,7 @@ export class CourseProductDetailEnroll extends React.Component<
       )
       : []
 
-    return product ? (
+    return run && product ? (
       showNewDesign ? (
         <Modal
           id={`upgrade-enrollment-dialog`}

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -86,26 +86,32 @@ export class CourseProductDetailEnroll extends React.Component<
   resolveFirstEnrollableRun() {
     const { courseRuns } = this.props
 
-    const enrollableRun = courseRuns && courseRuns
-      .sort((a: EnrollmentFlaggedCourseRun, b: EnrollmentFlaggedCourseRun) => {
-        if (moment(a.enrollment_start).isBefore(moment(b.enrollment_start))) {
-          return -1
-        } else if (
-          moment(a.enrollment_start).isAfter(moment(b.enrollment_start))
-        ) {
-          return 1
-        } else {
-          return 0
-        }
-      })
-      .find((run: EnrollmentFlaggedCourseRun) => {
-        return (
-          (run.enrollment_start === null ||
-            moment(run.enrollment_start).isBefore(moment.now())) &&
-          (run.enrollment_end === null ||
-            moment(run.enrollment_end).isAfter(moment.now()))
+    const enrollableRun =
+      courseRuns &&
+      courseRuns
+        .sort(
+          (a: EnrollmentFlaggedCourseRun, b: EnrollmentFlaggedCourseRun) => {
+            if (
+              moment(a.enrollment_start).isBefore(moment(b.enrollment_start))
+            ) {
+              return -1
+            } else if (
+              moment(a.enrollment_start).isAfter(moment(b.enrollment_start))
+            ) {
+              return 1
+            } else {
+              return 0
+            }
+          }
         )
-      })
+        .find((run: EnrollmentFlaggedCourseRun) => {
+          return (
+            (run.enrollment_start === null ||
+              moment(run.enrollment_start).isBefore(moment.now())) &&
+            (run.enrollment_end === null ||
+              moment(run.enrollment_end).isAfter(moment.now()))
+          )
+        })
 
     return enrollableRun || (courseRuns && courseRuns[0])
   }
@@ -340,8 +346,12 @@ export class CourseProductDetailEnroll extends React.Component<
     const run = this.resolveCurrentRun()
 
     const course =
-      courses && courses.find((elem: any) => elem.id === run.course.id)
+      courses &&
+      courses.find(
+        (elem: any) => run && run.course && elem.id === run.course.id
+      )
     const needFinancialAssistanceLink =
+      run &&
       isFinancialAssistanceAvailable(run) &&
       !run.approved_flexible_price_exists ? (
           <p className="financial-assistance-link">
@@ -355,7 +365,7 @@ export class CourseProductDetailEnroll extends React.Component<
           </p>
         ) : null
     const { upgradeEnrollmentDialogVisibility } = this.state
-    const product = run.products ? run.products[0] : null
+    const product = run && run.products ? run.products[0] : null
     const upgradableCourseRuns = courseRuns
       ? courseRuns.filter(
         (run: EnrollmentFlaggedCourseRun) => run.is_upgradable

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -86,14 +86,26 @@ export class CourseProductDetailEnroll extends React.Component<
   resolveFirstEnrollableRun() {
     const { courseRuns } = this.props
 
-    const enrollableRun = courseRuns.find((run: EnrollmentFlaggedCourseRun) => {
-      return (
-        (run.enrollment_start === null ||
-          moment(run.enrollment_start).isBefore(moment.now())) &&
-        (run.enrollment_end === null ||
-          moment(run.enrollment_end).isAfter(moment.now()))
-      )
-    })
+    const enrollableRun = courseRuns
+      .sort((a: EnrollmentFlaggedCourseRun, b: EnrollmentFlaggedCourseRun) => {
+        if (moment(a.enrollment_start).isBefore(moment(b.enrollment_start))) {
+          return -1
+        } else if (
+          moment(a.enrollment_start).isAfter(moment(b.enrollment_start))
+        ) {
+          return 1
+        } else {
+          return 0
+        }
+      })
+      .find((run: EnrollmentFlaggedCourseRun) => {
+        return (
+          (run.enrollment_start === null ||
+            moment(run.enrollment_start).isBefore(moment.now())) &&
+          (run.enrollment_end === null ||
+            moment(run.enrollment_end).isAfter(moment.now()))
+        )
+      })
 
     return enrollableRun
   }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -107,7 +107,7 @@ export class CourseProductDetailEnroll extends React.Component<
         )
       })
 
-    return enrollableRun || courseRuns[0]
+    return enrollableRun || (courseRuns && courseRuns[0])
   }
 
   resolveCurrentRun() {

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -83,11 +83,26 @@ export class CourseProductDetailEnroll extends React.Component<
     destinationUrl:                    ""
   }
 
+  resolveFirstEnrollableRun() {
+    const { courseRuns } = this.props
+
+    const enrollableRun = courseRuns.find((run: EnrollmentFlaggedCourseRun) => {
+      return (
+        (run.enrollment_start === null ||
+          moment(run.enrollment_start).isBefore(moment.now())) &&
+        (run.enrollment_end === null ||
+          moment(run.enrollment_end).isAfter(moment.now()))
+      )
+    })
+
+    return enrollableRun
+  }
+
   resolveCurrentRun() {
     const { courseRuns } = this.props
 
     return !this.getCurrentCourseRun() && courseRuns
-      ? courseRuns[0]
+      ? this.resolveFirstEnrollableRun()
       : this.getCurrentCourseRun()
   }
 


### PR DESCRIPTION
# What are the relevant tickets?

mitodl/hq#3295

# Description (What does it do?)

If the app has to resolve which course run it should be working with, sometimes it will fail back to just the first one in the list that comes back from the API. This can result in a course run that's not enrollable being chosen. This PR adds a check to favor the first enrollable course run over just the first one in the list, and then fall back to the first one in the list if there's not one that's eligible. 

# How can this be tested?

I tested by copying the courserun info for `course-v1:MITxT+14.100x+3T2023` and `1T2024` from production, making sure both had products, and then forcing an audit enrollment in 3T2023. Once done, you should be able to load the course page for 14.100x, and clicking Enroll Now should offer to upgrade you to 1T2024. Clicking upgrade _or_ hitting Enroll for Free should enroll you in the correct (1T2024) run.
