### PR TITLE
display course number on program enroll modal

### DIFF
--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -266,7 +266,7 @@ export class ProgramProductDetailEnroll extends React.Component<
                       key={`selectable-courserun-${run.id}`}
                       value={run.courseware_id}
                     >
-                      {run.title} - {run.courseware_id}
+                      {run.title} - {run.course_number}
                     </option>
                   ))}
                 </select>


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/2623#issuecomment-1875972496

# Description (What does it do?)
<!--- Describe your changes in detail -->
display the course number instead of course ID on program enroll modal

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
![image](https://github.com/mitodl/mitxonline/assets/3138890/2bb56229-3038-419f-8d57-34700e7397da)

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Go to program enrollment page (It requires setting up courses, programs locally)
Click on "Enroll now"
A upgrade enrollment dialog should popup, it should list all the courses in that program.
Note that the display name should be course title + course number
The screen reader should read the course title and course number as well
