### PR TITLE
add next parameter to course and program enrollment pages for unauthenticated users

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -611,7 +611,9 @@ export class CourseProductDetailEnroll extends React.Component<
     return !currentUser || !currentUser.id ? (
       <h2>
         <a
-          href={`${routes.login}?next=${encodeURIComponent(window.location.pathname)}`}
+          href={`${routes.login}?next=${encodeURIComponent(
+            window.location.pathname
+          )}`}
           className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight"
         >
           Enroll now

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -611,7 +611,7 @@ export class CourseProductDetailEnroll extends React.Component<
     return !currentUser || !currentUser.id ? (
       <h2>
         <a
-          href={routes.login}
+          href={`${routes.login}?next=${encodeURIComponent(window.location.pathname)}`}
           className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight"
         >
           Enroll now

--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -420,7 +420,7 @@ export class ProgramProductDetailEnroll extends React.Component<
                 <Fragment>
                   {currentUser && !currentUser.id ? (
                     <a
-                      href={routes.login}
+                      href={`${routes.login}?next=${encodeURIComponent(window.location.pathname)}`}
                       className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight"
                     >
                       Enroll now

--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -420,7 +420,9 @@ export class ProgramProductDetailEnroll extends React.Component<
                 <Fragment>
                   {currentUser && !currentUser.id ? (
                     <a
-                      href={`${routes.login}?next=${encodeURIComponent(window.location.pathname)}`}
+                      href={`${routes.login}?next=${encodeURIComponent(
+                        window.location.pathname
+                      )}`}
                       className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight"
                     >
                       Enroll now


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/714

# Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `?next=` to course and program enrollment pages to remember where user was going after login 

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
As anonymous users, go to course and program page
Click on enroll now
You are redirected to login page with `?next=` on url
Log in with your credential
You should be taken to the course or program page where you were before login

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
