### PR TITLE
Add css in for visual focus on modal buttons

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -397,6 +397,10 @@ body.new-design {
       font-size: 16px;
       font-weight: 400;
     }
+    .enroll-now-free:focus-visible {
+      border-radius: 0;
+      outline: 2px #28977e solid;
+    }
 
     form {
       margin-bottom: 0;
@@ -411,6 +415,11 @@ body.new-design {
         background-repeat: no-repeat;
         padding: 11px 22px;
       }
+      .btn-upgrade:focus-visible {
+          border-color: #82192a;
+          outline: 0;
+          box-shadow: 0 0 0 0.25rem rgba(177, 65, 82, .5);
+        }
     }
 
     ul {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2750

### Description (What does it do?)
Adds visual focus to two elements mentioned above - the enroll now button and enroll free "button" (that looks like a link)

### Screenshots (if appropriate):
![Screenshot_2024-01-09_10-03-03](https://github.com/mitodl/mitxonline/assets/7756053/af09eecd-6f70-43f6-afe2-c660bf3246fe)
![Screenshot_2024-01-09_10-03-22](https://github.com/mitodl/mitxonline/assets/7756053/b42f0261-ec7b-4a20-b3f5-2b47944724d5)


### How can this be tested?
Make sure your course has pricing set so it launches the modal. You should be able to tab through and it should highlight the various elements. These should be:

- The X (previously worked and should still)
- The Enroll Now button (did not have a border prior)
- The Financial aid link (previously worked and should still - you will have to add a form to make this work OR - as I did - make a small change to the logic in the component to display it regardless)
- The No thanks, I'll take it free "button"/link at the end (did not have a border prior)
