### PR TITLE
create_courseware command no department defined error

### DIFF
--- a/courses/management/commands/create_courseware.py
+++ b/courses/management/commands/create_courseware.py
@@ -227,7 +227,7 @@ class Command(BaseCommand):
                 live=kwargs["live"],
             )
 
-            if add_depts:
+            if "add_depts" in locals():
                 new_program.departments.add(*add_depts)
                 new_program.save()
 
@@ -285,7 +285,7 @@ class Command(BaseCommand):
                 live=kwargs["live"],
             )
 
-            if add_depts:
+            if "add_depts" in locals():
                 new_course.departments.add(*add_depts)
                 new_course.save()
 


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
When running the quickstart management command (main/management/commands/configure_instance.py) an error occurs when the quickstart command executes the create_courseware command (courses/management/commands/create_courseware.py).  The create_courseware command is executed without specifying a department argument.  The create_courseware throws an error when it checks the value of the local variable `add_depts` which, when no department argument is provided, is undefined.

This PR resolves the issue by checking whether `add_depts` is defined as a local variable.  `add_depts` is defined when the department argument is defined, otherwise the local variable is not defined.

The `add_depts` variable is checked when creating a program or course.

### How can this be tested?
Run the configure_instance management command using instructions here (docs/source/configuration/quickstart.rst).
