### PR TITLE
Delay alert when rendering the page in order to engage screen reader alert

### DIFF
--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -11,7 +11,7 @@ import {
   firstNotNil,
   newSetWith,
   newSetWithout,
-  timeoutPromise,
+  timeoutPromise
 } from "../lib/util"
 import { getNotificationAlertProps } from "../lib/notificationsApi"
 import { notificationTypeMap, TextNotification } from "./notifications"
@@ -23,16 +23,16 @@ const DEFAULT_REMOVE_DELAY_MS = 1000
 type Props = {
   userNotifications: UserNotificationMapping,
   removeUserNotification: Function,
-  messageRemoveDelayMs?: number,
+  messageRemoveDelayMs?: number
 }
 
 type State = {
-  hiddenNotifications: Set<string>,
+  hiddenNotifications: Set<string>
 }
 
 export class NotificationContainer extends React.Component<Props, State> {
   state = {
-    hiddenNotifications: new Set(),
+    hiddenNotifications: new Set()
   }
 
   onDismiss = (notificationKey: string) => {
@@ -44,15 +44,12 @@ export class NotificationContainer extends React.Component<Props, State> {
     // The message could be simply removed from the global state to get rid of it, but the
     // local state and the delay gives the Alert a chance to animate the message out.
     this.setState({
-      hiddenNotifications: newSetWith(hiddenNotifications, notificationKey),
+      hiddenNotifications: newSetWith(hiddenNotifications, notificationKey)
     })
     return timeoutPromise(() => {
       removeUserNotification(notificationKey)
       this.setState({
-        hiddenNotifications: newSetWithout(
-          hiddenNotifications,
-          notificationKey
-        ),
+        hiddenNotifications: newSetWithout(hiddenNotifications, notificationKey)
       })
     }, messageRemoveDelayMs || DEFAULT_REMOVE_DELAY_MS)
   }
@@ -70,7 +67,7 @@ export class NotificationContainer extends React.Component<Props, State> {
           const color = firstNotNil([
             notification.color,
             alertProps.color,
-            "info",
+            "info"
           ])
           const AlertBodyComponent =
             notificationTypeMap[notification.type] || TextNotification
@@ -95,7 +92,7 @@ export class NotificationContainer extends React.Component<Props, State> {
 }
 
 const mapStateToProps = state => ({
-  userNotifications: state.ui.userNotifications,
+  userNotifications: state.ui.userNotifications
 })
 
 export default compose(connect(mapStateToProps, { removeUserNotification }))(

--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -83,7 +83,6 @@ export class NotificationContainer extends React.Component<Props, State> {
               closeClassName="btn-close-white"
             >
               <AlertBodyComponent
-                aria-live="assertive"
                 dismiss={dismiss}
                 {...notification.props}
               />

--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -11,7 +11,7 @@ import {
   firstNotNil,
   newSetWith,
   newSetWithout,
-  timeoutPromise
+  timeoutPromise,
 } from "../lib/util"
 import { getNotificationAlertProps } from "../lib/notificationsApi"
 import { notificationTypeMap, TextNotification } from "./notifications"
@@ -23,16 +23,16 @@ const DEFAULT_REMOVE_DELAY_MS = 1000
 type Props = {
   userNotifications: UserNotificationMapping,
   removeUserNotification: Function,
-  messageRemoveDelayMs?: number
+  messageRemoveDelayMs?: number,
 }
 
 type State = {
-  hiddenNotifications: Set<string>
+  hiddenNotifications: Set<string>,
 }
 
 export class NotificationContainer extends React.Component<Props, State> {
   state = {
-    hiddenNotifications: new Set()
+    hiddenNotifications: new Set(),
   }
 
   onDismiss = (notificationKey: string) => {
@@ -44,12 +44,15 @@ export class NotificationContainer extends React.Component<Props, State> {
     // The message could be simply removed from the global state to get rid of it, but the
     // local state and the delay gives the Alert a chance to animate the message out.
     this.setState({
-      hiddenNotifications: newSetWith(hiddenNotifications, notificationKey)
+      hiddenNotifications: newSetWith(hiddenNotifications, notificationKey),
     })
     return timeoutPromise(() => {
       removeUserNotification(notificationKey)
       this.setState({
-        hiddenNotifications: newSetWithout(hiddenNotifications, notificationKey)
+        hiddenNotifications: newSetWithout(
+          hiddenNotifications,
+          notificationKey
+        ),
       })
     }, messageRemoveDelayMs || DEFAULT_REMOVE_DELAY_MS)
   }
@@ -67,7 +70,7 @@ export class NotificationContainer extends React.Component<Props, State> {
           const color = firstNotNil([
             notification.color,
             alertProps.color,
-            "info"
+            "info",
           ])
           const AlertBodyComponent =
             notificationTypeMap[notification.type] || TextNotification
@@ -82,10 +85,7 @@ export class NotificationContainer extends React.Component<Props, State> {
               fade={true}
               closeClassName="btn-close-white"
             >
-              <AlertBodyComponent
-                dismiss={dismiss}
-                {...notification.props}
-              />
+              <AlertBodyComponent dismiss={dismiss} {...notification.props} />
             </Alert>
           )
         })}
@@ -94,8 +94,8 @@ export class NotificationContainer extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = state => ({
-  userNotifications: state.ui.userNotifications
+const mapStateToProps = (state) => ({
+  userNotifications: state.ui.userNotifications,
 })
 
 export default compose(connect(mapStateToProps, { removeUserNotification }))(

--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -94,7 +94,7 @@ export class NotificationContainer extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   userNotifications: state.ui.userNotifications,
 })
 

--- a/frontend/public/src/components/TopBar.js
+++ b/frontend/public/src/components/TopBar.js
@@ -17,11 +17,13 @@ type Props = {
 }
 
 const TopBar = ({ currentUser }: Props) => {
+  // Delay any alert displayed on page-load by 500ms in order to
+  // ensure the alert is read by screen readers.
   const [showComponent, setShowComponent] = useState(false)
   useEffect(() => {
     const timeout = setTimeout(() => {
       setShowComponent(true)
-    }, 3000)
+    }, 500)
 
     return () => clearTimeout(timeout)
   }, [])

--- a/frontend/public/src/components/TopBar.js
+++ b/frontend/public/src/components/TopBar.js
@@ -13,7 +13,7 @@ import MixedLink from "./MixedLink"
 
 type Props = {
   currentUser: CurrentUser,
-  location: ?Location
+  location: ?Location,
 }
 
 const TopBar = ({ currentUser }: Props) => {
@@ -28,7 +28,9 @@ const TopBar = ({ currentUser }: Props) => {
 
   return (
     <header className="site-header new-design d-flex d-flex flex-column">
-      {showComponent ? <NotificationContainer id="notifications-container" /> : null}
+      {showComponent ? (
+        <NotificationContainer id="notifications-container" />
+      ) : null}
       <nav
         className={`order-1 sub-nav navbar navbar-expand-md top-navbar ${
           currentUser.is_authenticated ? "nowrap login" : ""
@@ -40,7 +42,7 @@ const TopBar = ({ currentUser }: Props) => {
           </a>
           <div className="divider-grey" />
           <a href={routes.root} className="mitx-online-link">
-          MITx Online
+            MITx Online
           </a>
         </div>
         <button
@@ -71,7 +73,7 @@ const TopBar = ({ currentUser }: Props) => {
                   className="top-nav-link"
                   aria-label="Catalog"
                 >
-                Catalog
+                  Catalog
                 </MixedLink>
                 <UserMenu currentUser={currentUser} useScreenOverlay={false} />
               </>
@@ -91,6 +93,5 @@ const TopBar = ({ currentUser }: Props) => {
     </header>
   )
 }
-
 
 export default TopBar

--- a/frontend/public/src/components/TopBar.js
+++ b/frontend/public/src/components/TopBar.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react"
+import React, { useEffect, useState } from "react"
 
 import { routes } from "../lib/urls"
 import UserMenu from "./UserMenu"
@@ -16,69 +16,81 @@ type Props = {
   location: ?Location
 }
 
-const TopBar = ({ currentUser }: Props) => (
-  <header className="site-header new-design d-flex d-flex flex-column">
-    <NotificationContainer id="notifications-container" />
-    <nav
-      className={`order-1 sub-nav navbar navbar-expand-md top-navbar ${
-        currentUser.is_authenticated ? "nowrap login" : ""
-      }`}
-    >
-      <div className="top-branding">
-        <a href="https://mit.edu" className="logo-link">
-          <InstituteLogo />
-        </a>
-        <div className="divider-grey" />
-        <a href={routes.root} className="mitx-online-link">
+const TopBar = ({ currentUser }: Props) => {
+  const [showComponent, setShowComponent] = useState(false)
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setShowComponent(true)
+    }, 3000)
+
+    return () => clearTimeout(timeout)
+  }, [])
+
+  return (
+    <header className="site-header new-design d-flex d-flex flex-column">
+      {showComponent ? <NotificationContainer id="notifications-container" /> : null}
+      <nav
+        className={`order-1 sub-nav navbar navbar-expand-md top-navbar ${
+          currentUser.is_authenticated ? "nowrap login" : ""
+        }`}
+      >
+        <div className="top-branding">
+          <a href="https://mit.edu" className="logo-link">
+            <InstituteLogo />
+          </a>
+          <div className="divider-grey" />
+          <a href={routes.root} className="mitx-online-link">
           MITx Online
-        </a>
-      </div>
-      <button
-        className="navbar-toggler nav-opener collapsed"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#nav"
-        aria-controls="nav"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span className="bar" />
-        <span className="bar" />
-        <span className="bar" />
-      </button>
-      <div
-        id="nav"
-        className={`${
-          currentUser.is_authenticated ? "" : "collapse"
-        } user-menu-overlay px-0 justify-content-end`}
-      >
-        <div className="full-screen-top-menu">
-          {currentUser.is_authenticated ? (
-            <>
-              <MixedLink
-                id="catalog"
-                dest={routes.catalog}
-                className="top-nav-link"
-                aria-label="Catalog"
-              >
+          </a>
+        </div>
+        <button
+          className="navbar-toggler nav-opener collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#nav"
+          aria-controls="nav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span className="bar" />
+          <span className="bar" />
+          <span className="bar" />
+        </button>
+        <div
+          id="nav"
+          className={`${
+            currentUser.is_authenticated ? "" : "collapse"
+          } user-menu-overlay px-0 justify-content-end`}
+        >
+          <div className="full-screen-top-menu">
+            {currentUser.is_authenticated ? (
+              <>
+                <MixedLink
+                  id="catalog"
+                  dest={routes.catalog}
+                  className="top-nav-link"
+                  aria-label="Catalog"
+                >
                 Catalog
-              </MixedLink>
-              <UserMenu currentUser={currentUser} useScreenOverlay={false} />
-            </>
-          ) : (
-            <AnonymousMenu mobileView={false} />
-          )}
+                </MixedLink>
+                <UserMenu currentUser={currentUser} useScreenOverlay={false} />
+              </>
+            ) : (
+              <AnonymousMenu mobileView={false} />
+            )}
+          </div>
+          <div className="mobile-auth-buttons">
+            {currentUser.is_authenticated ? (
+              <UserMenu currentUser={currentUser} useScreenOverlay={true} />
+            ) : (
+              <AnonymousMenu mobileView={true} />
+            )}
+          </div>
         </div>
-        <div className="mobile-auth-buttons">
-          {currentUser.is_authenticated ? (
-            <UserMenu currentUser={currentUser} useScreenOverlay={true} />
-          ) : (
-            <AnonymousMenu mobileView={true} />
-          )}
-        </div>
-      </div>
-    </nav>
-  </header>
-)
+      </nav>
+    </header>
+  )
+}
+
 
 export default TopBar

--- a/frontend/public/src/components/TopBar.js
+++ b/frontend/public/src/components/TopBar.js
@@ -13,7 +13,7 @@ import MixedLink from "./MixedLink"
 
 type Props = {
   currentUser: CurrentUser,
-  location: ?Location,
+  location: ?Location
 }
 
 const TopBar = ({ currentUser }: Props) => {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/715

### Description (What does it do?)
After paying for a course, a user is redirected to the user's Dashboard in MITx Online where they are presented with an alert indicating whether the payment process was successful or not.  For screen readers, the alert is rendered when the page is loaded which does not trigger the use of `role="alert` on the alert.  This PR adds a 3 second delay, after the page has loaded, before displaying the alert.  This delay means that the alert is rendered 3 seconds after the page has loaded and results in the alert being read by the screen reader in a fashion expected of `role="alert`.  

The functionality that`role="alert` provides to screen readers can also be observed when unenrolling from a course from the user dashboard.

### How can this be tested?

1. Enroll and pay for a course using the instructions here: docs/source/configuration/ecommerce.rst
2. After completing payment for the course and being redirected back to the MITx Online user Dashboard, verify that the alert is read by a screen reader as soon as it's rendered.
