### PR TITLE
Show More link on product about page accessibility

### DIFF
--- a/cms/templatetags/expand.py
+++ b/cms/templatetags/expand.py
@@ -37,11 +37,10 @@ def expand(text):
         output = f'{pre}<p class="expand_here_container"><a href="#" class="expand_here_link" data-expand-body="{container_uuid}">Show More</a></p><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[0])}{post}</div>'
     elif len(soup.find_all(["p", "div"])) > 1:
         expand_here = soup.find_all(["p", "div"], limit=2)
-
         pre = str(expand_here[0])
         post = "".join([str(sib) for sib in expand_here[1].find_next_siblings()])
 
-        output = f'<!-- pre -->{pre}<!-- /pre --><div class="expand_here_body" id="exp{container_uuid}">{str(expand_here[1])}{post}</div><p class="expand_here_container"><a href="#" class="expand_here_link fade" data-expand-body="{container_uuid}">Show More</a></p>'
+        output = f'<!-- pre -->{pre}<!-- /pre --><p class="expand_here_container"><a href="#" class="expand_here_link fade" data-expand-body="{container_uuid}">Show More</a></p><div class="expand_here_body hide" id="exp{container_uuid}">{str(expand_here[1])}{post}</div>'
     elif len(text.split("\n\n")) > 1:
         (pre, post) = text.split("\n\n", maxsplit=1)
 


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/2596

### Description (What does it do?)
Fixes two things:

- the hide class should be on the hidden element from the very begining
- the Show More link is now in between the visible text and the hidden text.

### Screenshots (if appropriate):
<img width="888" alt="Screenshot 2024-01-18 at 1 54 00 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/342dfe9b-e1cb-4d95-b170-da95f87989c2">

### How can this be tested?
Use a screen reader to tab through a product page that has hidden "about" section text. Make sure the the links in the hidden text are not read by the reader.
Play with the Show More button and make sure that the hidden text appears after the button.