### PR TITLE
3382: self paced courses with future start dates show start anytime

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -73,7 +73,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     enrollment.run.id === courseRun.id
                 ))
                 ? this.renderEnrolledDateLink(courseRun)
-                : getStartDateText(courseRun, true)}
+                : getStartDateText(courseRun)}
             </li>
           )
         }

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -346,24 +346,22 @@ export const getStartDateText = (
     ? courseware.courseruns
     : [courseware]
 
-  if (CourseRuns.length > 0) {
-    const futureStartDateCourseRuns = CourseRuns.filter(courseRun =>
-      moment(courseRun.start_date).isAfter(moment())
+  const futureStartDateCourseRuns = CourseRuns.filter(courseRun =>
+    moment(courseRun.start_date).isAfter(moment())
+  )
+  if (futureStartDateCourseRuns.length > 0) {
+    const startDate = parseDateString(
+      futureStartDateCourseRuns.sort(compareCourseRunStartDates)[0].start_date
     )
-    if (futureStartDateCourseRuns.length > 0) {
-      const startDate = parseDateString(
-        futureStartDateCourseRuns.sort(compareCourseRunStartDates)[0].start_date
-      )
-      return `Start Date: ${formatPrettyDate(startDate)}`
-    } else {
-      if (showPast) {
-        return `Start Date: ${formatPrettyDate(
-          parseDateString(
-            CourseRuns.sort(reverseCompareCourseRunStartDates)[0].start_date
-          )
-        )}`
-      }
-      return "Start Anytime"
+    return `Start Date: ${formatPrettyDate(startDate)}`
+  } else {
+    if (showPast) {
+      return `Start Date: ${formatPrettyDate(
+        parseDateString(
+          CourseRuns.sort(reverseCompareCourseRunStartDates)[0].start_date
+        )
+      )}`
     }
+    return "Start Anytime"
   }
 }

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -342,9 +342,7 @@ export const getStartDateText = (
   courseware: BaseCourseRun | CourseDetailWithRuns,
   showPast: boolean = false
 ) => {
-  const CourseRuns = courseware.courseruns
-    ? courseware.courseruns
-    : [courseware]
+  const CourseRuns = courseware.courseruns ? courseware.courseruns : [courseware]
 
   if (CourseRuns.length > 0) {
     const futureStartDateCourseRuns = CourseRuns.filter(courseRun =>
@@ -359,7 +357,8 @@ export const getStartDateText = (
       if (showPast) {
         return `Start Date: ${formatPrettyDate(
           parseDateString(
-            CourseRuns.sort(reverseCompareCourseRunStartDates)[0].start_date
+            CourseRuns.sort(reverseCompareCourseRunStartDates)[0]
+              .start_date
           )
         )}`
       }

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -328,9 +328,12 @@ export const reverseCompareCourseRunStartDates = (
 /**
  * Returns the text to be displayed on a course catalog card's tag.
  * This text will either be "Start Anytime" or "Start Date: <most recent, future, start date for the course>".
- * If the course run with the earliest start date, and associated with the course, has a start date that is in the future, return 'Start Date: <earliest course run start date>'.
- * If the course run with the earliest start date, and associated with the course, has a start date in the past and is self paced, return 'Start Anytime'.
- * If the course run with the earliest start date, and associated with the course, has a start date in the past and is NOT self paced, return 'Started: <earliest course run start date>'.
+ * If the course run with the earliest start date, and associated with the course,
+ * has a start date that is in the future, return 'Starts: <earliest course run start date>'.
+ * If the course run with the earliest start date, and associated with the course,
+ * has a start date in the past and is self paced, return 'Start Anytime'.
+ * If the course run with the earliest start date, and associated with the course,
+ * has a start date in the past and is NOT self paced, return 'Started: <earliest course run start date>'.
  * @param {CourseDetailWithRuns|BaseCourseRun} course The course being evaluated, or an individual course run to display the start text for.
  */
 

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -342,7 +342,9 @@ export const getStartDateText = (
   courseware: BaseCourseRun | CourseDetailWithRuns,
   showPast: boolean = false
 ) => {
-  const CourseRuns = courseware.courseruns ? courseware.courseruns : [courseware]
+  const CourseRuns = courseware.courseruns
+    ? courseware.courseruns
+    : [courseware]
 
   if (CourseRuns.length > 0) {
     const futureStartDateCourseRuns = CourseRuns.filter(courseRun =>
@@ -357,8 +359,7 @@ export const getStartDateText = (
       if (showPast) {
         return `Start Date: ${formatPrettyDate(
           parseDateString(
-            CourseRuns.sort(reverseCompareCourseRunStartDates)[0]
-              .start_date
+            CourseRuns.sort(reverseCompareCourseRunStartDates)[0].start_date
           )
         )}`
       }

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -328,13 +328,12 @@ export const reverseCompareCourseRunStartDates = (
 /**
  * Returns the text to be displayed on a course catalog card's tag.
  * This text will either be "Start Anytime" or "Start Date: <most recent, future, start date for the course>".
- * If the Course has at least one associated Course Run which is not self-paced, and
- * Course Run start date is in the future, then return "Start Date: <most recent, future, start date for the course>".
- * If the Course has at least one associated Course Run which is not self-paced, and
- * Course Run start date is in the past, and showPast is not true, then return "Start Anytime".
- * If the Course has at least one associated Course Run which is not self-paced, and
+ * If the Course has at least one associated Course Run, with a Course Run start date in the future,
+ * then return "Start Date: <most recent, future, start date for the course>".
+ * If the Course has at least one associated Course Run, with a Course Run start date in the past,
+ * and showPast is not true, then return "Start Anytime".
+ * If the Course has at least one associated Course Run, and
  * Course Run start date is in the past, and showPast is true, then return "Start Date: <most recent start date for the course>".
- * If the course only has Course Runs which are self-paced, display "Start Anytime".
  * @param {CourseDetailWithRuns|BaseCourseRun} course The course being evaluated, or an individual course run to display the start text for.
  * @param {showPast} boolean If the start date for the course is in the past, and showPast is true, then render the most recent start date for the course.
  */
@@ -343,14 +342,10 @@ export const getStartDateText = (
   courseware: BaseCourseRun | CourseDetailWithRuns,
   showPast: boolean = false
 ) => {
-  const nonSelfPacedCourseRuns = courseware.courseruns
-    ? courseware.courseruns.filter(courseRun => !courseRun.is_self_paced)
-    : courseware.is_self_paced
-      ? []
-      : [courseware]
+  const CourseRuns = courseware.courseruns ? courseware.courseruns : [courseware]
 
-  if (nonSelfPacedCourseRuns.length > 0) {
-    const futureStartDateCourseRuns = nonSelfPacedCourseRuns.filter(courseRun =>
+  if (CourseRuns.length > 0) {
+    const futureStartDateCourseRuns = CourseRuns.filter(courseRun =>
       moment(courseRun.start_date).isAfter(moment())
     )
     if (futureStartDateCourseRuns.length > 0) {
@@ -362,14 +357,12 @@ export const getStartDateText = (
       if (showPast) {
         return `Start Date: ${formatPrettyDate(
           parseDateString(
-            nonSelfPacedCourseRuns.sort(reverseCompareCourseRunStartDates)[0]
+            CourseRuns.sort(reverseCompareCourseRunStartDates)[0]
               .start_date
           )
         )}`
       }
       return "Start Anytime"
     }
-  } else {
-    return "Start Anytime"
   }
 }

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -346,22 +346,24 @@ export const getStartDateText = (
     ? courseware.courseruns
     : [courseware]
 
-  const futureStartDateCourseRuns = CourseRuns.filter(courseRun =>
-    moment(courseRun.start_date).isAfter(moment())
-  )
-  if (futureStartDateCourseRuns.length > 0) {
-    const startDate = parseDateString(
-      futureStartDateCourseRuns.sort(compareCourseRunStartDates)[0].start_date
+  if (CourseRuns.length > 0) {
+    const futureStartDateCourseRuns = CourseRuns.filter(courseRun =>
+      moment(courseRun.start_date).isAfter(moment())
     )
-    return `Start Date: ${formatPrettyDate(startDate)}`
-  } else {
-    if (showPast) {
-      return `Start Date: ${formatPrettyDate(
-        parseDateString(
-          CourseRuns.sort(reverseCompareCourseRunStartDates)[0].start_date
-        )
-      )}`
+    if (futureStartDateCourseRuns.length > 0) {
+      const startDate = parseDateString(
+        futureStartDateCourseRuns.sort(compareCourseRunStartDates)[0].start_date
+      )
+      return `Start Date: ${formatPrettyDate(startDate)}`
+    } else {
+      if (showPast) {
+        return `Start Date: ${formatPrettyDate(
+          parseDateString(
+            CourseRuns.sort(reverseCompareCourseRunStartDates)[0].start_date
+          )
+        )}`
+      }
+      return "Start Anytime"
     }
-    return "Start Anytime"
   }
 }

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -328,48 +328,28 @@ export const reverseCompareCourseRunStartDates = (
 /**
  * Returns the text to be displayed on a course catalog card's tag.
  * This text will either be "Start Anytime" or "Start Date: <most recent, future, start date for the course>".
- * If the Course has at least one associated Course Run which is not self-paced, and
- * Course Run start date is in the future, then return "Start Date: <most recent, future, start date for the course>".
- * If the Course has at least one associated Course Run which is not self-paced, and
- * Course Run start date is in the past, and showPast is not true, then return "Start Anytime".
- * If the Course has at least one associated Course Run which is not self-paced, and
- * Course Run start date is in the past, and showPast is true, then return "Start Date: <most recent start date for the course>".
- * If the course only has Course Runs which are self-paced, display "Start Anytime".
+ * If the course run with the earliest start date, and associated with the course, has a start date that is in the future, return 'Start Date: <earliest course run start date>'.
+ * If the course run with the earliest start date, and associated with the course, has a start date in the past and is self paced, return 'Start Anytime'.
+ * If the course run with the earliest start date, and associated with the course, has a start date in the past and is NOT self paced, return 'Started: <earliest course run start date>'.
  * @param {CourseDetailWithRuns|BaseCourseRun} course The course being evaluated, or an individual course run to display the start text for.
- * @param {showPast} boolean If the start date for the course is in the past, and showPast is true, then render the most recent start date for the course.
  */
 
 export const getStartDateText = (
-  courseware: BaseCourseRun | CourseDetailWithRuns,
-  showPast: boolean = false
+  courseware: BaseCourseRun | CourseDetailWithRuns
 ) => {
-  const nonSelfPacedCourseRuns = courseware.courseruns
-    ? courseware.courseruns.filter(courseRun => !courseRun.is_self_paced)
-    : courseware.is_self_paced
-      ? []
-      : [courseware]
+  const courseRun = courseware.courseruns
+    ? courseware.courseruns.sort(compareCourseRunStartDates)[0]
+    : courseware
 
-  if (nonSelfPacedCourseRuns.length > 0) {
-    const futureStartDateCourseRuns = nonSelfPacedCourseRuns.filter(courseRun =>
-      moment(courseRun.start_date).isAfter(moment())
-    )
-    if (futureStartDateCourseRuns.length > 0) {
-      const startDate = parseDateString(
-        futureStartDateCourseRuns.sort(compareCourseRunStartDates)[0].start_date
-      )
-      return `Start Date: ${formatPrettyDate(startDate)}`
-    } else {
-      if (showPast) {
-        return `Start Date: ${formatPrettyDate(
-          parseDateString(
-            nonSelfPacedCourseRuns.sort(reverseCompareCourseRunStartDates)[0]
-              .start_date
-          )
-        )}`
-      }
-      return "Start Anytime"
-    }
+  if (moment(courseRun.start_date).isAfter(moment())) {
+    return `Starts: ${formatPrettyDate(parseDateString(courseRun.start_date))}`
   } else {
-    return "Start Anytime"
+    if (courseRun.is_self_paced) {
+      return "Start Anytime"
+    } else {
+      return `Started: ${formatPrettyDate(
+        parseDateString(courseRun.start_date)
+      )}`
+    }
   }
 }

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -339,23 +339,23 @@ describe("utility functions", () => {
 
   describe("getStartDateText", () => {
     [
-      ["course", "past", false, "Start Anytime"],
-      ["course run", "past", false, "Start Anytime"],
-      ["course", "future", false, "Start Date"],
-      ["course run", "future", false, "Start Date"],
+      ["course", "past", false, "Started"],
+      ["course run", "past", false, "Started"],
+      ["course", "future", false, "Starts"],
+      ["course run", "future", false, "Starts"],
       ["course", "past", true, "Start Anytime"],
       ["course run", "past", true, "Start Anytime"],
-      ["course", "future", true, "Start Anytime"],
-      ["course run", "future", true, "Start Anytime"]
-    ].forEach(([coursewareType, datePosition, selfPaced, displayText]) => {
-      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there ${
+      ["course", "future", true, "Starts"],
+      ["course run", "future", true, "Starts"]
+    ].forEach(([coursewareType, startDatePosition, selfPaced, displayText]) => {
+      it(`displays the ${displayText} text when the ${coursewareType} has a start date in the ${startDatePosition} and there ${
         selfPaced ? "are" : "are no"
       } self-paced courses`, () => {
         const course = {
           courseruns: [
             {
               start_date:
-                datePosition === "future"
+                startDatePosition === "future"
                   ? moment().add(1, "days")
                   : moment().subtract(1, "days"),
               is_self_paced: false
@@ -375,7 +375,7 @@ describe("utility functions", () => {
       })
     })
 
-    it("displays the closest start date if there are multiple future start dates", () => {
+    it("displays the earliest start date if there are multiple future start dates", () => {
       const startDates = [
         moment().add(1, "days"),
         moment().add(2, "days"),
@@ -396,7 +396,7 @@ describe("utility functions", () => {
         ]
       }
 
-      assert.isTrue(getStartDateText(course).includes("Start Date"))
+      assert.isTrue(getStartDateText(course).includes("Starts"))
       assert.isTrue(
         getStartDateText(course).includes(formatPrettyDate(startDates[0]))
       )
@@ -405,7 +405,7 @@ describe("utility functions", () => {
       )
     })
 
-    it("displays the closest start date if there are multiple past start dates and showPast is true", () => {
+    it("displays the earliest start date if there are multiple past start dates", () => {
       const startDates = [
         moment().subtract(1, "days"),
         moment().subtract(2, "days"),
@@ -426,12 +426,12 @@ describe("utility functions", () => {
         ]
       }
 
-      assert.isTrue(getStartDateText(course, true).includes("Start Date"))
+      assert.isTrue(getStartDateText(course).includes("Started"))
       assert.isTrue(
-        getStartDateText(course, true).includes(formatPrettyDate(startDates[0]))
+        getStartDateText(course).includes(formatPrettyDate(startDates[2]))
       )
       assert.isFalse(
-        getStartDateText(course, true).includes(formatPrettyDate(startDates[2]))
+        getStartDateText(course).includes(formatPrettyDate(startDates[0]))
       )
     })
   })

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -346,7 +346,8 @@ describe("utility functions", () => {
       ["course", "past", "Start Anytime"],
       ["course run", "past", "Start Anytime"]
     ].forEach(([coursewareType, datePosition, displayText]) => {
-      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition}`, () => {
+      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there
+      } self-paced courses`, () => {
         const course = {
           courseruns: [
             {

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -339,14 +339,17 @@ describe("utility functions", () => {
 
   describe("getStartDateText", () => {
     [
-      ["course", "past", "Start Anytime"],
-      ["course run", "past", "Start Anytime"],
-      ["course", "future", "Start Date"],
-      ["course run", "future", "Start Date"],
-      ["course", "past", "Start Anytime"],
-      ["course run", "past", "Start Anytime"],
-    ].forEach(([coursewareType, datePosition, displayText]) => {
-      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there
+      ["course", "past", false, "Start Anytime"],
+      ["course run", "past", false, "Start Anytime"],
+      ["course", "future", false, "Start Date"],
+      ["course run", "future", false, "Start Date"],
+      ["course", "past", true, "Start Anytime"],
+      ["course run", "past", true, "Start Anytime"],
+      ["course", "future", true, "Start Anytime"],
+      ["course run", "future", true, "Start Anytime"]
+    ].forEach(([coursewareType, datePosition, selfPaced, displayText]) => {
+      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there ${
+        selfPaced ? "are" : "are no"
       } self-paced courses`, () => {
         const course = {
           courseruns: [
@@ -358,6 +361,10 @@ describe("utility functions", () => {
               is_self_paced: false
             }
           ]
+        }
+
+        if (selfPaced) {
+          course["courseruns"][0]["is_self_paced"] = true
         }
 
         assert.isTrue(

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -339,17 +339,14 @@ describe("utility functions", () => {
 
   describe("getStartDateText", () => {
     [
-      ["course", "past", false, "Start Anytime"],
-      ["course run", "past", false, "Start Anytime"],
-      ["course", "future", false, "Start Date"],
-      ["course run", "future", false, "Start Date"],
-      ["course", "past", true, "Start Anytime"],
-      ["course run", "past", true, "Start Anytime"],
-      ["course", "future", true, "Start Anytime"],
-      ["course run", "future", true, "Start Anytime"]
-    ].forEach(([coursewareType, datePosition, selfPaced, displayText]) => {
-      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there ${
-        selfPaced ? "are" : "are no"
+      ["course", "past", "Start Anytime"],
+      ["course run", "past", "Start Anytime"],
+      ["course", "future", "Start Date"],
+      ["course run", "future", "Start Date"],
+      ["course", "past", "Start Anytime"],
+      ["course run", "past", "Start Anytime"],
+    ].forEach(([coursewareType, datePosition, displayText]) => {
+      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there
       } self-paced courses`, () => {
         const course = {
           courseruns: [
@@ -361,10 +358,6 @@ describe("utility functions", () => {
               is_self_paced: false
             }
           ]
-        }
-
-        if (selfPaced) {
-          course["courseruns"][0]["is_self_paced"] = true
         }
 
         assert.isTrue(

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -346,8 +346,7 @@ describe("utility functions", () => {
       ["course", "past", "Start Anytime"],
       ["course run", "past", "Start Anytime"]
     ].forEach(([coursewareType, datePosition, displayText]) => {
-      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there
-      } self-paced courses`, () => {
+      it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition}`, () => {
         const course = {
           courseruns: [
             {

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -344,7 +344,7 @@ describe("utility functions", () => {
       ["course", "future", "Start Date"],
       ["course run", "future", "Start Date"],
       ["course", "past", "Start Anytime"],
-      ["course run", "past", "Start Anytime"]
+      ["course run", "past", "Start Anytime"],
     ].forEach(([coursewareType, datePosition, displayText]) => {
       it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there
       } self-paced courses`, () => {

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -344,7 +344,7 @@ describe("utility functions", () => {
       ["course", "future", "Start Date"],
       ["course run", "future", "Start Date"],
       ["course", "past", "Start Anytime"],
-      ["course run", "past", "Start Anytime"],
+      ["course run", "past", "Start Anytime"]
     ].forEach(([coursewareType, datePosition, displayText]) => {
       it(`displays the ${displayText} text when the ${coursewareType} is in the ${datePosition} and there
       } self-paced courses`, () => {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3382

### Description (What does it do?)
Updates the logic that controls which date is displayed first to users on the course about page.  The updated logic is described in the code and here: https://mitodl.slack.com/archives/C02649X2P1V/p1705690944470659?thread_ts=1705689453.418639&cid=C02649X2P1V 

### How can this be tested?
Run through different course run start date configurations in order to trigger the following to be shown in the course about page start date field:

1. 'Starts: earliest course run start date'
2. 'Start Anytime'
3. 'Started: earliest course run start date'

