### PR TITLE
Update Publish Documentation to newer versions of stuff so it runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install ghp-import
         run: pip install ghp-import
       - name: Build documentation

--- a/pants-plugins/mitol/docs/register.py
+++ b/pants-plugins/mitol/docs/register.py
@@ -1,3 +1,6 @@
+import logging
+from dataclasses import dataclass
+
 from pants.backend.python.target_types import ConsoleScript
 from pants.backend.python.util_rules.interpreter_constraints import (
     InterpreterConstraints,
@@ -9,21 +12,17 @@ from pants.backend.python.util_rules.pex import (
     PexRequirements,
 )
 from pants.core.util_rules.distdir import DistDir
-from pants.engine.fs import Digest, Workspace, MergeDigests, PathGlobs
-from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, MultiGet, goal_rule, collect_rules, rule
+from pants.engine.fs import Digest, MergeDigests, PathGlobs, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.process import FallibleProcessResult
+from pants.engine.rules import Get, collect_rules, goal_rule
 from pants.engine.target import (
-    Target,
-    Tags,
     COMMON_TARGET_FIELDS,
-    Targets,
-    Sources,
-    StringField,
     FieldSet,
+    StringField,
+    Target,
+    Targets,
 )
-from dataclasses import dataclass
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +34,7 @@ class DocsGoalSubsystem(GoalSubsystem):
 
 class Docs(Goal):
     subsystem_cls = DocsGoalSubsystem
+    environment_behavior = None
 
 
 class SphinxSources(StringField):
@@ -55,7 +55,6 @@ class SphinxDocs(Target):
 
 @goal_rule
 async def build_docs(targets: Targets, dist_dir: DistDir, workspace: Workspace) -> Docs:
-
     pex = await Get(
         Pex,
         PexRequest(

--- a/pants.toml
+++ b/pants.toml
@@ -5,7 +5,7 @@ backend_packages = [
   # local plugins
   "mitol.docs"
 ]
-pants_version = "2.18.2"
+pants_version = "2.17.1"
 pythonpath = ["%(buildroot)s/pants-plugins"]
 
 [anonymous-telemetry]

--- a/pants.toml
+++ b/pants.toml
@@ -5,7 +5,7 @@ backend_packages = [
   # local plugins
   "mitol.docs"
 ]
-pants_version = "2.8.1"
+pants_version = "2.18.2"
 pythonpath = ["%(buildroot)s/pants-plugins"]
 
 [anonymous-telemetry]

--- a/pants.toml
+++ b/pants.toml
@@ -5,7 +5,7 @@ backend_packages = [
   # local plugins
   "mitol.docs"
 ]
-pants_version = "2.8.1rc1"
+pants_version = "2.8.1"
 pythonpath = ["%(buildroot)s/pants-plugins"]
 
 [anonymous-telemetry]


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

For version 0.85.0, the production deploy got stuck because the Publish Documentation action failed. It looks like this was mostly due  to Pants being too old, so this bumps that to 2.17.1 and makes some minor changes to the `docs` plugin to make it work. 

### How can this be tested?

Running `./pants docs ::` should work as expected.

### Additional Context

The latest Pants is 2.18.2 but that didn't seem to work; [there's a warning here](https://github.com/mitodl/mitxonline/actions/runs/7641957862/job/20820461026#step:5:100) that is likely the issue. (We're not using SCIE pants here yet so moving to that is probably the right move but there's also [specifically an init-pants action](https://github.com/pantsbuild/actions/tree/main/init-pants) that we could also look at. Or, both, though bumping to 2.18.2 locally worked OK without also switching to SCIE pants.) 
