### PR TITLE
Wrapping product creation in a create_version block so versions happen like they should

### DIFF
--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -2,7 +2,6 @@
 Tests for courses api views v2
 """
 import logging
-import operator as op
 import random
 
 import pytest
@@ -10,7 +9,6 @@ from django.db import connection
 from django.urls import reverse
 from rest_framework import status
 
-from courses.conftest import course_catalog_data
 from courses.factories import DepartmentFactory
 from courses.models import Program
 from courses.serializers.v2.courses import CourseWithCourseRunsSerializer
@@ -22,7 +20,6 @@ from courses.views.test_utils import (
     num_queries_from_programs,
 )
 from courses.views.v2 import Pagination
-from fixtures.common import raise_nplusone
 from main.test_utils import assert_drf_json_equal, duplicate_queries_check
 
 pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("raise_nplusone")]

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -75,7 +75,7 @@ def test_get_departments(
 
 
 @pytest.mark.parametrize("course_catalog_course_count", [100], indirect=True)
-@pytest.mark.parametrize("course_catalog_program_count", [15], indirect=True)
+@pytest.mark.parametrize("course_catalog_program_count", [12], indirect=True)
 def test_get_programs(
     user_drf_client, django_assert_max_num_queries, course_catalog_data
 ):

--- a/ecommerce/management/commands/create_product.py
+++ b/ecommerce/management/commands/create_product.py
@@ -2,6 +2,8 @@
 Creates a product for the given courseware ID. This only supports course runs
 for right now (since we don't really do program runs).
 """
+
+import reversion
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import BaseCommand
 
@@ -56,12 +58,13 @@ class Command(BaseCommand):
         if "description" in kwargs and kwargs["description"] is not None:
             description = kwargs["description"]
 
-        product = Product.objects.create(
-            object_id=courserun.id,
-            content_type=content_type,
-            price=kwargs["price"],
-            description=description,
-            is_active=kwargs["inactive"],
-        )
+        with reversion.create_revision():
+            product = Product.objects.create(
+                object_id=courserun.id,
+                content_type=content_type,
+                price=kwargs["price"],
+                description=description,
+                is_active=kwargs["inactive"],
+            )
 
         self.stdout.write(f"Created product {product}.")


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#3463

### Description (What does it do?)

`create_product` wasn't creating the initial version of the product it created - it just made the row in the `ecommerce_product` table, so trying to buy the resulting product would fail. This fixes that.

### How can this be tested?

Run `create_product` - the new product it creates should have a version. (Easy way to check is just to grab the last row of the `reversion_version` table, or doing a `like` on `object_repr` in that table with the product name you created.) 

Checkout should work with the newly created product.
