### PR TITLE
Fixes use of "redemption_type" when generating discount codes in bulk

### DIFF
--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from courses.factories import DepartmentFactory
-from courses.models import Program
+from courses.models import Course, Program
 from courses.serializers.v2.courses import CourseWithCourseRunsSerializer
 from courses.serializers.v2.departments import DepartmentWithCountSerializer
 from courses.serializers.v2.programs import ProgramSerializer
@@ -165,7 +165,7 @@ def test_delete_program(
 
 
 @pytest.mark.parametrize("course_catalog_course_count", [100], indirect=True)
-@pytest.mark.parametrize("course_catalog_program_count", [15], indirect=True)
+@pytest.mark.parametrize("course_catalog_program_count", [12], indirect=True)
 @pytest.mark.parametrize("include_finaid", [True, False])
 def test_get_courses(
     user_drf_client,
@@ -175,9 +175,11 @@ def test_get_courses(
     include_finaid,
 ):
     """Test the view that handles requests for all Courses"""
-    courses, _, _ = course_catalog_data
+    course_catalog_data
     courses_from_fixture = []
     num_queries = 0
+
+    courses = Course.objects.order_by("title").prefetch_related("departments").all()
 
     if include_finaid:
         mock_context["include_approved_financial_aid"] = True

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -20,6 +20,7 @@ from courses.constants import ENROLL_CHANGE_STATUS_REFUNDED
 from ecommerce.constants import (
     ALL_DISCOUNT_TYPES,
     ALL_PAYMENT_TYPES,
+    ALL_REDEMPTION_TYPES,
     DISCOUNT_TYPE_PERCENT_OFF,
     PAYMENT_TYPE_FINANCIAL_ASSISTANCE,
     REDEMPTION_TYPE_ONE_TIME,
@@ -671,9 +672,13 @@ def generate_discount_code(**kwargs):
     UUID - if you want one (the convention is a -), you need to ensure it's
     there in the prefix (and that counts against the limit)
 
+    If you specify redemption_type, specifying one_time or one_time_per_user will not be
+    honored.
+
     Keyword Args:
     * discount_type - one of the valid discount types
     * payment_type - one of the valid payment types
+    * redemption_type - one of the valid redemption types (overrules use of the flags)
     * amount - the value of the discount
     * one_time - boolean; discount can only be redeemed once
     * one_time_per_user - boolean; discount can only be redeemed once per user
@@ -729,6 +734,12 @@ def generate_discount_code(**kwargs):
 
     if "once_per_user" in kwargs and kwargs["once_per_user"]:
         redemption_type = REDEMPTION_TYPE_ONE_TIME_PER_USER
+
+    if (
+        "redemption_type" in kwargs
+        and kwargs["redemption_type"] in ALL_REDEMPTION_TYPES
+    ):
+        redemption_type = kwargs["redemption_type"]
 
     if "expires" in kwargs and kwargs["expires"] is not None:
         expiration_date = parse_supplied_date(kwargs["expires"])


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

I noticed when processing a bulk code creation form in the staff dashboard that codes that I'd requested be created as one-time discounts were being created as unlimited ones instead. As it turns out, the API call for this was not looking at the `POST`ed redemption type - it expected flags instead. This fixes the API to use _either_ the flags or the `redemption_type` kwarg (which is how it's sent via POST), so the redemption type is saved correctly. 

This also fixes the `test_get_courses` test - this had similar problems to `test_get_programs`, which was fixed in https://github.com/mitodl/mitxonline/pull/2073 , which was also rolled into that PR because the tests were failing. 

### How can this be tested?

Create a set of discount codes from the staff dashboard that are of a redemption type that's not unlimited. The type should be correctly set.

### Additional Context

I noticed this processing https://github.com/mitodl/hq/issues/3515 . Upon further examination, this is a fairly longstanding bug - I went ahead and fixed all the discounts in production that had the `in_bulk` flag set to be `one-time` redemption instead. This was around 1170 discount codes. (I did look to make sure the codes were all ones that should have been one-time discounts, and they were.) 

I know multiple redemptions has come up once but I don't know at this point if any codes have been redeemed more than once. Note that the redemption status is calculated by looking at actual redemptions so any unlimited discount that had any redemptions in the past will now not be redeemable.