### PR TITLE
2075: some dialogs email settings unenroll not keyboard navigable

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -255,8 +255,10 @@ export class EnrolledItemCard extends React.Component<
               enrollmentId:    enrollment.id,
               courseNumber:    enrollment.run.course_number
             }}
-            render={({ values }) => (
-              <Form className="text-center">
+            render={({ values, handleSubmit }) => (
+              <Form className="text-center"
+                onSubmit={handleSubmit}
+              >
                 <section>
                   <Field
                     type="hidden"
@@ -276,7 +278,6 @@ export class EnrolledItemCard extends React.Component<
                   />{" "}
                   <label
                     id={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
-                    check
                   >
                     Receive course emails
                   </label>

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -276,7 +276,6 @@ export class EnrolledItemCard extends React.Component<
                   />{" "}
                   <label
                     id={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
-                    check
                   >
                     Receive course emails
                   </label>
@@ -534,7 +533,6 @@ export class EnrolledItemCard extends React.Component<
                     >
                       Unenroll
                     </DropdownItem>
-                    {this.renderRunUnenrollmentModal(enrollment)}
                   </span>
                   <span id="subscribeButtonWrapper">
                     <DropdownItem
@@ -543,10 +541,11 @@ export class EnrolledItemCard extends React.Component<
                     >
                       Email Settings
                     </DropdownItem>
-                    {this.renderEmailSettingsDialog(enrollment)}
                   </span>
                 </DropdownMenu>
               </Dropdown>
+              {this.renderRunUnenrollmentModal(enrollment)}
+              {this.renderEmailSettingsDialog(enrollment)}
             </div>
             <div className="detail pt-1">
               {courseId}

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -255,10 +255,8 @@ export class EnrolledItemCard extends React.Component<
               enrollmentId:    enrollment.id,
               courseNumber:    enrollment.run.course_number
             }}
-            render={({ values, handleSubmit }) => (
-              <Form className="text-center"
-                onSubmit={handleSubmit}
-              >
+            render={({ values }) => (
+              <Form className="text-center">
                 <section>
                   <Field
                     type="hidden"
@@ -278,6 +276,7 @@ export class EnrolledItemCard extends React.Component<
                   />{" "}
                   <label
                     id={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
+                    check
                   >
                     Receive course emails
                   </label>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/2075

### Description (What does it do?)
Resolves in issue with using the keyboard to navigate and control the browser when the either the unenroll modal or email settings modal is open for a course enrollment.

### How can this be tested?
You should have a course created and be enrolled.
1. Visit http://mitxonline.odl.local:8013/dashboard/.
2. Using only your keyboard, open the unenroll modal or email settings modal from the course enrollment card.
3. Verify that you can move focus to one of the buttons on the modal.  When you press enter, the focused button should perform it's expected action (close the modal, or submit).
