### PR TITLE
Program certificate for different program types

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -452,7 +452,9 @@ class CertificatePage(CourseProgramChildPage):
                 "end_date": end_date,
                 "CEUs": CEUs,
                 "is_program_certificate": is_program_certificate,
-                "program_type": self.parent.program.program_type if is_program_certificate else ""
+                "program_type": self.parent.program.program_type
+                if is_program_certificate
+                else "",
             }
         else:
             raise Http404()

--- a/cms/models.py
+++ b/cms/models.py
@@ -452,6 +452,7 @@ class CertificatePage(CourseProgramChildPage):
                 "end_date": end_date,
                 "CEUs": CEUs,
                 "is_program_certificate": is_program_certificate,
+                "program_type": self.parent.program.program_type if is_program_certificate else ""
             }
         else:
             raise Http404()

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -66,7 +66,7 @@
                     </div>
                     <span class="certify-text">This is to certify that</span>
                     <span class="certify-name">{{ learner_name }}</span>
-                    <span class="success-text">has successfully completed {% if is_program_certificate %}all courses and received passing grades to earn a MicroMasters program certificate in{% endif %}</span>
+                    <span class="success-text">has successfully completed {% if is_program_certificate %}all courses and received passing grades to earn a {{ program_type }} program certificate in{% endif %}</span>
                     <span class="degree-text">{{ product_name }}</span>
                     {% if is_program_certificate %}
                         <span class="success-text">a program of study offered by MITx, an online learning initiative of the Massachusetts Institute of Technology<br></span>


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3370

### Description (What does it do?)
Uses program type to specify the type of program for which a certificate is issued.

Something to think about: omitting the Series might be a better solution.

### Screenshots (if appropriate):
<img width="785" alt="Screenshot 2024-02-07 at 5 05 04 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/b627adb2-5dff-4772-9b76-cd33a0610102">
<img width="859" alt="Screenshot 2024-02-07 at 5 06 07 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/17ea4b57-9031-4807-9fc0-e7a1936df1ae">
