### PR TITLE
Fix the width of course image

### DIFF
--- a/frontend/public/scss/product-page/program-courses.scss
+++ b/frontend/public/scss/product-page/program-courses.scss
@@ -57,6 +57,7 @@ body.new-design {
                 max-width: 243px;
                 max-height: 222px;
                 height: 222px;
+                width: 243px;
                 transition: .25s;
                 cursor: pointer;
 
@@ -67,6 +68,7 @@ body.new-design {
                         max-width: 243px;
                         max-height: 136px;
                         height: 136px;
+                        width: 243px;
                         object-fit: cover;
                         object-position: center;
                         @include media-breakpoint-down(sm) {
@@ -99,10 +101,6 @@ body.new-design {
                 .program-course-card-info {
                     overflow: hidden;
                     padding: 15px;
-
-                    @include media-breakpoint-down(md) {
-                        margin-top: 20px;
-                    }
 
                     .start-date {
                         font-weight: 400;


### PR DESCRIPTION
### What are the relevant tickets?
Fix an issue with image width and older degression.

### Description (What does it do?)
The current immages have smaller width. This PR sets the width on the img.

Also fixes padding on tablet view for course cards.

### Screenshots (if appropriate):
<img width="352" alt="Screenshot 2024-02-12 at 12 20 34 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/54a01153-104e-491d-b711-1cf8bafe0d2e">
<img width="859" alt="Screenshot 2024-02-12 at 12 22 14 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/59641bb1-1069-40d5-86a3-f48197bd35e1">
