### PR TITLE
Admin improvements to CourseRunEnrollmentAudit model

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -191,6 +191,13 @@ class ProgramEnrollmentAuditAdmin(TimestampedModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
+class CourseRunEnrollmentAuditInline(admin.TabularInline):
+    """Inline editor for CourseRunEnrollmentAudit"""
+
+    model = CourseRunEnrollmentAudit
+    readonly_fields = ["enrollment_id", "created_on", ]
+    min_num = 0
+    extra = 0
 
 class CourseRunEnrollmentAdmin(AuditableModelAdmin):
     """Admin for CourseRunEnrollment"""
@@ -214,6 +221,7 @@ class CourseRunEnrollmentAdmin(AuditableModelAdmin):
         "user",
         "run",
     )
+    inlines = [CourseRunEnrollmentAuditInline,]
 
     def get_queryset(self, request):
         """
@@ -247,6 +255,11 @@ class CourseRunEnrollmentAuditAdmin(TimestampedModelAdmin):
 
     model = CourseRunEnrollmentAudit
     include_created_on_in_list = True
+    search_fields = [
+        "enrollment__user__email",
+        "enrollment__user__username",
+        "enrollment__run__courseware_id",
+    ]
     list_display = ("id", "enrollment_id", "get_run_courseware_id", "get_user")
     readonly_fields = get_field_names(CourseRunEnrollmentAudit)
 

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -191,13 +191,18 @@ class ProgramEnrollmentAuditAdmin(TimestampedModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
+
 class CourseRunEnrollmentAuditInline(admin.TabularInline):
     """Inline editor for CourseRunEnrollmentAudit"""
 
     model = CourseRunEnrollmentAudit
-    readonly_fields = ["enrollment_id", "created_on", ]
+    readonly_fields = [
+        "enrollment_id",
+        "created_on",
+    ]
     min_num = 0
     extra = 0
+
 
 class CourseRunEnrollmentAdmin(AuditableModelAdmin):
     """Admin for CourseRunEnrollment"""
@@ -221,7 +226,9 @@ class CourseRunEnrollmentAdmin(AuditableModelAdmin):
         "user",
         "run",
     )
-    inlines = [CourseRunEnrollmentAuditInline,]
+    inlines = [
+        CourseRunEnrollmentAuditInline,
+    ]
 
     def get_queryset(self, request):
         """

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -199,9 +199,17 @@ class CourseRunEnrollmentAuditInline(admin.TabularInline):
     readonly_fields = [
         "enrollment_id",
         "created_on",
+        "acting_user",
+        "data_before",
+        "data_after",
     ]
     min_num = 0
     extra = 0
+    can_delete = False
+    can_add = False
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 class CourseRunEnrollmentAdmin(AuditableModelAdmin):


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/3580

### Description (What does it do?)
adds search fields to CourseRunEnrollmentsAuditAdmin model and inlines to `CourseRunEnrollmentAdmin`

Make sure you have an enrollment instance. View it in the admin.
Then modify the course enrollment. A new audit model should get created. Try searching for the audit by username or email.
View the enrollment in the admin and see the audit instances related to the enrollment.

