### PR TITLE
fix course card not keyboard accessible issue

### DIFF
--- a/cms/templates/course_list_card.html
+++ b/cms/templates/course_list_card.html
@@ -1,20 +1,20 @@
 <ul>
     {% for card in cards %}
     <li>
+      <a href="{{card.course.page.url}}" class="program-course-card-link">
         <div class="program-course-card">
-            <a href="{{card.course.page.url}}" class="program-course-card-link">
-                <div class="image">
-                    <img src="{{card.featured_image}}" alt="">
-                    <div class="overlay"></div>
+            <div class="image">
+                <img src="{{card.featured_image}}" alt="">
+                <div class="overlay"></div>
+            </div>
+            <div class="program-course-card-info">
+                <div class="start-date">
+                {{card.start_descriptor}}
                 </div>
-                <div class="program-course-card-info">
-                    <div class="start-date">
-                    {{card.start_descriptor}}
-                    </div>
-                    <h3 class="title">{{card.course.title}}</h3>
-                </div>
-            </a>
+                <h3 class="title">{{card.course.title}}</h3>
+            </div>
         </div>
+      </a>
     </li>
     {% endfor %}
 </ul>

--- a/cms/templates/course_list_card.html
+++ b/cms/templates/course_list_card.html
@@ -1,17 +1,19 @@
 <ul>
     {% for card in cards %}
-    <li onClick="javascript:window.open('{{card.course.page.url}}');"> 
+    <li>
         <div class="program-course-card">
-            <div class="image">
-                <img src="{{card.featured_image}}" alt="">
-                <div class="overlay"></div>
-            </div>
-            <div class="program-course-card-info">
-                <div class="start-date">
-                {{card.start_descriptor}}
+            <a href="{{card.course.page.url}}" class="program-course-card-link">
+                <div class="image">
+                    <img src="{{card.featured_image}}" alt="">
+                    <div class="overlay"></div>
                 </div>
-                <h3 class="title">{{card.course.title}}</h3>
-            </div>
+                <div class="program-course-card-info">
+                    <div class="start-date">
+                    {{card.start_descriptor}}
+                    </div>
+                    <h3 class="title">{{card.course.title}}</h3>
+                </div>
+            </a>
         </div>
     </li>
     {% endfor %}

--- a/frontend/public/scss/product-page/program-courses.scss
+++ b/frontend/public/scss/product-page/program-courses.scss
@@ -140,6 +140,10 @@ body.new-design {
                     }
                 }
             }
+
+            .program-course-card-link {
+                text-decoration: none;
+            }
         }
     }
 }

--- a/frontend/public/scss/product-page/program-courses.scss
+++ b/frontend/public/scss/product-page/program-courses.scss
@@ -143,6 +143,8 @@ body.new-design {
 
             .program-course-card-link {
                 text-decoration: none;
+                display: block;
+                width: fit-content;
             }
         }
     }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3361

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing the keyboard accessible issue for the course card on program page. 

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
Course card is now focusable
![image](https://github.com/mitodl/mitxonline/assets/3138890/b9855e36-afe0-4f54-b7dd-36f8d9a03903)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- You will need to setup courses and programs to test it
- Turn on voiceover and go to program page
- you should be able to tab to the course card and then use keyboard to open it