### PR TITLE
Create certs only for live programs

### DIFF
--- a/courses/signals.py
+++ b/courses/signals.py
@@ -27,7 +27,9 @@ def handle_create_course_run_certificate(
         user = instance.user
         course = instance.course_run.course
         programs = list(
-            Program.objects.filter(all_requirements__course=course, live=True).distinct()
+            Program.objects.filter(
+                all_requirements__course=course, live=True
+            ).distinct()
         )
         if programs:
             transaction.on_commit(

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -27,7 +27,7 @@ def handle_create_course_run_certificate(
         user = instance.user
         course = instance.course_run.course
         programs = list(
-            Program.objects.filter(all_requirements__course=course).distinct()
+            Program.objects.filter(all_requirements__course=course, live=True).distinct()
         )
         if programs:
             transaction.on_commit(

--- a/courses/signals_test.py
+++ b/courses/signals_test.py
@@ -35,6 +35,24 @@ def test_create_course_certificate(generate_program_cert_mock, mock_on_commit):
     generate_program_cert_mock.assert_called_once_with(user, [program])
 
 
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("courses.signals.generate_multiple_programs_certificate", autospec=True)
+def test_generate_program_certificate_if_not_live(
+    generate_program_cert_mock, mock_on_commit
+):
+    """
+    Test that generate_multiple_programs_certificate is not called when a program is not live
+    """
+    user = UserFactory.create()
+    course_run = CourseRunFactory.create()
+    program = ProgramFactory.create(live=False)
+    program.add_requirement(course_run.course)
+    cert = CourseRunCertificateFactory.create(user=user, course_run=course_run)
+    generate_program_cert_mock.assert_not_called()
+    cert.save()
+    generate_program_cert_mock.assert_not_called()
+
+
 # pylint: disable=unused-argument
 @patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
 @patch("courses.signals.generate_multiple_programs_certificate", autospec=True)


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Updates the signal to check whether the program is live before generating the cert.
### How can this be tested?
Take a look at the tests. 

Create a program with a required course. When you create a cert for that course, a program cert should get generated. 
If you set the program `live=False` and then create a course cert then no program cert should get generated.