### PR TITLE
Certificate Page: End date should be certificate creation date

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -898,10 +898,8 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
 
     @property
     def start_end_dates(self):
-        """Returns the start and end date for courseware object duration"""
-        if self.course_run.is_self_paced:
-            return self.course_run.start_date, self.created_on
-        return self.course_run.start_date, self.course_run.end_date
+        """Returns the start date for courseware object and certificate creation date"""
+        return self.course_run.start_date, self.created_on
 
     def __str__(self):
         return (

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -490,7 +490,7 @@ def test_course_run_certificate_start_end_dates_and_page_revision():
     )
     start_date, end_date = certificate.start_end_dates
     assert start_date == certificate.course_run.start_date
-    assert end_date == certificate.course_run.end_date
+    assert end_date == certificate.created_on
     certificate_page = certificate.course_run.course.page.certificate_page
     assert (
         certificate_page.get_latest_revision() == certificate.certificate_page_revision


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3622

### Description (What does it do?)
On course certificate page show the end date equivalent to certificate creation date. The actual end date of the course run can be changed by the course team.


### How can this be tested?
Create a course certificate. Go to view the certificate, the end date that is displayed should be the certificate creation date.