### PR TITLE
Change the callback to respond on programs page as well

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -125,7 +125,7 @@ export class CatalogPage extends React.Component<Props> {
         }
       } else {
         const { getNextProgramPage, programsNextPage } = this.props
-        if (programsNextPage) {
+        if (programsNextPage && !this.state.isLoadingMoreItems) {
           this.setState({ isLoadingMoreItems: true })
           const response = await getNextProgramPage(
             this.state.programQueryPage + 1

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -202,6 +202,12 @@ export class CatalogPage extends React.Component<Props> {
       this.setState({
         filteredPrograms: filteredPrograms
       })
+      // Detect when the bottom of the catalog page has been reached and display more catalog items.
+      this.io = new window.IntersectionObserver(
+        this.bottomOfLoadedCatalogCallback,
+        { threshold: 1.0 }
+      )
+      this.io.observe(this.container.current)
     }
   }
 


### PR DESCRIPTION
### What are the relevant tickets?
fixes https://github.com/mitodl/hq/issues/3141
fixes https://github.com/mitodl/hq/issues/2992
fixes https://github.com/mitodl/hq/issues/2910
fixes https://github.com/mitodl/hq/issues/2909

### Description (What does it do?)
Rather than just call the callback on the courses page, also calls it on the programs page as well.

### How can this be tested?
Ensure that your database has at least 24+ relevant courses and programs for a department or two. I can provide a seed script if need be.
Load the catalog page. you should see number of courses and programs match the count at the top right.

### Additional Context
This pulls back from the previous iteration of how I'd like to see this work - in the future we should rework the page to asynchronously seed the data to redux, but in the meantime, we're adding the callback to the bottom of programs which was not there previously.

