### PR TITLE
Fix mobile counts on catalog

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -374,13 +374,9 @@ export class CatalogPage extends React.Component<Props> {
    */
   renderNumberOfCatalogCourses() {
     const { coursesCount, departments } = this.props
-    if (
-      this.state.selectedDepartment === ALL_DEPARTMENTS
-    ) {
+    if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
       return coursesCount
-    } else if (
-      this.state.selectedDepartment !== ALL_DEPARTMENTS
-    ) {
+    } else if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
       return departments.find(
         department => department.name === this.state.selectedDepartment
       ).courses
@@ -389,13 +385,9 @@ export class CatalogPage extends React.Component<Props> {
 
   renderNumberOfCatalogPrograms() {
     const { programsCount, departments } = this.props
-    if (
-      this.state.selectedDepartment === ALL_DEPARTMENTS
-    ) {
+    if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
       return programsCount
-    } else if (
-      this.state.selectedDepartment !== ALL_DEPARTMENTS
-    ) {
+    } else if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
       return departments.find(
         department => department.name === this.state.selectedDepartment
       ).programs
@@ -604,9 +596,7 @@ export class CatalogPage extends React.Component<Props> {
                                 ? "selected-tab"
                                 : "unselected-tab"
                             } ${
-                              this.props.programsCount
-                                ? ""
-                                : "display-none"
+                              this.props.programsCount ? "" : "display-none"
                             }`}
                           >
                             <button
@@ -639,7 +629,9 @@ export class CatalogPage extends React.Component<Props> {
                           <h2>
                             {/* Hidden on small screens. */}
                             {/* Could add logic to display only "course" if only 1 course is showing. */}
-                            {this.state.tabSelected === PROGRAMS_TAB ? this.renderNumberOfCatalogPrograms() : this.renderNumberOfCatalogCourses()}{" "}
+                            {this.state.tabSelected === PROGRAMS_TAB
+                              ? this.renderNumberOfCatalogPrograms()
+                              : this.renderNumberOfCatalogCourses()}{" "}
                             {this.state.tabSelected}
                           </h2>
                         </CSSTransition>

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -594,7 +594,7 @@ export class CatalogPage extends React.Component<Props> {
                             >
                               Courses{" "}
                               <div className="product-number d-inline-block d-sm-none">
-                                ({this.state.filteredCourses.length})
+                                ({this.props.coursesCount})
                               </div>
                             </button>
                           </div>
@@ -604,7 +604,7 @@ export class CatalogPage extends React.Component<Props> {
                                 ? "selected-tab"
                                 : "unselected-tab"
                             } ${
-                              this.state.filteredPrograms.length
+                              this.props.programsCount
                                 ? ""
                                 : "display-none"
                             }`}
@@ -616,7 +616,7 @@ export class CatalogPage extends React.Component<Props> {
                             >
                               Programs{" "}
                               <div className="product-number d-inline-block d-sm-none">
-                                ({this.state.filteredPrograms.length})
+                                ({this.props.programsCount})
                               </div>
                             </button>
                           </div>

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -125,7 +125,7 @@ export class CatalogPage extends React.Component<Props> {
         }
       } else {
         const { getNextProgramPage, programsNextPage } = this.props
-        if (programsNextPage) {
+        if (programsNextPage && !this.state.isLoadingMoreItems) {
           this.setState({ isLoadingMoreItems: true })
           const response = await getNextProgramPage(
             this.state.programQueryPage + 1

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -202,6 +202,12 @@ export class CatalogPage extends React.Component<Props> {
       this.setState({
         filteredPrograms: filteredPrograms
       })
+      // Detect when the bottom of the catalog page has been reached and display more catalog items.
+      this.io = new window.IntersectionObserver(
+        this.bottomOfLoadedCatalogCallback,
+        { threshold: 1.0 }
+      )
+      this.io.observe(this.container.current)
     }
   }
 

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -372,34 +372,34 @@ export class CatalogPage extends React.Component<Props> {
   /**
    * Returns the number of courseRuns or programs based on the selected catalog tab.
    */
-  renderNumberOfCatalogItems() {
-    const { coursesCount, programsCount, departments } = this.props
+  renderNumberOfCatalogCourses() {
+    const { coursesCount, departments } = this.props
     if (
-      this.state.tabSelected === PROGRAMS_TAB &&
-      this.state.selectedDepartment === ALL_DEPARTMENTS
-    ) {
-      return programsCount
-    } else if (
-      this.state.tabSelected === PROGRAMS_TAB &&
-      this.state.selectedDepartment !== ALL_DEPARTMENTS
-    ) {
-      return departments.find(
-        department => department.name === this.state.selectedDepartment
-      ).programs
-    }
-    if (
-      this.state.tabSelected === COURSES_TAB &&
       this.state.selectedDepartment === ALL_DEPARTMENTS
     ) {
       return coursesCount
     } else if (
-      this.state.tabSelected === COURSES_TAB &&
       this.state.selectedDepartment !== ALL_DEPARTMENTS
     ) {
       return departments.find(
         department => department.name === this.state.selectedDepartment
       ).courses
     }
+  }
+
+  renderNumberOfCatalogPrograms() {
+    const { programsCount, departments } = this.props
+    if (
+      this.state.selectedDepartment === ALL_DEPARTMENTS
+    ) {
+      return programsCount
+    } else if (
+      this.state.selectedDepartment !== ALL_DEPARTMENTS
+    ) {
+      return departments.find(
+        department => department.name === this.state.selectedDepartment
+      ).programs
+    } else return 0
   }
 
   /**
@@ -594,7 +594,7 @@ export class CatalogPage extends React.Component<Props> {
                             >
                               Courses{" "}
                               <div className="product-number d-inline-block d-sm-none">
-                                ({this.props.coursesCount})
+                                ({this.renderNumberOfCatalogCourses()})
                               </div>
                             </button>
                           </div>
@@ -616,7 +616,7 @@ export class CatalogPage extends React.Component<Props> {
                             >
                               Programs{" "}
                               <div className="product-number d-inline-block d-sm-none">
-                                ({this.props.programsCount})
+                                ({this.renderNumberOfCatalogPrograms()})
                               </div>
                             </button>
                           </div>
@@ -639,7 +639,7 @@ export class CatalogPage extends React.Component<Props> {
                           <h2>
                             {/* Hidden on small screens. */}
                             {/* Could add logic to display only "course" if only 1 course is showing. */}
-                            {this.renderNumberOfCatalogItems()}{" "}
+                            {this.state.tabSelected === PROGRAMS_TAB ? this.renderNumberOfCatalogPrograms() : this.renderNumberOfCatalogCourses()}{" "}
                             {this.state.tabSelected}
                           </h2>
                         </CSSTransition>

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -190,7 +190,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().allCoursesRetrieved)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
   })
 
   it("updates state from changeSelectedTab when selecting program tab", async () => {
@@ -247,7 +247,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().allProgramsRetrieved)).equals(
       JSON.stringify(programs)
     )
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(5)
+    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(5)
   })
 
   it("renders catalog department filter for courses and programs tabs", async () => {
@@ -554,14 +554,14 @@ describe("CatalogPage", function() {
       JSON.stringify(courses)
     )
     // Number of catalog items should match the number of visible courses.
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(3)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(3)
 
     // Select a department to filter by.
     inner.instance().changeSelectedDepartment("History", "courses")
     // Confirm the state updated to reflect the selected department.
     expect(inner.state().selectedDepartment).equals("History")
     // Confirm the number of catalog items updated to reflect the items filtered by department.
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(2)
     // Confirm the courses filtered are those which have a department name matching the selected department.
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify([course2, course3])
@@ -622,7 +622,7 @@ describe("CatalogPage", function() {
       JSON.stringify(courses)
     )
     // one shows visually, but the total is 2
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(2)
     expect(inner.state().courseQueryPage).equals(1)
 
     // Mock the second page of course API results.
@@ -651,7 +651,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify([displayedCourse, displayedCourse])
     )
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(2)
   })
 
   it("do not load more at the bottom of the courses catalog page if next page is null", async () => {
@@ -692,7 +692,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().allCoursesRetrieved)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
     expect(inner.state().courseQueryPage).equals(1)
 
     // Simulate the user reaching the bottom of the catalog page.
@@ -707,7 +707,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
   })
 
   it("do not load more at the bottom of the courses catalog page if isLoadingMoreItems is true", async () => {
@@ -745,7 +745,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
     expect(inner.state().courseQueryPage).equals(1)
 
     // Simulate the user reaching the bottom of the catalog page.
@@ -764,7 +764,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
   })
 
   it("load more at the bottom of the programs catalog page, all departments filter", async () => {
@@ -821,7 +821,7 @@ describe("CatalogPage", function() {
       JSON.stringify(programs)
     )
     // While there is only one showing, there are still 2 total. The total should be shown.
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
+    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(2)
     expect(inner.state().programQueryPage).equals(1)
 
     // Mock the second page of program API results.
@@ -851,7 +851,8 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredPrograms)).equals(
       JSON.stringify([displayedProgram, displayedProgram])
     )
+
     // This should still be 2 because we haven't changed the filter - no matter if one or two have loaded, there are 2
-    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
+    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(2)
   })
 })


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/3664
blocks https://github.com/mitodl/hq/issues/3663

### Description (What does it do?)
Splits the render number of items function into two - one for courses and one for programs, and uses those in the desktop and mobile versions alike. This will also be used to determine how many loading divs are needed in a follow-on PR

### How can this be tested?
Make sure the counts match on desktop and mobile and are correct for each item type and filter

