### PR TITLE
3689: add department filter to the api endpoints for courses and programs

### DIFF
--- a/courses/serializers/v2/departments.py
+++ b/courses/serializers/v2/departments.py
@@ -1,4 +1,4 @@
-from django.db.models import Prefetch, Q, Count
+from django.db.models import Q
 from mitol.common.utils import now_in_utc
 from rest_framework import serializers
 
@@ -13,13 +13,25 @@ class DepartmentSerializer(serializers.ModelSerializer):
         fields = ["id", "name"]
 
 
-class DepartmentWithCountSerializer(DepartmentSerializer):
+class DepartmentWithCoursesAndProgramsSerializer(DepartmentSerializer):
     """Department model serializer that includes the number of courses and programs associated with each"""
 
-    courses = serializers.SerializerMethodField()
-    programs = serializers.SerializerMethodField()
+    course_ids = serializers.SerializerMethodField()
+    program_ids = serializers.SerializerMethodField()
 
-    def get_courses(self, instance):
+    def get_course_ids(self, instance):
+        """
+        Returns a list of course IDs associated with courses which are live and
+        have a CMS page that is live.  The associated course runs must be live,
+        have a start date, enrollment start date in the past, and enrollment end
+        date in the future or not defined.
+
+        Args:
+            instance (courses.models.Department): Department model instance.
+
+        Returns:
+            list: Course IDs associated with the Department.
+        """
         now = now_in_utc()
         related_courses = instance.course_set.filter(live=True, page__live=True)
         relevant_courseruns = CourseRun.objects.filter(
@@ -29,21 +41,32 @@ class DepartmentWithCountSerializer(DepartmentSerializer):
             & Q(enrollment_start__lt=now)
             & (Q(enrollment_end=None) | Q(enrollment_end__gt=now))
         ).values_list("id", flat=True)
-
         return (
             related_courses.filter(courseruns__id__in=relevant_courseruns)
             .distinct()
-            .count()
+            .values_list("id", flat=True)
         )
 
-    def get_programs(self, instance):
+    def get_program_ids(self, instance):
+        """
+        Returns a list of program IDs associated with the department
+        if the program is live and has a live CMS page.
+
+        Args:
+            instance (courses.models.Department): Department model instance.
+
+        Returns:
+            list: Program IDs associated with the Department.
+        """
         return (
-            instance.program_set.filter(live=True, page__live=True).distinct().count()
+            instance.program_set.filter(live=True, page__live=True)
+            .distinct()
+            .values_list("id", flat=True)
         )
 
     class Meta:
         model = Department
         fields = DepartmentSerializer.Meta.fields + [
-            "courses",
-            "programs",
+            "course_ids",
+            "program_ids",
         ]

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -18,7 +18,7 @@ from courses.serializers.v2.programs import ProgramSerializer
 from courses.serializers.v2.courses import (
     CourseWithCourseRunsSerializer,
 )
-from courses.serializers.v2.departments import DepartmentWithCountSerializer
+from courses.serializers.v2.departments import DepartmentWithCoursesAndProgramsSerializer
 
 
 class Pagination(PageNumberPagination):
@@ -130,7 +130,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
 class DepartmentViewSet(viewsets.ReadOnlyModelViewSet):
     """API view set for Departments"""
 
-    serializer_class = DepartmentWithCountSerializer
+    serializer_class = DepartmentWithCoursesAndProgramsSerializer
     pagination_class = Pagination
     permission_classes = []
 

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -1,6 +1,7 @@
 """
 Course API Views version 2
 """
+
 from rest_framework import viewsets
 from rest_framework.pagination import PageNumberPagination
 import django_filters
@@ -18,7 +19,9 @@ from courses.serializers.v2.programs import ProgramSerializer
 from courses.serializers.v2.courses import (
     CourseWithCourseRunsSerializer,
 )
-from courses.serializers.v2.departments import DepartmentWithCoursesAndProgramsSerializer
+from courses.serializers.v2.departments import (
+    DepartmentWithCoursesAndProgramsSerializer,
+)
 
 
 class Pagination(PageNumberPagination):

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -1,6 +1,7 @@
 """
 Tests for courses api views v2
 """
+
 import logging
 import random
 
@@ -12,7 +13,9 @@ from rest_framework import status
 from courses.factories import DepartmentFactory
 from courses.models import Course, Program
 from courses.serializers.v2.courses import CourseWithCourseRunsSerializer
-from courses.serializers.v2.departments import DepartmentWithCountSerializer
+from courses.serializers.v2.departments import (
+    DepartmentWithCoursesAndProgramsSerializer,
+)
 from courses.serializers.v2.programs import ProgramSerializer
 from courses.views.test_utils import (
     num_queries_from_course,
@@ -37,7 +40,7 @@ def test_get_departments(
     empty_departments_from_fixture = []
     for department in departments:
         empty_departments_from_fixture.append(
-            DepartmentWithCountSerializer(
+            DepartmentWithCoursesAndProgramsSerializer(
                 instance=department, context=mock_context
             ).data
         )
@@ -65,7 +68,7 @@ def test_get_departments(
     departments_from_fixture = []
     for department in departments:
         departments_from_fixture.append(
-            DepartmentWithCountSerializer(
+            DepartmentWithCoursesAndProgramsSerializer(
                 instance=department, context=mock_context
             ).data
         )

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -313,7 +313,7 @@ export class CatalogPage extends React.Component<Props> {
   /**
    * Returns a filtered array of Course Runs which are live and:
    * - Have a start_date before the current date and time
-   * - Have an enrollment_start_date that is before the current date and time 
+   * - Have an enrollment_start_date that is before the current date and time
    * - Has an enrollment_end_date that is not defined or is after the current date and time.
    * @param {Array<BaseCourseRun>} courseRuns The array of Course Runs apply the filter to.
    */

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -224,7 +224,7 @@ export class CatalogPage extends React.Component<Props> {
           ...new Set([
             ALL_DEPARTMENTS,
             ...departments.flatMap(department =>
-              department.courses > 0 ? department.name : []
+              department.course_ids.length > 0 ? department.name : []
             )
           ])
         ]
@@ -233,7 +233,7 @@ export class CatalogPage extends React.Component<Props> {
           ...new Set([
             ALL_DEPARTMENTS,
             ...departments.flatMap(department =>
-              department.programs > 0 ? department.name : []
+              department.program_ids.length > 0 ? department.name : []
             )
           ])
         ]
@@ -311,8 +311,8 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * Returns a filtered array of Course Runs which are live, define a start date,
-   * enrollment start date is before the current date and time, and
+   * Returns a filtered array of Course Runs which are live, define a start date
+   * and enrollment start date that is before the current date and time, and
    * enrollment end date is not defined or is after the current date and time.
    * @param {Array<BaseCourseRun>} courseRuns The array of Course Runs apply the filter to.
    */
@@ -379,7 +379,7 @@ export class CatalogPage extends React.Component<Props> {
     } else if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
       return departments.find(
         department => department.name === this.state.selectedDepartment
-      ).courses
+      ).course_ids.length
     }
   }
 
@@ -390,7 +390,7 @@ export class CatalogPage extends React.Component<Props> {
     } else if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
       return departments.find(
         department => department.name === this.state.selectedDepartment
-      ).programs
+      ).program_ids.length
     } else return 0
   }
 

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -311,9 +311,10 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * Returns a filtered array of Course Runs which are live, define a start date
-   * and enrollment start date that is before the current date and time, and
-   * enrollment end date is not defined or is after the current date and time.
+   * Returns a filtered array of Course Runs which are live and:
+   * - Have a start_date before the current date and time
+   * - Have an enrollment_start_date that is before the current date and time 
+   * - Has an enrollment_end_date that is not defined or is after the current date and time.
    * @param {Array<BaseCourseRun>} courseRuns The array of Course Runs apply the filter to.
    */
   validateCoursesCourseRuns(courseRuns: Array<BaseCourseRun>) {

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -225,7 +225,7 @@ describe("CatalogPage", function() {
             {
               name:        "History",
               course_ids:  [],
-              program_ids: [2, 2, 2, 2, 2]
+              program_ids: [1, 2, 3, 4, 5]
             },
             {
               name:        "Science",

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -223,14 +223,14 @@ describe("CatalogPage", function() {
           },
           departments: [
             {
-              name:     "History",
-              courses:  0,
-              programs: 5
+              name:        "History",
+              course_ids:  [],
+              program_ids: [2, 2, 2, 2, 2]
             },
             {
-              name:     "Science",
-              courses:  1,
-              programs: 0
+              name:        "Science",
+              course_ids:  [2],
+              program_ids: []
             }
           ]
         }
@@ -262,24 +262,24 @@ describe("CatalogPage", function() {
         entities: {
           departments: [
             {
-              name:     "department1",
-              courses:  1,
-              programs: 0
+              name:        "department1",
+              course_ids:  [1],
+              program_ids: []
             },
             {
-              name:     "department2",
-              courses:  1,
-              programs: 1
+              name:        "department2",
+              course_ids:  [1],
+              program_ids: [1]
             },
             {
-              name:     "department3",
-              courses:  0,
-              programs: 1
+              name:        "department3",
+              course_ids:  [],
+              program_ids: [1]
             },
             {
-              name:     "department4",
-              courses:  0,
-              programs: 0
+              name:        "department4",
+              course_ids:  [],
+              program_ids: []
             }
           ]
         }
@@ -522,19 +522,19 @@ describe("CatalogPage", function() {
           },
           departments: [
             {
-              name:     "History",
-              courses:  2,
-              programs: 1
+              name:        "History",
+              course_ids:  [1, 2],
+              program_ids: [1]
             },
             {
-              name:     "Math",
-              courses:  3,
-              programs: 0
+              name:        "Math",
+              course_ids:  [1, 2, 3],
+              program_ids: []
             },
             {
-              name:     "department4",
-              courses:  0,
-              programs: 0
+              name:        "department4",
+              course_ids:  [],
+              program_ids: []
             }
           ]
         }
@@ -799,9 +799,9 @@ describe("CatalogPage", function() {
           },
           departments: [
             {
-              name:     "History",
-              courses:  1,
-              programs: 1
+              name:        "History",
+              course_ids:  [1],
+              program_ids: [1]
             }
           ]
         }

--- a/main/test_utils.py
+++ b/main/test_utils.py
@@ -1,5 +1,5 @@
 """Testing utils"""
-import abc
+
 import csv
 import json
 import logging
@@ -7,7 +7,6 @@ import tempfile
 import traceback
 from collections import Counter
 from contextlib import contextmanager
-from unittest.mock import Mock
 
 import pytest
 from deepdiff import DeepDiff


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3689

### Description
This PR modifies the `/api/v2/departments/` endpoint.  The endpoint previously provided the number of courses and programs associated with each department.  This PR removes the number of courses and programs, and instead provides a list of course and program IDs associated with each department.

**Example response**
```
{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 1,
            "name": "dept1",
            "course_ids": [
                1,
                2
            ],
            "program_ids": []
        },
        {
            "id": 2,
            "name": "dept2",
            "course_ids": [
                1
            ],
            "program_ids": [
                1
            ]
        }
    ]
}
```

The intention of this change is to better support filtering by department on the catalog page.  When a user filters by department on the catalog page, future development will utilize the course and program IDs provided by the department API in this PR.  Using those course and program IDs, the front-end can make an API call to retrieve those course or programs.

### How can this be tested?
1. You should have a few courses, a program, and departments created.  The courses and program should be associated with one or more departments.
2. You can make a GET request to the departments API http://mitxonline.odl.local:8013/api/v2/departments/ and verify the response.
3. You can then verify that the course catalog continues to display as it currently does. 
