### PR TITLE
Fetch by department when selected

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -71,7 +71,8 @@ export class CatalogPage extends React.Component<Props> {
     items_per_row:              3,
     courseQueryPage:            1,
     programQueryPage:           1,
-    isLoadingMoreItems:         false
+    isLoadingMoreItems:         false,
+    queryIDList:                [],
   }
 
   constructor(props) {
@@ -157,13 +158,30 @@ export class CatalogPage extends React.Component<Props> {
    * Updates the filteredDepartments state variable once departmentsIsLoading
    * is false.
    */
-  componentDidUpdate = () => {
+  componentDidUpdate = prevState => {
     const {
       courses,
       coursesIsLoading,
       programsIsLoading,
-      programs
+      programs,
+      departments,
+      departmentsIsLoading,
     } = this.props
+    console.log(prevState.selectedDepartment, this.state.selectedDepartment)
+    if ((prevState.selectedDepartment !== this.state.selectedDepartment) && (this.state.selectedDepartment != ALL_DEPARTMENTS)) {
+      if (!departmentsIsLoading && departments.length > 0) {
+        const newDepartment = departments.find(
+          department => department.name === this.state.selectedDepartment
+        )
+        if (this.state.tabSelected === COURSES_TAB) {
+          this.setState({courseQueryPage: 1})
+          this.setState({queryIDList: newDepartment.course_ids})
+        } else {
+          this.setState({programQueryPage: 1})
+          this.setState({queryIDList: newDepartment.program_ids})
+        }
+      }
+    }
     if (!coursesIsLoading && !this.state.filterCoursesCalled) {
       this.setState({ filterCoursesCalled: true })
       this.setState({ allCoursesRetrieved: courses })
@@ -670,9 +688,9 @@ const courseLoaderGrid = (
   </div>
 )
 
-const getNextCoursePage = page =>
+const getNextCoursePage = (page, ids) =>
   requestAsync({
-    ...coursesQuery(page),
+    ...coursesQuery(page, ids),
     force: true
   })
 

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -179,13 +179,6 @@ export class CatalogPage extends React.Component<Props> {
         )
       })
     }
-    if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
-      const newDepartment = departments.find(
-        department => department.name === this.state.selectedDepartment
-      )
-    } else {
-      const newDepartment = undefined
-    }
     if (!departmentsIsLoading && departments.length > 0) {
       if (!coursesIsLoading && !this.state.filterCoursesCalled) {
         this.setState({filterCoursesCalled: true})
@@ -197,12 +190,17 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({filteredCourses: filteredCourses})
         if (this.state.selectedDepartment !== ALL_DEPARTMENTS && this.state.selectedDepartment !== "") {
           // If the number of courses is equal to the number of expected courses on filter, no need to grab more data
-          if (filteredCourses.length !== newDepartment.course_ids.length) {
-            const remainingIDs = newDepartment.course_ids.filter(
-              id => !this.state.queryIDListString.includes(id)
+          if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
+            const newDepartment = departments.find(
+              department => department.name === this.state.selectedDepartment
             )
-            this.setState({courseQueryPage: 0})
-            this.setState({queryIDListString: remainingIDs.toString()})
+            if (filteredCourses.length !== newDepartment.course_ids.length) {
+              const remainingIDs = newDepartment.course_ids.filter(
+                id => !this.state.queryIDListString.includes(id)
+              )
+              this.setState({courseQueryPage: 0})
+              this.setState({queryIDListString: remainingIDs.toString()})
+            }
           }
         }
         this.io = new window.IntersectionObserver(
@@ -222,6 +220,9 @@ export class CatalogPage extends React.Component<Props> {
           filteredPrograms: filteredPrograms
         })
         if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
+          const newDepartment = departments.find(
+            department => department.name === this.state.selectedDepartment
+          )
           if (filteredPrograms.length !== newDepartment.program_ids.length) {
             const remainingIDs = newDepartment.program_ids.filter(
               id => !this.state.queryIDListString.includes(id)

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -109,7 +109,6 @@ export class CatalogPage extends React.Component<Props> {
     } = this.props
     const [entry] = entries
     if (entry.isIntersecting) {
-      console.log(this.state.allProgramsRetrieved)
       if (this.state.tabSelected === COURSES_TAB) {
         // Only request the next page if a next page exists (coursesNextPage)
         // and if we aren't already requesting the next page (isLoadingMoreItems).
@@ -147,9 +146,10 @@ export class CatalogPage extends React.Component<Props> {
           !this.state.isLoadingMoreItems &&
           programsNextPage
         ) {
+          console.log("we iffed")
           this.setState({ isLoadingMoreItems: true })
-          console.log(this.state.programQueryPage)
           getNextProgramPage(this.state.programQueryPage).then(response => {
+            console.log(response)
             this.setState({ isLoadingMoreItems: false })
             this.setState({ programQueryPage: this.state.programQueryPage + 1 })
             const updatedAllPrograms = this.mergeNewObjects(
@@ -844,16 +844,16 @@ const getNextCoursePage = (page, ids) =>
     force: true
   })
 
-const getNextProgramPage = (page, ids) =>
+const getNextProgramPage = page =>
   requestAsync({
-    ...programsQuery(page, ids),
+    ...programsQuery(page),
     force: true
   })
 
 const mapPropsToConfig = () => [
   coursesQuery(1, ""),
-  programsQuery(1, ""),
-  departmentsQuery(1, "")
+  programsQuery(1),
+  departmentsQuery(1)
 ]
 
 const mapDispatchToProps = {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -30,7 +30,7 @@ import { compose } from "redux"
 import { connect } from "react-redux"
 import { requestAsync } from "redux-query"
 import { connectRequest } from "redux-query-react"
-import {mergeDeepRight, pathOr} from "ramda"
+import { mergeDeepRight, pathOr } from "ramda"
 import CourseLoader from "../../components/CourseLoader"
 
 type Props = {
@@ -171,7 +171,7 @@ export class CatalogPage extends React.Component<Props> {
       departmentsIsLoading
     } = this.props
     if (!departmentsIsLoading && !this.state.filterDepartmentsCalled) {
-      this.setState({filterDepartmentsCalled: true})
+      this.setState({ filterDepartmentsCalled: true })
       this.setState({
         filteredDepartments: this.filterDepartmentsByTabName(
           this.state.tabSelected
@@ -181,44 +181,52 @@ export class CatalogPage extends React.Component<Props> {
     if (!departmentsIsLoading && departments.length > 0) {
       if (!coursesIsLoading && this.state.filteredCoursesCalled) {
         if (this.state.selectedDepartment !== prevState.selectedDepartment) {
-          this.setState({courseQueryPage: 1})
-          this.setState({queryIDListString: ""})
-          this.setState({filteredCoursesCalled: false})
+          this.setState({ courseQueryPage: 1 })
+          this.setState({ queryIDListString: "" })
+          this.setState({ filteredCoursesCalled: false })
         }
       }
       if (!coursesIsLoading && !this.state.filterCoursesCalled) {
-        this.setState({filterCoursesCalled: true})
-        this.setState({allCoursesRetrieved: courses})
+        this.setState({ filterCoursesCalled: true })
+        this.setState({ allCoursesRetrieved: courses })
         const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
           this.state.selectedDepartment,
           courses
         )
-        this.setState({filteredCourses: filteredCourses})
-        if (this.state.selectedDepartment !== ALL_DEPARTMENTS && this.state.selectedDepartment !== "") {
+        this.setState({ filteredCourses: filteredCourses })
+        if (
+          this.state.selectedDepartment !== ALL_DEPARTMENTS &&
+          this.state.selectedDepartment !== ""
+        ) {
           // If the number of courses is equal to the number of expected courses on filter, no need to grab more data
           if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
             const newDepartment = departments.find(
               department => department.name === this.state.selectedDepartment
             )
-            if (filteredCourses.length !== newDepartment.course_ids.length) {
+            if (filteredCourses.length !== newDepartment.course_ids.length && !this.state.isLoadingMoreItems) {
               const remainingIDs = newDepartment.course_ids.filter(
                 id => !this.state.queryIDListString.includes(id)
               )
-              this.setState({courseQueryPage: 0})
-              this.setState({queryIDListString: remainingIDs.toString()})
-              this.props.getNextCoursePage(this.state.courseQueryPage, this.state.queryIDListString)
+              this.setState({ isLoadingMoreItems: true })
+              this.setState({ courseQueryPage: 0 })
+              this.setState({ queryIDListString: remainingIDs.toString() })
+              this.props.getNextCoursePage(
+                this.state.courseQueryPage,
+                this.state.queryIDListString
+              )
+              this.setState({ isLoadingMoreItems: false })
             }
           }
         }
         this.io = new window.IntersectionObserver(
           this.bottomOfLoadedCatalogCallback,
-          {threshold: 1.0}
+          { threshold: 1.0 }
         )
         this.io.observe(this.container.current)
       }
       if (!programsIsLoading && !this.state.filterProgramsCalled) {
-        this.setState({filterProgramsCalled: true})
-        this.setState({allProgramsRetrieved: programs})
+        this.setState({ filterProgramsCalled: true })
+        this.setState({ allProgramsRetrieved: programs })
         const filteredPrograms = this.filteredProgramsByDepartmentAndCriteria(
           this.state.selectedDepartment,
           programs
@@ -230,18 +238,23 @@ export class CatalogPage extends React.Component<Props> {
           const newDepartment = departments.find(
             department => department.name === this.state.selectedDepartment
           )
-          if (filteredPrograms.length !== newDepartment.program_ids.length) {
+          if (filteredPrograms.length !== newDepartment.program_ids.length && !this.state.isLoadingMoreItems) {
             const remainingIDs = newDepartment.program_ids.filter(
               id => !this.state.queryIDListString.includes(id)
             )
-            this.setState({programQueryPage: 1})
-            this.setState({queryIDListString: remainingIDs.toString()})
-            this.props.getNextProgramPage(this.state.programQueryPage, this.state.queryIDListString)
+            this.setState({ isLoadingMoreItems: true })
+            this.setState({ programQueryPage: 1 })
+            this.setState({ queryIDListString: remainingIDs.toString() })
+            this.props.getNextProgramPage(
+              this.state.programQueryPage,
+              this.state.queryIDListString
+            )
+            this.setState({ isLoadingMoreItems: false })
           }
           // Detect when the bottom of the catalog page has been reached and display more catalog items.
           this.io = new window.IntersectionObserver(
             this.bottomOfLoadedCatalogCallback,
-            {threshold: 1.0}
+            { threshold: 1.0 }
           )
           this.io.observe(this.container.current)
         }
@@ -332,14 +345,17 @@ export class CatalogPage extends React.Component<Props> {
    * @param {string} selectedDepartment The department name to set selectedDepartment to and filter courses by.
    */
   changeSelectedDepartment = (selectedDepartment: string) => {
-    const {departments} = this.props
+    const { departments } = this.props
     if (selectedDepartment === ALL_DEPARTMENTS) {
-      this.setState({courseQueryPage: 1})
-      this.setState({programQueryPage: 1})
-      this.setState({queryIDListString: ""})
+      this.setState({ courseQueryPage: 1 })
+      this.setState({ programQueryPage: 1 })
+      this.setState({ queryIDListString: "" })
     }
     this.setState({ selectedDepartment: selectedDepartment })
-    const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(selectedDepartment, this.state.allCoursesRetrieved)
+    const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
+      selectedDepartment,
+      this.state.allCoursesRetrieved
+    )
     this.setState({
       filteredCourses: filteredCourses
     })
@@ -354,26 +370,29 @@ export class CatalogPage extends React.Component<Props> {
       const newDepartment = departments.find(
         department => department.name === selectedDepartment
       )
-      if (filteredCourses.length !== newDepartment.course_ids.length) {
+      if (filteredCourses.length !== newDepartment.course_ids.length && !this.state.isLoadingMoreItems) {
         const remainingIDs = newDepartment.course_ids.filter(
           id => !this.state.queryIDListString.includes(id)
         )
-        this.setState({courseQueryPage: 0})
-        this.setState({queryIDListString: remainingIDs.toString()})
-        this.setState({isLoadingMoreItems: true})
-        this.props.getNextCoursePage(1, remainingIDs.toString()).then(
-          response => {
-            this.setState({isLoadingMoreItems: false})
-            const allCourses = [...response.body.results, ...this.state.allCoursesRetrieved]
-            this.setState({allCoursesRetrieved: allCourses})
-            this.setState({filterProgramsCalled: true})
+        this.setState({ courseQueryPage: 0 })
+        this.setState({ queryIDListString: remainingIDs.toString() })
+        this.setState({ isLoadingMoreItems: true })
+        this.props
+          .getNextCoursePage(1, remainingIDs.toString())
+          .then(response => {
+            this.setState({ isLoadingMoreItems: false })
+            const allCourses = [
+              ...response.body.results,
+              ...this.state.allCoursesRetrieved
+            ]
+            this.setState({ allCoursesRetrieved: allCourses })
+            this.setState({ filterProgramsCalled: true })
             const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
               this.state.selectedDepartment,
               allCourses
             )
-            this.setState({filteredCourses: filteredCourses})
-          }
-        )
+            this.setState({ filteredCourses: filteredCourses })
+          })
       }
     }
   }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -203,9 +203,11 @@ export class CatalogPage extends React.Component<Props> {
     }
     if (this.state.allCoursesRetrieved.length === 0 && !coursesIsLoading) {
       this.setState({ allCoursesRetrieved: courses })
+      this.setState({filteredCourses: courses})
     }
     if (this.state.allProgramsRetrieved.length === 0 && !programsIsLoading) {
       this.setState({ allProgramsRetrieved: programs })
+      this.setState({filteredPrograms: programs})
     }
     if (!departmentsIsLoading && departments.length > 0) {
       if (!coursesIsLoading && this.state.filterCoursesCalled) {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -206,7 +206,6 @@ export class CatalogPage extends React.Component<Props> {
               )
               this.setState({courseQueryPage: 0})
               this.setState({queryIDListString: remainingIDs.toString()})
-              console.log(this.state.queryIDListString)
               this.props.getNextCoursePage(this.state.courseQueryPage, this.state.queryIDListString)
             }
           }
@@ -333,7 +332,6 @@ export class CatalogPage extends React.Component<Props> {
    * @param {string} selectedDepartment The department name to set selectedDepartment to and filter courses by.
    */
   changeSelectedDepartment = (selectedDepartment: string) => {
-    console.log("this fires")
     const {departments} = this.props
     if (selectedDepartment === ALL_DEPARTMENTS) {
       this.setState({courseQueryPage: 1})
@@ -353,18 +351,15 @@ export class CatalogPage extends React.Component<Props> {
     })
     this.toggleMobileFilterWindowExpanded(false)
     if (selectedDepartment !== ALL_DEPARTMENTS) {
-      console.log(selectedDepartment, "selectedDepartment")
       const newDepartment = departments.find(
         department => department.name === selectedDepartment
       )
       if (filteredCourses.length !== newDepartment.course_ids.length) {
-        console.log("we don't have enoguh")
         const remainingIDs = newDepartment.course_ids.filter(
           id => !this.state.queryIDListString.includes(id)
         )
         this.setState({courseQueryPage: 0})
         this.setState({queryIDListString: remainingIDs.toString()})
-        console.log("getnextcoursepage")
         this.setState({isLoadingMoreItems: true})
         this.props.getNextCoursePage(1, remainingIDs.toString()).then(
           response => {
@@ -412,7 +407,6 @@ export class CatalogPage extends React.Component<Props> {
     selectedDepartment: string,
     courses: Array<CourseDetailWithRuns>
   ) {
-    console.log(courses, "whyyyy")
     return courses.filter(
       course =>
         (selectedDepartment === ALL_DEPARTMENTS ||

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -100,52 +100,72 @@ export class CatalogPage extends React.Component<Props> {
    * updated allCoursesRetrieved or allProgramsRetrieved state variable.
    */
   bottomOfLoadedCatalogCallback = async entries => {
-    const {coursesIsLoading, getNextCoursePage, getNextProgramPage, programsIsLoading, programsNextPage} = this.props
+    const {
+      coursesIsLoading,
+      getNextCoursePage,
+      getNextProgramPage,
+      programsIsLoading,
+      programsNextPage
+    } = this.props
     const [entry] = entries
     if (entry.isIntersecting) {
       if (this.state.tabSelected === COURSES_TAB) {
         // Only request the next page if a next page exists (coursesNextPage)
         // and if we aren't already requesting the next page (isLoadingMoreItems).
-        if (!coursesIsLoading && !this.state.isLoadingMoreItems && this.state.filteredCourses.length < this.renderNumberOfCatalogCourses()) {
-          this.setState({isLoadingMoreItems: true})
+        if (
+          !coursesIsLoading &&
+          !this.state.isLoadingMoreItems &&
+          this.state.filteredCourses.length <
+            this.renderNumberOfCatalogCourses()
+        ) {
+          this.setState({ isLoadingMoreItems: true })
           const response = await getNextCoursePage(
             this.state.courseQueryPage,
             this.state.queryIDListString
           )
-          this.setState({isLoadingMoreItems: false})
-          this.setState({courseQueryPage: this.state.courseQueryPage + 1})
+          this.setState({ isLoadingMoreItems: false })
+          this.setState({ courseQueryPage: this.state.courseQueryPage + 1 })
           if (response.body.results) {
-            const allCourses = this.mergeNewObjects(this.state.allCoursesRetrieved, response.body.results)
+            const allCourses = this.mergeNewObjects(
+              this.state.allCoursesRetrieved,
+              response.body.results
+            )
             const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
               this.state.selectedDepartment,
               allCourses
             )
-            this.setState({filteredCourses: filteredCourses})
+            this.setState({ filteredCourses: filteredCourses })
             this.setState({
               allCoursesRetrieved: allCourses
             })
           }
         }
       } else {
-        if (!programsIsLoading && !this.state.isLoadingMoreItems && programsNextPage) {
-          this.setState({isLoadingMoreItems: true})
+        if (
+          !programsIsLoading &&
+          !this.state.isLoadingMoreItems &&
+          programsNextPage
+        ) {
+          this.setState({ isLoadingMoreItems: true })
 
           getNextProgramPage(this.state.programQueryPage).then(response => {
-            this.setState({isLoadingMoreItems: false})
-            this.setState({programQueryPage: this.state.programQueryPage + 1})
-            const updatedAllPrograms = this.mergeNewObjects(this.state.allProgramsRetrieved, response.body.results)
+            this.setState({ isLoadingMoreItems: false })
+            this.setState({ programQueryPage: this.state.programQueryPage + 1 })
+            const updatedAllPrograms = this.mergeNewObjects(
+              this.state.allProgramsRetrieved,
+              response.body.results
+            )
             const filteredPrograms = this.filteredProgramsByDepartmentAndCriteria(
               this.state.selectedDepartment,
               updatedAllPrograms
             )
-            this.setState({filteredPrograms: filteredPrograms})
-            this.setState({allProgramsRetrieved: updatedAllPrograms})
+            this.setState({ filteredPrograms: filteredPrograms })
+            this.setState({ allProgramsRetrieved: updatedAllPrograms })
           })
         }
       }
     }
   }
-
 
   /**
    * Updates the filteredCourses state variable
@@ -200,7 +220,10 @@ export class CatalogPage extends React.Component<Props> {
           this.state.allCoursesRetrieved
         )
         this.setState({ filteredCourses: filteredCourses })
-        this.countAndRetrieveMoreCourses(filteredCourses, this.state.selectedDepartment)
+        this.countAndRetrieveMoreCourses(
+          filteredCourses,
+          this.state.selectedDepartment
+        )
       }
       if (!programsIsLoading && this.state.filterProgramsCalled) {
         if (this.state.selectedDepartment !== prevState.selectedDepartment) {
@@ -209,7 +232,10 @@ export class CatalogPage extends React.Component<Props> {
       }
       if (!programsIsLoading && !this.state.filterProgramsCalled) {
         this.setState({ filterProgramsCalled: true })
-        this.countAndRetrieveMorePrograms(this.state.allProgramsRetrieved, this.state.selectedDepartment)
+        this.countAndRetrieveMorePrograms(
+          this.state.allProgramsRetrieved,
+          this.state.selectedDepartment
+        )
       }
       this.io = new window.IntersectionObserver(
         this.bottomOfLoadedCatalogCallback,
@@ -249,7 +275,6 @@ export class CatalogPage extends React.Component<Props> {
     }
   }
 
-
   /**
    * Resets the query-related variables to their default values.
    * This is used when the selected department or tab changes to restart the api calls from the beginning.
@@ -258,9 +283,9 @@ export class CatalogPage extends React.Component<Props> {
     if (this.state.tabSelected === COURSES_TAB) {
       this.setState({ courseQueryPage: 1 })
       this.setState({ queryIDListString: "" })
-      this.setState({ filterCoursesCalled: false})
+      this.setState({ filterCoursesCalled: false })
     } else {
-      this.setState({ filterProgramsCalled: false})
+      this.setState({ filterProgramsCalled: false })
     }
   }
 
@@ -293,7 +318,10 @@ export class CatalogPage extends React.Component<Props> {
         if (this.renderNumberOfCatalogPrograms() === 0) {
           this.setState({ selectedDepartment: ALL_DEPARTMENTS })
         }
-        this.countAndRetrieveMorePrograms(programsToFilter, this.state.selectedDepartment)
+        this.countAndRetrieveMorePrograms(
+          programsToFilter,
+          this.state.selectedDepartment
+        )
       }
     }
     if (selectTabName === COURSES_TAB) {
@@ -318,7 +346,10 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({
           filteredCourses: filteredCourses
         })
-        this.countAndRetrieveMoreCourses(filteredCourses, this.state.selectedDepartment)
+        this.countAndRetrieveMoreCourses(
+          filteredCourses,
+          this.state.selectedDepartment
+        )
       }
     }
     this.io = new window.IntersectionObserver(
@@ -355,7 +386,10 @@ export class CatalogPage extends React.Component<Props> {
     if (this.state.tabSelected === COURSES_TAB) {
       this.countAndRetrieveMoreCourses(filteredCourses, selectedDepartment)
     } else if (this.state.tabSelected === PROGRAMS_TAB) {
-      this.countAndRetrieveMorePrograms(this.state.allProgramsRetrieved, selectedDepartment)
+      this.countAndRetrieveMorePrograms(
+        this.state.allProgramsRetrieved,
+        selectedDepartment
+      )
     }
     this.io = new window.IntersectionObserver(
       this.bottomOfLoadedCatalogCallback,
@@ -366,19 +400,30 @@ export class CatalogPage extends React.Component<Props> {
 
   countAndRetrieveMoreCourses(filteredCourses, selectedDepartment) {
     const { departments, getNextCoursePage } = this.props
-    if (selectedDepartment !== ALL_DEPARTMENTS && selectedDepartment !== "" && departments.length > 0) {
+    if (
+      selectedDepartment !== ALL_DEPARTMENTS &&
+      selectedDepartment !== "" &&
+      departments.length > 0
+    ) {
       const newDepartment = this.props.departments.find(
         department => department.name === selectedDepartment
       )
-      if (filteredCourses.length !== newDepartment.course_ids.length && !this.state.isLoadingMoreItems) {
+      if (
+        filteredCourses.length !== newDepartment.course_ids.length &&
+        !this.state.isLoadingMoreItems
+      ) {
         const remainingIDs = newDepartment.course_ids.filter(
-          id => !this.state.allCoursesRetrieved.map(course => course.id).includes(id)
+          id =>
+            !this.state.allCoursesRetrieved
+              .map(course => course.id)
+              .includes(id)
         )
         this.setState({ isLoadingMoreItems: true })
-        getNextCoursePage(1,
-          remainingIDs.toString()
-        ).then(response => {
-          const allCourses = this.mergeNewObjects(this.state.allCoursesRetrieved, response.body.results)
+        getNextCoursePage(1, remainingIDs.toString()).then(response => {
+          const allCourses = this.mergeNewObjects(
+            this.state.allCoursesRetrieved,
+            response.body.results
+          )
           this.setState({ allCoursesRetrieved: allCourses })
           this.setState({ courseQueryPage: 2 })
           this.setState({ queryIDListString: remainingIDs.toString() })
@@ -401,10 +446,17 @@ export class CatalogPage extends React.Component<Props> {
       allPrograms
     )
     this.setState({ filteredPrograms: filteredPrograms })
-    if (programsNextPage && !this.state.isLoadingMoreItems && this.state.allProgramsRetrieved.length < this.state.allProgramsCount) {
+    if (
+      programsNextPage &&
+      !this.state.isLoadingMoreItems &&
+      this.state.allProgramsRetrieved.length < this.state.allProgramsCount
+    ) {
       this.setState({ isLoadingMoreItems: true })
       getNextProgramPage(this.state.programQueryPage).then(response => {
-        const updatedAllPrograms = this.mergeNewObjects(allPrograms, response.body.results)
+        const updatedAllPrograms = this.mergeNewObjects(
+          allPrograms,
+          response.body.results
+        )
         this.setState({ allProgramsRetrieved: updatedAllPrograms })
         this.setState({ programQueryPage: this.state.programQueryPage + 1 })
         filteredPrograms = this.filteredProgramsByDepartmentAndCriteria(

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -324,17 +324,16 @@ export class CatalogPage extends React.Component<Props> {
    * @param {string} selectedDepartment The department name to set selectedDepartment to and filter courses by.
    */
   changeSelectedDepartment = (selectedDepartment: string) => {
+    const {departments} = this.props
     if (selectedDepartment === ALL_DEPARTMENTS) {
       this.setState({courseQueryPage: 1})
       this.setState({programQueryPage: 1})
       this.setState({queryIDListString: ""})
     }
     this.setState({ selectedDepartment: selectedDepartment })
+    const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(selectedDepartment, this.state.allCoursesRetrieved)
     this.setState({
-      filteredCourses: this.filteredCoursesBasedOnCourseRunCriteria(
-        selectedDepartment,
-        this.state.allCoursesRetrieved
-      )
+      filteredCourses: filteredCourses
     })
     this.setState({
       filteredPrograms: this.filteredProgramsByDepartmentAndCriteria(
@@ -343,6 +342,17 @@ export class CatalogPage extends React.Component<Props> {
       )
     })
     this.toggleMobileFilterWindowExpanded(false)
+    const newDepartment = departments.find(
+      department => department.name === this.state.selectedDepartment
+    )
+    if (filteredCourses.length !== newDepartment.course_ids.length) {
+      const remainingIDs = newDepartment.course_ids.filter(
+        id => !this.state.queryIDListString.includes(id)
+      )
+      this.setState({courseQueryPage: 0})
+      this.setState({queryIDListString: remainingIDs.toString()})
+      getNextCoursePage(this.state.courseQueryPage, this.state.queryIDListString)
+    }
   }
 
   /**

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -146,10 +146,8 @@ export class CatalogPage extends React.Component<Props> {
           !this.state.isLoadingMoreItems &&
           programsNextPage
         ) {
-          console.log("we iffed")
           this.setState({ isLoadingMoreItems: true })
           getNextProgramPage(this.state.programQueryPage).then(response => {
-            console.log(response)
             this.setState({ isLoadingMoreItems: false })
             this.setState({ programQueryPage: this.state.programQueryPage + 1 })
             const updatedAllPrograms = this.mergeNewObjects(
@@ -475,6 +473,7 @@ export class CatalogPage extends React.Component<Props> {
   mergeNewObjects(oldArray, newArray) {
     const oldIds = oldArray.map(a => a.id)
     const newObjects = newArray.filter(a => !oldIds.includes(a.id))
+    console.log(oldArray, newArray, newObjects)
     return oldArray.concat(newObjects)
   }
 

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -175,7 +175,8 @@ export class CatalogPage extends React.Component<Props> {
         )
       })
     }
-    // Initialize allCourses and allPrograms variables in state since the value will change when changing departments
+    // Initialize allCourses and allPrograms variables in state once they finish loading to store since the value will
+    // change when changing departments
     if (this.state.allCoursesCount === 0 && !coursesIsLoading) {
       this.setState({ allCoursesCount: coursesCount })
     }
@@ -189,7 +190,7 @@ export class CatalogPage extends React.Component<Props> {
       this.setState({ allProgramsRetrieved: programs })
     }
     if (!departmentsIsLoading && departments.length > 0) {
-      if (!coursesIsLoading && this.state.filteredCoursesCalled) {
+      if (!coursesIsLoading && this.state.filterCoursesCalled) {
         if (this.state.selectedDepartment !== prevState.selectedDepartment) {
           this.resetQueryVariablesToDefault()
         }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -72,7 +72,7 @@ export class CatalogPage extends React.Component<Props> {
     courseQueryPage:            1,
     programQueryPage:           1,
     isLoadingMoreItems:         false,
-    queryIDListString:          "",
+    queryIDListString:          ""
   }
 
   constructor(props) {
@@ -107,7 +107,10 @@ export class CatalogPage extends React.Component<Props> {
         if (coursesNextPage && !this.state.isLoadingMoreItems) {
           this.setState({ isLoadingMoreItems: true })
           this.setState({ courseQueryPage: this.state.courseQueryPage + 1 })
-          const response = await getNextCoursePage(this.state.courseQueryPage, this.state.queryIDListString)
+          const response = await getNextCoursePage(
+            this.state.courseQueryPage,
+            this.state.queryIDListString
+          )
           this.setState({ isLoadingMoreItems: false })
           if (response.body.results) {
             const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
@@ -165,10 +168,10 @@ export class CatalogPage extends React.Component<Props> {
       programsIsLoading,
       programs,
       departments,
-      departmentsIsLoading,
+      departmentsIsLoading
     } = this.props
     if (!departmentsIsLoading && !this.state.filterDepartmentsCalled) {
-      this.setState({filterDepartmentsCalled: true})
+      this.setState({ filterDepartmentsCalled: true })
       this.setState({
         filteredDepartments: this.filterDepartmentsByTabName(
           this.state.tabSelected
@@ -177,13 +180,13 @@ export class CatalogPage extends React.Component<Props> {
     }
     if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
       if (this.state.queryIDListString.length > 0) {
-        this.setState({courseQueryPage: 1})
-        this.setState({programQueryPage: 1})
-        this.setState({queryIDListString: ""})
+        this.setState({ courseQueryPage: 1 })
+        this.setState({ programQueryPage: 1 })
+        this.setState({ queryIDListString: "" })
       }
       this.io = new window.IntersectionObserver(
         this.bottomOfLoadedCatalogCallback,
-        {threshold: 1.0}
+        { threshold: 1.0 }
       )
       this.io.observe(this.container.current)
     } else if (!departmentsIsLoading && departments.length > 0) {
@@ -191,30 +194,30 @@ export class CatalogPage extends React.Component<Props> {
         department => department.name === this.state.selectedDepartment
       )
       if (!coursesIsLoading && !this.state.filterCoursesCalled) {
-        this.setState({filterCoursesCalled: true})
-        this.setState({allCoursesRetrieved: courses})
+        this.setState({ filterCoursesCalled: true })
+        this.setState({ allCoursesRetrieved: courses })
         const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
           this.state.selectedDepartment,
           courses
         )
-        this.setState({filteredCourses: filteredCourses})
+        this.setState({ filteredCourses: filteredCourses })
         // If the number of courses is equal to the number of expected courses on filter, no need to grab more data
         if (filteredCourses.length !== newDepartment.course_ids.length) {
           const remainingIDs = newDepartment.course_ids.filter(
             id => !this.state.queryIDListString.includes(id)
           )
-          this.setState({courseQueryPage: 1})
-          this.setState({queryIDListString: remainingIDs.toString()})
+          this.setState({ courseQueryPage: 1 })
+          this.setState({ queryIDListString: remainingIDs.toString() })
         }
         this.io = new window.IntersectionObserver(
           this.bottomOfLoadedCatalogCallback,
-          {threshold: 1.0}
+          { threshold: 1.0 }
         )
         this.io.observe(this.container.current)
       }
       if (!programsIsLoading && !this.state.filterProgramsCalled) {
-        this.setState({filterProgramsCalled: true})
-        this.setState({allProgramsRetrieved: programs})
+        this.setState({ filterProgramsCalled: true })
+        this.setState({ allProgramsRetrieved: programs })
         const filteredPrograms = this.filteredProgramsByDepartmentAndCriteria(
           this.state.selectedDepartment,
           programs
@@ -226,13 +229,13 @@ export class CatalogPage extends React.Component<Props> {
           const remainingIDs = newDepartment.program_ids.filter(
             id => !this.state.queryIDListString.includes(id)
           )
-          this.setState({programQueryPage: 1})
-          this.setState({queryIDListString: remainingIDs.toString()})
+          this.setState({ programQueryPage: 1 })
+          this.setState({ queryIDListString: remainingIDs.toString() })
         }
         // Detect when the bottom of the catalog page has been reached and display more catalog items.
         this.io = new window.IntersectionObserver(
           this.bottomOfLoadedCatalogCallback,
-          {threshold: 1.0}
+          { threshold: 1.0 }
         )
         this.io.observe(this.container.current)
       }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -446,7 +446,7 @@ export class CatalogPage extends React.Component<Props> {
               this.setState({isLoadingMoreItems: false})
               const allCourses = this.mergeNewObjects(this.state.allCoursesRetrieved, response.body.results)
               this.setState({allCoursesRetrieved: allCourses})
-              this.setState({filterProgramsCalled: true})
+              this.setState({filterCoursesCalled: true})
               this.setState({courseQueryPage: 2})
               const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
                 this.state.selectedDepartment,

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -172,53 +172,48 @@ export class CatalogPage extends React.Component<Props> {
       departmentsIsLoading
     } = this.props
     if (!departmentsIsLoading && !this.state.filterDepartmentsCalled) {
-      this.setState({ filterDepartmentsCalled: true })
+      this.setState({filterDepartmentsCalled: true})
       this.setState({
         filteredDepartments: this.filterDepartmentsByTabName(
           this.state.tabSelected
         )
       })
     }
-    if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
-      if (this.state.queryIDListString.length > 0) {
-        this.setState({ courseQueryPage: 1 })
-        this.setState({ programQueryPage: 1 })
-        this.setState({ queryIDListString: "" })
-      }
-      this.io = new window.IntersectionObserver(
-        this.bottomOfLoadedCatalogCallback,
-        { threshold: 1.0 }
-      )
-      this.io.observe(this.container.current)
-    } else if (!departmentsIsLoading && departments.length > 0) {
+    if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
       const newDepartment = departments.find(
         department => department.name === this.state.selectedDepartment
       )
+    } else {
+      const newDepartment = undefined
+    }
+    if (!departmentsIsLoading && departments.length > 0) {
       if (!coursesIsLoading && !this.state.filterCoursesCalled) {
-        this.setState({ filterCoursesCalled: true })
-        this.setState({ allCoursesRetrieved: courses })
+        this.setState({filterCoursesCalled: true})
+        this.setState({allCoursesRetrieved: courses})
         const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
           this.state.selectedDepartment,
           courses
         )
-        this.setState({ filteredCourses: filteredCourses })
-        // If the number of courses is equal to the number of expected courses on filter, no need to grab more data
-        if (filteredCourses.length !== newDepartment.course_ids.length) {
-          const remainingIDs = newDepartment.course_ids.filter(
-            id => !this.state.queryIDListString.includes(id)
-          )
-          this.setState({ courseQueryPage: 1 })
-          this.setState({ queryIDListString: remainingIDs.toString() })
+        this.setState({filteredCourses: filteredCourses})
+        if (this.state.selectedDepartment !== ALL_DEPARTMENTS && this.state.selectedDepartment !== "") {
+          // If the number of courses is equal to the number of expected courses on filter, no need to grab more data
+          if (filteredCourses.length !== newDepartment.course_ids.length) {
+            const remainingIDs = newDepartment.course_ids.filter(
+              id => !this.state.queryIDListString.includes(id)
+            )
+            this.setState({courseQueryPage: 0})
+            this.setState({queryIDListString: remainingIDs.toString()})
+          }
         }
         this.io = new window.IntersectionObserver(
           this.bottomOfLoadedCatalogCallback,
-          { threshold: 1.0 }
+          {threshold: 1.0}
         )
         this.io.observe(this.container.current)
       }
       if (!programsIsLoading && !this.state.filterProgramsCalled) {
-        this.setState({ filterProgramsCalled: true })
-        this.setState({ allProgramsRetrieved: programs })
+        this.setState({filterProgramsCalled: true})
+        this.setState({allProgramsRetrieved: programs})
         const filteredPrograms = this.filteredProgramsByDepartmentAndCriteria(
           this.state.selectedDepartment,
           programs
@@ -226,19 +221,21 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({
           filteredPrograms: filteredPrograms
         })
-        if (filteredPrograms.length !== newDepartment.program_ids.length) {
-          const remainingIDs = newDepartment.program_ids.filter(
-            id => !this.state.queryIDListString.includes(id)
+        if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
+          if (filteredPrograms.length !== newDepartment.program_ids.length) {
+            const remainingIDs = newDepartment.program_ids.filter(
+              id => !this.state.queryIDListString.includes(id)
+            )
+            this.setState({programQueryPage: 1})
+            this.setState({queryIDListString: remainingIDs.toString()})
+          }
+          // Detect when the bottom of the catalog page has been reached and display more catalog items.
+          this.io = new window.IntersectionObserver(
+            this.bottomOfLoadedCatalogCallback,
+            {threshold: 1.0}
           )
-          this.setState({ programQueryPage: 1 })
-          this.setState({ queryIDListString: remainingIDs.toString() })
+          this.io.observe(this.container.current)
         }
-        // Detect when the bottom of the catalog page has been reached and display more catalog items.
-        this.io = new window.IntersectionObserver(
-          this.bottomOfLoadedCatalogCallback,
-          { threshold: 1.0 }
-        )
-        this.io.observe(this.container.current)
       }
     }
   }
@@ -326,6 +323,11 @@ export class CatalogPage extends React.Component<Props> {
    * @param {string} selectedDepartment The department name to set selectedDepartment to and filter courses by.
    */
   changeSelectedDepartment = (selectedDepartment: string) => {
+    if (selectedDepartment === ALL_DEPARTMENTS) {
+      this.setState({courseQueryPage: 1})
+      this.setState({programQueryPage: 1})
+      this.setState({queryIDListString: ""})
+    }
     this.setState({ selectedDepartment: selectedDepartment })
     this.setState({
       filteredCourses: this.filteredCoursesBasedOnCourseRunCriteria(

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -372,7 +372,7 @@ export class CatalogPage extends React.Component<Props> {
       )
       if (filteredCourses.length !== newDepartment.course_ids.length && !this.state.isLoadingMoreItems) {
         const remainingIDs = newDepartment.course_ids.filter(
-          id => !this.state.queryIDListString.includes(id)
+          id => !this.state.allCoursesRetrieved.map(course => course.id).includes(id)
         )
         this.setState({ courseQueryPage: 0 })
         this.setState({ queryIDListString: remainingIDs.toString() })

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -30,7 +30,7 @@ import { compose } from "redux"
 import { connect } from "react-redux"
 import { requestAsync } from "redux-query"
 import { connectRequest } from "redux-query-react"
-import { mergeDeepRight, pathOr } from "ramda"
+import { pathOr } from "ramda"
 import CourseLoader from "../../components/CourseLoader"
 
 type Props = {
@@ -59,7 +59,9 @@ export class CatalogPage extends React.Component<Props> {
   state = {
     tabSelected:                COURSES_TAB,
     allCoursesRetrieved:        [],
+    allCoursesCount:            0,
     allProgramsRetrieved:       [],
+    allProgramsCount:           0,
     filteredCourses:            [],
     filteredPrograms:           [],
     filterProgramsCalled:       false,
@@ -164,9 +166,11 @@ export class CatalogPage extends React.Component<Props> {
   componentDidUpdate = prevState => {
     const {
       courses,
+      coursesCount,
       coursesIsLoading,
       programsIsLoading,
       programs,
+      programsCount,
       departments,
       departmentsIsLoading
     } = this.props
@@ -177,6 +181,13 @@ export class CatalogPage extends React.Component<Props> {
           this.state.tabSelected
         )
       })
+    }
+    if (this.state.allCoursesCount === 0) {
+      console.log("changing allCoursesCount")
+      this.setState({ allCoursesCount: coursesCount })
+    }
+    if (this.state.allProgramsCount === 0) {
+      this.setState({ allProgramsCount: programsCount })
     }
     if (!departmentsIsLoading && departments.length > 0) {
       if (!coursesIsLoading && this.state.filteredCoursesCalled) {
@@ -461,9 +472,9 @@ export class CatalogPage extends React.Component<Props> {
    * Returns the number of courseRuns or programs based on the selected catalog tab.
    */
   renderNumberOfCatalogCourses() {
-    const { coursesCount, departments } = this.props
+    const { departments } = this.props
     if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
-      return coursesCount
+      return this.state.allCoursesCount
     } else if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
       return departments.find(
         department => department.name === this.state.selectedDepartment
@@ -472,9 +483,9 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   renderNumberOfCatalogPrograms() {
-    const { programsCount, departments } = this.props
+    const { departments } = this.props
     if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
-      return programsCount
+      return this.state.allProgramsCount
     } else if (this.state.selectedDepartment !== ALL_DEPARTMENTS) {
       return departments.find(
         department => department.name === this.state.selectedDepartment

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -168,17 +168,27 @@ export class CatalogPage extends React.Component<Props> {
       departmentsIsLoading,
     } = this.props
     console.log(prevState.selectedDepartment, this.state.selectedDepartment)
-    if ((prevState.selectedDepartment !== this.state.selectedDepartment) && (this.state.selectedDepartment != ALL_DEPARTMENTS)) {
-      if (!departmentsIsLoading && departments.length > 0) {
-        const newDepartment = departments.find(
-          department => department.name === this.state.selectedDepartment
-        )
-        if (this.state.tabSelected === COURSES_TAB) {
+    if (prevState.selectedDepartment !== this.state.selectedDepartment) {
+      if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
+        if (this.state.tabSelected === COURSES_TAB && this.state.queryIDList.length > 0) {
           this.setState({courseQueryPage: 1})
-          this.setState({queryIDList: newDepartment.course_ids})
-        } else {
+          this.setState({queryIDList: []})
+        } else if (this.state.tabSelected === PROGRAMS_TAB && this.state.queryIDList.length > 0) {
           this.setState({programQueryPage: 1})
-          this.setState({queryIDList: newDepartment.program_ids})
+          this.setState({queryIDList: []})
+        }
+      } else {
+        if (!departmentsIsLoading && departments.length > 0) {
+          const newDepartment = departments.find(
+            department => department.name === this.state.selectedDepartment
+          )
+          if (this.state.tabSelected === COURSES_TAB) {
+            this.setState({courseQueryPage: 1})
+            this.setState({queryIDList: newDepartment.course_ids})
+          } else {
+            this.setState({programQueryPage: 1})
+            this.setState({queryIDList: newDepartment.program_ids})
+          }
         }
       }
     }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -109,6 +109,7 @@ export class CatalogPage extends React.Component<Props> {
     } = this.props
     const [entry] = entries
     if (entry.isIntersecting) {
+      console.log(this.state.allProgramsRetrieved)
       if (this.state.tabSelected === COURSES_TAB) {
         // Only request the next page if a next page exists (coursesNextPage)
         // and if we aren't already requesting the next page (isLoadingMoreItems).
@@ -147,7 +148,7 @@ export class CatalogPage extends React.Component<Props> {
           programsNextPage
         ) {
           this.setState({ isLoadingMoreItems: true })
-
+          console.log(this.state.programQueryPage)
           getNextProgramPage(this.state.programQueryPage).then(response => {
             this.setState({ isLoadingMoreItems: false })
             this.setState({ programQueryPage: this.state.programQueryPage + 1 })
@@ -203,11 +204,11 @@ export class CatalogPage extends React.Component<Props> {
     }
     if (this.state.allCoursesRetrieved.length === 0 && !coursesIsLoading) {
       this.setState({ allCoursesRetrieved: courses })
-      this.setState({filteredCourses: courses})
+      this.setState({ filteredCourses: courses })
     }
     if (this.state.allProgramsRetrieved.length === 0 && !programsIsLoading) {
       this.setState({ allProgramsRetrieved: programs })
-      this.setState({filteredPrograms: programs})
+      this.setState({ filteredPrograms: programs })
     }
     if (!departmentsIsLoading && departments.length > 0) {
       if (!coursesIsLoading && this.state.filterCoursesCalled) {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -102,6 +102,7 @@ export class CatalogPage extends React.Component<Props> {
     if (entry.isIntersecting) {
       if (this.state.tabSelected === COURSES_TAB) {
         const { getNextCoursePage, coursesNextPage } = this.props
+        console.log(coursesNextPage)
         // Only request the next page if a next page exists (coursesNextPage)
         // and if we aren't already requesting the next page (isLoadingMoreItems).
         if (coursesNextPage && !this.state.isLoadingMoreItems) {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -223,7 +223,7 @@ export class CatalogPage extends React.Component<Props> {
               this.setState({ isLoadingMoreItems: false })
               const allCourses = this.mergeNewObjects(this.state.allCoursesRetrieved, response.body.results)
               this.setState({ allCoursesRetrieved: allCourses })
-              this.setState({ filterProgramsCalled: true })
+              this.setState({ filterCoursesCalled: true })
               const filteredCourses = this.filteredCoursesBasedOnCourseRunCriteria(
                 this.state.selectedDepartment,
                 allCourses

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -800,7 +800,7 @@ describe("CatalogPage", function() {
             next:    "http://fake.com/api/courses/?page=2"
           },
           programs: {
-            count:   2,
+            count:   4,
             results: programs,
             next:    "http://fake.com/api/courses/?page=2"
           },
@@ -829,17 +829,6 @@ describe("CatalogPage", function() {
     )
     // While there is only one showing, there are still 2 total. The total should be shown.
     expect(inner.instance().renderNumberOfCatalogPrograms()).equals(2)
-    const anotherProgram = JSON.parse(JSON.stringify(displayedProgram))
-    anotherProgram.id = 8
-
-    // Mock the second page of program API results.
-    helper.handleRequestStub.returns({
-      body: {
-        next:    null,
-        results: [anotherProgram],
-        count:   2
-      }
-    })
 
     inner.state().allProgramsCount = 4
     // simulate the state variables changing correctly since the shallow render doesn't actually change the state
@@ -855,14 +844,8 @@ describe("CatalogPage", function() {
       "/api/v2/programs/?page=2&live=true&page__live=true",
       "GET"
     )
-    expect(JSON.stringify(inner.state().allProgramsRetrieved)).equals(
-      JSON.stringify([displayedProgram, anotherProgram])
-    )
-    expect(JSON.stringify(inner.state().filteredPrograms)).equals(
-      JSON.stringify([displayedProgram, anotherProgram])
-    )
 
-    // This should still be 2 because we haven't changed the filter - no matter if one or two have loaded, there are 2
-    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(2)
+    // If allProgramsCount changes, when we load more, we should see the new count
+    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(4)
   })
 })

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -593,7 +593,7 @@ describe("CatalogPage", function() {
         queries: {
           courses: {
             isPending: false,
-            status:    200,
+            status:    200
           },
           programs: {
             isPending: false,
@@ -617,9 +617,8 @@ describe("CatalogPage", function() {
 
     expect(inner.state().courseQueryPage).equals(1)
     inner.instance().componentDidUpdate({}, {})
-    inner.instance().setState({ courseQueryPage: 2})
+    inner.state().courseQueryPage = 2
     expect(inner.state().selectedDepartment).equals("All Departments")
-    // inner.instance().changeSelectedDepartment("All Departments", "courses")
     expect(inner.state().tabSelected).equals("courses")
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
@@ -761,7 +760,7 @@ describe("CatalogPage", function() {
 
     // Set isLoadingMoreItems to true which simualtes that the next page
     // request is already in progress.
-    inner.instance().setState({ isLoadingMoreItems: true })
+    inner.state().isLoadingMoreItems = true
     await inner.instance().bottomOfLoadedCatalogCallback(entry)
 
     // Should not expect any additional courses.
@@ -830,14 +829,14 @@ describe("CatalogPage", function() {
     )
     // While there is only one showing, there are still 2 total. The total should be shown.
     expect(inner.instance().renderNumberOfCatalogPrograms()).equals(2)
-    const anotherProgram = displayedProgram
-    anotherProgram.id = 3
-    const morePrograms = [anotherProgram]
+    const anotherProgram = JSON.parse(JSON.stringify(displayedProgram))
+    anotherProgram.id = 8
+
     // Mock the second page of program API results.
     helper.handleRequestStub.returns({
       body: {
         next:    null,
-        results: morePrograms,
+        results: [anotherProgram],
         count:   2
       }
     })
@@ -856,7 +855,6 @@ describe("CatalogPage", function() {
       "/api/v2/programs/?page=2&live=true&page__live=true",
       "GET"
     )
-
     expect(JSON.stringify(inner.state().allProgramsRetrieved)).equals(
       JSON.stringify([displayedProgram, anotherProgram])
     )

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -847,4 +847,39 @@ describe("CatalogPage", function() {
     // The count should still be 4 regardless of how many are added or not, since the highest provided count was 4.
     expect(inner.instance().renderNumberOfCatalogPrograms()).equals(4)
   })
+
+  it("mergeNewObjects removes duplicates if present", async () => {
+    const oldArray = [displayedProgram]
+    const newArray = [displayedProgram]
+    const { inner } = await renderPage()
+    const mergedArray = inner.instance().mergeNewObjects(oldArray, newArray)
+    expect(mergedArray.length).equals(1)
+    expect(JSON.stringify(mergedArray)).equals(JSON.stringify(oldArray))
+  })
+
+  it("mergeNewObjects merges objects if they are not duplicates", async () => {
+    const oldArray = [displayedProgram]
+    const newProgram = JSON.parse(JSON.stringify(displayedProgram))
+    newProgram.id = 3
+    const newArray = [newProgram]
+    const { inner } = await renderPage()
+    const mergedArray = inner.instance().mergeNewObjects(oldArray, newArray)
+    expect(mergedArray.length).equals(2)
+    expect(JSON.stringify(mergedArray)).equals(
+      JSON.stringify([displayedProgram, newProgram])
+    )
+  })
+
+  it("mergeNewObjects keeps items with different IDs and removes duplicates", async () => {
+    const oldArray = [displayedProgram]
+    const newProgram = JSON.parse(JSON.stringify(displayedProgram))
+    newProgram.id = 3
+    const newArray = [newProgram, displayedProgram, displayedProgram]
+    const { inner } = await renderPage()
+    const mergedArray = inner.instance().mergeNewObjects(oldArray, newArray)
+    expect(mergedArray.length).equals(2)
+    expect(JSON.stringify(mergedArray)).equals(
+      JSON.stringify([displayedProgram, newProgram])
+    )
+  })
 })

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -181,11 +181,11 @@ describe("CatalogPage", function() {
       },
       {}
     )
+
     inner.instance().componentDidUpdate({}, {})
     expect(inner.state().selectedDepartment).equals("All Departments")
     expect(inner.state().tabSelected).equals("courses")
     inner.instance().componentDidUpdate({}, {})
-    console.log(inner.state())
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )
@@ -835,6 +835,8 @@ describe("CatalogPage", function() {
       }
     })
 
+    inner.state().allProgramsCount = 4
+
     // Simulate the user reaching the bottom of the catalog page.
     const entry = [{ isIntersecting: true }]
     await inner.instance().bottomOfLoadedCatalogCallback(entry)
@@ -845,8 +847,7 @@ describe("CatalogPage", function() {
       "GET"
     )
 
-    // Should expect 2 courses to be displayed in the catalog now.
-    expect(inner.state().programQueryPage).equals(2)
+
     expect(JSON.stringify(inner.state().allProgramsRetrieved)).equals(
       JSON.stringify([displayedProgram, displayedProgram])
     )

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -184,6 +184,8 @@ describe("CatalogPage", function() {
     inner.instance().componentDidUpdate({}, {})
     expect(inner.state().selectedDepartment).equals("All Departments")
     expect(inner.state().tabSelected).equals("courses")
+    inner.instance().componentDidUpdate({}, {})
+    console.log(inner.state())
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -827,10 +827,9 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().allProgramsRetrieved)).equals(
       JSON.stringify(programs)
     )
-    // While there is only one showing, there are still 2 total. The total should be shown.
-    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(2)
+    // While there is only one showing, there are still 4 total per the count. The total should be shown.
+    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(4)
 
-    inner.state().allProgramsCount = 4
     // simulate the state variables changing correctly since the shallow render doesn't actually change the state
     inner.state().programQueryPage = 2
     inner.state().isLoadingMoreItems = false
@@ -845,7 +844,7 @@ describe("CatalogPage", function() {
       "GET"
     )
 
-    // If allProgramsCount changes, when we load more, we should see the new count
+    // The count should still be 4 regardless of how many are added or not, since the highest provided count was 4.
     expect(inner.instance().renderNumberOfCatalogPrograms()).equals(4)
   })
 })

--- a/frontend/public/src/lib/queries/catalogCourses.js
+++ b/frontend/public/src/lib/queries/catalogCourses.js
@@ -19,9 +19,9 @@ export const coursesNextPageSelector = pathOr(null, [
 export const coursesQueryKey = "courses"
 
 export const coursesQuery = (page, ids) => ({
-  queryKey:  coursesQueryKey,
+  queryKey: coursesQueryKey,
   url:
-    (ids && ids.length > 0)
+    ids && ids.length > 0
       ? `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}`
       : `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
   transform: json => ({

--- a/frontend/public/src/lib/queries/catalogCourses.js
+++ b/frontend/public/src/lib/queries/catalogCourses.js
@@ -21,7 +21,7 @@ export const coursesQueryKey = "courses"
 export const coursesQuery = (page, ids) => ({
   queryKey:  coursesQueryKey,
   url:
-    ids.length > 0
+    (ids && ids.length > 0)
       ? `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}`
       : `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
   transform: json => ({

--- a/frontend/public/src/lib/queries/catalogCourses.js
+++ b/frontend/public/src/lib/queries/catalogCourses.js
@@ -18,9 +18,12 @@ export const coursesNextPageSelector = pathOr(null, [
 
 export const coursesQueryKey = "courses"
 
-export const coursesQuery = page => ({
+export const coursesQuery = (page, ids) => ({
   queryKey:  coursesQueryKey,
-  url:       `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
+  url:
+    ids.length > 0
+      ? `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}`
+      : `/api/v2/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
   transform: json => ({
     courses: json
   }),

--- a/frontend/public/src/lib/queries/courses.js
+++ b/frontend/public/src/lib/queries/courses.js
@@ -13,8 +13,11 @@ export const coursesNextPageSelector = pathOr(null, [
 export const coursesQueryKey = "courses"
 
 export const coursesQuery = (page, ids) => ({
-  queryKey:  coursesQueryKey,
-  url:       ids.length > 0 ? `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}` : `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
+  queryKey: coursesQueryKey,
+  url:
+    ids.length > 0
+      ? `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}`
+      : `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
   transform: json => ({
     courses: json
   }),

--- a/frontend/public/src/lib/queries/courses.js
+++ b/frontend/public/src/lib/queries/courses.js
@@ -16,8 +16,8 @@ export const coursesQuery = (page, ids) => ({
   queryKey: coursesQueryKey,
   url:
     ids.length > 0
-      ? `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}`
-      : `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
+      ? `/api/courses/v2/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}`
+      : `/api/courses/v2/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
   transform: json => ({
     courses: json
   }),

--- a/frontend/public/src/lib/queries/courses.js
+++ b/frontend/public/src/lib/queries/courses.js
@@ -14,7 +14,7 @@ export const coursesQueryKey = "courses"
 
 export const coursesQuery = (page, ids) => ({
   queryKey:  coursesQueryKey,
-  url:       ids.length > 0 ? `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids.toString()}` : `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
+  url:       ids.length > 0 ? `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids}` : `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
   transform: json => ({
     courses: json
   }),

--- a/frontend/public/src/lib/queries/courses.js
+++ b/frontend/public/src/lib/queries/courses.js
@@ -12,9 +12,9 @@ export const coursesNextPageSelector = pathOr(null, [
 
 export const coursesQueryKey = "courses"
 
-export const coursesQuery = page => ({
+export const coursesQuery = (page, ids) => ({
   queryKey:  coursesQueryKey,
-  url:       `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
+  url:       ids.length > 0 ? `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true&id=${ids.toString()}` : `/api/courses/?page=${page}&live=true&page__live=true&courserun_is_enrollable=true`,
   transform: json => ({
     courses: json
   }),

--- a/frontend/public/src/lib/queries/programs.js
+++ b/frontend/public/src/lib/queries/programs.js
@@ -23,8 +23,11 @@ export const programsCountSelector = pathOr(null, [
 export const programsQueryKey = "programs"
 
 export const programsQuery = (page, ids) => ({
-  queryKey:  programsQueryKey,
-  url:       ids.length > 0 ? `/api/v2/programs/?page=${page}&live=true&page__live=true&id=${ids}` : `/api/v2/programs/?page=${page}&live=true&page__live=true`,
+  queryKey: programsQueryKey,
+  url:
+    ids.length > 0
+      ? `/api/v2/programs/?page=${page}&live=true&page__live=true&id=${ids}`
+      : `/api/v2/programs/?page=${page}&live=true&page__live=true`,
   transform: json => ({
     programs: json
   }),

--- a/frontend/public/src/lib/queries/programs.js
+++ b/frontend/public/src/lib/queries/programs.js
@@ -22,12 +22,9 @@ export const programsCountSelector = pathOr(null, [
 
 export const programsQueryKey = "programs"
 
-export const programsQuery = (page, ids) => ({
-  queryKey: programsQueryKey,
-  url:
-    ids.length > 0
-      ? `/api/v2/programs/?page=${page}&live=true&page__live=true&id=${ids}`
-      : `/api/v2/programs/?page=${page}&live=true&page__live=true`,
+export const programsQuery = page => ({
+  queryKey:   programsQueryKey,
+  url:        `/api/v2/programs/?page=${page}&live=true&page__live=true`,
   transform: json => ({
     programs: json
   }),

--- a/frontend/public/src/lib/queries/programs.js
+++ b/frontend/public/src/lib/queries/programs.js
@@ -22,9 +22,9 @@ export const programsCountSelector = pathOr(null, [
 
 export const programsQueryKey = "programs"
 
-export const programsQuery = page => ({
+export const programsQuery = (page, ids) => ({
   queryKey:  programsQueryKey,
-  url:       `/api/v2/programs/?page=${page}&live=true&page__live=true`,
+  url:       ids.length > 0 ? `/api/v2/programs/?page=${page}&live=true&page__live=true&id=${ids}` : `/api/v2/programs/?page=${page}&live=true&page__live=true`,
   transform: json => ({
     programs: json
   }),

--- a/frontend/public/src/lib/queries/programs.js
+++ b/frontend/public/src/lib/queries/programs.js
@@ -23,8 +23,8 @@ export const programsCountSelector = pathOr(null, [
 export const programsQueryKey = "programs"
 
 export const programsQuery = page => ({
-  queryKey:   programsQueryKey,
-  url:        `/api/v2/programs/?page=${page}&live=true&page__live=true`,
+  queryKey:  programsQueryKey,
+  url:       `/api/v2/programs/?page=${page}&live=true&page__live=true`,
   transform: json => ({
     programs: json
   }),


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3748

### Description (What does it do?)
This PR adds in a `queryIDListString` to the `getNextCoursePage` function which takes in a string of course IDs and appends that as a parameter for` id=` to the end of the API url.  This is set when a department other than `ALL_DEPARTMENTS` is selected and `getNextCoursePage` is called.

This should make it so that on a page with less than the expected numebr of courses already loaded, the missing courses are loaded.


### How can this be tested?
Load up with more than 12 courses. You should have a few in a couple of departments. This will allow you to see if, when you swap to one, it loads after swapping.