### PR TITLE
Change program end date to certificate creation date

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -992,7 +992,7 @@ class ProgramCertificate(TimestampedModel, BaseCertificate):
     def start_end_dates(self):
         """
         Start date: earliest course run start date
-        End date: latest course run end date
+        End date: program certificate creation date
         """
         course_ids = [course[0].id for course in self.program.courses]
         dates = CourseRunCertificate.objects.filter(

--- a/courses/models.py
+++ b/courses/models.py
@@ -997,9 +997,7 @@ class ProgramCertificate(TimestampedModel, BaseCertificate):
         course_ids = [course[0].id for course in self.program.courses]
         dates = CourseRunCertificate.objects.filter(
             user_id=self.user_id, course_run__course_id__in=course_ids
-        ).aggregate(
-            start_date=models.Min("course_run__start_date")
-        )
+        ).aggregate(start_date=models.Min("course_run__start_date"))
         return dates["start_date"], self.created_on
 
     def __str__(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -998,10 +998,9 @@ class ProgramCertificate(TimestampedModel, BaseCertificate):
         dates = CourseRunCertificate.objects.filter(
             user_id=self.user_id, course_run__course_id__in=course_ids
         ).aggregate(
-            start_date=models.Min("course_run__start_date"),
-            end_date=models.Max("course_run__end_date"),
+            start_date=models.Min("course_run__start_date")
         )
-        return dates["start_date"], dates["end_date"]
+        return dates["start_date"], self.created_on
 
     def __str__(self):
         return 'ProgramCertificate for user={user}, program={program} ({uuid})"'.format(

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -523,7 +523,7 @@ def test_program_certificate_start_end_dates_and_page_revision(user):
     certificate = ProgramCertificateFactory.create(program=program, user=user)
     program_start_date, program_end_date = certificate.start_end_dates
     assert program_start_date == early_course_run.start_date
-    assert program_end_date == later_course_run.end_date
+    assert program_end_date == certificate.created_on
     certificate_page = certificate.program.page.certificate_page
     assert (
         certificate_page.get_latest_revision() == certificate.certificate_page_revision

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -499,7 +499,9 @@ def test_course_run_certificate_start_end_dates_and_page_revision():
 
 def test_program_certificate_start_end_dates_and_page_revision(user):
     """
-    Test that the ProgramCertificate start_end_dates property works properly
+    Test that the ProgramCertificate start_end_dates property works properly.
+    The start date is the start date of the first course run passed.
+    The end date is the date the user received the program certificate.
     """
     now = now_in_utc()
     start_date = now + timedelta(days=1)


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3622

### Description (What does it do?)
The end date for the program on the certificate is the date the certificate was created.

To test this:
Create a program certificate, go to view the certificate, make sure the the end date on the certificate is showing the date it was created.
### Screenshots (if appropriate):
<img width="748" alt="Screenshot 2024-03-07 at 8 37 26 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/915d74cf-3777-40f4-8f90-c76a794fc188">
