### PR TITLE
Upgrade dialog choose any course run

### DIFF
--- a/frontend/public/scss/product-details.scss
+++ b/frontend/public/scss/product-details.scss
@@ -490,6 +490,7 @@
     text-decoration: underline;
     box-shadow: none;
     font-weight: bold;
+    border: none;
   }
 
   form {

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -44,7 +44,6 @@ import AddlProfileFieldsForm from "./forms/AddlProfileFieldsForm"
 import CourseInfoBox from "./CourseInfoBox"
 
 import type { User } from "../flow/authTypes"
-import type { Product } from "../flow/cartTypes"
 
 type Props = {
   courseId: ?string,
@@ -537,14 +536,12 @@ export class CourseProductDetailEnroll extends React.Component<
       enrollments,
       enrollmentsIsLoading
     } = this.props
-    let run,
-      product = null
+    let run = null
 
     if (courses && courseRuns) {
       run = getFirstRelevantRun(courses[0], courseRuns)
 
       if (run) {
-        product = run && run.products ? run.products[0] : null
         this.updateDate(run)
       }
     }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -509,19 +509,33 @@ export class CourseProductDetailEnroll extends React.Component<
   }
 
   renderEnrollNowButton(run: EnrollmentFlaggedCourseRun) {
-    const { currentUser } = this.props
+    const { currentUser, courseRuns } = this.props
+    const csrfToken = getCookie("csrftoken")
     return currentUser &&
       currentUser.id &&
       run &&
       isWithinEnrollmentPeriod(run) ? (
         <h2>
-          <button
-            id="upgradeEnrollBtn"
-            className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
-            onClick={() => this.toggleUpgradeDialogVisibility()}
-          >
-          Enroll now
-          </button>
+          {courseRuns && courseRuns.length > 1 ? (
+            <button
+              id="upgradeEnrollBtn"
+              className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
+              onClick={() => this.toggleUpgradeDialogVisibility()}
+            >
+            Enroll now
+            </button>
+          ) : (
+            <form action="/enrollments/" method="post">
+              <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
+              <input type="hidden" name="run" value={run ? run.id : ""} />
+              <button
+                type="submit"
+                className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
+              >
+              Enroll now
+              </button>
+            </form>
+          )}
         </h2>
       ) : null
   }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -183,7 +183,6 @@ export class CourseProductDetailEnroll extends React.Component<
 
   hndSetCourseRun = (event: any) => {
     const { courseRuns } = this.props
-
     if (event.target.value === "") {
       this.setCurrentCourseRun(null)
       return
@@ -194,7 +193,6 @@ export class CourseProductDetailEnroll extends React.Component<
         (elem: EnrollmentFlaggedCourseRun) =>
           elem.id === parseInt(event.target.value)
       )
-
     if (matchingCourseRun) {
       this.setCurrentCourseRun(matchingCourseRun)
     }
@@ -240,7 +238,7 @@ export class CourseProductDetailEnroll extends React.Component<
           onChange={this.hndSetCourseRun.bind(this)}
           className="form-control"
         >
-          <option value="" key="default-select">
+          <option value="d" key="default-select">
             Please Select
           </option>
           {courseRuns &&

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -358,7 +358,7 @@ export class CourseProductDetailEnroll extends React.Component<
           {run.title}
         </ModalHeader>
         <ModalBody>
-          {courseRuns.length > 1 ? (
+          {courseRuns && courseRuns.length > 1 ? (
             <div className="row date-selector-button-bar">
               <div className="col-12">
                 <div>{this.renderRunSelectorButtons(run)}</div>
@@ -509,12 +509,8 @@ export class CourseProductDetailEnroll extends React.Component<
     ) : null
   }
 
-  renderEnrollNowButton(
-    run: EnrollmentFlaggedCourseRun,
-    product: Product | null
-  ) {
+  renderEnrollNowButton(run: EnrollmentFlaggedCourseRun) {
     const { currentUser } = this.props
-    const csrfToken = getCookie("csrftoken")
     return currentUser &&
       currentUser.id &&
       run &&
@@ -560,7 +556,7 @@ export class CourseProductDetailEnroll extends React.Component<
           <Loader key="product_detail_enroll_loader" isLoading={isLoading}>
             <>
               {this.renderEnrollLoginButton()}
-              {this.renderEnrollNowButton(run, product)}
+              {this.renderEnrollNowButton(run)}
 
               {currentUser ? this.renderAddlProfileFieldsModal() : null}
               {run ? this.renderUpgradeEnrollmentDialog() : null}

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -274,18 +274,17 @@ export class CourseProductDetailEnroll extends React.Component<
           className="form-control"
         >
           {courseRuns &&
-            courseRuns
-              .map((elem: EnrollmentFlaggedCourseRun) => (
-                <option
-                  selected={run.id === elem.id}
-                  value={elem.id}
-                  key={`courserun-selection-${elem.id}`}
-                >
-                  {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
-                  {formatPrettyDate(moment(new Date(elem.end_date)))} {" "}
-                  {elem.is_upgradable ? "(can upgrade)" : ""}
-                </option>
-              ))}
+            courseRuns.map((elem: EnrollmentFlaggedCourseRun) => (
+              <option
+                selected={run.id === elem.id}
+                value={elem.id}
+                key={`courserun-selection-${elem.id}`}
+              >
+                {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
+                {formatPrettyDate(moment(new Date(elem.end_date)))}{" "}
+                {elem.is_upgradable ? "(can upgrade)" : ""}
+              </option>
+            ))}
         </select>
       </>
     )
@@ -390,8 +389,8 @@ export class CourseProductDetailEnroll extends React.Component<
                     <li>Highlight on your resume/CV</li>
                     <li>Share on your social channels &amp; LinkedIn</li>
                     <li>
-                      Enhance your college application with an earned certificate
-                      from MIT
+                      Enhance your college application with an earned
+                      certificate from MIT
                     </li>
                   </ul>
                 </div>
@@ -411,16 +410,33 @@ export class CourseProductDetailEnroll extends React.Component<
                       <br />
                       {product && run.upgrade_deadline ? (
                         <span className="text-danger">
-                        Payment date:{" "}
+                          Payment date:{" "}
                           {formatPrettyDate(moment(run.upgrade_deadline))}
-                        </span>) : <strong id="certificate-price-info">not available</strong>}
+                        </span>
+                      ) : (
+                        <strong id="certificate-price-info">
+                          not available
+                        </strong>
+                      )}
                     </>
                   </p>
                 </div>
                 <div className="col-md-6 col-sm-12 pr-0 enroll-and-pay">
-                  <form action="/cart/add/" method="get" className="text-center">
-                    <input type="hidden" name="product_id" value={product && product.id} />
-                    <button type="submit" className="btn btn-upgrade">
+                  <form
+                    action="/cart/add/"
+                    method="get"
+                    className="text-center"
+                  >
+                    <input
+                      type="hidden"
+                      name="product_id"
+                      value={product && product.id}
+                    />
+                    <button
+                      type="submit"
+                      className="btn btn-upgrade"
+                      disabled={!product}
+                    >
                       <strong>Enroll and Pay</strong>
                       <br />
                       <span>for the certificate track</span>
@@ -428,7 +444,8 @@ export class CourseProductDetailEnroll extends React.Component<
                   </form>
                 </div>
               </div>
-            </>) : null}
+            </>
+          ) : null}
           <div className="row upgrade-options-row">
             <div>{needFinancialAssistanceLink}</div>
             <div>{this.getEnrollmentForm(run)}</div>

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -248,7 +248,7 @@ export class CourseProductDetailEnroll extends React.Component<
               <option value={elem.id} key={`courserun-selection-${elem.id}`}>
                 {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
                 {formatPrettyDate(moment(new Date(elem.end_date)))}{" "}
-                {elem.is_upgradable ? "" : "(no certificate available"}
+                {elem.is_upgradable ? "" : "(no certificate available)"}
               </option>
             ))}
         </select>
@@ -256,8 +256,7 @@ export class CourseProductDetailEnroll extends React.Component<
     )
   }
 
-  getEnrollmentForm() {
-    const run = this.getCurrentCourseRun()
+  getEnrollmentForm(run: EnrollmentFlaggedCourseRun) {
     const csrfToken = getCookie("csrftoken")
 
     return (
@@ -289,8 +288,12 @@ export class CourseProductDetailEnroll extends React.Component<
 
   renderUpgradeEnrollmentDialog(firstRelevantRun: EnrollmentFlaggedCourseRun) {
     const { courseRuns } = this.props
-    const run = this.getCurrentCourseRun() || firstRelevantRun
+    let run = this.getCurrentCourseRun()
     const course = courseRuns && courseRuns[0].course
+    const hasMultipleEnrollableRuns = courseRuns && courseRuns.length > 1
+    if (!run && !hasMultipleEnrollableRuns) {
+      run = firstRelevantRun
+    }
     const needFinancialAssistanceLink =
       run &&
       isFinancialAssistanceAvailable(run) &&
@@ -306,7 +309,6 @@ export class CourseProductDetailEnroll extends React.Component<
           </p>
         ) : null
     const { upgradeEnrollmentDialogVisibility } = this.state
-    const hasMultipleEnrollableRuns = courseRuns && courseRuns.length > 1
     const product = run && run.products ? run.products[0] : null
     const upgradableCourseRuns = courseRuns
       ? courseRuns.filter(
@@ -420,7 +422,7 @@ export class CourseProductDetailEnroll extends React.Component<
           ) : null}
           <div className="row upgrade-options-row">
             <div>{needFinancialAssistanceLink}</div>
-            <div>{this.getEnrollmentForm()}</div>
+            <div>{this.getEnrollmentForm(run)}</div>
           </div>
         </ModalBody>
       </Modal>

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -316,7 +316,7 @@ export class CourseProductDetailEnroll extends React.Component<
       )
       : []
 
-    return (
+    return upgradableCourseRuns.length > 0 || hasMultipleEnrollableRuns ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
         className="upgrade-enrollment-modal"
@@ -426,7 +426,7 @@ export class CourseProductDetailEnroll extends React.Component<
           </div>
         </ModalBody>
       </Modal>
-    )
+    ) : null
   }
 
   renderAddlProfileFieldsModal() {

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -69,6 +69,7 @@ type ProductDetailState = {
   upgradeEnrollmentDialogVisibility: boolean,
   showAddlProfileFieldsModal: boolean,
   currentCourseRun: ?EnrollmentFlaggedCourseRun,
+  isUserSelectedCourseRun: boolean,
   destinationUrl: string
 }
 
@@ -79,6 +80,7 @@ export class CourseProductDetailEnroll extends React.Component<
   state = {
     upgradeEnrollmentDialogVisibility: false,
     currentCourseRun:                  null,
+    isUserSelectedCourseRun:           false,
     showAddlProfileFieldsModal:        false,
     destinationUrl:                    ""
   }
@@ -230,6 +232,9 @@ export class CourseProductDetailEnroll extends React.Component<
 
     if (matchingCourseRun) {
       this.setCurrentCourseRun(matchingCourseRun)
+      this.setState({
+        isUserSelectedCourseRun: true
+      })
     }
   }
 

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -44,6 +44,7 @@ import AddlProfileFieldsForm from "./forms/AddlProfileFieldsForm"
 import CourseInfoBox from "./CourseInfoBox"
 
 import type { User } from "../flow/authTypes"
+import type { Product } from "../flow/cartTypes"
 
 type Props = {
   courseId: ?string,
@@ -508,7 +509,10 @@ export class CourseProductDetailEnroll extends React.Component<
     ) : null
   }
 
-  renderEnrollNowButton(run: EnrollmentFlaggedCourseRun, product: Product | null) {
+  renderEnrollNowButton(
+    run: EnrollmentFlaggedCourseRun,
+    product: Product | null
+  ) {
     const { currentUser, courseRuns } = this.props
     const csrfToken = getCookie("csrftoken")
     return currentUser &&
@@ -516,26 +520,27 @@ export class CourseProductDetailEnroll extends React.Component<
       run &&
       isWithinEnrollmentPeriod(run) ? (
         <h2>
-          {(product && run.is_upgradable) || (courseRuns && courseRuns.length > 1) ? (
-            <button
-              id="upgradeEnrollBtn"
-              className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
-              onClick={() => this.toggleUpgradeDialogVisibility()}
-            >
-            Enroll now
-            </button>
-          ) : (
-            <form action="/enrollments/" method="post">
-              <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
-              <input type="hidden" name="run" value={run ? run.id : ""} />
+          {(product && run.is_upgradable) ||
+        (courseRuns && courseRuns.length > 1) ? (
               <button
-                type="submit"
-                className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
+                id="upgradeEnrollBtn"
+                className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
+                onClick={() => this.toggleUpgradeDialogVisibility()}
               >
-              Enroll now
+            Enroll now
               </button>
-            </form>
-          )}
+            ) : (
+              <form action="/enrollments/" method="post">
+                <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
+                <input type="hidden" name="run" value={run ? run.id : ""} />
+                <button
+                  type="submit"
+                  className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
+                >
+              Enroll now
+                </button>
+              </form>
+            )}
         </h2>
       ) : null
   }
@@ -550,12 +555,14 @@ export class CourseProductDetailEnroll extends React.Component<
       enrollments,
       enrollmentsIsLoading
     } = this.props
-    let run, product = null
+    let run,
+      product = null
 
     if (courses && courseRuns) {
       run = getFirstRelevantRun(courses[0], courseRuns)
 
       if (run) {
+        product = run && run.products ? run.products[0] : null
         this.updateDate(run)
       }
     }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -240,13 +240,12 @@ export class CourseProductDetailEnroll extends React.Component<
           onChange={this.hndSetCourseRun.bind(this)}
           className="form-control"
         >
-          <option value="" key="default-select">-- nothing selected --</option>
+          <option value="" key="default-select">
+            Nothing Selected
+          </option>
           {courseRuns &&
             courseRuns.map((elem: EnrollmentFlaggedCourseRun) => (
-              <option
-                value={elem.id}
-                key={`courserun-selection-${elem.id}`}
-              >
+              <option value={elem.id} key={`courserun-selection-${elem.id}`}>
                 {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
                 {formatPrettyDate(moment(new Date(elem.end_date)))}{" "}
                 {elem.is_upgradable ? "(can upgrade)" : ""}
@@ -257,14 +256,19 @@ export class CourseProductDetailEnroll extends React.Component<
     )
   }
 
-  getEnrollmentForm(run: EnrollmentFlaggedCourseRun) {
+  getEnrollmentForm() {
+    const run = this.getCurrentCourseRun()
     const csrfToken = getCookie("csrftoken")
 
     return (
       <form action="/enrollments/" method="post">
         <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
         <input type="hidden" name="run" value={run ? run.id : ""} />
-        <button type="submit" className="btn enroll-now enroll-now-free">
+        <button
+          type="submit"
+          className="btn enroll-now enroll-now-free"
+          disabled={!run}
+        >
           <strong>Enroll for Free</strong> without a certificate
         </button>
       </form>
@@ -286,7 +290,7 @@ export class CourseProductDetailEnroll extends React.Component<
   renderUpgradeEnrollmentDialog() {
     const { courseRuns } = this.props
     const run = this.getCurrentCourseRun()
-    const course = courseRuns[0].course
+    const course = courseRuns && courseRuns[0].course
     const needFinancialAssistanceLink =
       run &&
       isFinancialAssistanceAvailable(run) &&
@@ -318,13 +322,13 @@ export class CourseProductDetailEnroll extends React.Component<
         centered
       >
         <ModalHeader toggle={() => this.cancelEnrollment()}>
-          {course.title}
+          {course && course.title}
         </ModalHeader>
         <ModalBody>
           {courseRuns && courseRuns.length > 1 ? (
             <div className="row date-selector-button-bar">
               <div className="col-12">
-                <div>{this.renderRunSelectorButtons(run)}</div>
+                <div>{this.renderRunSelectorButtons()}</div>
               </div>
             </div>
           ) : null}
@@ -359,7 +363,11 @@ export class CourseProductDetailEnroll extends React.Component<
                 </div>
               </div>
               <div className="row certificate-pricing-row d-sm-flex flex-md-row flex-sm-column">
-                <div className="col-md-6 col-sm-12 certificate-pricing d-flex align-items-center">
+                <div
+                  className={`col-md-6 col-sm-12 certificate-pricing d-flex align-items-center ${
+                    run ? "" : "opacity-50"
+                  }`}
+                >
                   <div className="certificate-pricing-logo">
                     <img src="/static/images/certificates/certificate-logo.svg" />
                   </div>
@@ -393,7 +401,7 @@ export class CourseProductDetailEnroll extends React.Component<
                     <input
                       type="hidden"
                       name="product_id"
-                      value={product && product.id}
+                      value={(product && product.id) || ""}
                     />
                     <button
                       type="submit"
@@ -411,7 +419,7 @@ export class CourseProductDetailEnroll extends React.Component<
           ) : null}
           <div className="row upgrade-options-row">
             <div>{needFinancialAssistanceLink}</div>
-            <div>{this.getEnrollmentForm(run)}</div>
+            <div>{this.getEnrollmentForm()}</div>
           </div>
         </ModalBody>
       </Modal>
@@ -540,7 +548,7 @@ export class CourseProductDetailEnroll extends React.Component<
               {this.renderEnrollNowButton(run, product)}
 
               {currentUser ? this.renderAddlProfileFieldsModal() : null}
-              {run ? this.renderUpgradeEnrollmentDialog(run) : null}
+              {run ? this.renderUpgradeEnrollmentDialog() : null}
             </>
           </Loader>
         }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -508,7 +508,7 @@ export class CourseProductDetailEnroll extends React.Component<
     ) : null
   }
 
-  renderEnrollNowButton(run: EnrollmentFlaggedCourseRun) {
+  renderEnrollNowButton(run: EnrollmentFlaggedCourseRun, product: Product | null) {
     const { currentUser, courseRuns } = this.props
     const csrfToken = getCookie("csrftoken")
     return currentUser &&
@@ -516,7 +516,7 @@ export class CourseProductDetailEnroll extends React.Component<
       run &&
       isWithinEnrollmentPeriod(run) ? (
         <h2>
-          {courseRuns && courseRuns.length > 1 ? (
+          {(product && run.is_upgradable) || (courseRuns && courseRuns.length > 1) ? (
             <button
               id="upgradeEnrollBtn"
               className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
@@ -550,7 +550,7 @@ export class CourseProductDetailEnroll extends React.Component<
       enrollments,
       enrollmentsIsLoading
     } = this.props
-    let run = null
+    let run, product = null
 
     if (courses && courseRuns) {
       run = getFirstRelevantRun(courses[0], courseRuns)
@@ -567,7 +567,7 @@ export class CourseProductDetailEnroll extends React.Component<
           <Loader key="product_detail_enroll_loader" isLoading={isLoading}>
             <>
               {this.renderEnrollLoginButton()}
-              {this.renderEnrollNowButton(run)}
+              {this.renderEnrollNowButton(run, product)}
 
               {currentUser ? this.renderAddlProfileFieldsModal() : null}
               {run ? this.renderUpgradeEnrollmentDialog() : null}

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -248,7 +248,7 @@ export class CourseProductDetailEnroll extends React.Component<
               <option value={elem.id} key={`courserun-selection-${elem.id}`}>
                 {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
                 {formatPrettyDate(moment(new Date(elem.end_date)))}{" "}
-                {elem.is_upgradable ? "(can upgrade)" : ""}
+                {elem.is_upgradable ? "" : "(no certificate available"}
               </option>
             ))}
         </select>
@@ -287,9 +287,9 @@ export class CourseProductDetailEnroll extends React.Component<
     }
   }
 
-  renderUpgradeEnrollmentDialog() {
+  renderUpgradeEnrollmentDialog(firstRelevantRun: EnrollmentFlaggedCourseRun) {
     const { courseRuns } = this.props
-    const run = this.getCurrentCourseRun()
+    const run = this.getCurrentCourseRun() || firstRelevantRun
     const course = courseRuns && courseRuns[0].course
     const needFinancialAssistanceLink =
       run &&
@@ -306,6 +306,7 @@ export class CourseProductDetailEnroll extends React.Component<
           </p>
         ) : null
     const { upgradeEnrollmentDialogVisibility } = this.state
+    const hasMultipleEnrollableRuns = courseRuns && courseRuns.length > 1
     const product = run && run.products ? run.products[0] : null
     const upgradableCourseRuns = courseRuns
       ? courseRuns.filter(
@@ -325,7 +326,7 @@ export class CourseProductDetailEnroll extends React.Component<
           {course && course.title}
         </ModalHeader>
         <ModalBody>
-          {courseRuns && courseRuns.length > 1 ? (
+          {hasMultipleEnrollableRuns ? (
             <div className="row date-selector-button-bar">
               <div className="col-12">
                 <div>{this.renderRunSelectorButtons()}</div>
@@ -535,7 +536,6 @@ export class CourseProductDetailEnroll extends React.Component<
       if (run) {
         product = run && run.products ? run.products[0] : null
         this.updateDate(run)
-        this.setCurrentCourseRun(run)
       }
     }
 
@@ -549,7 +549,7 @@ export class CourseProductDetailEnroll extends React.Component<
               {this.renderEnrollNowButton(run, product)}
 
               {currentUser ? this.renderAddlProfileFieldsModal() : null}
-              {run ? this.renderUpgradeEnrollmentDialog() : null}
+              {run ? this.renderUpgradeEnrollmentDialog(run) : null}
             </>
           </Loader>
         }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -535,6 +535,7 @@ export class CourseProductDetailEnroll extends React.Component<
       if (run) {
         product = run && run.products ? run.products[0] : null
         this.updateDate(run)
+        this.setCurrentCourseRun(run)
       }
     }
 

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -275,7 +275,6 @@ export class CourseProductDetailEnroll extends React.Component<
         >
           {courseRuns &&
             courseRuns
-              .filter((elem: EnrollmentFlaggedCourseRun) => elem.is_upgradable)
               .map((elem: EnrollmentFlaggedCourseRun) => (
                 <option
                   selected={run.id === elem.id}
@@ -283,7 +282,8 @@ export class CourseProductDetailEnroll extends React.Component<
                   key={`courserun-selection-${elem.id}`}
                 >
                   {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
-                  {formatPrettyDate(moment(new Date(elem.end_date)))}
+                  {formatPrettyDate(moment(new Date(elem.end_date)))} {" "}
+                  {elem.is_upgradable ? "(can upgrade)" : ""}
                 </option>
               ))}
         </select>
@@ -347,7 +347,7 @@ export class CourseProductDetailEnroll extends React.Component<
       )
       : []
 
-    return run && product ? (
+    return run ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
         className="upgrade-enrollment-modal"
@@ -359,7 +359,7 @@ export class CourseProductDetailEnroll extends React.Component<
           {run.title}
         </ModalHeader>
         <ModalBody>
-          {upgradableCourseRuns.length > 1 ? (
+          {courseRuns.length > 1 ? (
             <div className="row date-selector-button-bar">
               <div className="col-12">
                 <div>{this.renderRunSelectorButtons(run)}</div>
@@ -367,69 +367,68 @@ export class CourseProductDetailEnroll extends React.Component<
             </div>
           ) : null}
 
-          <div className="row upsell-messaging-header">
-            <div className="col-12 p-0 font-weight-bold">
-              Do you want to earn a certificate?
-            </div>
-          </div>
-
-          <div className="row d-sm-flex flex-md-row flex-sm-column">
-            <div className="col-md-6 col-sm-12">
-              <ul>
-                <li> Certificate is signed by MIT faculty</li>
-                <li>
-                  {" "}
-                  Demonstrates knowledge and skills taught in this course
-                </li>
-                <li> Enhance your college &amp; earn a promotion</li>
-              </ul>
-            </div>
-            <div className="col-md-6 col-sm-12">
-              <ul>
-                <li>Highlight on your resume/CV</li>
-                <li>Share on your social channels &amp; LinkedIn</li>
-                <li>
-                  Enhance your college application with an earned certificate
-                  from MIT
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <div className="row certificate-pricing-row d-sm-flex flex-md-row flex-sm-column">
-            <div className="col-md-6 col-sm-12 certificate-pricing d-flex align-items-center">
-              <div className="certificate-pricing-logo">
-                <img src="/static/images/certificates/certificate-logo.svg" />
+          {upgradableCourseRuns.length > 0 ? (
+            <>
+              <div className="row upsell-messaging-header">
+                <div className="col-12 p-0 font-weight-bold">
+                  Do you want to earn a certificate?
+                </div>
               </div>
-              <p>
-                Certificate track:{" "}
-                <strong id="certificate-price-info">
-                  {product &&
-                    formatLocalePrice(getFlexiblePriceForProduct(product))}
-                </strong>
-                {run.upgrade_deadline ? (
-                  <>
-                    <br />
-                    <span className="text-danger">
-                      Payment date:{" "}
-                      {formatPrettyDate(moment(run.upgrade_deadline))}
-                    </span>
-                  </>
-                ) : null}
-              </p>
-            </div>
-            <div className="col-md-6 col-sm-12 pr-0 enroll-and-pay">
-              <form action="/cart/add/" method="get" className="text-center">
-                <input type="hidden" name="product_id" value={product.id} />
-                <button type="submit" className="btn btn-upgrade">
-                  <strong>Enroll and Pay</strong>
-                  <br />
-                  <span>for the certificate track</span>
-                </button>
-              </form>
-            </div>
-          </div>
-
+              <div className="row d-sm-flex flex-md-row flex-sm-column">
+                <div className="col-md-6 col-sm-12">
+                  <ul>
+                    <li> Certificate is signed by MIT faculty</li>
+                    <li>
+                      {" "}
+                      Demonstrates knowledge and skills taught in this course
+                    </li>
+                    <li> Enhance your college &amp; earn a promotion</li>
+                  </ul>
+                </div>
+                <div className="col-md-6 col-sm-12">
+                  <ul>
+                    <li>Highlight on your resume/CV</li>
+                    <li>Share on your social channels &amp; LinkedIn</li>
+                    <li>
+                      Enhance your college application with an earned certificate
+                      from MIT
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div className="row certificate-pricing-row d-sm-flex flex-md-row flex-sm-column">
+                <div className="col-md-6 col-sm-12 certificate-pricing d-flex align-items-center">
+                  <div className="certificate-pricing-logo">
+                    <img src="/static/images/certificates/certificate-logo.svg" />
+                  </div>
+                  <p>
+                    Certificate track:{" "}
+                    <strong id="certificate-price-info">
+                      {product &&
+                        formatLocalePrice(getFlexiblePriceForProduct(product))}
+                    </strong>
+                    <>
+                      <br />
+                      {product && run.upgrade_deadline ? (
+                        <span className="text-danger">
+                        Payment date:{" "}
+                          {formatPrettyDate(moment(run.upgrade_deadline))}
+                        </span>) : <strong id="certificate-price-info">not available</strong>}
+                    </>
+                  </p>
+                </div>
+                <div className="col-md-6 col-sm-12 pr-0 enroll-and-pay">
+                  <form action="/cart/add/" method="get" className="text-center">
+                    <input type="hidden" name="product_id" value={product && product.id} />
+                    <button type="submit" className="btn btn-upgrade">
+                      <strong>Enroll and Pay</strong>
+                      <br />
+                      <span>for the certificate track</span>
+                    </button>
+                  </form>
+                </div>
+              </div>
+            </>) : null}
           <div className="row upgrade-options-row">
             <div>{needFinancialAssistanceLink}</div>
             <div>{this.getEnrollmentForm(run)}</div>
@@ -504,26 +503,13 @@ export class CourseProductDetailEnroll extends React.Component<
       run &&
       isWithinEnrollmentPeriod(run) ? (
         <h2>
-          {product && run.is_upgradable ? (
-            <button
-              id="upgradeEnrollBtn"
-              className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
-              onClick={() => this.toggleUpgradeDialogVisibility()}
-            >
-            Enroll now
-            </button>
-          ) : (
-            <form action="/enrollments/" method="post">
-              <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
-              <input type="hidden" name="run" value={run ? run.id : ""} />
-              <button
-                type="submit"
-                className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
-              >
-              Enroll now
-              </button>
-            </form>
-          )}
+          <button
+            id="upgradeEnrollBtn"
+            className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
+            onClick={() => this.toggleUpgradeDialogVisibility()}
+          >
+          Enroll now
+          </button>
         </h2>
       ) : null
   }

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -241,7 +241,7 @@ export class CourseProductDetailEnroll extends React.Component<
           className="form-control"
         >
           <option value="" key="default-select">
-            Nothing Selected
+            Please Select
           </option>
           {courseRuns &&
             courseRuns.map((elem: EnrollmentFlaggedCourseRun) => (

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -346,7 +346,7 @@ export class CourseProductDetailEnroll extends React.Component<
       )
       : []
 
-    return run ? (
+    return run && isWithinEnrollmentPeriod(run) ? (
       <Modal
         id={`upgrade-enrollment-dialog`}
         className="upgrade-enrollment-modal"

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -494,7 +494,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
   ].forEach(([showsQualifier, runsQualifier, multiples]) => {
     it(`${showsQualifier} the course run selector for a course with ${runsQualifier} active run${
       multiples ? "s" : ""
-    } and dis/enables enroll buttons on selection`, async () => {
+    } and enables enroll buttons on selection`, async () => {
       courseRun["products"] = [
         {
           id:                     1,

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -52,7 +52,11 @@ describe("CourseProductDetailEnrollShallowRender", () => {
           currentUser: currentUser
         }
       },
-      {}
+      {
+        state: {
+          currentCourseRun: courseRun
+        }
+      }
     )
 
     SETTINGS.features = {
@@ -136,9 +140,15 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     )
     assert.isNotOk(
       inner
-        .find(".enroll-now")
+        .find("#enrollNowBtn")
         .at(0)
         .exists()
+    )
+    assert.isTrue(
+      inner
+        .find(".enroll-now-free")
+        .at(0)
+        .prop("disabled")
     )
   })
 
@@ -269,6 +279,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       isWithinEnrollmentPeriodStub.returns(true)
       isFinancialAssistanceAvailableStub.returns(true)
       const { inner } = await renderPage()
+      inner.setState({ currentCourseRun: courseRun })
 
       const enrollBtn = inner.find(".enroll-now").at(0)
       assert.isTrue(enrollBtn.exists())
@@ -413,7 +424,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       ]
       isWithinEnrollmentPeriodStub.returns(true)
       const { inner } = await renderPage()
-
       const enrollBtn = inner.find(".enroll-now").at(0)
       assert.isTrue(enrollBtn.exists())
       await enrollBtn.prop("onClick")()
@@ -447,7 +457,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       isWithinEnrollmentPeriodStub.returns(true)
       isFinancialAssistanceAvailableStub.returns(false)
       const { inner } = await renderPage()
-
       const enrollBtn = inner.find(".enroll-now").at(0)
       assert.isTrue(enrollBtn.exists())
       await enrollBtn.prop("onClick")()
@@ -531,7 +540,8 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       if (multiples) {
         assert.isTrue(selectorControl.exists())
         const selectorControlItems = selectorControl.find("option")
-        assert.isTrue(selectorControlItems.length === 2)
+        assert.isTrue(selectorControlItems.length === 3)
+        assert.isTrue(selectorControlItems.at(0).text() === "Nothing Selected")
       } else {
         assert.isFalse(selectorControl.exists())
       }

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -144,12 +144,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         .at(0)
         .exists()
     )
-    assert.isTrue(
-      inner
-        .find(".enroll-now-free")
-        .at(0)
-        .prop("disabled")
-    )
   })
 
   it("checks for enroll now button should appear if enrollment start not in future", async () => {

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -494,7 +494,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
   ].forEach(([showsQualifier, runsQualifier, multiples]) => {
     it(`${showsQualifier} the course run selector for a course with ${runsQualifier} active run${
       multiples ? "s" : ""
-    }`, async () => {
+    } and dis/enables enroll buttons on selection`, async () => {
       courseRun["products"] = [
         {
           id:                     1,
@@ -582,7 +582,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     })
   })
 
-  it(`renders enrollment dialog for a course with multiple non-upgradable active runs`, async () => {
+  it(`renders enrollment dialog for a course with multiple non-upgradable active runs and enables enroll button on selection`, async () => {
     courseRun["products"] = []
     courseRun["is_upgradable"] = false
     const courseRuns = [courseRun]

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -140,7 +140,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     )
     assert.isNotOk(
       inner
-        .find("#enrollNowBtn")
+        .find(".enroll-now")
         .at(0)
         .exists()
     )
@@ -535,7 +535,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         assert.isTrue(selectorControl.exists())
         const selectorControlItems = selectorControl.find("option")
         assert.isTrue(selectorControlItems.length === 3)
-        assert.isTrue(selectorControlItems.at(0).text() === "Nothing Selected")
+        assert.isTrue(selectorControlItems.at(0).text() === "Please Select")
       } else {
         assert.isFalse(selectorControl.exists())
       }

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -134,7 +134,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       },
       {}
     )
-
     assert.isNotOk(
       inner
         .find(".enroll-now")


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3671 and partially https://github.com/mitodl/hq/issues/3109

### Description (What does it do?)
Changes the enroll now button to open the dialog whenever there is more then one course run available for enrollment.
In the dialog the dropdown select course run shows all enrollable course runs. The runs that can't be upgraded have a label  `(no certificate available)`




### How can this be tested?
There are few scenarios to test:
**1. All course runs for a given course don't have products but are enrollable**
<img width="746" alt="Screenshot 2024-03-20 at 2 19 36 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/3a749416-5a21-4d25-a569-790c309dc9d4">

**2. One course run has product and other not, but both are enrollable**
<img width="747" alt="Screenshot 2024-03-20 at 2 33 10 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/ea377894-bdcb-434d-a649-935d268e4758">

**3. two course runs both have products both are enrollable, but only one is upgradable** (meaning payment_deadline is in the future) - in this scenario the dialog looks the same as case 2.
**4. Has one enrollable course run with no product** - in this case when you click enroll button it just enrolls you, no dialog is shown.
**5. Has one enrollable and upgradable run**   
<img width="747" alt="Screenshot 2024-03-20 at 2 35 41 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/5de5e4c2-292f-4978-b391-12bb2b872dec">

**6. has two runs both self paced and enrollable** ( and upgradable?)
If at least one of the course runs is upgradable the dialog would look like case 2. Otherwise, the dialog would show up as case 1.