### PR TITLE
2846 Course About: Replace Free with Free to Learn

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -178,7 +178,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               <img src="/static/images/products/cost.png" alt="Cost" />
             </div>
             <div className="enrollment-info-text">
-              <b>Free</b>
+              <b>Free to Learn</b>
             </div>
           </div>
           <div className="row d-flex align-items-top course-certificate-message">

--- a/frontend/public/src/components/ProgramInfoBox.js
+++ b/frontend/public/src/components/ProgramInfoBox.js
@@ -167,7 +167,7 @@ export default class ProgramInfoBox extends React.PureComponent<ProgramInfoBoxPr
             <div className="enrollment-info-icon">
               <img src="/static/images/products/cost.png" alt="Cost" />
             </div>
-            <div className="enrollment-info-text font-weight-bold">Free</div>
+            <div className="enrollment-info-text font-weight-bold">Free to Learn</div>
           </div>
           <div className="row d-flex align-items-top">
             <div className="enrollment-info-icon">

--- a/frontend/public/src/components/ProgramInfoBox.js
+++ b/frontend/public/src/components/ProgramInfoBox.js
@@ -167,7 +167,9 @@ export default class ProgramInfoBox extends React.PureComponent<ProgramInfoBoxPr
             <div className="enrollment-info-icon">
               <img src="/static/images/products/cost.png" alt="Cost" />
             </div>
-            <div className="enrollment-info-text font-weight-bold">Free to Learn</div>
+            <div className="enrollment-info-text font-weight-bold">
+              Free to Learn
+            </div>
           </div>
           <div className="row d-flex align-items-top">
             <div className="enrollment-info-icon">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/2846

### Description
Changes course about page text to "Free to Learn" from "Free".

### Screenshots
![Screenshot 2024-03-11 at 7 54 32 PM](https://github.com/mitodl/mitxonline/assets/8311573/15b9efc9-693a-4436-969f-267ad5958471)


### How can this be tested?
1. Using one of the courses created from the quickstart command (https://github.com/mitodl/mitxonline/blob/main/docs/source/configuration/quickstart.rst), view the associated course about page.
2. Verify that the course about page displays "Free to Learn".
