### PR TITLE
3360: on account registration redirect new users to the page they started on

### DIFF
--- a/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
@@ -9,7 +9,7 @@ import { connect } from "react-redux"
 import { mutateAsync, requestAsync } from "redux-query"
 import { connectRequest } from "redux-query-react"
 import { createStructuredSelector } from "reselect"
-import type { RouterHistory } from "react-router"
+import { routes } from "../../../lib/urls"
 
 import { qsNextSelector } from "../../../lib/selectors"
 
@@ -50,7 +50,7 @@ const getInitialValues = (user: User) => ({
 
 export class RegisterAdditionalDetailsPage extends React.Component<Props> {
   async onSubmit(detailsData: any, { setSubmitting, setErrors }: any) {
-    const { editProfile, params: { next }, history } = this.props
+    const { editProfile, params: { next } } = this.props
 
     // On this page, if the user selects stuff for learner type and education
     // level, we also set the field flag so we don't ping the learner later to
@@ -73,11 +73,11 @@ export class RegisterAdditionalDetailsPage extends React.Component<Props> {
       if (body.errors && body.errors.length > 0) {
         setErrors(body.errors)
       } else {
-        console.log(next)
-        window.location = next
-        //history.push(next)
-        //return
-        //window.location = next
+        if (next) {
+          window.location = next
+        } else {
+          window.location = routes.dashboard
+        }
       }
     } finally {
       setSubmitting(false)

--- a/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
@@ -9,9 +9,11 @@ import { connect } from "react-redux"
 import { mutateAsync, requestAsync } from "redux-query"
 import { connectRequest } from "redux-query-react"
 import { createStructuredSelector } from "reselect"
+import type { RouterHistory } from "react-router"
+
+import { qsNextSelector } from "../../../lib/selectors"
 
 import users, { currentUserSelector } from "../../../lib/queries/users"
-import { routes } from "../../../lib/urls"
 import queries from "../../../lib/queries"
 
 import {
@@ -32,10 +34,12 @@ type DispatchProps = {|
   getCurrentUser: () => Promise<HttpResponse<User>>
 |}
 
-type Props = {|
+type Props = {
+  history: RouterHistory,
+  params: { next: string },
   ...StateProps,
   ...DispatchProps
-|}
+}
 
 const getInitialValues = (user: User) => ({
   name:          user.name,
@@ -46,7 +50,7 @@ const getInitialValues = (user: User) => ({
 
 export class RegisterAdditionalDetailsPage extends React.Component<Props> {
   async onSubmit(detailsData: any, { setSubmitting, setErrors }: any) {
-    const { editProfile } = this.props
+    const { editProfile, params: { next }, history } = this.props
 
     // On this page, if the user selects stuff for learner type and education
     // level, we also set the field flag so we don't ping the learner later to
@@ -64,13 +68,16 @@ export class RegisterAdditionalDetailsPage extends React.Component<Props> {
 
     try {
       const {
-        body: { errors }
+        body
       }: { body: Object } = await editProfile(detailsData)
-
-      if (errors && errors.length > 0) {
-        setErrors(errors)
+      if (body.errors && body.errors.length > 0) {
+        setErrors(body.errors)
       } else {
-        window.location = routes.dashboard
+        console.log(next)
+        window.location = next
+        //history.push(next)
+        //return
+        //window.location = next
       }
     } finally {
       setSubmitting(false)
@@ -135,7 +142,10 @@ export class RegisterAdditionalDetailsPage extends React.Component<Props> {
 }
 
 const mapStateToProps = createStructuredSelector({
-  currentUser: currentUserSelector
+  currentUser: currentUserSelector,
+  params:      createStructuredSelector({
+    next: qsNextSelector
+  })
 })
 
 const mapPropsToConfig = () => [queries.users.countriesQuery()]

--- a/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
@@ -50,7 +50,10 @@ const getInitialValues = (user: User) => ({
 
 export class RegisterAdditionalDetailsPage extends React.Component<Props> {
   async onSubmit(detailsData: any, { setSubmitting, setErrors }: any) {
-    const { editProfile, params: { next } } = this.props
+    const {
+      editProfile,
+      params: { next }
+    } = this.props
 
     // On this page, if the user selects stuff for learner type and education
     // level, we also set the field flag so we don't ping the learner later to
@@ -67,9 +70,7 @@ export class RegisterAdditionalDetailsPage extends React.Component<Props> {
     }
 
     try {
-      const {
-        body
-      }: { body: Object } = await editProfile(detailsData)
+      const { body }: { body: Object } = await editProfile(detailsData)
       if (body.errors && body.errors.length > 0) {
         setErrors(body.errors)
       } else {

--- a/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
@@ -35,7 +35,6 @@ type DispatchProps = {|
 |}
 
 type Props = {
-  history: RouterHistory,
   params: { next: string },
   ...StateProps,
   ...DispatchProps

--- a/frontend/public/src/containers/pages/register/RegisterDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterDetailsPage.js
@@ -100,8 +100,11 @@ export class RegisterDetailsPage extends React.Component<Props> {
       }
 
       if (body.state === STATE_SUCCESS) {
-        // COLLIN, can you append the ?next value to this?
-        body.redirect_url = `${routes.register.additionalDetails}?next=${encodeURIComponent(body.redirect_url)}`
+        const nextParam = body.redirect_url
+        body.redirect_url = routes.register.additionalDetails
+        if (nextParam) {
+          body.redirect_url += `?next=${encodeURIComponent(nextParam)}`
+        }
       }
 
       /* eslint-disable camelcase */

--- a/frontend/public/src/containers/pages/register/RegisterDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterDetailsPage.js
@@ -55,8 +55,7 @@ type DispatchProps = {|
     username: string,
     legalAddress: LegalAddress,
     userProfile: UserProfile,
-    partialToken: string,
-    next: ?string
+    partialToken: string
   ) => Promise<HttpResponse<AuthResponse>>,
   getCurrentUser: () => Promise<HttpResponse<User>>,
   addUserNotification: Function
@@ -101,7 +100,8 @@ export class RegisterDetailsPage extends React.Component<Props> {
       }
 
       if (body.state === STATE_SUCCESS) {
-        body.redirect_url = routes.register.additionalDetails
+        // COLLIN, can you append the ?next value to this?
+        body.redirect_url = `${routes.register.additionalDetails}?next=${encodeURIComponent(body.redirect_url)}`
       }
 
       /* eslint-disable camelcase */

--- a/frontend/public/src/lib/queries/auth.js
+++ b/frontend/public/src/lib/queries/auth.js
@@ -66,7 +66,7 @@ export default {
     username: string,
     legalAddress: LegalAddress,
     userProfile: ?UserProfile,
-    partialToken: string
+    partialToken: string,
   ) => ({
     ...DEFAULT_OPTIONS,
     url:  "/api/register/details/",
@@ -87,7 +87,8 @@ export default {
     username: string,
     legalAddress: LegalAddress,
     userProfile: ?UserProfile,
-    partialToken: string
+    partialToken: string,
+    next: ?string
   ) => ({
     ...DEFAULT_OPTIONS,
     url:  "/api/register/extra/",
@@ -98,7 +99,8 @@ export default {
       legal_address: legalAddress,
       user_profile:  userProfile,
       flow:          FLOW_REGISTER,
-      partial_token: partialToken
+      partial_token: partialToken,
+      next
     }
   }),
 

--- a/frontend/public/src/lib/queries/auth.js
+++ b/frontend/public/src/lib/queries/auth.js
@@ -66,7 +66,7 @@ export default {
     username: string,
     legalAddress: LegalAddress,
     userProfile: ?UserProfile,
-    partialToken: string,
+    partialToken: string
   ) => ({
     ...DEFAULT_OPTIONS,
     url:  "/api/register/details/",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3360

### Description
This PR adds functionality to redirect users, who begin the registration process after attempting to enroll into a course, back to the course page after completing the registration process and additional-details page.

### How can this be tested?

1. Load a course page while signed out of MITx Online.
2. Attempt to enroll into the course.  When you are redirected to the login page, click create an account.
3. Complete the registration process.  Verify that you are redirected back to the course page from step 1 after you submit the additional-details page.
4. Repeat steps 1-3 using a program and program page.
5. Ensure that you are redirected to the MITx Online homepage when you initiate the registration process from the main or catalog page.
