### PR TITLE
Upgrade enrollment dialog fixes

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -341,7 +341,8 @@ export class CourseProductDetailEnroll extends React.Component<
                   <p>
                     Certificate track:{" "}
                     <strong id="certificate-price-info">
-                      {product && run.is_upgradable &&
+                      {product &&
+                        run.is_upgradable &&
                         formatLocalePrice(getFlexiblePriceForProduct(product))}
                     </strong>
                     <>


### PR DESCRIPTION
### What are the relevant tickets?
none

### Description (What does it do?)
This PR corrects some behaviors when `is_upgrade` and `products` could be true or false independent of each other.

fixes couple of things:
1. When the dialog is closed and opened again the current run is reset to null
2. if a run has a product but the upgrade deadline has passed it should say "certificate not available", and disable upgrade buttons accordingly
3. removes unnecessary code
### How to test

to test this :
1. create a product for your run and set the upgrade deadline to the future.
2. create another run with a product and set upgrade deadline to the past
3. open the upgrade dialog as you select course the messaging should be consistent.

For example:
Here it says in the select element (no certificate available), but underneath shows the cost

<img width="744" alt="Screenshot 2024-03-25 at 3 19 34 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/6a6b2632-b1c9-4fe1-bdcd-7c26197f38eb">
