### PR TITLE
Deferrals: set to audit instead of unenrolling

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -555,6 +555,7 @@ def defer_enrollment(
     to_enrollments, enroll_success = create_run_enrollments(
         user,
         [to_run],
+        change_status=None,
         keep_failed_enrollments=keep_failed_enrollments,
         mode=EDX_ENROLLMENT_VERIFIED_MODE,
     )
@@ -569,7 +570,7 @@ def defer_enrollment(
             user=user,
             runs=[from_enrollment.run],
             change_status=ENROLL_CHANGE_STATUS_DEFERRED,
-            keep_failed_enrollments=True,
+            keep_failed_enrollments=keep_failed_enrollments,
             mode=EDX_ENROLLMENT_AUDIT_MODE,
         )
         if not enroll_success:

--- a/courses/api.py
+++ b/courses/api.py
@@ -254,6 +254,7 @@ def create_run_enrollments(
     Args:
         user (User): The user to enroll
         runs (iterable of CourseRun): The course runs to enroll in
+        change_status (str): The status of the enrollment
         keep_failed_enrollments: (boolean): If True, keeps the local enrollment record
             in the database even if the enrollment fails in edX.
         mode (str): The course mode

--- a/courses/api.py
+++ b/courses/api.py
@@ -34,7 +34,8 @@ from courses.models import (
     Program,
     ProgramCertificate,
     ProgramEnrollment,
-    ProgramRequirement, PaidCourseRun,
+    ProgramRequirement,
+    PaidCourseRun,
 )
 from courses.tasks import subscribe_edx_course_emails
 from courses.utils import (

--- a/courses/api.py
+++ b/courses/api.py
@@ -551,7 +551,8 @@ def defer_enrollment(
         to_enrollments = CourseRunEnrollment.objects.filter(
             user=user, run=to_run, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
         ).first()
-        return from_enrollment, to_enrollments
+        if to_enrollments:
+            return from_enrollment, to_enrollments
 
     to_enrollments, enroll_success = create_run_enrollments(
         user=user,
@@ -582,7 +583,7 @@ def defer_enrollment(
     if PaidCourseRun.fulfilled_paid_course_run_exists(user, from_enrollment.run):
         from_enrollment.change_payment_to_run(to_run)
 
-    return downgraded_enrollments, first_or_none(to_enrollments)
+    return first_or_none(downgraded_enrollments), first_or_none(to_enrollments)
 
 
 def ensure_course_run_grade(user, course_run, edx_grade, should_update=False):

--- a/courses/models.py
+++ b/courses/models.py
@@ -1201,7 +1201,7 @@ class CourseRunEnrollment(EnrollmentModel):
         ).first()
         if paid_run:
             paid_run.course_run = to_run
-            paid_run.save_and_log()
+            paid_run.save()
 
     def to_dict(self):
         return {**super().to_dict(), "text_id": self.run.courseware_id}

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -32,8 +32,10 @@ from courses.models import (
     ProgramRequirement,
     ProgramRequirementNodeType,
     limit_to_certificate_pages,
+    PaidCourseRun,
 )
 from ecommerce.factories import ProductFactory
+from ecommerce.models import Order
 from main.test_utils import format_as_iso8601
 from users.factories import UserFactory
 
@@ -349,6 +351,24 @@ def test_deactivate_and_save():
         enrollment.refresh_from_db()
         enrollment.active = False
         enrollment.change_status = ENROLL_CHANGE_STATUS_REFUNDED
+
+
+def test_change_payment_to_run():
+    """Test that the change_payment_to_run updates the obj to new run"""
+    course_run_enrollment = CourseRunEnrollmentFactory.create(
+        active=True, change_status=None
+    )
+    user = UserFactory.create()
+
+    paid_course_run = PaidCourseRun.objects.create(
+        user=user,
+        course_run=course_run_enrollment.run,
+        order__state=Order.STATE.FULFILLED,
+    ).first()
+    new_run = CourseRunFactory.create()
+    course_run_enrollment.change_payment_to_run(new_run)
+    paid_course_run.refresh_from_db()
+    assert paid_course_run.run == new_run
 
 
 @pytest.mark.parametrize(

--- a/sheets/deferrals_plugin.py
+++ b/sheets/deferrals_plugin.py
@@ -19,6 +19,7 @@ class DeferralPlugin:
             user,
             from_courseware_id,
             to_courseware_id,
+            keep_failed_enrollments=True,
             force=True,
         )
         if to_courseware_id and not to_enrollment:


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3781

### Description (What does it do?)
Update the deferral procedure to downgrade enrollment to audit instead of unenrolling.

Testing:
Have a user with existing enrollment and fullfilled order for that run.
Create another run that is open for enrollment
Then run the management command:
`./manage.py defer_enrollment --user <username> --from-run <readable_id> --to-run <readable_id> -k`
Then check in the admin that the `from_run` enrollment is now set to audit, and the `to_run` is set to verified.