### PR TITLE
Enrollment request make sure not enrolled

### DIFF
--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -274,7 +274,7 @@ def _validate_enrollment_post_request(
     if (
         PaidCourseRun.fulfilled_paid_course_run_exists(user, run)
         or CourseRunEnrollment.objects.filter(
-            user, run=run, change_status=None
+            user=user, run=run, change_status=None
         ).exists()
     ):
         resp = redirect_with_user_message(

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -271,7 +271,12 @@ def _validate_enrollment_post_request(
             max_age=USER_MSG_COOKIE_MAX_AGE,
         )
         return resp, None, None
-    if PaidCourseRun.fulfilled_paid_course_run_exists(user, run):
+    if (
+        PaidCourseRun.fulfilled_paid_course_run_exists(user, run)
+        or CourseRunEnrollment.objects.filter(
+            user, run=run, change_status=None
+        ).exists()
+    ):
         resp = redirect_with_user_message(
             reverse("user-dashboard"),
             {"type": USER_MSG_TYPE_ENROLL_DUPLICATED},


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3013

### Description (What does it do?)
If you are already enrolled in this course run, and you go to product page and try to enroll again, it will not call `create_run_enrollments`

### How can this be tested?
Enroll in a course run in certificate track. Make sure that PaidCourseRun is deleted.
Go to course product page try to enroll in the same run again. The enrollment post request should return duplicate error.
Repeat the same with the program product page. The program page enrolls you in the run it find convenient so make sure you are already enrolled for that run.
### Question
I am not sure if we should should restrict re-enrollment only if the user is enrolled in verified track, or any type.