### PR TITLE
Form error messages should appear consistently and be accessible 

### DIFF
--- a/frontend/public/package.json
+++ b/frontend/public/package.json
@@ -55,7 +55,7 @@
     "flow": "0.2.3",
     "flow-bin": "0.95.1",
     "flow-typed": "3.7.0",
-    "formik": "1.5.8",
+    "formik": "^2.4.5",
     "history": "4.10.1",
     "isomorphic-fetch": "2.2.1",
     "jquery": "3.6.0",

--- a/frontend/public/package.json
+++ b/frontend/public/package.json
@@ -55,6 +55,7 @@
     "flow": "0.2.3",
     "flow-bin": "0.95.1",
     "flow-typed": "3.7.0",
+    "focus-formik-error": "^1.1.0",
     "formik": "^2.4.5",
     "history": "4.10.1",
     "isomorphic-fetch": "2.2.1",

--- a/frontend/public/scss/cards.scss
+++ b/frontend/public/scss/cards.scss
@@ -132,7 +132,11 @@ div.std-card {
             margin-bottom: 10px;
         }
 
-        div.form-group {            
+        div.form-group {
+
+            .form-error {
+                color: $primary;
+            }
             label {
                 color: $footer-blue-bg;
                 font-family: Inter;

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -255,42 +255,45 @@ export class EnrolledItemCard extends React.Component<
               enrollmentId:    enrollment.id,
               courseNumber:    enrollment.run.course_number
             }}
-            render={({ values }) => (
-              <Form className="text-center">
-                <section>
-                  <Field
-                    type="hidden"
-                    name="enrollmentId"
-                    value={values.enrollmentId}
-                  />
-                  <Field
-                    type="hidden"
-                    name="courseNumber"
-                    value={values.courseNumber}
-                  />
-                  <Field
-                    type="checkbox"
-                    name="subscribeEmails"
-                    checked={values.subscribeEmails}
-                    aria-labelledby={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
-                  />{" "}
-                  <label
-                    id={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
+          >
+            {({ values }) => {
+              return (
+                <Form className="text-center">
+                  <section>
+                    <Field
+                      type="hidden"
+                      name="enrollmentId"
+                      value={values.enrollmentId}
+                    />
+                    <Field
+                      type="hidden"
+                      name="courseNumber"
+                      value={values.courseNumber}
+                    />
+                    <Field
+                      type="checkbox"
+                      name="subscribeEmails"
+                      checked={values.subscribeEmails}
+                      aria-labelledby={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
+                    />{" "}
+                    <label
+                      id={`verified-unenrollment-${values.enrollmentId}-email-checkbox`}
+                    >
+                      Receive course emails
+                    </label>
+                  </section>
+                  <Button type="submit" color="success">
+                    Save Settings
+                  </Button>{" "}
+                  <Button
+                    onClick={() => this.toggleEmailSettingsModalVisibility()}
                   >
-                    Receive course emails
-                  </label>
-                </section>
-                <Button type="submit" color="success">
-                  Save Settings
-                </Button>{" "}
-                <Button
-                  onClick={() => this.toggleEmailSettingsModalVisibility()}
-                >
-                  Cancel
-                </Button>
-              </Form>
-            )}
-          />
+                    Cancel
+                  </Button>
+                </Form>
+              )
+            }}
+          </Formik>
         </ModalBody>
       </Modal>
     )

--- a/frontend/public/src/components/forms/AddlProfileFieldsForm.js
+++ b/frontend/public/src/components/forms/AddlProfileFieldsForm.js
@@ -54,35 +54,31 @@ const AddlProfileFieldsForm = ({
       initialValues={getInitialValues(user)}
       validateOnChange={false}
       validateOnBlur={false}
-      render={({ isSubmitting, setFieldValue, setFieldTouched, values }) => (
-        <Form>
-          <ProfileFields
-            setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
-            values={values}
-            isNewAccount={false}
-          />
-          <AddlProfileFields
-            setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
-            values={values}
-            isNewAccount={false}
-            requireAddlFields={requireTypeFields}
-          />
-          <div className="row submit-row no-gutters">
-            <div className="col d-flex justify-content-end">
-              <button
-                type="submit"
-                className="btn btn-primary btn-gradient-red-to-blue"
-                disabled={isSubmitting}
-              >
-                Submit
-              </button>
+    >
+      {({ isSubmitting, values }) => {
+        return (
+          <Form>
+            <ProfileFields values={values} isNewAccount={false} />
+            <AddlProfileFields
+              values={values}
+              isNewAccount={false}
+              requireAddlFields={requireTypeFields}
+            />
+            <div className="row submit-row no-gutters">
+              <div className="col d-flex justify-content-end">
+                <button
+                  type="submit"
+                  className="btn btn-primary btn-gradient-red-to-blue"
+                  disabled={isSubmitting}
+                >
+                  Submit
+                </button>
+              </div>
             </div>
-          </div>
-        </Form>
-      )}
-    />
+          </Form>
+        )
+      }}
+    </Formik>
   )
 }
 

--- a/frontend/public/src/components/forms/ApplyCouponForm.js
+++ b/frontend/public/src/components/forms/ApplyCouponForm.js
@@ -2,6 +2,7 @@
 import React from "react"
 import { Formik, Form, ErrorMessage, Field } from "formik"
 import FormError from "./elements/FormError"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type Props = {
   onSubmit: Function,
@@ -18,50 +19,57 @@ const ApplyCouponForm = ({ onSubmit, couponCode, discounts }: Props) => (
   <Formik
     onSubmit={onSubmit}
     initialValues={getInitialValues(couponCode, discounts)}
-    render={() => (
-      <Form>
-        <div className="coupon-form">
-          <div className="d-flex align-content-end align-items-end justify-content-between flex-sm-column flex-md-row">
-            <div className="form-group">
-              <label htmlFor="couponCode" className="fw-bold">
-                Coupon code
-              </label>
-              <Field
-                type="text"
-                name="couponCode"
-                id="couponCode"
-                className="form-control"
-                autoComplete="given-name"
-                aria-describedby="couponCodeError"
-              />
-              <ErrorMessage
-                name="couponCode"
-                className="form-control"
-                id="couponCodeError"
-                component={FormError}
-              />
-            </div>
+  >
+    {({ errors }) => {
+      return (
+        <Form>
+          <ConnectedFocusError />
+          <div className="coupon-form">
+            <div className="d-flex align-content-end align-items-end justify-content-between flex-sm-column flex-md-row">
+              <div className="form-group">
+                <label htmlFor="couponCode" className="fw-bold">
+                  Coupon code
+                </label>
+                <Field
+                  type="text"
+                  name="couponCode"
+                  id="couponCode"
+                  className="form-control"
+                  autoComplete="given-name"
+                  aria-invalid={errors.couponCode ? "true" : null}
+                  aria-describedby={
+                    errors.couponCode ? "couponCodeError" : null
+                  }
+                />
+                <ErrorMessage
+                  name="couponCode"
+                  className="form-control"
+                  id="couponCodeError"
+                  component={FormError}
+                />
+              </div>
 
-            <button
-              className="btn btn-primary btn-gradient-red-to-blue btn-apply-coupon"
-              type="submit"
-              aria-label="Apply coupon"
-            >
-              Apply
-            </button>
-          </div>
-          {discounts !== null && discounts.length > 0 ? (
-            <div
-              id="codeApplicationWarning"
-              className="text-primary mt-2 font-weight-bold cart-text-smaller"
-            >
-              Adding another coupon will replace the currently applied coupon.
+              <button
+                className="btn btn-primary btn-gradient-red-to-blue btn-apply-coupon"
+                type="submit"
+                aria-label="Apply coupon"
+              >
+                Apply
+              </button>
             </div>
-          ) : null}
-        </div>
-      </Form>
-    )}
-  />
+            {discounts !== null && discounts.length > 0 ? (
+              <div
+                id="codeApplicationWarning"
+                className="text-primary mt-2 font-weight-bold cart-text-smaller"
+              >
+                Adding another coupon will replace the currently applied coupon.
+              </div>
+            ) : null}
+          </div>
+        </Form>
+      )
+    }}
+  </Formik>
 )
 
 export default ApplyCouponForm

--- a/frontend/public/src/components/forms/ChangeEmailForm.js
+++ b/frontend/public/src/components/forms/ChangeEmailForm.js
@@ -1,14 +1,19 @@
 // @flow
 import React from "react"
 
-import { Formik, Field, Form } from "formik"
+import { Formik, Field, Form, ErrorMessage } from "formik"
 
 import { PasswordInput, EmailInput } from "./elements/inputs"
 import CardLabel from "../input/CardLabel"
 
 import type { User } from "../../flow/authTypes"
 
-import { changeEmailValidationRegex } from "../../lib/validation"
+import {
+  changeEmailFormValidation,
+  changeEmailValidationRegex
+} from "../../lib/validation"
+import FormError from "./elements/FormError"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type Props = {
   onSubmit: Function,
@@ -24,62 +29,80 @@ const ChangeEmailForm = ({ onSubmit, user }: Props) => {
   return (
     <Formik
       onSubmit={onSubmit}
+      validationSchema={changeEmailFormValidation}
       initialValues={{
         email:           user.email,
         confirmPassword: ""
       }}
-      render={({ isSubmitting }) => (
-        <Form>
-          <section className="email-section">
-            <h2 aria-label="Change Email Form">Change Email</h2>
-            <div className="form-group">
-              <CardLabel htmlFor="email" isRequired={true} label="Email" />
-              <Field
-                name="email"
-                id="email"
-                className="form-control"
-                component={EmailInput}
-                autoComplete="email"
-                required
-                pattern={changeEmailValidationRegex(user.email)}
-                title="Email must be different than your current one."
-              />
-            </div>
-            <div className="form-group">
-              <CardLabel
-                htmlFor="confirmPassword"
-                isRequired={true}
-                label="Confirm Password"
-                subLabel="Password required to change email address"
-              />
-              <Field
-                id="confirmPassword"
-                name="confirmPassword"
-                className="form-control"
-                component={PasswordInput}
-                autoComplete="current-password"
-                aria-describedby="confirmPasswordError"
-                aria-label="Confirm Password"
-                required
-              />
-            </div>
-          </section>
+    >
+      {({ isSubmitting, errors }) => {
+        return (
+          <Form>
+            <ConnectedFocusError />
+            <section className="email-section">
+              <h2 aria-label="Change Email Form">Change Email</h2>
+              <div className="form-group">
+                <CardLabel htmlFor="email" isRequired={true} label="Email" />
+                <Field
+                  name="email"
+                  id="email"
+                  className="form-control"
+                  component={EmailInput}
+                  autoComplete="email"
+                  pattern={changeEmailValidationRegex(user.email)}
+                  title="Email must be different than your current one."
+                  aria-invalid={errors.email ? "true" : null}
+                  aria-describedby={errors.email ? "emailError" : null}
+                />
+                <ErrorMessage
+                  name="email"
+                  id="emailError"
+                  component={FormError}
+                />
+              </div>
+              <div className="form-group">
+                <CardLabel
+                  htmlFor="confirmPassword"
+                  isRequired={true}
+                  label="Confirm Password"
+                  subLabel="Password required to change email address"
+                />
+                <Field
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  className="form-control"
+                  component={PasswordInput}
+                  autoComplete="current-password"
+                  aria-invalid={errors.confirmPassword ? "true" : null}
+                  aria-describedby={
+                    errors.confirmPassword ? "confirmPasswordError" : null
+                  }
+                  aria-label="Confirm Password"
+                />
+                <ErrorMessage
+                  name="confirmPassword"
+                  id="confirmPasswordError"
+                  component={FormError}
+                />
+              </div>
+            </section>
 
-          <div className="row submit-row no-gutters">
-            <div className="col d-flex justify-content-end">
-              <button
-                type="submit"
-                aria-label="sumbit form change email"
-                className="btn btn-primary btn-gradient-red-to-blue"
-                disabled={isSubmitting}
-              >
-                Submit
-              </button>
+            <div className="row submit-row no-gutters">
+              <div className="col d-flex justify-content-end">
+                <button
+                  type="submit"
+                  aria-label="sumbit form change email"
+                  className="btn btn-primary btn-gradient-red-to-blue"
+                  disabled={isSubmitting}
+                >
+                  Submit
+                </button>
+              </div>
             </div>
-          </div>
-        </Form>
-      )}
-    />
+          </Form>
+        )
+      }}
+    </Formik>
   )
 }
 

--- a/frontend/public/src/components/forms/ChangePasswordForm.js
+++ b/frontend/public/src/components/forms/ChangePasswordForm.js
@@ -11,6 +11,7 @@ import {
   changePasswordFormValidation
 } from "../../lib/validation"
 import CardLabel from "../input/CardLabel"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type Props = {
   onSubmit: Function
@@ -33,90 +34,101 @@ const ChangePasswordForm = ({ onSubmit }: Props) => (
     }}
     validateOnChange={false}
     validateOnBlur={false}
-    render={({ isSubmitting }) => (
-      <Form>
-        <section className="email-section">
-          <h2 aria-label="Change Password Form">Change Password</h2>
-          <div className="form-group">
-            <CardLabel
-              htmlFor="oldPassword"
-              isRequired={true}
-              label="Old Password"
-            />
-            <Field
-              name="oldPassword"
-              id="oldPassword"
-              className="form-control"
-              component={PasswordInput}
-              autoComplete="current-password"
-              aria-label="Old Password"
-              required
-            />
+  >
+    {({ isSubmitting, errors }) => {
+      return (
+        <Form>
+          <ConnectedFocusError />
+          <section className="email-section">
+            <h2 aria-label="Change Password Form">Change Password</h2>
+            <div className="form-group">
+              <CardLabel
+                htmlFor="oldPassword"
+                isRequired={true}
+                label="Old Password"
+              />
+              <Field
+                name="oldPassword"
+                id="oldPassword"
+                className="form-control"
+                component={PasswordInput}
+                autoComplete="current-password"
+                aria-label="Old Password"
+                aria-invalid={errors.oldPassword ? "true" : null}
+                aria-describedby={
+                  errors.oldPassword ? "odlPasswordError" : null
+                }
+              />
+            </div>
+            <div className="form-group">
+              <CardLabel
+                htmlFor="newPassword"
+                isRequired={true}
+                label="New Password"
+              />
+              <Field
+                name="newPassword"
+                id="newPassword"
+                className="form-control"
+                component={PasswordInput}
+                autoComplete="new-password"
+                aria-label="New Password"
+                aria-invalid={errors.newPassword ? "true" : null}
+                aria-describedby={
+                  errors.newPassword ? "newPasswordError" : null
+                }
+                pattern={passwordFieldRegex}
+                title={passwordFieldErrorMessage}
+              />
+              <ErrorMessage
+                name="newPassword"
+                id="newPasswordError"
+                component={FormError}
+              />
+            </div>
+            <div className="form-group">
+              <CardLabel
+                htmlFor="confirmPassword"
+                isRequired={true}
+                label="Confirm Password"
+              />
+              <Field
+                name="confirmPassword"
+                id="confirmPassword"
+                className="form-control"
+                component={PasswordInput}
+                autoComplete="new-password"
+                aria-label="Confirm Password"
+                aria-invalid={errors.confirmPassword ? "true" : null}
+                aria-describedby={
+                  errors.confirmPassword ? "confirmPasswordError" : null
+                }
+                pattern={passwordFieldRegex}
+                title={passwordFieldErrorMessage}
+              />
+              <ErrorMessage
+                name="confirmPassword"
+                id="confirmPasswordError"
+                component={FormError}
+              />
+            </div>
+          </section>
+          <div className="row submit-row no-gutters">
+            <div className="col d-flex justify-content-end">
+              <button
+                type="submit"
+                aria-label="submit form change password"
+                className="btn btn-primary btn-gradient-red-to-blue"
+                disabled={isSubmitting}
+              >
+                Submit
+              </button>
+            </div>
           </div>
-          <div className="form-group">
-            <CardLabel
-              htmlFor="newPassword"
-              isRequired={true}
-              label="New Password"
-            />
-            <Field
-              name="newPassword"
-              id="newPassword"
-              className="form-control"
-              component={PasswordInput}
-              autoComplete="new-password"
-              aria-describedby="newPasswordError"
-              aria-label="New Password"
-              required
-              pattern={passwordFieldRegex}
-              title={passwordFieldErrorMessage}
-            />
-            <ErrorMessage
-              name="newPassword"
-              id="newPasswordError"
-              component={FormError}
-            />
-          </div>
-          <div className="form-group">
-            <CardLabel
-              htmlFor="confirmPassword"
-              isRequired={true}
-              label="Confirm Password"
-            />
-            <Field
-              name="confirmPassword"
-              id="confirmPassword"
-              className="form-control"
-              component={PasswordInput}
-              autoComplete="new-password"
-              aria-describedby="confirmPasswordError"
-              aria-label="Confirm Password"
-              required
-              pattern={passwordFieldRegex}
-              title={passwordFieldErrorMessage}
-            />
-            <ErrorMessage
-              name="confirmPassword"
-              id="confirmPasswordError"
-              component={FormError}
-            />
-          </div>
-        </section>
-        <div className="row submit-row no-gutters">
-          <div className="col d-flex justify-content-end">
-            <button
-              type="submit"
-              aria-label="submit form change password"
-              className="btn btn-primary btn-gradient-red-to-blue"
-              disabled={isSubmitting}
-            >
-              Submit
-            </button>
-          </div>
-        </div>
-      </Form>
-    )}
-  />
+        </Form>
+      )
+    }}
+  </Formik>
 )
 
 export default ChangePasswordForm

--- a/frontend/public/src/components/forms/ChangePasswordForm.js
+++ b/frontend/public/src/components/forms/ChangePasswordForm.js
@@ -59,6 +59,11 @@ const ChangePasswordForm = ({ onSubmit }: Props) => (
                   errors.oldPassword ? "odlPasswordError" : null
                 }
               />
+              <ErrorMessage
+                name="oldPassword"
+                id="oldPasswordError"
+                component={FormError}
+              />
             </div>
             <div className="form-group">
               <CardLabel

--- a/frontend/public/src/components/forms/EditProfileForm.js
+++ b/frontend/public/src/components/forms/EditProfileForm.js
@@ -37,27 +37,37 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => {
       initialValues={getInitialValues(user)}
       validateOnChange={false}
       validateOnBlur={false}
-      render={({ isSubmitting, setFieldValue, setFieldTouched, values }) => (
+    >
+      {({
+        values,
+        errors,
+        touched,
+        handleChange,
+        handleBlur,
+        handleSubmit,
+        isSubmitting,
+        /* and other goodies */
+      }) => (
         <Form>
           <LegalAddressFields
+            touched={touched}
+            errors={errors}
             countries={countries}
-            setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
             values={values}
             isNewAccount={false}
           />
           <ProfileFields
-            setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
+            touched={touched}
+            errors={errors}
             values={values}
             isNewAccount={false}
           />
-          <AddlProfileFields
-            setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
-            values={values}
-            isNewAccount={false}
-          />
+          {/*<AddlProfileFields*/}
+          {/*  setFieldValue={setFieldValue}*/}
+          {/*  setFieldTouched={setFieldTouched}*/}
+          {/*  values={values}*/}
+          {/*  isNewAccount={false}*/}
+          {/*/>*/}
           <div className="row submit-row no-gutters">
             <div className="col d-flex justify-content-end">
               <button
@@ -71,7 +81,7 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => {
           </div>
         </Form>
       )}
-    />
+    </Formik>
   )
 }
 

--- a/frontend/public/src/components/forms/EditProfileForm.js
+++ b/frontend/public/src/components/forms/EditProfileForm.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import { Formik, Form, Field, ErrorMessage } from "formik"
+import { Formik, Form } from "formik"
 import {
   legalAddressValidation,
   profileValidation,

--- a/frontend/public/src/components/forms/EditProfileForm.js
+++ b/frontend/public/src/components/forms/EditProfileForm.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import { Formik, Form } from "formik"
+import {Formik, Form, Field, ErrorMessage} from "formik"
 import {
   legalAddressValidation,
   profileValidation,
@@ -11,6 +11,7 @@ import {
 } from "./ProfileFormFields"
 
 import type { Country, User } from "../../flow/authTypes"
+import {ConnectedFocusError} from "focus-formik-error"
 
 type Props = {
   onSubmit: Function,
@@ -27,7 +28,6 @@ const getInitialValues = (user: User) => ({
 
 const EditProfileForm = ({ onSubmit, countries, user }: Props) => {
   const validation = legalAddressValidation.concat(profileValidation)
-
   validation.concat(addlProfileFieldsValidation)
 
   return (
@@ -42,45 +42,45 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => {
         values,
         errors,
         touched,
-        handleChange,
-        handleBlur,
-        handleSubmit,
         isSubmitting,
-        /* and other goodies */
-      }) => (
-        <Form>
-          <LegalAddressFields
-            touched={touched}
-            errors={errors}
-            countries={countries}
-            values={values}
-            isNewAccount={false}
-          />
-          <ProfileFields
-            touched={touched}
-            errors={errors}
-            values={values}
-            isNewAccount={false}
-          />
-          {/*<AddlProfileFields*/}
-          {/*  setFieldValue={setFieldValue}*/}
-          {/*  setFieldTouched={setFieldTouched}*/}
-          {/*  values={values}*/}
-          {/*  isNewAccount={false}*/}
-          {/*/>*/}
-          <div className="row submit-row no-gutters">
-            <div className="col d-flex justify-content-end">
-              <button
-                type="submit"
-                className="btn btn-primary btn-gradient-red-to-blue"
-                disabled={isSubmitting}
-              >
-                Submit
-              </button>
+      }) => {
+        return (
+          <Form>
+            <ConnectedFocusError />
+            <LegalAddressFields
+              touched={touched}
+              errors={errors}
+              countries={countries}
+              values={values}
+              isNewAccount={false}
+            />
+            <ProfileFields
+              touched={touched}
+              errors={errors}
+              values={values}
+              isNewAccount={false}
+            />
+            <AddlProfileFields
+              touched={touched}
+              errors={errors}
+              values={values}
+              isNewAccount={false}
+            />
+            <div className="row submit-row no-gutters">
+              <div className="col d-flex justify-content-end">
+                <button
+                  type="submit"
+                  className="btn btn-primary btn-gradient-red-to-blue"
+                  disabled={isSubmitting}
+                >
+                  Submit
+                </button>
+              </div>
             </div>
-          </div>
-        </Form>
-      )}
+          </Form>
+        )
+      }
+      }
     </Formik>
   )
 }

--- a/frontend/public/src/components/forms/EditProfileForm.js
+++ b/frontend/public/src/components/forms/EditProfileForm.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import {Formik, Form, Field, ErrorMessage} from "formik"
+import { Formik, Form, Field, ErrorMessage } from "formik"
 import {
   legalAddressValidation,
   profileValidation,
@@ -11,7 +11,7 @@ import {
 } from "./ProfileFormFields"
 
 import type { Country, User } from "../../flow/authTypes"
-import {ConnectedFocusError} from "focus-formik-error"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type Props = {
   onSubmit: Function,
@@ -38,12 +38,7 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => {
       validateOnChange={false}
       validateOnBlur={false}
     >
-      {({
-        values,
-        errors,
-        touched,
-        isSubmitting,
-      }) => {
+      {({ values, errors, touched, isSubmitting }) => {
         return (
           <Form>
             <ConnectedFocusError />
@@ -79,8 +74,7 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => {
             </div>
           </Form>
         )
-      }
-      }
+      }}
     </Formik>
   )
 }

--- a/frontend/public/src/components/forms/EmailForm.js
+++ b/frontend/public/src/components/forms/EmailForm.js
@@ -6,6 +6,7 @@ import { Formik, Field, Form, ErrorMessage } from "formik"
 import { EmailInput } from "./elements/inputs"
 import FormError from "./elements/FormError"
 import * as yup from "yup"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type EmailFormProps = {
   onSubmit: Function,
@@ -30,34 +31,38 @@ const EmailForm = ({ onSubmit, children }: EmailFormProps) => (
     validationSchema={EmailFormValidation}
     validateOnChange={false}
     validateOnBlur={false}
-    render={({ isSubmitting }) => (
-      <Form>
-        <div className="form-group small-gap">
-          <label htmlFor="email">Email</label>
-          <Field
-            name="email"
-            id="email"
-            className="form-control"
-            component={EmailInput}
-            autoComplete="email"
-            aria-errormessage="emailError"
-            required
-          />
-          <ErrorMessage name="email" id="emailError" component={FormError} />
-        </div>
-        {children}
-        <div className="form-group">
-          <button
-            type="submit"
-            className="btn btn-primary btn-gradient-red-to-blue large"
-            disabled={isSubmitting}
-          >
-            Continue
-          </button>
-        </div>
-      </Form>
-    )}
-  />
+  >
+    {({ isSubmitting, errors }) => {
+      return (
+        <Form>
+          <ConnectedFocusError />
+          <div className="form-group small-gap">
+            <label htmlFor="email">Email</label>
+            <Field
+              name="email"
+              id="email"
+              className="form-control"
+              component={EmailInput}
+              autoComplete="email"
+              aria-invalid={errors.email ? "true" : null}
+              aria-describedby={errors.email ? "passwordError" : null}
+            />
+            <ErrorMessage name="email" id="emailError" component={FormError} />
+          </div>
+          {children}
+          <div className="form-group">
+            <button
+              type="submit"
+              className="btn btn-primary btn-gradient-red-to-blue large"
+              disabled={isSubmitting}
+            >
+              Continue
+            </button>
+          </div>
+        </Form>
+      )
+    }}
+  </Formik>
 )
 
 export default EmailForm

--- a/frontend/public/src/components/forms/LoginPasswordForm.js
+++ b/frontend/public/src/components/forms/LoginPasswordForm.js
@@ -47,7 +47,7 @@ const LoginPasswordForm = ({ onSubmit }: LoginPasswordFormProps) => (
             />
           </div>
           <div className="form-group">
-            <Link to={routes.login.forgot.begin}>Forgot Password?Here</Link>
+            <Link to={routes.login.forgot.begin}>Forgot Password?</Link>
           </div>
           <div className="row submit-row no-gutters">
             <div className="col d-flex justify-content-end">

--- a/frontend/public/src/components/forms/LoginPasswordForm.js
+++ b/frontend/public/src/components/forms/LoginPasswordForm.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react"
+import * as yup from "yup"
 
 import { Formik, Field, Form, ErrorMessage } from "formik"
 import { Link } from "react-router-dom"
@@ -7,53 +8,62 @@ import { Link } from "react-router-dom"
 import { PasswordInput } from "./elements/inputs"
 import { routes } from "../../lib/urls"
 import FormError from "./elements/FormError"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type LoginPasswordFormProps = {
   onSubmit: Function
 }
+const passwordValidation = yup.object().shape({
+  password: yup.string().required("Password is required")
+})
 
 const LoginPasswordForm = ({ onSubmit }: LoginPasswordFormProps) => (
   <Formik
     onSubmit={onSubmit}
     initialValues={{ password: "" }}
+    validationSchema={passwordValidation}
     validateOnChange={false}
     validateOnBlur={false}
-    render={({ isSubmitting }) => (
-      <Form>
-        <div className="form-group">
-          <label htmlFor="password">Password</label>
-          <Field
-            name="password"
-            id="password"
-            className="form-control"
-            component={PasswordInput}
-            autoComplete="current-password"
-            aria-describedby="passwordError"
-            required
-          />
-          <ErrorMessage
-            name="password"
-            id="passwordError"
-            component={FormError}
-          />
-        </div>
-        <div className="form-group">
-          <Link to={routes.login.forgot.begin}>Forgot Password?</Link>
-        </div>
-        <div className="row submit-row no-gutters">
-          <div className="col d-flex justify-content-end">
-            <button
-              type="submit"
-              className="btn btn-primary btn-gradient-red-to-blue large"
-              disabled={isSubmitting}
-            >
-              Sign in
-            </button>
+  >
+    {({ isSubmitting, errors }) => {
+      return (
+        <Form>
+          <ConnectedFocusError />
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <Field
+              name="password"
+              id="password"
+              className="form-control"
+              component={PasswordInput}
+              autoComplete="current-password"
+              aria-invalid={errors.password ? "true" : null}
+              aria-describedby={errors.password ? "passwordError" : null}
+            />
+            <ErrorMessage
+              name="password"
+              id="passwordError"
+              component={FormError}
+            />
           </div>
-        </div>
-      </Form>
-    )}
-  />
+          <div className="form-group">
+            <Link to={routes.login.forgot.begin}>Forgot Password?Here</Link>
+          </div>
+          <div className="row submit-row no-gutters">
+            <div className="col d-flex justify-content-end">
+              <button
+                type="submit"
+                className="btn btn-primary btn-gradient-red-to-blue large"
+                disabled={isSubmitting}
+              >
+                Sign in
+              </button>
+            </div>
+          </div>
+        </Form>
+      )
+    }}
+  </Formik>
 )
 
 export default LoginPasswordForm

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -171,9 +171,8 @@ const findStates = (country: string, countries: Array<Country>) => {
     : null
 }
 
-const renderYearOfBirthField = props => {
-  const hasError =
-    props.errors.user_profile && props.errors.user_profile.year_of_birth
+const renderYearOfBirthField = errors => {
+  const hasError = errors.user_profile && errors.user_profile.year_of_birth
   return (
     <div>
       <CardLabel
@@ -208,7 +207,7 @@ export const LegalAddressFields = ({
   isNewAccount,
   values
 }: LegalAddressProps) => {
-  const addressErrors = errors.legal_address
+  const addressErrors = errors && errors.legal_address
   return (
     <React.Fragment>
       <div className="form-group">
@@ -389,7 +388,7 @@ export const LegalAddressFields = ({
         </div>
       ) : null}
       {isNewAccount ? (
-        <div className="form-group">{renderYearOfBirthField()}</div>
+        <div className="form-group">{renderYearOfBirthField(errors)}</div>
       ) : null}
     </React.Fragment>
   )
@@ -424,7 +423,9 @@ export const ProfileFields = props => {
           </div>
         </div>
         <div className="col">
-          <div className="form-group">{renderYearOfBirthField(props)}</div>
+          <div className="form-group">
+            {renderYearOfBirthField(props.errors)}
+          </div>
         </div>
       </div>
     </React.Fragment>

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -74,7 +74,6 @@ export const profileValidation = yup.object().shape({
       .min(13 - new Date().getFullYear())
       .label("Year of Birth")
       .required()
-      .typeError("Year of Birth is a required field")
   })
 })
 
@@ -189,204 +188,212 @@ const renderYearOfBirthField = () => {
 }
 
 export const LegalAddressFields = ({
+  touched,
+  errors,
   countries,
   isNewAccount,
   values
-}: LegalAddressProps) => (
-  <React.Fragment>
-    <div className="form-group">
-      <CardLabel
-        htmlFor="legal_address.first_name"
-        isRequired={true}
-        label="First Name"
-        subLabel="Name that will appear on emails"
-      />
-      <Field
-        type="text"
-        name="legal_address.first_name"
-        id="legal_address.first_name"
-        className="form-control"
-        autoComplete="given-name"
-        aria-describedby="first-name-subtitle"
-        aria-label="First Name"
-        required
-        pattern={NAME_REGEX}
-        title={NAME_REGEX_FAIL_MESSAGE}
-      />
-    </div>
-    <div className="form-group">
-      <CardLabel
-        htmlFor="legal_address.last_name"
-        isRequired={true}
-        label="Last Name"
-      />
-      <Field
-        type="text"
-        name="legal_address.last_name"
-        id="legal_address.last_name"
-        className="form-control"
-        autoComplete="family-name"
-        required
-        pattern={NAME_REGEX}
-        title={NAME_REGEX_FAIL_MESSAGE}
-      />
-    </div>
-    <div className="form-group">
-      <CardLabel
-        htmlFor="name"
-        isRequired={true}
-        label="Full Name"
-        subLabel="Name that will appear on your certificate"
-      />
-      <Field
-        type="text"
-        name="name"
-        id="name"
-        className="form-control"
-        autoComplete="name"
-        aria-describedby="full-name-subtitle"
-        aria-label="Full Name"
-        required
-        pattern={fullNameRegex}
-        title={fullNameErrorMessage}
-      />
-    </div>
-    {isNewAccount ? (
-      <React.Fragment>
-        <div className="form-group">
-          <CardLabel
-            htmlFor="username"
-            isRequired={true}
-            label="Public Username"
-            subLabel="Name that will identify you in courses"
-          />
-          <Field
-            type="text"
-            name="username"
-            className="form-control"
-            autoComplete="username"
-            id="username"
-            aria-describedby="username-subtitle"
-            aria-label="Public Username"
-            required
-            pattern={usernameFieldRegex}
-            title={usernameFieldErrorMessage}
-          />
-          <ErrorMessage name="username" component={FormError} />
-        </div>
-        <div className="form-group">
-          <CardLabel htmlFor="password" isRequired={true} label="Password" />
-          <Field
-            type="password"
-            name="password"
-            id="password"
-            aria-describedby="password-subtitle"
-            className="form-control"
-            autoComplete="new-password"
-            required
-            pattern={passwordFieldRegex}
-            title={passwordFieldErrorMessage}
-          />
-          <div id="password-subtitle" className="label-secondary">
-            Passwords must contain at least 8 characters and at least 1 number
-            and 1 letter.
-          </div>
-        </div>
-      </React.Fragment>
-    ) : null}
-    <div className="form-group">
-      <CardLabel
-        htmlFor="legal_address.country"
-        isRequired={true}
-        label="Country"
-      />
-      <Field
-        component="select"
-        name="legal_address.country"
-        id="legal_address.country"
-        className="form-control"
-        autoComplete="country"
-        required
-        pattern={countryRegex}
-      >
-        <option value="">-----</option>
-        {countries
-          ? countries.map((country, i) => (
-            <option key={i} value={country.code}>
-              {country.name}
-            </option>
-          ))
-          : null}
-      </Field>
-    </div>
-    {findStates(values.legal_address.country, countries) ? (
+}: LegalAddressProps) => {
+  return (
+    <React.Fragment>
       <div className="form-group">
         <CardLabel
-          htmlFor="legal_address.state"
+          htmlFor="legal_address.first_name"
           isRequired={true}
-          label="State"
+          label="First Name"
+          subLabel="Name that will appear on emails"
+        />
+        <Field
+          type="text"
+          name="legal_address.first_name"
+          id="legal_address.first_name"
+          className="form-control"
+          autoComplete="given-name"
+          aria-describedby="first-name-subtitle"
+          aria-label="First Name"
+          required
+          pattern={NAME_REGEX}
+          title={NAME_REGEX_FAIL_MESSAGE}
+        />
+      </div>
+      <div className="form-group">
+        <CardLabel
+          htmlFor="legal_address.last_name"
+          isRequired={true}
+          label="Last Name"
+        />
+        <Field
+          type="text"
+          name="legal_address.last_name"
+          id="legal_address.last_name"
+          className="form-control"
+          autoComplete="family-name"
+          required
+          pattern={NAME_REGEX}
+          title={NAME_REGEX_FAIL_MESSAGE}
+        />
+      </div>
+      <div className="form-group">
+        <CardLabel
+          htmlFor="name"
+          isRequired={true}
+          label="Full Name"
+          subLabel="Name that will appear on your certificate"
+        />
+        <Field
+          type="text"
+          name="name"
+          id="name"
+          className="form-control"
+          autoComplete="name"
+          aria-describedby="full-name-subtitle"
+          aria-label="Full Name"
+          required
+          pattern={fullNameRegex}
+          title={fullNameErrorMessage}
+        />
+      </div>
+      {isNewAccount ? (
+        <React.Fragment>
+          <div className="form-group">
+            <CardLabel
+              htmlFor="username"
+              isRequired={true}
+              label="Public Username"
+              subLabel="Name that will identify you in courses"
+            />
+            <Field
+              type="text"
+              name="username"
+              className="form-control"
+              autoComplete="username"
+              id="username"
+              aria-describedby="username-subtitle"
+              aria-label="Public Username"
+              required
+              pattern={usernameFieldRegex}
+              title={usernameFieldErrorMessage}
+            />
+            <ErrorMessage name="username" component={FormError} />
+          </div>
+          <div className="form-group">
+            <CardLabel htmlFor="password" isRequired={true} label="Password" />
+            <Field
+              type="password"
+              name="password"
+              id="password"
+              aria-describedby="password-subtitle"
+              className="form-control"
+              autoComplete="new-password"
+              required
+              pattern={passwordFieldRegex}
+              title={passwordFieldErrorMessage}
+            />
+            <div id="password-subtitle" className="label-secondary">
+              Passwords must contain at least 8 characters and at least 1 number
+              and 1 letter.
+            </div>
+          </div>
+        </React.Fragment>
+      ) : null}
+      <div className="form-group">
+        <CardLabel
+          htmlFor="legal_address.country"
+          isRequired={true}
+          label="Country"
         />
         <Field
           component="select"
-          name="legal_address.state"
-          id="legal_address.state"
+          name="legal_address.country"
+          id="legal_address.country"
           className="form-control"
-          autoComplete="state"
+          autoComplete="country"
           required
+          pattern={countryRegex}
         >
           <option value="">-----</option>
-          {findStates(values.legal_address.country, countries)
-            ? findStates(values.legal_address.country, countries).map(
-              (state, i) => (
-                <option key={i} value={state.code}>
-                  {state.name}
-                </option>
-              )
-            )
+          {countries
+            ? countries.map((country, i) => (
+              <option key={i} value={country.code}>
+                {country.name}
+              </option>
+            ))
             : null}
         </Field>
       </div>
-    ) : null}
-    {isNewAccount ? (
-      <div className="form-group">{renderYearOfBirthField()}</div>
-    ) : null}
-  </React.Fragment>
-)
-
-export const ProfileFields = () => (
-  <React.Fragment>
-    <div className="row small-gap">
-      <div className="col">
+      {findStates(values.legal_address.country, countries) ? (
         <div className="form-group">
-          <CardLabel htmlFor="user_profile.gender" label="Gender" />
-
+          <CardLabel
+            htmlFor="legal_address.state"
+            isRequired={true}
+            label="State"
+          />
           <Field
             component="select"
-            name="user_profile.gender"
-            id="user_profile.gender"
+            name="legal_address.state"
+            id="legal_address.state"
             className="form-control"
-            aria-describedby="user_profile.genderError"
+            autoComplete="state"
+            required
           >
             <option value="">-----</option>
-            <option value="f">Female</option>
-            <option value="m">Male</option>
-            <option value="t">Transgender</option>
-            <option value="nb">Non-binary/non-conforming</option>
-            <option value="o">Other / Prefer not to say</option>
+            {findStates(values.legal_address.country, countries)
+              ? findStates(values.legal_address.country, countries).map(
+                (state, i) => (
+                  <option key={i} value={state.code}>
+                    {state.name}
+                  </option>
+                )
+              )
+              : null}
           </Field>
-          <ErrorMessage
-            name="user_profile.gender"
-            id="user_profile.genderError"
-            component={FormError}
-          />
+        </div>
+      ) : null}
+      {isNewAccount ? (
+        <div className="form-group">{renderYearOfBirthField()}</div>
+      ) : null}
+    </React.Fragment>
+  )
+}
+
+export const ProfileFields = props => {
+  const hasError = props.errors && props.errors.user_profile && props.errors.user_profile.genderError
+  return (
+    <React.Fragment>
+      <div className="row small-gap">
+        <div className="col">
+          <div className="form-group">
+            <CardLabel htmlFor="user_profile.gender" label="Gender" />
+
+            <Field
+              component="select"
+              name="user_profile.gender"
+              id="user_profile.gender"
+              className="form-control"
+              aria-invalid={hasError ? 'true' : null}
+              aria-describedby={hasError ? 'gender-error' : null}
+            >
+              <option value="">-----</option>
+              <option value="f">Female</option>
+              <option value="m">Male</option>
+              <option value="t">Transgender</option>
+              <option value="nb">Non-binary/non-conforming</option>
+              <option value="o">Other / Prefer not to say</option>
+            </Field>
+            <ErrorMessage
+              name="user_profile.gender"
+              id="user_profile.genderError"
+              component={FormError}
+            />
+          </div>
+        </div>
+        <div className="col">
+          <div className="form-group">{renderYearOfBirthField()}</div>
         </div>
       </div>
-      <div className="col">
-        <div className="form-group">{renderYearOfBirthField()}</div>
-      </div>
-    </div>
-  </React.Fragment>
-)
+    </React.Fragment>
+  )
+}
 
 export const AddlProfileFields = ({
   values,

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -485,7 +485,6 @@ export const AddlProfileFields = ({
             className="form-check-input"
             aria-labelledby="occupation-label student-label"
             defaultChecked={values.user_profile.type_is_student}
-            required={false}
           />
           <label
             className="form-check-label"

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -451,7 +451,6 @@ export const AddlProfileFields = ({
             name="user_profile.highest_education"
             id="user_profile.highest_education"
             className="form-control"
-            required={requireAddlFields}
           >
             <option value="">-----</option>
             {HIGHEST_EDUCATION_CHOICES.map((level, i) => (

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -39,12 +39,24 @@ const fullNameErrorMessage = "Full name must be between 2 and 254 characters."
 const countryRegex = "^\\S{2,}$"
 
 export const legalAddressValidation = yup.object().shape({
-  name:          yup.string().label("Full Name"),
+  name: yup
+    .string()
+    .required()
+    .label("Full Name"),
   legal_address: yup.object().shape({
-    first_name: yup.string().required("First Name is required").label("First Name"),
-    last_name:  yup.string().label("Last Name"),
-    country:    yup.string().label("Country"),
-    state:      yup
+    first_name: yup
+      .string()
+      .required()
+      .label("First Name"),
+    last_name: yup
+      .string()
+      .required()
+      .label("Last Name"),
+    country: yup
+      .string()
+      .required()
+      .label("Country"),
+    state: yup
       .string()
       .label("State")
       .when("country", {
@@ -159,7 +171,9 @@ const findStates = (country: string, countries: Array<Country>) => {
     : null
 }
 
-const renderYearOfBirthField = () => {
+const renderYearOfBirthField = props => {
+  const hasError =
+    props.errors.user_profile && props.errors.user_profile.year_of_birth
   return (
     <div>
       <CardLabel
@@ -173,8 +187,8 @@ const renderYearOfBirthField = () => {
         id="user_profile.year_of_birth"
         className="form-control"
         autoComplete="bday-year"
-        aria-describedby="user_profile.year_of_birth_error"
-        required
+        aria-invalid={hasError ? "true" : null}
+        aria-describedby={hasError ? "year-of-birth-error" : null}
       >
         <option value="">-----</option>
         {reverse(range(seedYear - 120, seedYear - 13)).map((year, i) => (
@@ -183,17 +197,18 @@ const renderYearOfBirthField = () => {
           </option>
         ))}
       </Field>
+      <ErrorMessage name="user_profile.year_of_birth" component={FormError} />
     </div>
   )
 }
 
 export const LegalAddressFields = ({
-  touched,
   errors,
   countries,
   isNewAccount,
   values
 }: LegalAddressProps) => {
+  const addressErrors = errors.legal_address
   return (
     <React.Fragment>
       <div className="form-group">
@@ -209,12 +224,20 @@ export const LegalAddressFields = ({
           id="legal_address.first_name"
           className="form-control"
           autoComplete="given-name"
-          aria-describedby="first-name-subtitle"
+          aria-invalid={
+            addressErrors && addressErrors.first_name ? "true" : null
+          }
+          aria-describedby={
+            addressErrors && addressErrors.first_name
+              ? "first-name-error"
+              : null
+          }
+          aria-required="true"
           aria-label="First Name"
           pattern={NAME_REGEX}
           title={NAME_REGEX_FAIL_MESSAGE}
         />
-        <ErrorMessage name="legal_address.first_name"/>
+        <ErrorMessage name="legal_address.first_name" component={FormError} />
       </div>
       <div className="form-group">
         <CardLabel
@@ -228,9 +251,16 @@ export const LegalAddressFields = ({
           id="legal_address.last_name"
           className="form-control"
           autoComplete="family-name"
+          aria-invalid={
+            addressErrors && addressErrors.last_name ? "true" : null
+          }
+          aria-describedby={
+            addressErrors && addressErrors.last_name ? "last-name-error" : null
+          }
           pattern={NAME_REGEX}
           title={NAME_REGEX_FAIL_MESSAGE}
         />
+        <ErrorMessage name="legal_address.last_name" component={FormError} />
       </div>
       <div className="form-group">
         <CardLabel
@@ -245,11 +275,13 @@ export const LegalAddressFields = ({
           id="name"
           className="form-control"
           autoComplete="name"
-          aria-describedby="full-name-subtitle"
+          aria-invalid={errors.name ? "true" : null}
+          aria-describedby={errors.name ? "full-name-error" : null}
           aria-label="Full Name"
           pattern={fullNameRegex}
           title={fullNameErrorMessage}
         />
+        <ErrorMessage name="name" component={FormError} />
       </div>
       {isNewAccount ? (
         <React.Fragment>
@@ -266,7 +298,8 @@ export const LegalAddressFields = ({
               className="form-control"
               autoComplete="username"
               id="username"
-              aria-describedby="username-subtitle"
+              aria-invalid={errors.username ? "true" : null}
+              aria-describedby={errors.username ? "username-error" : null}
               aria-label="Public Username"
               pattern={usernameFieldRegex}
               title={usernameFieldErrorMessage}
@@ -279,12 +312,14 @@ export const LegalAddressFields = ({
               type="password"
               name="password"
               id="password"
-              aria-describedby="password-subtitle"
+              aria-invalid={errors.password ? "true" : null}
+              aria-describedby={errors.password ? "password-error" : null}
               className="form-control"
               autoComplete="new-password"
               pattern={passwordFieldRegex}
               title={passwordFieldErrorMessage}
             />
+            <ErrorMessage name="passwrod" component={FormError} />
             <div id="password-subtitle" className="label-secondary">
               Passwords must contain at least 8 characters and at least 1 number
               and 1 letter.
@@ -302,9 +337,12 @@ export const LegalAddressFields = ({
           component="select"
           name="legal_address.country"
           id="legal_address.country"
+          aria-invalid={addressErrors && addressErrors.country ? "true" : null}
+          aria-describedby={
+            addressErrors && addressErrors.country ? "country-error" : null
+          }
           className="form-control"
           autoComplete="country"
-          required
           pattern={countryRegex}
         >
           <option value="">-----</option>
@@ -316,6 +354,7 @@ export const LegalAddressFields = ({
             ))
             : null}
         </Field>
+        <ErrorMessage name="legal_address.country" component={FormError} />
       </div>
       {findStates(values.legal_address.country, countries) ? (
         <div className="form-group">
@@ -328,9 +367,12 @@ export const LegalAddressFields = ({
             component="select"
             name="legal_address.state"
             id="legal_address.state"
+            aria-invalid={addressErrors && addressErrors.state ? "true" : null}
+            aria-describedby={
+              addressErrors && addressErrors.state ? "state-error" : null
+            }
             className="form-control"
             autoComplete="state"
-            required
           >
             <option value="">-----</option>
             {findStates(values.legal_address.country, countries)
@@ -343,6 +385,7 @@ export const LegalAddressFields = ({
               )
               : null}
           </Field>
+          <ErrorMessage name="legal_address.state" component={FormError} />
         </div>
       ) : null}
       {isNewAccount ? (
@@ -353,7 +396,6 @@ export const LegalAddressFields = ({
 }
 
 export const ProfileFields = props => {
-  const hasError = props.errors && props.errors.user_profile && props.errors.user_profile.genderError
   return (
     <React.Fragment>
       <div className="row small-gap">
@@ -366,8 +408,6 @@ export const ProfileFields = props => {
               name="user_profile.gender"
               id="user_profile.gender"
               className="form-control"
-              aria-invalid={hasError ? 'true' : null}
-              aria-describedby={hasError ? 'gender-error' : null}
             >
               <option value="">-----</option>
               <option value="f">Female</option>
@@ -384,7 +424,7 @@ export const ProfileFields = props => {
           </div>
         </div>
         <div className="col">
-          <div className="form-group">{renderYearOfBirthField()}</div>
+          <div className="form-group">{renderYearOfBirthField(props)}</div>
         </div>
       </div>
     </React.Fragment>

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -41,7 +41,7 @@ const countryRegex = "^\\S{2,}$"
 export const legalAddressValidation = yup.object().shape({
   name:          yup.string().label("Full Name"),
   legal_address: yup.object().shape({
-    first_name: yup.string().label("First Name"),
+    first_name: yup.string().required("First Name is required").label("First Name"),
     last_name:  yup.string().label("Last Name"),
     country:    yup.string().label("Country"),
     state:      yup
@@ -211,10 +211,10 @@ export const LegalAddressFields = ({
           autoComplete="given-name"
           aria-describedby="first-name-subtitle"
           aria-label="First Name"
-          required
           pattern={NAME_REGEX}
           title={NAME_REGEX_FAIL_MESSAGE}
         />
+        <ErrorMessage name="legal_address.first_name"/>
       </div>
       <div className="form-group">
         <CardLabel
@@ -228,7 +228,6 @@ export const LegalAddressFields = ({
           id="legal_address.last_name"
           className="form-control"
           autoComplete="family-name"
-          required
           pattern={NAME_REGEX}
           title={NAME_REGEX_FAIL_MESSAGE}
         />
@@ -248,7 +247,6 @@ export const LegalAddressFields = ({
           autoComplete="name"
           aria-describedby="full-name-subtitle"
           aria-label="Full Name"
-          required
           pattern={fullNameRegex}
           title={fullNameErrorMessage}
         />
@@ -270,7 +268,6 @@ export const LegalAddressFields = ({
               id="username"
               aria-describedby="username-subtitle"
               aria-label="Public Username"
-              required
               pattern={usernameFieldRegex}
               title={usernameFieldErrorMessage}
             />
@@ -285,7 +282,6 @@ export const LegalAddressFields = ({
               aria-describedby="password-subtitle"
               className="form-control"
               autoComplete="new-password"
-              required
               pattern={passwordFieldRegex}
               title={passwordFieldErrorMessage}
             />

--- a/frontend/public/src/components/forms/RegisterDetailsForm.js
+++ b/frontend/public/src/components/forms/RegisterDetailsForm.js
@@ -10,6 +10,7 @@ import {
 } from "./ProfileFormFields"
 
 import type { Country } from "../../flow/authTypes"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type Props = {
   onSubmit: Function,
@@ -40,27 +41,30 @@ const RegisterDetailsForm = ({ onSubmit, countries }: Props) => (
     initialValues={INITIAL_VALUES}
     validateOnChange={false}
     validateOnBlur={false}
-    render={({ isSubmitting, setFieldValue, setFieldTouched, values }) => (
-      <Form>
-        <LegalAddressFields
-          countries={countries}
-          setFieldValue={setFieldValue}
-          setFieldTouched={setFieldTouched}
-          values={values}
-          isNewAccount={true}
-        />
-        <div className="submit-row">
-          <button
-            type="submit"
-            className="btn btn-primary btn-gradient-red-to-blue large"
-            disabled={isSubmitting}
-          >
-            Continue
-          </button>
-        </div>
-      </Form>
-    )}
-  />
+  >
+    {({ values, errors, isSubmitting }) => {
+      return (
+        <Form>
+          <ConnectedFocusError />
+          <LegalAddressFields
+            errors={errors}
+            countries={countries}
+            values={values}
+            isNewAccount={true}
+          />
+          <div className="submit-row">
+            <button
+              type="submit"
+              className="btn btn-primary btn-gradient-red-to-blue large"
+              disabled={isSubmitting}
+            >
+              Continue
+            </button>
+          </div>
+        </Form>
+      )
+    }}
+  </Formik>
 )
 
 export default RegisterDetailsForm

--- a/frontend/public/src/components/forms/RegisterEmailForm.js
+++ b/frontend/public/src/components/forms/RegisterEmailForm.js
@@ -9,11 +9,16 @@ import ScaledRecaptcha from "../ScaledRecaptcha"
 import { EmailInput } from "./elements/inputs"
 import FormError from "./elements/FormError"
 import { routes } from "../../lib/urls"
+import { ConnectedFocusError } from "focus-formik-error"
 
 const emailValidation = yup.object().shape({
   recaptcha: SETTINGS.recaptchaKey
     ? yup.string().required("Please verify you're not a robot")
-    : yup.mixed().notRequired()
+    : yup.mixed().notRequired(),
+  email: yup
+    .string()
+    .email("Please enter an email address")
+    .required("Email is required")
 })
 
 type Props = {
@@ -29,72 +34,78 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
   <Formik
     onSubmit={onSubmit}
     validationSchema={emailValidation}
+    validateOnChange={false}
+    validateOnBlur={false}
     initialValues={{
       email:     "",
       recaptcha: SETTINGS.recaptchaKey ? "" : undefined
     }}
-    render={({ isSubmitting, setFieldValue }) => (
-      <Form>
-        <div className="form-group">
-          <label htmlFor="email">Email</label>
-          <Field
-            name="email"
-            id="email"
-            className="form-control"
-            autoComplete="email"
-            component={EmailInput}
-            aria-describedby="emailError"
-            required
-          />
-
-          <p>
-            By creating an account I agree to the
-            <br />
-            <a
-              href={routes.informationLinks.honorCode}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Honor Code
-            </a>
-            {", "}
-            <a
-              href={routes.informationLinks.termsOfService}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Terms of Service
-            </a>
-            {" and "}
-            <a
-              href={routes.informationLinks.privacyPolicy}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Privacy Policy
-            </a>
-            {"."}
-          </p>
-        </div>
-        {SETTINGS.recaptchaKey ? (
+  >
+    {({ errors, isSubmitting }) => {
+      return (
+        <Form>
+          <ConnectedFocusError />
           <div className="form-group">
-            <ScaledRecaptcha
-              onRecaptcha={value => setFieldValue("recaptcha", value)}
-              recaptchaKey={SETTINGS.recaptchaKey}
+            <label htmlFor="email">Email</label>
+            <Field
+              name="email"
+              id="email"
+              className="form-control"
+              autoComplete="email"
+              component={EmailInput}
+              aria-invalid={errors.email ? "true" : null}
+              aria-describedby={errors.email ? "emailError" : null}
             />
-            <ErrorMessage name="recaptcha" component={FormError} />
+            <ErrorMessage name="email" component={FormError} />
+            <p>
+              By creating an account I agree to the
+              <br />
+              <a
+                href={routes.informationLinks.honorCode}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Honor Code
+              </a>
+              {", "}
+              <a
+                href={routes.informationLinks.termsOfService}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Terms of Service
+              </a>
+              {" and "}
+              <a
+                href={routes.informationLinks.privacyPolicy}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Privacy Policy
+              </a>
+              {"."}
+            </p>
           </div>
-        ) : null}
-        <button
-          type="submit"
-          className="btn btn-primary btn-gradient-red-to-blue large"
-          disabled={isSubmitting}
-        >
-          Continue
-        </button>
-      </Form>
-    )}
-  />
+          {SETTINGS.recaptchaKey ? (
+            <div className="form-group">
+              <ScaledRecaptcha
+                onRecaptcha={value => setFieldValue("recaptcha", value)}
+                recaptchaKey={SETTINGS.recaptchaKey}
+              />
+              <ErrorMessage name="recaptcha" component={FormError} />
+            </div>
+          ) : null}
+          <button
+            type="submit"
+            className="btn btn-primary btn-gradient-red-to-blue large"
+            disabled={isSubmitting}
+          >
+            Continue
+          </button>
+        </Form>
+      )
+    }}
+  </Formik>
 )
 
 export default RegisterEmailForm

--- a/frontend/public/src/components/forms/RegisterEmailForm.js
+++ b/frontend/public/src/components/forms/RegisterEmailForm.js
@@ -41,7 +41,7 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
       recaptcha: SETTINGS.recaptchaKey ? "" : undefined
     }}
   >
-    {({ errors, isSubmitting }) => {
+    {({ errors, setFieldValue, isSubmitting }) => {
       return (
         <Form>
           <ConnectedFocusError />

--- a/frontend/public/src/components/forms/ResetPasswordForm.js
+++ b/frontend/public/src/components/forms/ResetPasswordForm.js
@@ -11,6 +11,7 @@ import {
   passwordFieldErrorMessage
 } from "../../lib/validation"
 import CardLabel from "../input/CardLabel"
+import { ConnectedFocusError } from "focus-formik-error"
 
 type Props = {
   onSubmit: Function
@@ -29,64 +30,72 @@ const ResetPasswordForm = ({ onSubmit }: Props) => (
       newPassword:   "",
       reNewPassword: ""
     }}
-    render={({ isSubmitting }) => (
-      <Form>
-        <div className="form-group">
-          <CardLabel
-            htmlFor="newPassword"
-            isRequired={true}
-            label="New Password"
-          />
-          <Field
-            name="newPassword"
-            id="newPassword"
-            className="form-control"
-            component={PasswordInput}
-            aria-describedby="newPasswordError"
-            pattern={passwordFieldRegex}
-            title={passwordFieldErrorMessage}
-          />
-          <ErrorMessage
-            name="newPassword"
-            id="newPasswordError"
-            component={FormError}
-          />
-        </div>
-        <div className="form-group">
-          <CardLabel
-            htmlFor="confirmPassword"
-            isRequired={true}
-            label="Confirm Password"
-          />
-          <Field
-            name="confirmPassword"
-            id="confirmPassword"
-            className="form-control"
-            component={PasswordInput}
-            aria-describedby="confirmPasswordError"
-            pattern={passwordFieldRegex}
-            title={passwordFieldErrorMessage}
-          />
-          <ErrorMessage
-            name="confirmPassword"
-            id="confirmPasswordError"
-            component={FormError}
-          />
-        </div>
-        <div className="row submit-row no-gutters">
-          <div className="col d-flex justify-content-end">
-            <button
-              type="submit"
-              className="btn btn-primary btn-gradient-red-to-blue large"
-              disabled={isSubmitting}
-            >
-              Submit
-            </button>
+  >
+    {({ isSubmitting, errors }) => {
+      return (
+        <Form>
+          <ConnectedFocusError />
+          <div className="form-group">
+            <CardLabel
+              htmlFor="newPassword"
+              isRequired={true}
+              label="New Password"
+            />
+            <Field
+              name="newPassword"
+              id="newPassword"
+              className="form-control"
+              component={PasswordInput}
+              aria-invalid={errors.newPassword ? "true" : null}
+              aria-describedby={errors.newPassword ? "newPasswordError" : null}
+              pattern={passwordFieldRegex}
+              title={passwordFieldErrorMessage}
+            />
+            <ErrorMessage
+              name="newPassword"
+              id="newPasswordError"
+              component={FormError}
+            />
           </div>
-        </div>
-      </Form>
-    )}
-  />
+          <div className="form-group">
+            <CardLabel
+              htmlFor="confirmPassword"
+              isRequired={true}
+              label="Confirm Password"
+            />
+            <Field
+              name="confirmPassword"
+              id="confirmPassword"
+              className="form-control"
+              component={PasswordInput}
+              aria-invalid={errors.newPassword ? "true" : null}
+              aria-describedby={
+                errors.newPassword ? "confirmPasswordError" : null
+              }
+              pattern={passwordFieldRegex}
+              title={passwordFieldErrorMessage}
+            />
+            <ErrorMessage
+              name="confirmPassword"
+              id="confirmPasswordError"
+              component={FormError}
+            />
+          </div>
+          <div className="row submit-row no-gutters">
+            <div className="col d-flex justify-content-end">
+              <button
+                type="submit"
+                className="btn btn-primary btn-gradient-red-to-blue large"
+                disabled={isSubmitting}
+              >
+                Submit
+              </button>
+            </div>
+          </div>
+        </Form>
+      )
+    }}
+  </Formik>
 )
 
 export default ResetPasswordForm

--- a/frontend/public/src/containers/pages/profile/EditProfilePage.js
+++ b/frontend/public/src/containers/pages/profile/EditProfilePage.js
@@ -50,7 +50,6 @@ export class EditProfilePage extends React.Component<Props> {
       const {
         body: { errors }
       }: { body: Object } = await editProfile(profileData)
-
       if (errors && errors.length > 0) {
         setErrors({
           email: errors[0]

--- a/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
+++ b/frontend/public/src/containers/pages/records/LearnerRecordsPage.js
@@ -243,51 +243,54 @@ export class LearnerRecordsPage extends React.Component<Props, State> {
             initialValues={{
               partnerSchool: ""
             }}
-            render={() => (
-              <Form className="text-center">
-                <section>
-                  <label htmlFor="partnerSchool" className="text-start">
-                    Select School
-                  </label>
-                  <Field
-                    name="partnerSchool"
-                    render={({ field }) => (
-                      <select
-                        {...field}
-                        name="partnerSchool"
-                        className="form-control"
-                        aria-label="Select School"
-                      >
-                        <option aria-hidden="true">Choose one...</option>
-                        {learnerRecord.partner_schools.map(elem => (
-                          <option
-                            key={`partner-school-${elem.id}`}
-                            value={elem.id}
-                          >
-                            {elem.name}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                  />
-                </section>
-                <div className="mt-2">
-                  <Button
-                    type="submit"
-                    color="primary"
-                    className="btn-gradient-red-to-blue"
-                  >
-                    Send Record
-                  </Button>{" "}
-                  <Button
-                    onClick={() => this.togglePartnerSchoolSharingDialog()}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </Form>
-            )}
-          />
+          >
+            {() => {
+              return (
+                <Form className="text-center">
+                  <section>
+                    <label htmlFor="partnerSchool" className="text-start">
+                      Select School
+                    </label>
+                    <Field
+                      name="partnerSchool"
+                      render={({ field }) => (
+                        <select
+                          {...field}
+                          name="partnerSchool"
+                          className="form-control"
+                          aria-label="Select School"
+                        >
+                          <option aria-hidden="true">Choose one...</option>
+                          {learnerRecord.partner_schools.map(elem => (
+                            <option
+                              key={`partner-school-${elem.id}`}
+                              value={elem.id}
+                            >
+                              {elem.name}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    />
+                  </section>
+                  <div className="mt-2">
+                    <Button
+                      type="submit"
+                      color="primary"
+                      className="btn-gradient-red-to-blue"
+                    >
+                      Send Record
+                    </Button>{" "}
+                    <Button
+                      onClick={() => this.togglePartnerSchoolSharingDialog()}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </Form>
+              )
+            }}
+          </Formik>
 
           <div className="form-group"></div>
         </ModalBody>

--- a/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterAdditionalDetailsPage.js
@@ -106,31 +106,27 @@ export class RegisterAdditionalDetailsPage extends React.Component<Props> {
                   onSubmit={this.onSubmit.bind(this)}
                   validationSchema={addlProfileFieldsValidation}
                   initialValues={getInitialValues(currentUser)}
-                  render={({
-                    isSubmitting,
-                    setFieldValue,
-                    setFieldTouched,
-                    values
-                  }) => (
-                    <Form>
-                      <AddlProfileFields
-                        setFieldValue={setFieldValue}
-                        setFieldTouched={setFieldTouched}
-                        values={values}
-                        isNewAccount={false}
-                      />
-                      <div className="submit-row">
-                        <button
-                          type="submit"
-                          className="btn btn-primary btn-gradient-red-to-blue"
-                          disabled={isSubmitting}
-                        >
-                          Submit
-                        </button>
-                      </div>
-                    </Form>
-                  )}
-                />
+                >
+                  {({ isSubmitting, values }) => {
+                    return (
+                      <Form>
+                        <AddlProfileFields
+                          values={values}
+                          isNewAccount={false}
+                        />
+                        <div className="submit-row">
+                          <button
+                            type="submit"
+                            className="btn btn-primary btn-gradient-red-to-blue"
+                            disabled={isSubmitting}
+                          >
+                            Submit
+                          </button>
+                        </div>
+                      </Form>
+                    )
+                  }}
+                </Formik>
               </div>
             </div>
           </div>

--- a/frontend/public/src/lib/test_utils.js
+++ b/frontend/public/src/lib/test_utils.js
@@ -21,9 +21,7 @@ export const assertIsJust = (m: Maybe, val: any) => {
 }
 
 export const findFormikFieldByName = (wrapper: any, name: string) =>
-  wrapper
-    .find("FormikConnect(FieldInner)")
-    .filterWhere(node => node.prop("name") === name)
+  wrapper.find("Field").filterWhere(node => node.prop("name") === name)
 
 export const findFormikErrorByName = (wrapper: any, name: string) =>
   wrapper

--- a/frontend/public/src/lib/validation.js
+++ b/frontend/public/src/lib/validation.js
@@ -21,9 +21,15 @@ export const changeEmailValidationRegex = (email: string) => {
   return `^((?!${escapedUserEmail}).)*$`
 }
 
-export const passwordField = yup.string().label("Password")
+export const passwordField = yup
+  .string()
+  .required()
+  .label("Password")
 
-export const usernameField = yup.string().label("Username")
+export const usernameField = yup
+  .string()
+  .required()
+  .label("Username")
 
 export const resetPasswordFormValidation = yup.object().shape({
   newPassword:     passwordField.label("New Password"),
@@ -40,7 +46,7 @@ export const changePasswordFormValidation = yup.object().shape({
     .label("Old Password")
     .required(),
 
-  newPassword: passwordField.label("New Password"),
+  newPassword: passwordField.label("New Password").required(),
 
   confirmPassword: yup
     .string()

--- a/frontend/public/src/lib/validation.js
+++ b/frontend/public/src/lib/validation.js
@@ -21,6 +21,17 @@ export const changeEmailValidationRegex = (email: string) => {
   return `^((?!${escapedUserEmail}).)*$`
 }
 
+export const changeEmailFormValidation = yup.object().shape({
+  email: yup
+    .string()
+    .label("New Email")
+    .required(),
+  confirmPassword: yup
+    .string()
+    .label("Confirm Password")
+    .required()
+})
+
 export const passwordField = yup
   .string()
   .required()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4218,7 +4218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hoist-non-react-statics@npm:^3.3.0":
+"@types/hoist-non-react-statics@npm:^3.3.0, @types/hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.5
   resolution: "@types/hoist-non-react-statics@npm:3.3.5"
   dependencies:
@@ -7647,19 +7647,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-react-context@npm:^0.2.2":
-  version: 0.2.3
-  resolution: "create-react-context@npm:0.2.3"
-  dependencies:
-    fbjs: ^0.8.0
-    gud: ^1.0.0
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0
-  checksum: c48829815c90dc8fcd80a1542c70920fe9a1ba18c5f226de42f2494a82701fc5ca5197a64a412dcf1bf6e54b9ea603a8d14ad38df7870ed798490a505b38ac89
-  languageName: node
-  linkType: hard
-
 "create-require@npm:^1.1.0":
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
@@ -10259,7 +10246,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fbjs@npm:^0.8.0, fbjs@npm:^0.8.1":
+"fbjs@npm:^0.8.1":
   version: 0.8.18
   resolution: "fbjs@npm:0.8.18"
   dependencies:
@@ -10669,22 +10656,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formik@npm:1.5.8":
-  version: 1.5.8
-  resolution: "formik@npm:1.5.8"
+"formik@npm:^2.4.5":
+  version: 2.4.5
+  resolution: "formik@npm:2.4.5"
   dependencies:
-    create-react-context: ^0.2.2
+    "@types/hoist-non-react-statics": ^3.3.1
     deepmerge: ^2.1.1
     hoist-non-react-statics: ^3.3.0
-    lodash: ^4.17.14
-    lodash-es: ^4.17.14
-    prop-types: ^15.6.1
+    lodash: ^4.17.21
+    lodash-es: ^4.17.21
     react-fast-compare: ^2.0.1
     tiny-warning: ^1.0.2
-    tslib: ^1.9.3
+    tslib: ^2.0.0
   peerDependencies:
-    react: ">=15"
-  checksum: db6b2d8233cd45fa16b1bec5464f7096e5fd4eaaa37fc4f89d1f54d1120fe90cce0a0b1932f3830141dfd2f0f32b3b466cd232b28b3ca7936cd190d468bf6d6b
+    react: ">=16.8.0"
+  checksum: 316c91fc4e440094655c0d0ba47277a0f84f6082f77ae2ae959e97e2eebb8eab5b866a9e43d93a28efdae07c3f23e779da67922e2f2a1fb47d135b7346e0b5f3
   languageName: node
   linkType: hard
 
@@ -11206,13 +11192,6 @@ __metadata:
   version: 1.10.5
   resolution: "growl@npm:1.10.5"
   checksum: 4b86685de6831cebcbb19f93870bea624afee61124b0a20c49017013987cd129e73a8c4baeca295728f41d21265e1f859d25ef36731b142ca59c655fea94bb1a
-  languageName: node
-  linkType: hard
-
-"gud@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "gud@npm:1.0.0"
-  checksum: 3e2eb37cf794364077c18f036d6aa259c821c7fd188f2b7935cb00d589d82a41e0ebb1be809e1a93679417f62f1ad0513e745c3cf5329596e489aef8c5e5feae
   languageName: node
   linkType: hard
 
@@ -13890,7 +13869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.11, lodash-es@npm:^4.17.14, lodash-es@npm:^4.17.21, lodash-es@npm:^4.2.1":
+"lodash-es@npm:^4.17.11, lodash-es@npm:^4.17.21, lodash-es@npm:^4.2.1":
   version: 4.17.21
   resolution: "lodash-es@npm:4.17.21"
   checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
@@ -15229,7 +15208,7 @@ __metadata:
     flow: 0.2.3
     flow-bin: 0.95.1
     flow-typed: 3.7.0
-    formik: 1.5.8
+    formik: ^2.4.5
     history: 4.10.1
     isomorphic-fetch: 2.2.1
     jquery: 3.6.0
@@ -22052,7 +22031,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.3.1":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.3.1":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad

--- a/yarn.lock
+++ b/yarn.lock
@@ -7573,6 +7573,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:3.10.2":
+  version: 3.10.2
+  resolution: "core-js@npm:3.10.2"
+  checksum: b432c827d707c694f03d142e74c144e522c1f6a8632539913bd1f3660f522693b83a474409bb0dd6ccab7878c2ed91014082ce9938664e90f62193b90ce72501
+  languageName: node
+  linkType: hard
+
 "core-js@npm:^1.0.0":
   version: 1.2.7
   resolution: "core-js@npm:1.2.7"
@@ -10565,6 +10572,18 @@ __metadata:
   bin:
     flowgen: lib/cli/index.js
   checksum: 6f4e904a3c29e2095ce2122136f9575e51dd2ca930854d3aa8e24d63b404c91d1b69609833cd34796c0bf69e6c6389818322a6dcf792b9e51014511baf614fef
+  languageName: node
+  linkType: hard
+
+"focus-formik-error@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "focus-formik-error@npm:1.1.0"
+  dependencies:
+    core-js: 3.10.2
+  peerDependencies:
+    formik: ">=2.0.0"
+    react: ">=16.8.0"
+  checksum: 36679c18e0365496eaa347536730ecacfb756dd0c78a4c25d8ab59d4cd219d34d2f284ac0e5e8fdb4a5458442603f73d155048eea34849240684bc6c2968bf47
   languageName: node
   linkType: hard
 
@@ -15208,6 +15227,7 @@ __metadata:
     flow: 0.2.3
     flow-bin: 0.95.1
     flow-typed: 3.7.0
+    focus-formik-error: ^1.1.0
     formik: ^2.4.5
     history: 4.10.1
     isomorphic-fetch: 2.2.1


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3827

### Description (What does it do?)
Update formik
adds aria-invalid and  aria-describedby when validation errors.


### How can this be tested?
Go to profile page, try to submit the form without a required field filled out. When you click sbmit it should scroll you to the errored field, and show the error message in red.
<img width="539" alt="Screenshot 2024-04-09 at 9 12 09 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/5a75efd3-151c-47a4-aeaa-7b70eb68f337">

Do the same with all forms:
- Change email,
- change password
- profile fields
- learner records page
- reset password form
- Register email
- register password
- AddlProfileFiledsForm

Then test the accessibility of the form.
Use voiceover to move through the form, try to submit the form with empty required field. The screen reader should read the error message, and focus on the field with the error message.
