### PR TITLE
Fix catalog page for empty app

### DIFF
--- a/courses/management/commands/create_courseware.py
+++ b/courses/management/commands/create_courseware.py
@@ -7,7 +7,6 @@ from typing import List, Union
 
 from django.core.management import BaseCommand
 from django.db import models
-from django.utils.text import slugify
 
 from courses.models import Course, CourseRun, Department, Program
 from main.utils import parse_supplied_date

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -212,19 +212,23 @@ export class CatalogPage extends React.Component<Props> {
     }
     // Initialize allCourses and allPrograms variables in state once they finish loading to store since the value will
     // change when changing departments
-    if (this.state.allCoursesCount === 0 && !coursesIsLoading) {
-      this.setState({ allCoursesCount: coursesCount })
+    if (!coursesIsLoading && courses.length > 0) {
+      if (this.state.allCoursesCount === 0) {
+        this.setState({ allCoursesCount: coursesCount })
+      }
+      if (this.state.allCoursesRetrieved.length === 0 && !coursesIsLoading) {
+        this.setState({ allCoursesRetrieved: courses })
+        this.setState({ filteredCourses: courses })
+      }
     }
-    if (this.state.allProgramsCount === 0 && !programsIsLoading) {
-      this.setState({ allProgramsCount: programsCount })
-    }
-    if (this.state.allCoursesRetrieved.length === 0 && !coursesIsLoading) {
-      this.setState({ allCoursesRetrieved: courses })
-      this.setState({ filteredCourses: courses })
-    }
-    if (this.state.allProgramsRetrieved.length === 0 && !programsIsLoading) {
-      this.setState({ allProgramsRetrieved: programs })
-      this.setState({ filteredPrograms: programs })
+    if (!programsIsLoading && programs.length > 0) {
+      if (this.state.allProgramsCount === 0) {
+        this.setState({ allProgramsCount: programsCount })
+      }
+      if (this.state.allProgramsRetrieved.length === 0 && !programsIsLoading) {
+        this.setState({ allProgramsRetrieved: programs })
+        this.setState({ filteredPrograms: programs })
+      }
     }
     if (!departmentsIsLoading && departments.length > 0) {
       if (!coursesIsLoading && this.state.filterCoursesCalled) {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -541,8 +541,13 @@ export class CatalogPage extends React.Component<Props> {
     catalogItems: Array<CourseDetailWithRuns | Programs>,
     tabSelected: string
   ) {
-    const selectedDepartmentObject = this.getDepartmentForTab(selectedDepartmentSlug)
-    if (selectedDepartmentSlug === ALL_DEPARTMENTS || typeof selectedDepartmentObject === "undefined") {
+    const selectedDepartmentObject = this.getDepartmentForTab(
+      selectedDepartmentSlug
+    )
+    if (
+      selectedDepartmentSlug === ALL_DEPARTMENTS ||
+      typeof selectedDepartmentObject === "undefined"
+    ) {
       this.setState({ selectedDepartment: ALL_DEPARTMENTS })
       return catalogItems
     } else {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -175,12 +175,7 @@ export class CatalogPage extends React.Component<Props> {
     if (!departmentsIsLoading && departments.length > 0) {
       if (!this.state.filterDepartmentsByTabNameCalled) {
         // initialize the departments on page load.
-        this.setState({ filterDepartmentsByTabNameCalled: true })
-        this.setState({
-          filteredDepartments: this.filterDepartmentsByTabName(
-            this.state.tabSelected
-          )
-        })
+        this.changeSelectedTab(this.state.tabSelected)
       }
       if (!coursesIsLoading && !this.state.filterCoursesCalled) {
         this.setState({ filterCoursesCalled: true }) // This line must be before calling filteredCoursesOrProgramsByDepartmentSlug
@@ -259,6 +254,7 @@ export class CatalogPage extends React.Component<Props> {
     this.setState({
       filteredDepartments: filteredDepartments
     })
+    this.setState({ filterDepartmentsByTabNameCalled: true })
     const departmentObject = this.getDepartmentObjectFromSlug(
       this.state.selectedDepartment
     )
@@ -272,23 +268,23 @@ export class CatalogPage extends React.Component<Props> {
       // with an associated Department matching the
       // selected department, update the selected department
       // to ALL_DEPARTMENTS.
+      this.changeSelectedDepartment(ALL_DEPARTMENTS, selectedTabName)
       if (selectedTabName === PROGRAMS_TAB) {
         this.retrieveMorePrograms()
       }
       if (selectedTabName === COURSES_TAB) {
         this.retrieveMoreCourses()
       }
-      this.changeSelectedDepartment(ALL_DEPARTMENTS, selectedTabName)
     } else {
       // Update either the programs or courses based on the currently
       // selected tab.
+      this.changeSelectedDepartment(departmentObject.slug, selectedTabName)
       if (selectedTabName === PROGRAMS_TAB) {
         this.retrieveMorePrograms()
       }
       if (selectedTabName === COURSES_TAB) {
         this.retrieveMoreCoursesByDepartment(departmentObject)
       }
-      this.changeSelectedDepartment(departmentObject.slug, selectedTabName)
     }
   }
 
@@ -352,7 +348,6 @@ export class CatalogPage extends React.Component<Props> {
       // If departmentObjectForTab is undefined, then the selectedDepartmentSlug
       // does not exist or ALL_DEPARTMENTS has been selected.
       this.setState({ selectedDepartment: ALL_DEPARTMENTS })
-      console.log(tabSelectedValue)
       this.props.history.push(
         this.getUpdatedURL(tabSelectedValue, ALL_DEPARTMENTS)
       )
@@ -361,7 +356,6 @@ export class CatalogPage extends React.Component<Props> {
       if (tabSelectedValue === COURSES_TAB) {
         this.setState({ filteredCourses: this.state.allCoursesRetrieved })
       } else {
-        console.log("hi")
         this.setState({ filteredPrograms: this.state.allProgramsRetrieved })
       }
     } else {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -272,15 +272,14 @@ export class CatalogPage extends React.Component<Props> {
       // with an associated Department matching the
       // selected department, update the selected department
       // to ALL_DEPARTMENTS.
-      this.changeSelectedDepartment(ALL_DEPARTMENTS)
       if (selectedTabName === PROGRAMS_TAB) {
         this.retrieveMorePrograms()
       }
       if (selectedTabName === COURSES_TAB) {
         this.retrieveMoreCourses()
       }
+      this.changeSelectedDepartment(ALL_DEPARTMENTS, selectedTabName)
     } else {
-      this.changeSelectedDepartment(departmentObject.slug)
       // Update either the programs or courses based on the currently
       // selected tab.
       if (selectedTabName === PROGRAMS_TAB) {
@@ -289,10 +288,8 @@ export class CatalogPage extends React.Component<Props> {
       if (selectedTabName === COURSES_TAB) {
         this.retrieveMoreCoursesByDepartment(departmentObject)
       }
+      this.changeSelectedDepartment(departmentObject.slug, selectedTabName)
     }
-    this.props.history.push(
-      this.getUpdatedURL(selectedTabName, this.state.selectedDepartment)
-    )
   }
 
   /**
@@ -328,10 +325,19 @@ export class CatalogPage extends React.Component<Props> {
    * Resets the query variables via resetQueryVariablesToDefault.
    * Closes the mobile view filter window.
    * @param {string} selectedDepartmentSlug The department slug to set selectedDepartment to and filter courses by.
+   * @param {string} tabSelected The currently selected tab.  Optional.
    */
-  changeSelectedDepartment = (selectedDepartmentSlug: string) => {
+  changeSelectedDepartment = (
+    selectedDepartmentSlug: string,
+    tabSelected: string
+  ) => {
     this.resetQueryVariablesToDefault()
     this.toggleMobileFilterWindowExpanded(false)
+    let tabSelectedValue = tabSelected
+    if (typeof tabSelectedValue === "undefined") {
+      tabSelectedValue = this.state.tabSelected
+    }
+
     let departmentObjectForTab = undefined
     if (
       selectedDepartmentSlug !== ALL_DEPARTMENTS &&
@@ -345,27 +351,29 @@ export class CatalogPage extends React.Component<Props> {
       // If departmentObjectForTab is undefined, then the selectedDepartmentSlug
       // does not exist or ALL_DEPARTMENTS has been selected.
       this.setState({ selectedDepartment: ALL_DEPARTMENTS })
+      console.log(tabSelectedValue)
       this.props.history.push(
-        this.getUpdatedURL(this.state.tabSelected, selectedDepartmentSlug)
+        this.getUpdatedURL(tabSelectedValue, ALL_DEPARTMENTS)
       )
       // Return either all of the courses or programs
       // depending on the current tabSelected value.
-      if (this.state.tabSelected === COURSES_TAB) {
+      if (tabSelectedValue === COURSES_TAB) {
         this.setState({ filteredCourses: this.state.allCoursesRetrieved })
       } else {
+        console.log("hi")
         this.setState({ filteredPrograms: this.state.allProgramsRetrieved })
       }
     } else {
       // A valid department or ALL_DEPARTMENTS has been selected.
       this.setState({ selectedDepartment: selectedDepartmentSlug })
       this.props.history.push(
-        this.getUpdatedURL(this.state.tabSelected, selectedDepartmentSlug)
+        this.getUpdatedURL(tabSelectedValue, selectedDepartmentSlug)
       )
       // We need to attempt to retrieve more courses or programs
       // in order to populate the filtered catalog page.
-      if (this.state.tabSelected === COURSES_TAB) {
+      if (tabSelectedValue === COURSES_TAB) {
         this.retrieveMoreCoursesByDepartment(departmentObjectForTab)
-      } else if (this.state.tabSelected === PROGRAMS_TAB) {
+      } else if (tabSelectedValue === PROGRAMS_TAB) {
         this.retrieveMorePrograms(selectedDepartmentSlug)
       }
     }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -144,7 +144,7 @@ export class CatalogPage extends React.Component<Props> {
           this.setState({ isLoadingMoreItems: false })
           this.setState({ courseQueryPage: this.state.courseQueryPage + 1 })
           if (response.body.results) {
-            const allCourses = this.mergeNewObjects(
+            const allCourses = this.mergeCourseOrProgramArrays(
               this.state.allCoursesRetrieved,
               response.body.results
             )
@@ -168,7 +168,7 @@ export class CatalogPage extends React.Component<Props> {
           getNextProgramPage(this.state.programQueryPage).then(response => {
             this.setState({ isLoadingMoreItems: false })
             this.setState({ programQueryPage: this.state.programQueryPage + 1 })
-            const updatedAllPrograms = this.mergeNewObjects(
+            const updatedAllPrograms = this.mergeCourseOrProgramArrays(
               this.state.allProgramsRetrieved,
               response.body.results
             )
@@ -447,7 +447,7 @@ export class CatalogPage extends React.Component<Props> {
         )
         this.setState({ isLoadingMoreItems: true })
         getNextCoursePage(1, remainingIDs.toString()).then(response => {
-          const allCourses = this.mergeNewObjects(
+          const allCourses = this.mergeCourseOrProgramArrays(
             this.state.allCoursesRetrieved,
             response.body.results
           )
@@ -475,7 +475,7 @@ export class CatalogPage extends React.Component<Props> {
     ) {
       this.setState({ isLoadingMoreItems: true })
       getNextProgramPage(this.state.programQueryPage).then(response => {
-        updatedAllPrograms = this.mergeNewObjects(
+        updatedAllPrograms = this.mergeCourseOrProgramArrays(
           allPrograms,
           response.body.results
         )
@@ -492,35 +492,24 @@ export class CatalogPage extends React.Component<Props> {
     this.setState({ filterProgramsCalled: true })
   }
 
-  mergeNewObjects(oldArray, newArray) {
-    const oldIds = oldArray.map(a => a.id)
-    const newObjects = newArray.filter(a => !oldIds.includes(a.id))
-    return oldArray.concat(newObjects)
-  }
-
   /**
-   * Returns a filtered array of Course Runs which are live and:
-   * - Have a start_date before the current date and time
-   * - Have an enrollment_start_date that is before the current date and time
-   * - Has an enrollment_end_date that is not defined or is after the current date and time.
-   * @param {Array<BaseCourseRun>} courseRuns The array of Course Runs apply the filter to.
+   * Returns the union of two arrays of type CourseDetailWithRuns or Programs based on the
+   * ID of each object in the array.
+   * @param {Array<CourseDetailWithRuns | Program>} catalogItems
+   * @returns {Array<CourseDetailWithRuns | Program>} Union of both array parameters.
    */
-  validateCoursesCourseRuns(courseRuns: Array<BaseCourseRun>) {
-    return courseRuns.filter(
-      courseRun =>
-        courseRun.live &&
-        courseRun.start_date &&
-        moment(courseRun?.enrollment_start).isBefore(moment()) &&
-        (!courseRun.enrollment_end ||
-          moment(courseRun.enrollment_end).isAfter(moment()))
-    )
+  mergeCourseOrProgramArrays(aArray: Array<CourseDetailWithRuns | Program>, bArray: Array<CourseDetailWithRuns | Program>) {
+    const aIds = aArray.map(a => a.id)
+    const uniqueObjects = bArray.filter(b => !aIds.includes(b.id))
+    return aArray.concat(uniqueObjects)
   }
 
   /**
-   * Returns a filtered array of courses which have: an associated Department name matching the selectedDepartment
+   * Returns a filtered array of catalog items that are associated with a
+   * Department name matching the selectedDepartment.
    * if the selectedDepartment does not equal "All Departments",
-   * @param {Array<CourseDetailWithRuns | Program>} catalogItems An array of courses which will be filtered by Department.
-   * @param {string} selectedDepartment The Department name used to compare against the courses in the array.
+   * @param {Array<CourseDetailWithRuns | Program>} catalogItems An array of catalog items which will be filtered based on their associated Departments.
+   * @param {string} selectedDepartment The Department name used to compare against the catalogItems array.
    */
   filteredCoursesOrProgramsByDepartmentAndCriteria(
     selectedDepartment: string,

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -325,7 +325,8 @@ export class CatalogPage extends React.Component<Props> {
    * Resets the query variables via resetQueryVariablesToDefault.
    * Closes the mobile view filter window.
    * @param {string} selectedDepartmentSlug The department slug to set selectedDepartment to and filter courses by.
-   * @param {string} tabSelected The currently selected tab.  Optional.
+   * @param {string} tabSelected The currently selected tab.  Optional.  If not defined, this.state.tabSelected is used
+   * when updating this.props.history.
    */
   changeSelectedDepartment = (
     selectedDepartmentSlug: string,
@@ -393,7 +394,8 @@ export class CatalogPage extends React.Component<Props> {
    * - filteredCourses, updated with the courses in the API response.
    * - filterCoursesCalled, set to true.
    *
-   * @param {string} courseQueryIDListString a string containing a list of course IDs.  This is optional.
+   * @param {string} courseQueryIDListString a string containing a list of course IDs.  This is optional.  When not defined,
+   * this method will make paginated API requests without specifying course IDs.
    */
   retrieveMoreCourses(courseQueryIDListString: string) {
     const { coursesIsLoading, getNextCoursePage } = this.props
@@ -480,6 +482,7 @@ export class CatalogPage extends React.Component<Props> {
    * - filterProgramsCalled set to true.
    *
    * @param {string} selectedDepartmentSlug The department slug for the currently selected department.  This parameter is optional.
+   * If this is not defined when calling the method, the value of this.state.selectedDepartment will be used.
    */
   retrieveMorePrograms(selectedDepartmentSlug: string) {
     const {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -218,7 +218,7 @@ export class CatalogPage extends React.Component<Props> {
     }
     if (!departmentsIsLoading && departments.length > 0) {
       if (!this.state.filterDepartmentsByTabNameCalled) {
-        // Why is this here if we already handle it in the tab change?
+        // initialize the departments on page load.
         this.setState({
           filteredDepartments: this.filterDepartmentsByTabName(
             this.state.tabSelected
@@ -227,11 +227,7 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({ filterDepartmentsByTabNameCalled: true })
       }
       if (!coursesIsLoading) {
-        if (this.state.filterCoursesCalled) {
-          if (this.state.selectedDepartment !== prevState.selectedDepartment) {
-            this.resetQueryVariablesToDefault()
-          }
-        } else {
+        if (!this.state.filterCoursesCalled) {
           const filteredCourses = this.filteredCoursesOrProgramsByDepartmentSlug(
             this.state.selectedDepartment,
             this.state.allCoursesRetrieved,
@@ -239,19 +235,6 @@ export class CatalogPage extends React.Component<Props> {
           )
           this.setState({ filteredCourses: filteredCourses })
           this.setState({ filterCoursesCalled: true })
-          const departmentObject = this.getDepartmentForTab(
-            this.state.selectedDepartment
-          )
-          if (typeof departmentObject !== "undefined") {
-            this.retrieveMoreCourses(departmentObject)
-          }
-        }
-      }
-      if (!programsIsLoading) {
-        if (this.state.filterProgramsCalled) {
-          if (this.state.selectedDepartment !== prevState.selectedDepartment) {
-            this.resetQueryVariablesToDefault()
-          }
         }
       }
       this.io = new window.IntersectionObserver(
@@ -342,7 +325,6 @@ export class CatalogPage extends React.Component<Props> {
         const departmentObject = this.getDepartmentForTab(
           this.state.selectedDepartment
         )
-        console.log(this.renderNumberOfCatalogItems())
         if (
           this.renderNumberOfCatalogItems() === 0 ||
           typeof departmentObject === "undefined"
@@ -361,12 +343,12 @@ export class CatalogPage extends React.Component<Props> {
         })
       }
     }
-    // Can this be removed?
-    this.io = new window.IntersectionObserver(
-      this.bottomOfLoadedCatalogCallback,
-      { threshold: 1.0 }
-    )
-    this.io.observe(this.container.current)
+    // // Can this be removed?
+    // this.io = new window.IntersectionObserver(
+    //   this.bottomOfLoadedCatalogCallback,
+    //   { threshold: 1.0 }
+    // )
+    // this.io.observe(this.container.current)
   }
 
   /**
@@ -429,7 +411,6 @@ export class CatalogPage extends React.Component<Props> {
           COURSES_TAB
         )
         this.setState({ filteredCourses: filteredCoursesByDepartment })
-        this.setState({ filterCoursesCalled: true })
       } else if (this.state.tabSelected === PROGRAMS_TAB) {
         this.retrieveMorePrograms()
         const filteredProgramsByDepartment = this.filteredCoursesOrProgramsByDepartmentSlug(
@@ -556,8 +537,6 @@ export class CatalogPage extends React.Component<Props> {
           selectedDepartmentObject.course_ids.includes(catalogItem.id)
         )
       } else {
-        console.log(catalogItems)
-        console.log(selectedDepartmentObject)
         return catalogItems.filter(catalogItem =>
           selectedDepartmentObject.program_ids.includes(catalogItem.id)
         )

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -572,16 +572,16 @@ export class CatalogPage extends React.Component<Props> {
     }
   }
 
-    /**
+  /**
    * Returns the updated URL based on the given state of the catalog page.
    * @returns {string}
    */
-    getUpdatedURL(tabSelected, selectedDepartment) {
-      if (selectedDepartment === ALL_DEPARTMENTS) {
-        return `/catalog/${tabSelected}`
-      }
-      return `/catalog/${tabSelected}/${selectedDepartment}`
+  getUpdatedURL(tabSelected, selectedDepartment) {
+    if (selectedDepartment === ALL_DEPARTMENTS) {
+      return `/catalog/${tabSelected}`
     }
+    return `/catalog/${tabSelected}/${selectedDepartment}`
+  }
 
   /**
    * Returns the number of catalog items based on the selectedDepartment

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -247,9 +247,7 @@ export class CatalogPage extends React.Component<Props> {
             this.resetQueryVariablesToDefault()
           }
         } else {
-          this.retrieveMorePrograms(
-            this.state.selectedDepartment
-          )
+          this.retrieveMorePrograms(this.state.selectedDepartment)
         }
       }
       this.io = new window.IntersectionObserver(
@@ -334,9 +332,7 @@ export class CatalogPage extends React.Component<Props> {
         if (this.renderNumberOfCatalogItems() === 0) {
           this.setState({ selectedDepartment: ALL_DEPARTMENTS })
         }
-        this.retrieveMorePrograms(
-          this.state.selectedDepartment
-        )
+        this.retrieveMorePrograms(this.state.selectedDepartment)
       }
     }
     if (selectTabName === COURSES_TAB) {
@@ -398,11 +394,12 @@ export class CatalogPage extends React.Component<Props> {
         selectedDepartmentSlug,
         this.state.allCoursesRetrieved
       )
-      this.countAndRetrieveMoreCourses(filteredCatalogItems, selectedDepartmentSlug)
-    } else if (this.state.tabSelected === PROGRAMS_TAB) {
-      this.retrieveMorePrograms(
+      this.countAndRetrieveMoreCourses(
+        filteredCatalogItems,
         selectedDepartmentSlug
       )
+    } else if (this.state.tabSelected === PROGRAMS_TAB) {
+      this.retrieveMorePrograms(selectedDepartmentSlug)
       const filteredProgramsByDepartment = this.filteredCoursesOrProgramsByDepartment(
         selectedDepartmentSlug,
         this.state.allProgramsRetrieved
@@ -471,12 +468,9 @@ export class CatalogPage extends React.Component<Props> {
    * This will update the following state variables:
    * - allProgramsRetrieved, updated by adding newly retrieved programs.
    * - programQueryPage, increment by 1.
-   * - filteredPrograms, update with newly filtered programs.
-   * - filterProgramsCalled, set to true.
    *
-   * @param {string} selectedDepartmentSlug
    */
-  retrieveMorePrograms(selectedDepartmentSlug) {
+  retrieveMorePrograms() {
     const { programsNextPage, getNextProgramPage } = this.props
     if (
       programsNextPage &&

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -129,8 +129,8 @@ export class CatalogPage extends React.Component<Props> {
             this.renderNumberOfCatalogItems() &&
           this.state.allProgramsRetrieved.length > 0
         ) {
-          // Only retrieve more programs after we have already populated allProgramsRetrieved with the initial response
-          // from the API, and when not all programs, for the currently selected department, are currently displayed.
+          // Only retrieve more programs after we have already populated allProgramsRetrieved with the initial API response,
+          // and when not all programs, for the currently selected department, are currently displayed.
           this.retrieveMorePrograms()
         }
       }
@@ -138,7 +138,8 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   *
+   * Initializes many of the state variables with the responses from the programs, courses, and departments API.
+   * Adds an intersection observer in order to load more catalog items when the user scrolls to the bottom of the page.
    */
   componentDidUpdate = () => {
     const {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -236,7 +236,8 @@ export class CatalogPage extends React.Component<Props> {
           this.setState({ filteredCourses: filteredCourses })
           this.setState({ filterCoursesCalled: true })
           const departmentObject = this.getDepartmentForTab(this.state.selectedDepartment)
-          if (departmentObject) {
+          if (typeof departmentObject !== 'undefined') {
+            console.log(departmentObject)
             this.retrieveMoreCourses(
               departmentObject
             )
@@ -317,9 +318,8 @@ export class CatalogPage extends React.Component<Props> {
    */
   changeSelectedTab = (selectTabName: string) => {
     this.setState({ tabSelected: selectTabName })
-    const filteredDepartmentsByTabName = this.filterDepartmentsByTabName(selectTabName)
     this.setState({
-      filteredDepartments: filteredDepartmentsByTabName
+      filteredDepartments: this.filterDepartmentsByTabName(selectTabName)
     })
     if (selectTabName === PROGRAMS_TAB) {
       const { programs, programsIsLoading } = this.props
@@ -358,16 +358,13 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({
           filteredCourses: filteredCourses
         })
-        console.log(this.renderNumberOfCatalogItems())
-        if (this.renderNumberOfCatalogItems() !== 0) {
-          const departmentObject = this.getDepartmentForTab(this.state.selectedDepartment)
-          if (departmentObject) {
-            this.retrieveMoreCourses(
-              departmentObject
-            )
-          }
-        } else {
+        const departmentObject = this.getDepartmentForTab(this.state.selectedDepartment)
+        if (this.renderNumberOfCatalogItems() === 0 || typeof departmentObjectForTab === 'undefined') {
           this.changeSelectedDepartment(ALL_DEPARTMENTS)
+        } else {
+          this.retrieveMoreCourses(
+            departmentObject
+          )
         }
       }
     }
@@ -388,8 +385,9 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   getDepartmentForTab(selectedDepartmentSlug: string) {
-    if (this.state.filterDepartmentsByTabNameCalled) {
-      return this.state.filteredDepartments.find(
+    const { departments } = this.props
+    if (departments) {
+      return departments.find(
         department => department.slug === selectedDepartmentSlug
       )
     }
@@ -426,7 +424,7 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({ filteredPrograms: this.state.allProgramsRetrieved })
       }
     } else {
-      // A valid department other ALL_DEPARTMENTS has been selected.
+      // A valid department or ALL_DEPARTMENTS has been selected.
       this.setState({ selectedDepartment: selectedDepartmentSlug})
       // We need to attempt to retrieve more courses or programs
       // in order to populate the filtered catalog page.
@@ -455,7 +453,7 @@ export class CatalogPage extends React.Component<Props> {
    */
   retrieveMoreCourses(selectedDepartmentObject) {
     const {getNextCoursePage } = this.props
-
+    console.log(this.state.filteredCourses)
     // Only request more courses if we have not alraedy retrieved all courses associated with the department.
     if (
       !this.state.isLoadingMoreItems &&
@@ -589,20 +587,20 @@ export class CatalogPage extends React.Component<Props> {
   renderNumberOfCatalogItems() {
     const { departments } = this.props
     if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
-      console.log(this.state.tabSelected)
       return this.state.tabSelected === COURSES_TAB
         ? this.state.allCoursesCount
         : this.state.allProgramsCount
     } else if (!departments) return 0
-    if (!this.state.filteredDepartmentsByTabName.includes(this.state.selectedDepartment)) {
+    const departmentSlugs = this.state.filteredDepartments.map(department => department.slug)
+    if (!departmentSlugs.includes(this.state.selectedDepartment)) {
       return 0
     } else {
       if (this.state.tabSelected === COURSES_TAB) {
-        return this.state.filteredDepartmentsByTabName.find(
+        return this.state.filteredDepartments.find(
           department => department.slug === this.state.selectedDepartment
         ).course_ids.length
       } else {
-        return this.state.filteredDepartmentsByTabName.find(
+        return this.state.filteredDepartments.find(
           department => department.slug === this.state.selectedDepartment
         ).program_ids.length
       }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -117,12 +117,16 @@ export class CatalogPage extends React.Component<Props> {
     if (entry.isIntersecting) {
       if (this.state.tabSelected === COURSES_TAB) {
         if (
-          this.state.filteredCourses.length < this.renderNumberOfCatalogItems() && coursesNextPage
+          this.state.filteredCourses.length <
+            this.renderNumberOfCatalogItems() &&
+          coursesNextPage
         ) {
           this.retrieveMoreCourses()
         }
       } else {
-        if (this.state.filteredPrograms.length < this.renderNumberOfCatalogItems()) {
+        if (
+          this.state.filteredPrograms.length < this.renderNumberOfCatalogItems()
+        ) {
           this.retrieveMorePrograms()
         }
       }
@@ -130,7 +134,7 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * 
+   *
    */
   componentDidUpdate = () => {
     const {
@@ -254,26 +258,28 @@ export class CatalogPage extends React.Component<Props> {
     const departmentExistsForTab = filteredDepartments.find(
       department => department.slug === this.state.selectedDepartment
     )
-    if (
-      !departmentExistsForTab ||
-      typeof departmentObject === "undefined"
-    ) {
+    if (!departmentExistsForTab || typeof departmentObject === "undefined") {
       // If there are no courses on this tab
       // with an associated Department matching the
       // selected department, update the selected department
       // to ALL_DEPARTMENTS.
       this.changeSelectedDepartment(ALL_DEPARTMENTS)
+      if (selectedTabName === PROGRAMS_TAB) {
+        this.retrieveMorePrograms()
+      }
+      if (selectedTabName === COURSES_TAB) {
+        this.retrieveMoreCourses()
+      }
     } else {
       this.changeSelectedDepartment(departmentObject.slug)
-    }
-
-    // Update either the programs or courses based on the currently
-    // selected tab.
-    if (selectedTabName === PROGRAMS_TAB) {
-      this.retrieveMorePrograms()
-    }
-    if (selectedTabName === COURSES_TAB) {
-      this.retrieveMoreCoursesByDepartment(departmentObject)
+      // Update either the programs or courses based on the currently
+      // selected tab.
+      if (selectedTabName === PROGRAMS_TAB) {
+        this.retrieveMorePrograms()
+      }
+      if (selectedTabName === COURSES_TAB) {
+        this.retrieveMoreCoursesByDepartment(departmentObject)
+      }
     }
   }
 
@@ -284,7 +290,6 @@ export class CatalogPage extends React.Component<Props> {
   toggleMobileFilterWindowExpanded = (expanded: boolean) => {
     this.setState({ mobileFilterWindowExpanded: expanded })
   }
-
 
   /**
    * Returns the Department object that has a slug matching the parameter.
@@ -320,7 +325,9 @@ export class CatalogPage extends React.Component<Props> {
       selectedDepartmentSlug !== ALL_DEPARTMENTS &&
       selectedDepartmentSlug !== ""
     ) {
-      departmentObjectForTab = this.getDepartmentObjectFromSlug(selectedDepartmentSlug)
+      departmentObjectForTab = this.getDepartmentObjectFromSlug(
+        selectedDepartmentSlug
+      )
     }
 
     if (typeof departmentObjectForTab === "undefined") {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -320,7 +320,7 @@ export class CatalogPage extends React.Component<Props> {
       )
     }
     this.props.history.push(
-      this.getUpdatedURL(this.state.tabSelected, selectedDepartment)
+      this.getUpdatedURL(this.state.tabSelected, selectedDepartmentSlug)
     )
     return undefined
   }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -125,8 +125,12 @@ export class CatalogPage extends React.Component<Props> {
         }
       } else {
         if (
-          this.state.filteredPrograms.length < this.renderNumberOfCatalogItems()
+          this.state.filteredPrograms.length <
+            this.renderNumberOfCatalogItems() &&
+          this.state.allProgramsRetrieved.length > 0
         ) {
+          // Only retrieve more programs after we have already populated allProgramsRetrieved with the initial response
+          // from the API, and when not all programs, for the currently selected department, are currently displayed.
           this.retrieveMorePrograms()
         }
       }
@@ -458,7 +462,7 @@ export class CatalogPage extends React.Component<Props> {
    * - programQueryPage, increment by 1.
    * - filterProgramsCalled set to true.
    *
-   * @param {string} selectedDepartmentSlug The department slug for the currently selected department.
+   * @param {string} selectedDepartmentSlug The department slug for the currently selected department.  This parameter is optional.
    */
   retrieveMorePrograms(selectedDepartmentSlug: string) {
     const {
@@ -466,6 +470,10 @@ export class CatalogPage extends React.Component<Props> {
       programsNextPage,
       getNextProgramPage
     } = this.props
+    let currentDepartmentSlug = this.state.selectedDepartment
+    if (typeof selectedDepartmentSlug !== "undefined") {
+      currentDepartmentSlug = selectedDepartmentSlug
+    }
     if (
       !programsIsLoading &&
       programsNextPage &&
@@ -482,7 +490,7 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({ programQueryPage: this.state.programQueryPage + 1 })
         this.setState({ isLoadingMoreItems: false })
         const filteredPrograms = this.filteredCoursesOrProgramsByDepartmentSlug(
-          selectedDepartmentSlug,
+          currentDepartmentSlug,
           updatedAllPrograms,
           PROGRAMS_TAB
         )
@@ -492,7 +500,7 @@ export class CatalogPage extends React.Component<Props> {
       // All programs have been retrieved from the API.  We just need to update the
       // filteredPrograms state variable.
       const filteredPrograms = this.filteredCoursesOrProgramsByDepartmentSlug(
-        selectedDepartmentSlug,
+        currentDepartmentSlug,
         this.state.allProgramsRetrieved,
         PROGRAMS_TAB
       )

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -122,7 +122,9 @@ export class CatalogPage extends React.Component<Props> {
           this.retrieveMoreCourses()
         }
       } else {
-        this.retrieveMorePrograms()
+        if (this.state.filteredPrograms.length < this.renderNumberOfCatalogItems()) {
+          this.retrieveMorePrograms()
+        }
       }
     }
   }
@@ -230,7 +232,6 @@ export class CatalogPage extends React.Component<Props> {
     if (this.state.tabSelected === COURSES_TAB) {
       this.setState({ courseQueryPage: 1 })
       this.setState({ courseQueryIDListString: "" })
-      this.setState({ filterCoursesCalled: false })
     } else {
       this.setState({ filterProgramsCalled: false })
     }
@@ -257,11 +258,12 @@ export class CatalogPage extends React.Component<Props> {
         const departmentObject = this.getDepartmentObjectFromSlug(
           this.state.selectedDepartment
         )
+        console.log(this.renderNumberOfCatalogItems())
         if (
           this.renderNumberOfCatalogItems() === 0 ||
           typeof departmentObject === "undefined"
         ) {
-          // If there are no catalog items on this tab
+          // If there are no courses on this tab
           // with an associated Department matching the
           // selected department, update the selected department
           // to ALL_DEPARTMENTS.
@@ -340,7 +342,7 @@ export class CatalogPage extends React.Component<Props> {
       if (this.state.tabSelected === COURSES_TAB) {
         this.retrieveMoreCoursesByDepartment(departmentObjectForTab)
       } else if (this.state.tabSelected === PROGRAMS_TAB) {
-        this.retrieveMorePrograms()
+        this.retrieveMorePrograms(selectedDepartmentSlug)
       }
     }
   }
@@ -444,8 +446,10 @@ export class CatalogPage extends React.Component<Props> {
    * - allProgramsRetrieved, updated by adding newly retrieved programs.
    * - programQueryPage, increment by 1.
    * - filterProgramsCalled set to true.
+   *
+   * @param {string} selectedDepartmentSlug The department slug for the currently selected department.
    */
-  retrieveMorePrograms() {
+  retrieveMorePrograms(selectedDepartmentSlug: string) {
     const {
       programsIsLoading,
       programsNextPage,
@@ -467,7 +471,7 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({ programQueryPage: this.state.programQueryPage + 1 })
         this.setState({ isLoadingMoreItems: false })
         const filteredPrograms = this.filteredCoursesOrProgramsByDepartmentSlug(
-          this.state.selectedDepartment,
+          selectedDepartmentSlug,
           updatedAllPrograms,
           PROGRAMS_TAB
         )
@@ -477,11 +481,12 @@ export class CatalogPage extends React.Component<Props> {
       // All programs have been retrieved from the API.  We just need to update the
       // filteredPrograms state variable.
       const filteredPrograms = this.filteredCoursesOrProgramsByDepartmentSlug(
-        this.state.selectedDepartment,
+        selectedDepartmentSlug,
         this.state.allProgramsRetrieved,
         PROGRAMS_TAB
       )
       this.setState({ filteredPrograms: filteredPrograms })
+      console.log(filteredPrograms)
     }
     this.setState({ filterProgramsCalled: true })
   }

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -61,24 +61,24 @@ const TABS = [PROGRAMS_TAB, COURSES_TAB]
 
 export class CatalogPage extends React.Component<Props> {
   state = {
-    tabSelected:                COURSES_TAB,
-    allCoursesRetrieved:        [],
-    allCoursesCount:            0,
-    allProgramsRetrieved:       [],
-    allProgramsCount:           0,
-    filteredCourses:            [],
-    filteredPrograms:           [],
-    filterProgramsCalled:       false,
-    filterCoursesCalled:        false,
-    filteredDepartments:        [],
-    filterDepartmentsByTabName:    false,
-    selectedDepartment:         ALL_DEPARTMENTS,
-    mobileFilterWindowExpanded: false,
-    items_per_row:              3,
-    courseQueryPage:            1,
-    programQueryPage:           1,
-    isLoadingMoreItems:         false,
-    queryIDListString:          ""
+    tabSelected:                      COURSES_TAB,
+    allCoursesRetrieved:              [],
+    allCoursesCount:                  0,
+    allProgramsRetrieved:             [],
+    allProgramsCount:                 0,
+    filteredCourses:                  [],
+    filteredPrograms:                 [],
+    filterProgramsCalled:             false,
+    filterCoursesCalled:              false,
+    filteredDepartments:              [],
+    filterDepartmentsByTabNameCalled:    false,
+    selectedDepartment:               ALL_DEPARTMENTS,
+    mobileFilterWindowExpanded:       false,
+    items_per_row:                    3,
+    courseQueryPage:                  1,
+    programQueryPage:                 1,
+    isLoadingMoreItems:               false,
+    queryIDListString:                ""
   }
 
   constructor(props) {
@@ -219,13 +219,13 @@ export class CatalogPage extends React.Component<Props> {
       }
     }
     if (!departmentsIsLoading && departments.length > 0) {
-      if (!this.state.filterDepartmentsByTabName) {
+      if (!this.state.filterDepartmentsByTabNameCalled) {
         this.setState({
-          filteredDepartments: this.filterDepartmentsByTabName(
+          filteredDepartments: this.filterDepartmentsByTabNameCalled(
             this.state.tabSelected
           )
         })
-        this.setState({ filterDepartmentsByTabName: true })
+        this.setState({ filterDepartmentsByTabNameCalled: true })
       }
       if (!coursesIsLoading) {
         if (this.state.filterCoursesCalled) {
@@ -270,7 +270,7 @@ export class CatalogPage extends React.Component<Props> {
    * related to them depending on the currently selected tab.
    * @param {string} selectedTabName the name of the currently selected tab.
    */
-  filterDepartmentsByTabName(selectedTabName: string) {
+  filterDepartmentsByTabNameCalled(selectedTabName: string) {
     if (!this.props.departmentsIsLoading) {
       const { departments } = this.props
       const allDepartments = { name: ALL_DEPARTMENTS, slug: ALL_DEPARTMENTS }
@@ -322,7 +322,7 @@ export class CatalogPage extends React.Component<Props> {
   changeSelectedTab = (selectTabName: string) => {
     this.setState({ tabSelected: selectTabName })
     this.setState({
-      filteredDepartments: this.filterDepartmentsByTabName(selectTabName)
+      filteredDepartments: this.filterDepartmentsByTabNameCalled(selectTabName)
     })
     if (selectTabName === PROGRAMS_TAB) {
       const { programs, programsIsLoading } = this.props
@@ -420,7 +420,7 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * 
+   *
    */
   countAndRetrieveMoreCourses(filteredCourses, selectedDepartment) {
     const { departments, getNextCoursePage } = this.props
@@ -574,45 +574,38 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * Returns the number of courses based on the selectedDepartment.
-   * If the selectedDepartment is "All Departments", the total number of courses is returned.
+   * Returns the number of catalog items based on the selectedDepartment
+   * and the selectedTabName state variables.
+   * If the selectedDepartment is "All Departments" and selectedTabName is equal to COURSES_TAB,
+   * then total number of courses is returned.
+   * If the selectedDepartment is "All Departments" and selectedTabName is equal not equal to
+   * COURSES_TAB, then total number of programs is returned.
+   * If the selectDepartment state variable is equal to "slug" value for one of the entries in the
+   * "departments" prop, then the "course_ids" or "program_ids" value for that department, depending on the value
+   * of selectedTabName, will be displayed.
    * If the selectedDepartment is not found in the departments array, 0 is returned.
-   * @returns {number}
+   * @returns {number} the number of courses or programs associated with the department matching
+   * the selectedDepartment state variable.
    */
-  renderNumberOfCatalogCourses() {
+  renderNumberOfCatalogItems() {
     const { departments } = this.props
     const selectedDepartment = this.state.selectedDepartment
     if (selectedDepartment === ALL_DEPARTMENTS) {
-      return this.state.allCoursesCount
+      return this.state.selectedTabName === COURSES_TAB ? this.state.allCoursesCount : this.state.allProgramsCount
     } else if (!departments) return 0
     const departmentSlugs = departments.map(department => department.slug)
     if (!departmentSlugs.includes(selectedDepartment)) {
       return 0
     } else {
-      return departments.find(
-        department => department.slug === this.state.selectedDepartment
-      ).course_ids.length
-    }
-  }
-
-  /** Returns the number of programs based on the selectedDepartment
-   * or all programs if the selectedDepartment is "All Departments".
-   * If the selectedDepartment is not found in the departments array, 0 is returned.
-   * @returns {number}
-   */
-  renderNumberOfCatalogPrograms() {
-    const { departments } = this.props
-    if (!departments) return 0
-    const departmentSlugs = departments.map(department => department.slug)
-    const selectedDepartment = this.state.selectedDepartment
-    if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
-      return this.state.allProgramsCount
-    } else if (!departmentSlugs.includes(selectedDepartment)) {
-      return 0
-    } else {
-      return departments.find(
-        department => department.slug === this.state.selectedDepartment
-      ).program_ids.length
+      if (this.state.selectedTabName === COURSES_TAB) {
+        return departments.find(
+          department => department.slug === this.state.selectedDepartment
+        ).course_ids.length
+      } else {
+        return departments.find(
+          department => department.slug === this.state.selectedDepartment
+        ).program_ids.length
+      }
     }
   }
 
@@ -622,10 +615,7 @@ export class CatalogPage extends React.Component<Props> {
    * @returns {Element}
    */
   renderCatalogCount() {
-    const count =
-      this.state.tabSelected === PROGRAMS_TAB
-        ? this.renderNumberOfCatalogPrograms()
-        : this.renderNumberOfCatalogCourses()
+    const count = this.renderNumberOfCatalogItems()
     const tab = this.state.tabSelected
     return (
       <h2 className="catalog-count">

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -216,7 +216,7 @@ export class CatalogPage extends React.Component<Props> {
       if (this.state.allCoursesCount === 0) {
         this.setState({ allCoursesCount: coursesCount })
       }
-      if (this.state.allCoursesRetrieved.length === 0 && !coursesIsLoading) {
+      if (this.state.allCoursesRetrieved.length === 0) {
         this.setState({ allCoursesRetrieved: courses })
         this.setState({ filteredCourses: courses })
       }
@@ -225,40 +225,42 @@ export class CatalogPage extends React.Component<Props> {
       if (this.state.allProgramsCount === 0) {
         this.setState({ allProgramsCount: programsCount })
       }
-      if (this.state.allProgramsRetrieved.length === 0 && !programsIsLoading) {
+      if (this.state.allProgramsRetrieved.length === 0) {
         this.setState({ allProgramsRetrieved: programs })
         this.setState({ filteredPrograms: programs })
       }
     }
     if (!departmentsIsLoading && departments.length > 0) {
-      if (!coursesIsLoading && this.state.filterCoursesCalled) {
-        if (this.state.selectedDepartment !== prevState.selectedDepartment) {
-          this.resetQueryVariablesToDefault()
+      if (!coursesIsLoading) {
+        if (this.state.filterCoursesCalled) {
+          if (this.state.selectedDepartment !== prevState.selectedDepartment) {
+            this.resetQueryVariablesToDefault()
+          }
+        } else {
+          const filteredCourses = this.filteredCoursesBasedOnSelectedDepartment(
+            this.state.selectedDepartment,
+            this.state.allCoursesRetrieved
+          )
+          this.setState({ filteredCourses: filteredCourses })
+          this.setState({ filterCoursesCalled: true })
+          this.countAndRetrieveMoreCourses(
+            filteredCourses,
+            this.state.selectedDepartment
+          )
         }
       }
-      if (!coursesIsLoading && !this.state.filterCoursesCalled) {
-        this.setState({ filterCoursesCalled: true })
-        const filteredCourses = this.filteredCoursesBasedOnSelectedDepartment(
-          this.state.selectedDepartment,
-          this.state.allCoursesRetrieved
-        )
-        this.setState({ filteredCourses: filteredCourses })
-        this.countAndRetrieveMoreCourses(
-          filteredCourses,
-          this.state.selectedDepartment
-        )
-      }
-      if (!programsIsLoading && this.state.filterProgramsCalled) {
-        if (this.state.selectedDepartment !== prevState.selectedDepartment) {
-          this.resetQueryVariablesToDefault()
+      if (!programsIsLoading) {
+        if (this.state.filterProgramsCalled) {
+          if (this.state.selectedDepartment !== prevState.selectedDepartment) {
+            this.resetQueryVariablesToDefault()
+          }
+        } else {
+          this.setState({ filterProgramsCalled: true })
+          this.countAndRetrieveMorePrograms(
+            this.state.allProgramsRetrieved,
+            this.state.selectedDepartment
+          )
         }
-      }
-      if (!programsIsLoading && !this.state.filterProgramsCalled) {
-        this.setState({ filterProgramsCalled: true })
-        this.countAndRetrieveMorePrograms(
-          this.state.allProgramsRetrieved,
-          this.state.selectedDepartment
-        )
       }
       this.io = new window.IntersectionObserver(
         this.bottomOfLoadedCatalogCallback,

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -175,6 +175,8 @@ export class CatalogPage extends React.Component<Props> {
     if (!departmentsIsLoading && departments.length > 0) {
       if (!this.state.filterDepartmentsByTabNameCalled) {
         // initialize the departments on page load.
+        this.setState({ filterDepartmentsByTabNameCalled: true }) // This line must be before calling changeSelectedTab for the first time
+        // or else componentDidUpdate will end up in an infinite loop.
         this.changeSelectedTab(this.state.tabSelected)
       }
       if (!coursesIsLoading && !this.state.filterCoursesCalled) {
@@ -254,7 +256,6 @@ export class CatalogPage extends React.Component<Props> {
     this.setState({
       filteredDepartments: filteredDepartments
     })
-    this.setState({ filterDepartmentsByTabNameCalled: true })
     const departmentObject = this.getDepartmentObjectFromSlug(
       this.state.selectedDepartment
     )

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -319,9 +319,6 @@ export class CatalogPage extends React.Component<Props> {
         department => department.slug === selectedDepartmentSlug
       )
     }
-    this.props.history.push(
-      this.getUpdatedURL(this.state.tabSelected, selectedDepartmentSlug)
-    )
     return undefined
   }
 
@@ -348,7 +345,9 @@ export class CatalogPage extends React.Component<Props> {
       // If departmentObjectForTab is undefined, then the selectedDepartmentSlug
       // does not exist or ALL_DEPARTMENTS has been selected.
       this.setState({ selectedDepartment: ALL_DEPARTMENTS })
-
+      this.props.history.push(
+        this.getUpdatedURL(this.state.tabSelected, selectedDepartmentSlug)
+      )
       // Return either all of the courses or programs
       // depending on the current tabSelected value.
       if (this.state.tabSelected === COURSES_TAB) {
@@ -359,6 +358,9 @@ export class CatalogPage extends React.Component<Props> {
     } else {
       // A valid department or ALL_DEPARTMENTS has been selected.
       this.setState({ selectedDepartment: selectedDepartmentSlug })
+      this.props.history.push(
+        this.getUpdatedURL(this.state.tabSelected, selectedDepartmentSlug)
+      )
       // We need to attempt to retrieve more courses or programs
       // in order to populate the filtered catalog page.
       if (this.state.tabSelected === COURSES_TAB) {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -70,7 +70,7 @@ export class CatalogPage extends React.Component<Props> {
     filterProgramsCalled:             false,
     filterCoursesCalled:              false,
     filteredDepartments:              [],
-    filterDepartmentsByTabNameCalled:    false,
+    filterDepartmentsByTabNameCalled: false,
     selectedDepartment:               ALL_DEPARTMENTS,
     mobileFilterWindowExpanded:       false,
     items_per_row:                    3,
@@ -132,8 +132,7 @@ export class CatalogPage extends React.Component<Props> {
         if (
           !coursesIsLoading &&
           !this.state.isLoadingMoreItems &&
-          this.state.filteredCourses.length <
-            this.renderNumberOfCatalogItems()
+          this.state.filteredCourses.length < this.renderNumberOfCatalogItems()
         ) {
           this.setState({ isLoadingMoreItems: true })
           const response = await getNextCoursePage(
@@ -411,11 +410,6 @@ export class CatalogPage extends React.Component<Props> {
         selectedDepartment
       )
     }
-    this.io = new window.IntersectionObserver(
-      this.bottomOfLoadedCatalogCallback,
-      { threshold: 1.0 }
-    )
-    this.io.observe(this.container.current)
   }
 
   /**
@@ -428,15 +422,16 @@ export class CatalogPage extends React.Component<Props> {
       selectedDepartment !== "" &&
       departments.length > 0
     ) {
-      const newDepartment = this.props.departments.find(
+      const newDepartment = departments.find(
         department => department.slug === selectedDepartment
       )
       if (!newDepartment) {
-        this.setState({ selectedDepartment: ALL_DEPARTMENTS })
+        this.setState({ selectedDepartment: ALL_DEPARTMENTS }) // Why is does this not use changeSelectedDepartment
         return
       }
       if (
-        !this.state.isLoadingMoreItems && filteredCourses.length !== newDepartment.course_ids.length
+        !this.state.isLoadingMoreItems &&
+        filteredCourses.length !== newDepartment.course_ids.length
       ) {
         const remainingIDs = newDepartment.course_ids.filter(
           id =>
@@ -510,7 +505,10 @@ export class CatalogPage extends React.Component<Props> {
    * @param {Array<CourseDetailWithRuns | Program>} catalogItems
    * @returns {Array<CourseDetailWithRuns | Program>} Union of both array parameters.
    */
-  mergeCourseOrProgramArrays(aArray: Array<CourseDetailWithRuns | Program>, bArray: Array<CourseDetailWithRuns | Program>) {
+  mergeCourseOrProgramArrays(
+    aArray: Array<CourseDetailWithRuns | Program>,
+    bArray: Array<CourseDetailWithRuns | Program>
+  ) {
     const aIds = aArray.map(a => a.id)
     const uniqueObjects = bArray.filter(b => !aIds.includes(b.id))
     return aArray.concat(uniqueObjects)
@@ -518,8 +516,14 @@ export class CatalogPage extends React.Component<Props> {
 
   /**
    * Returns a filtered array of catalog items that are associated with a
-   * Department name matching the selectedDepartment.
-   * if the selectedDepartment does not equal "All Departments",
+   * Department whose name variable matches the selectedDepartment argument.
+   * The association between catalogItems and Departments is determined by the
+   * value of the tabSelected state variable:
+   * - If tabSelected equals COURSES_TAB, then the Department's course_ids array is compared
+   * with the catalog items IDs for matching IDs.
+   * - If tabSelected does not equal COURSES_TAB, then the Department's program_ids array is compared
+   * with the catalog items IDs for matching IDs.
+   * If selectedDepartment equals ALL_DEPARTMENTS, then the catalogItems array is returned.
    * @param {Array<CourseDetailWithRuns | Program>} catalogItems An array of catalog items which will be filtered based on their associated Departments.
    * @param {string} selectedDepartment The Department name used to compare against the catalogItems array.
    */
@@ -568,15 +572,15 @@ export class CatalogPage extends React.Component<Props> {
     const { departments } = this.props
     const selectedDepartment = this.state.selectedDepartment
     if (selectedDepartment === ALL_DEPARTMENTS) {
-      return this.state.tabSelected === COURSES_TAB ? this.state.allCoursesCount : this.state.allProgramsCount
+      return this.state.tabSelected === COURSES_TAB
+        ? this.state.allCoursesCount
+        : this.state.allProgramsCount
     } else if (!departments) return 0
     const departmentSlugs = departments.map(department => department.slug)
     if (!departmentSlugs.includes(selectedDepartment)) {
       return 0
     } else {
       if (this.state.tabSelected === COURSES_TAB) {
-        console.log("HI")
-        console.log(departments)
         return departments.find(
           department => department.slug === this.state.selectedDepartment
         ).course_ids.length

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -77,7 +77,7 @@ export class CatalogPage extends React.Component<Props> {
     courseQueryPage:                  1,
     programQueryPage:                 1,
     isLoadingMoreItems:               false,
-    courseQueryIDListString:                ""
+    courseQueryIDListString:          ""
   }
 
   constructor(props) {
@@ -215,7 +215,8 @@ export class CatalogPage extends React.Component<Props> {
       }
     }
     if (!departmentsIsLoading && departments.length > 0) {
-      if (!this.state.filterDepartmentsByTabNameCalled) { // Why is this here if we already handle it in the tab change?
+      if (!this.state.filterDepartmentsByTabNameCalled) {
+        // Why is this here if we already handle it in the tab change?
         this.setState({
           filteredDepartments: this.filterDepartmentsByTabName(
             this.state.tabSelected
@@ -235,12 +236,12 @@ export class CatalogPage extends React.Component<Props> {
           )
           this.setState({ filteredCourses: filteredCourses })
           this.setState({ filterCoursesCalled: true })
-          const departmentObject = this.getDepartmentForTab(this.state.selectedDepartment)
-          if (typeof departmentObject !== 'undefined') {
+          const departmentObject = this.getDepartmentForTab(
+            this.state.selectedDepartment
+          )
+          if (typeof departmentObject !== "undefined") {
             console.log(departmentObject)
-            this.retrieveMoreCourses(
-              departmentObject
-            )
+            this.retrieveMoreCourses(departmentObject)
           }
         }
       }
@@ -358,13 +359,16 @@ export class CatalogPage extends React.Component<Props> {
         this.setState({
           filteredCourses: filteredCourses
         })
-        const departmentObject = this.getDepartmentForTab(this.state.selectedDepartment)
-        if (this.renderNumberOfCatalogItems() === 0 || typeof departmentObjectForTab === 'undefined') {
+        const departmentObject = this.getDepartmentForTab(
+          this.state.selectedDepartment
+        )
+        if (
+          this.renderNumberOfCatalogItems() === 0 ||
+          typeof departmentObjectForTab === "undefined"
+        ) {
           this.changeSelectedDepartment(ALL_DEPARTMENTS)
         } else {
-          this.retrieveMoreCourses(
-            departmentObject
-          )
+          this.retrieveMoreCourses(departmentObject)
         }
       }
     }
@@ -411,7 +415,7 @@ export class CatalogPage extends React.Component<Props> {
       departmentObjectForTab = this.getDepartmentForTab(selectedDepartmentSlug)
     }
 
-    if (typeof departmentObjectForTab === 'undefined') {
+    if (typeof departmentObjectForTab === "undefined") {
       // If departmentObjectForTab is undefined, then the selectedDepartmentSlug
       // does not exist or ALL_DEPARTMENTS has been selected.
       this.setState({ selectedDepartment: ALL_DEPARTMENTS })
@@ -425,7 +429,7 @@ export class CatalogPage extends React.Component<Props> {
       }
     } else {
       // A valid department or ALL_DEPARTMENTS has been selected.
-      this.setState({ selectedDepartment: selectedDepartmentSlug})
+      this.setState({ selectedDepartment: selectedDepartmentSlug })
       // We need to attempt to retrieve more courses or programs
       // in order to populate the filtered catalog page.
       if (this.state.tabSelected === COURSES_TAB) {
@@ -452,19 +456,18 @@ export class CatalogPage extends React.Component<Props> {
    *
    */
   retrieveMoreCourses(selectedDepartmentObject) {
-    const {getNextCoursePage } = this.props
+    const { getNextCoursePage } = this.props
     console.log(this.state.filteredCourses)
     // Only request more courses if we have not alraedy retrieved all courses associated with the department.
     if (
       !this.state.isLoadingMoreItems &&
-      this.state.filteredCourses.length !== selectedDepartmentObject.course_ids.length
+      this.state.filteredCourses.length !==
+        selectedDepartmentObject.course_ids.length
     ) {
       // Determine the course IDs for courses associated with the department and not previously retrieved.
       const remainingIDs = selectedDepartmentObject.course_ids.filter(
         id =>
-          !this.state.allCoursesRetrieved
-            .map(course => course.id)
-            .includes(id)
+          !this.state.allCoursesRetrieved.map(course => course.id).includes(id)
       )
       this.setState({ isLoadingMoreItems: true })
       getNextCoursePage(1, remainingIDs.toString()).then(response => {
@@ -591,7 +594,9 @@ export class CatalogPage extends React.Component<Props> {
         ? this.state.allCoursesCount
         : this.state.allProgramsCount
     } else if (!departments) return 0
-    const departmentSlugs = this.state.filteredDepartments.map(department => department.slug)
+    const departmentSlugs = this.state.filteredDepartments.map(
+      department => department.slug
+    )
     if (!departmentSlugs.includes(this.state.selectedDepartment)) {
       return 0
     } else {

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -130,11 +130,7 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * Updates the filteredCourses state variable
-   * once coursesIsLoading is false..  Adds an observer to detect when
-   * the learner has scrolled to the bottom of the visible catalog items.
-   * Updates the filteredDepartments state variable once departmentsIsLoading
-   * is false.
+   * 
    */
   componentDidUpdate = () => {
     const {
@@ -242,37 +238,42 @@ export class CatalogPage extends React.Component<Props> {
    * - tabSelected, set to the parameter name.
    * - filteredDepartments, based on the return from filterDepartmentsByTabName.
    * Calls changeSelectedDepartment.
-   * @param {string} selectTabName The name of the tab that was selected.
+   * @param {string} selectedTabName The name of the tab that was selected.
    */
-  changeSelectedTab = (selectTabName: string) => {
-    this.setState({ tabSelected: selectTabName })
+  changeSelectedTab = (selectedTabName: string) => {
+    this.setState({ tabSelected: selectedTabName })
+    const filteredDepartments = this.filterDepartmentsByTabName(selectedTabName)
     this.setState({
-      filteredDepartments: this.filterDepartmentsByTabName(selectTabName)
+      filteredDepartments: filteredDepartments
     })
-    if (selectTabName === PROGRAMS_TAB) {
+    const departmentObject = this.getDepartmentObjectFromSlug(
+      this.state.selectedDepartment
+    )
+    // Check if the currently selected department exists for the
+    // newly selected tab.
+    const departmentExistsForTab = filteredDepartments.find(
+      department => department.slug === this.state.selectedDepartment
+    )
+    if (
+      !departmentExistsForTab ||
+      typeof departmentObject === "undefined"
+    ) {
+      // If there are no courses on this tab
+      // with an associated Department matching the
+      // selected department, update the selected department
+      // to ALL_DEPARTMENTS.
+      this.changeSelectedDepartment(ALL_DEPARTMENTS)
+    } else {
+      this.changeSelectedDepartment(departmentObject.slug)
+    }
+
+    // Update either the programs or courses based on the currently
+    // selected tab.
+    if (selectedTabName === PROGRAMS_TAB) {
       this.retrieveMorePrograms()
     }
-    if (selectTabName === COURSES_TAB) {
-      const { coursesIsLoading } = this.props
-      if (!coursesIsLoading) {
-        const departmentObject = this.getDepartmentObjectFromSlug(
-          this.state.selectedDepartment
-        )
-        console.log(this.renderNumberOfCatalogItems())
-        if (
-          this.renderNumberOfCatalogItems() === 0 ||
-          typeof departmentObject === "undefined"
-        ) {
-          // If there are no courses on this tab
-          // with an associated Department matching the
-          // selected department, update the selected department
-          // to ALL_DEPARTMENTS.
-          this.changeSelectedDepartment(ALL_DEPARTMENTS)
-        } else {
-          this.changeSelectedDepartment(departmentObject.slug)
-          this.retrieveMoreCoursesByDepartment(departmentObject)
-        }
-      }
+    if (selectedTabName === COURSES_TAB) {
+      this.retrieveMoreCoursesByDepartment(departmentObject)
     }
   }
 

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -567,7 +567,7 @@ describe("CatalogPage", function() {
     expect(inner.instance().renderNumberOfCatalogItems()).equals(3)
 
     // Select a department to filter by.
-    inner.instance().changeSelectedDepartment("history")
+    inner.instance().changeSelectedDepartment("history", "courses")
     // Confirm the state updated to reflect the selected department.
     expect(inner.state().selectedDepartment).equals("history")
     expect(inner.state().tabSelected).equals("courses")

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -584,7 +584,6 @@ describe("CatalogPage", function() {
     // Change to the programs tab.
     inner.instance().changeSelectedTab("programs")
     expect(inner.state().tabSelected).equals("programs")
-    inner.instance().changeSelectedDepartment("history")
     // Confirm that the selected department is the same as before.
     expect(inner.state().selectedDepartment).equals("history")
 

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -131,8 +131,12 @@ const displayedProgram = {
       "http://mitxonline.odl.local:8013/static/images/mit-dome.png"
   },
   program_type: "Series",
-  departments:  ["Science"],
-  live:         true
+  departments:  [
+    {
+      name: "Science"
+    }
+  ],
+  live: true
 }
 
 describe("CatalogPage", function() {
@@ -210,7 +214,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().allCoursesRetrieved)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
   })
 
   it("updates state from changeSelectedTab when selecting program tab", async () => {
@@ -269,7 +273,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().allProgramsRetrieved)).equals(
       JSON.stringify(programs)
     )
-    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(5)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(5)
   })
 
   it("renders catalog department filter for courses and programs tabs", async () => {
@@ -392,27 +396,34 @@ describe("CatalogPage", function() {
     inner.state().selectedDepartment = "math"
     let coursesFilteredByCriteriaAndDepartment = inner
       .instance()
-      .filteredCoursesBasedOnSelectedDepartment("math", courses)
+      .filteredCoursesOrProgramsByDepartmentSlug("math", courses, "courses")
     expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
     inner.state().selectedDepartment = "science"
     coursesFilteredByCriteriaAndDepartment = inner
       .instance()
-      .filteredCoursesBasedOnSelectedDepartment("science", courses)
+      .filteredCoursesOrProgramsByDepartmentSlug("science", courses, "courses")
     expect(coursesFilteredByCriteriaAndDepartment.length).equals(2)
     inner.state().selectedDepartment = "All Departments"
     coursesFilteredByCriteriaAndDepartment = inner
       .instance()
-      .filteredCoursesBasedOnSelectedDepartment("All Departments", courses)
+      .filteredCoursesOrProgramsByDepartmentSlug(
+        "All Departments",
+        courses,
+        "courses"
+      )
     expect(coursesFilteredByCriteriaAndDepartment.length).equals(3)
   })
 
   it("renders catalog programs when filtered by department", async () => {
     const program1 = JSON.parse(JSON.stringify(displayedProgram))
     program1.departments = ["Math"]
+    program1.id = 1
     const program2 = JSON.parse(JSON.stringify(displayedProgram))
     program2.departments = ["History"]
+    program2.id = 2
     const program3 = JSON.parse(JSON.stringify(displayedProgram))
     program3.departments = ["History"]
+    program3.id = 3
     programs = [program1, program2, program3]
     const { inner } = await renderPage({
       queries: {
@@ -454,132 +465,28 @@ describe("CatalogPage", function() {
     })
     inner.state().tabSelected = "programs"
     inner.state().selectedDepartment = "math"
-    let programsFilteredByCriteriaAndDepartment = inner
+    let programsFilteredByDepartment = inner
       .instance()
-      .filteredProgramsByDepartmentAndCriteria("math", programs)
-    expect(programsFilteredByCriteriaAndDepartment.length).equals(1)
+      .filteredCoursesOrProgramsByDepartmentSlug("math", programs, "programs")
+    expect(programsFilteredByDepartment.length).equals(1)
     inner.state().selectedDepartment = "history"
-    programsFilteredByCriteriaAndDepartment = inner
+    programsFilteredByDepartment = inner
       .instance()
-      .filteredProgramsByDepartmentAndCriteria("history", programs)
-    expect(programsFilteredByCriteriaAndDepartment.length).equals(2)
+      .filteredCoursesOrProgramsByDepartmentSlug(
+        "history",
+        programs,
+        "programs"
+      )
+    expect(programsFilteredByDepartment.length).equals(2)
     inner.state().selectedDepartment = "All Departments"
-    programsFilteredByCriteriaAndDepartment = inner
+    programsFilteredByDepartment = inner
       .instance()
-      .filteredProgramsByDepartmentAndCriteria("All Departments", programs)
-    expect(programsFilteredByCriteriaAndDepartment.length).equals(3)
-  })
-
-  it("renders no catalog courses if the course's associated course run is not live", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    courseRuns[0].live = false
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(0)
-  })
-
-  it("renders no catalog courses if the course's associated course run has no start date", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    delete courseRuns[0].start_date
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(0)
-  })
-
-  it("renders no catalog courses if the course's associated course run has no enrollment start date", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    delete courseRuns[0].enrollment_start
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(0)
-  })
-
-  it("renders no catalog courses if the course's associated course run has an enrollment start date in the future", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    courseRuns[0].enrollment_start = moment().add(2, "M")
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(0)
-  })
-
-  it("renders no catalog courses if the course's associated course run has an enrollment end date in the past", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    courseRuns[0].enrollment_end = moment().subtract(2, "M")
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(0)
-  })
-
-  it("renders catalog courses if the course's associated course run has no enrollment end date", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    delete courseRuns[0].enrollment_end
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-  })
-
-  it("renders catalog courses if the course's associated course run has an enrollment end date in the future", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    courseRuns[0].enrollment_end = moment().add(2, "M")
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-  })
-
-  it("renders catalog courses if the course's associated course run has an enrollment start date in the past", async () => {
-    const courseRuns = JSON.parse(JSON.stringify(displayedCourse.courseruns))
-    const { inner } = await renderPage()
-    let coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
-    courseRuns[0].enrollment_start = moment().subtract(2, "M")
-    coursesFilteredByCriteriaAndDepartment = inner
-      .instance()
-      .validateCoursesCourseRuns(courseRuns)
-    expect(coursesFilteredByCriteriaAndDepartment.length).equals(1)
+      .filteredCoursesOrProgramsByDepartmentSlug(
+        "All Departments",
+        programs,
+        "programs"
+      )
+    expect(programsFilteredByDepartment.length).equals(3)
   })
 
   it("renders catalog courses based on selected department", async () => {
@@ -593,6 +500,9 @@ describe("CatalogPage", function() {
     course3.departments = [{ name: "Math" }, { name: "History" }]
     course3.id = 3
     courses = [course1, course2, course3]
+    const program1 = JSON.parse(JSON.stringify(displayedProgram))
+    program1.departments = [{ name: "History" }]
+    program1.id = 1
     const { inner } = await renderPage(
       {
         queries: {
@@ -615,7 +525,7 @@ describe("CatalogPage", function() {
             results: courses
           },
           programs: {
-            results: [displayedProgram]
+            results: [program1]
           },
           departments: [
             {
@@ -654,7 +564,7 @@ describe("CatalogPage", function() {
       JSON.stringify(courses)
     )
     // Number of catalog items should match the number of visible courses.
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(3)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(3)
 
     // Select a department to filter by.
     inner.instance().changeSelectedDepartment("history")
@@ -662,7 +572,7 @@ describe("CatalogPage", function() {
     expect(inner.state().selectedDepartment).equals("history")
     expect(inner.state().tabSelected).equals("courses")
     // Confirm the number of catalog items updated to reflect the items filtered by department.
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(2)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
     // Confirm the courses filtered are those which have a department name matching the selected department.
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify([course2, course3])
@@ -673,6 +583,8 @@ describe("CatalogPage", function() {
 
     // Change to the programs tab.
     inner.instance().changeSelectedTab("programs")
+    expect(inner.state().tabSelected).equals("programs")
+    inner.instance().changeSelectedDepartment("history")
     // Confirm that the selected department is the same as before.
     expect(inner.state().selectedDepartment).equals("history")
 
@@ -726,7 +638,7 @@ describe("CatalogPage", function() {
       JSON.stringify(courses)
     )
     // one shows visually, but the total is 2
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(2)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
     const course2 = JSON.parse(JSON.stringify(displayedCourse))
     course2.id = 3
     course2.departments = [{ name: "Math" }, { name: "History" }]
@@ -750,14 +662,8 @@ describe("CatalogPage", function() {
     )
 
     // Should expect 2 courses to be visually displayed in the catalog now. Total count should stay 2.
-    expect(inner.state().courseQueryPage).equals(3)
-    expect(JSON.stringify(inner.state().allCoursesRetrieved)).equals(
-      JSON.stringify([displayedCourse, course2])
-    )
-    expect(JSON.stringify(inner.state().filteredCourses)).equals(
-      JSON.stringify([displayedCourse, course2])
-    )
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(2)
+    expect(inner.state().courseQueryPage).equals(2)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(2)
   })
 
   it("do not load more at the bottom of the courses catalog page if next page is null", async () => {
@@ -798,7 +704,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().allCoursesRetrieved)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
     expect(inner.state().courseQueryPage).equals(1)
 
     // Simulate the user reaching the bottom of the catalog page.
@@ -813,7 +719,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
   })
 
   it("do not load more at the bottom of the courses catalog page if isLoadingMoreItems is true", async () => {
@@ -851,7 +757,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
     expect(inner.state().courseQueryPage).equals(1)
 
     // Simulate the user reaching the bottom of the catalog page.
@@ -870,7 +776,7 @@ describe("CatalogPage", function() {
     expect(JSON.stringify(inner.state().filteredCourses)).equals(
       JSON.stringify(courses)
     )
-    expect(inner.instance().renderNumberOfCatalogCourses()).equals(1)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(1)
   })
 
   it("load more at the bottom of the programs catalog page, all departments filter", async () => {
@@ -927,7 +833,7 @@ describe("CatalogPage", function() {
       JSON.stringify(programs)
     )
     // While there is only one showing, there are still 4 total per the count. The total should be shown.
-    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(4)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(4)
 
     // simulate the state variables changing correctly since the shallow render doesn't actually change the state
     inner.state().programQueryPage = 2
@@ -944,38 +850,44 @@ describe("CatalogPage", function() {
     )
 
     // The count should still be 4 regardless of how many are added or not, since the highest provided count was 4.
-    expect(inner.instance().renderNumberOfCatalogPrograms()).equals(4)
+    expect(inner.instance().renderNumberOfCatalogItems()).equals(4)
   })
 
-  it("mergeNewObjects removes duplicates if present", async () => {
+  it("mergeCourseOrProgramArrays removes duplicates if present", async () => {
     const oldArray = [displayedProgram]
     const newArray = [displayedProgram]
     const { inner } = await renderPage()
-    const mergedArray = inner.instance().mergeNewObjects(oldArray, newArray)
+    const mergedArray = inner
+      .instance()
+      .mergeCourseOrProgramArrays(oldArray, newArray)
     expect(mergedArray.length).equals(1)
     expect(JSON.stringify(mergedArray)).equals(JSON.stringify(oldArray))
   })
 
-  it("mergeNewObjects merges objects if they are not duplicates", async () => {
+  it("mergeCourseOrProgramArrays merges objects if they are not duplicates", async () => {
     const oldArray = [displayedProgram]
     const newProgram = JSON.parse(JSON.stringify(displayedProgram))
     newProgram.id = 3
     const newArray = [newProgram]
     const { inner } = await renderPage()
-    const mergedArray = inner.instance().mergeNewObjects(oldArray, newArray)
+    const mergedArray = inner
+      .instance()
+      .mergeCourseOrProgramArrays(oldArray, newArray)
     expect(mergedArray.length).equals(2)
     expect(JSON.stringify(mergedArray)).equals(
       JSON.stringify([displayedProgram, newProgram])
     )
   })
 
-  it("mergeNewObjects keeps items with different IDs and removes duplicates", async () => {
+  it("mergeCourseOrProgramArrays keeps items with different IDs and removes duplicates", async () => {
     const oldArray = [displayedProgram]
     const newProgram = JSON.parse(JSON.stringify(displayedProgram))
     newProgram.id = 3
     const newArray = [newProgram, displayedProgram, displayedProgram]
     const { inner } = await renderPage()
-    const mergedArray = inner.instance().mergeNewObjects(oldArray, newArray)
+    const mergedArray = inner
+      .instance()
+      .mergeCourseOrProgramArrays(oldArray, newArray)
     expect(mergedArray.length).equals(2)
     expect(JSON.stringify(mergedArray)).equals(
       JSON.stringify([displayedProgram, newProgram])

--- a/frontend/public/src/util/integration_test_helper.js
+++ b/frontend/public/src/util/integration_test_helper.js
@@ -96,10 +96,7 @@ export default class IntegrationTestHelper {
           {...extraProps}
         />,
         {
-          context: {
-            // TODO: should be removed in the near future after upgrading enzyme
-            store
-          }
+          context: {}
         }
       )
 


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description

1. Removes a bunch of unused or duplicate code.
2. Refines logic and methods to be more single-purpose/functional.
3. Allows for Program + department URLs such as http://mitxonline.odl.local:8013/catalog/programs/science
4. Resolves and issue where https://rc.mitxonline.mit.edu/catalog/programs loads an empty catalog page.

### How can this be tested?

1. Verify that you can navigate the catalog page for both courses and programs, switching between departments, switching between tabs, and loading more courses and programs as you scroll.
2. Verify that you can navigate to the course and program tab using a URL such as http://mitxonline.odl.local:8013/catalog/programs/
3. Verify that you can navigate to the course and program tab, and filter by department, using a URL such as http://mitxonline.odl.local:8013/catalog/programs/science
4. Accessibility of the catalog page should not change.
