### PR TITLE
Ensure filteredPrograms is set earlier and change the route when navigation changes.

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -374,7 +374,9 @@ export class CatalogPage extends React.Component<Props> {
       }
     }
     console.log("changeSelectedTab")
-    this.props.history.push(this.getUpdatedURL(selectTabName, this.state.selectedDepartment))
+    this.props.history.push(
+      this.getUpdatedURL(selectTabName, this.state.selectedDepartment)
+    )
     this.io = new window.IntersectionObserver(
       this.bottomOfLoadedCatalogCallback,
       { threshold: 1.0 }
@@ -414,7 +416,9 @@ export class CatalogPage extends React.Component<Props> {
         selectedDepartment
       )
     }
-    this.props.history.push(this.getUpdatedURL(this.state.tabSelected, selectedDepartment))
+    this.props.history.push(
+      this.getUpdatedURL(this.state.tabSelected, selectedDepartment)
+    )
     console.log("changeSelectedDepartment")
     this.io = new window.IntersectionObserver(
       this.bottomOfLoadedCatalogCallback,

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -251,7 +251,6 @@ export class CatalogPage extends React.Component<Props> {
       }
       if (!programsIsLoading && !this.state.filterProgramsCalled) {
         this.setState({ filterProgramsCalled: true })
-        this.setState({ filteredPrograms: programs })
         this.countAndRetrieveMorePrograms(
           this.state.allProgramsRetrieved,
           this.state.selectedDepartment
@@ -739,7 +738,7 @@ export class CatalogPage extends React.Component<Props> {
         filteredCourses,
         this.renderCourseCatalogCard.bind(this)
       )
-    } else if (tabSelected === PROGRAMS_TAB && filteredPrograms.length > 0) {
+    } else if (tabSelected === PROGRAMS_TAB) {
       return this.renderCatalogRows(
         filteredPrograms,
         this.renderProgramCatalogCard.bind(this)

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -251,6 +251,7 @@ export class CatalogPage extends React.Component<Props> {
       }
       if (!programsIsLoading && !this.state.filterProgramsCalled) {
         this.setState({ filterProgramsCalled: true })
+        this.setState({ filteredPrograms: programs })
         this.countAndRetrieveMorePrograms(
           this.state.allProgramsRetrieved,
           this.state.selectedDepartment
@@ -372,6 +373,8 @@ export class CatalogPage extends React.Component<Props> {
         )
       }
     }
+    console.log("changeSelectedTab")
+    this.props.history.push(this.getUpdatedURL(selectTabName, this.state.selectedDepartment))
     this.io = new window.IntersectionObserver(
       this.bottomOfLoadedCatalogCallback,
       { threshold: 1.0 }
@@ -411,6 +414,8 @@ export class CatalogPage extends React.Component<Props> {
         selectedDepartment
       )
     }
+    this.props.history.push(this.getUpdatedURL(this.state.tabSelected, selectedDepartment))
+    console.log("changeSelectedDepartment")
     this.io = new window.IntersectionObserver(
       this.bottomOfLoadedCatalogCallback,
       { threshold: 1.0 }
@@ -575,6 +580,17 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
+   * Returns the updated URL based on the given state of the catalog page.
+   * @returns {string}
+   */
+  getUpdatedURL(tabSelected, selectedDepartment) {
+    if (selectedDepartment === ALL_DEPARTMENTS) {
+      return `/catalog/${tabSelected}`
+    }
+    return `/catalog/${tabSelected}/${selectedDepartment}`
+  }
+
+  /**
    * Returns the number of courses based on the selectedDepartment.
    * If the selectedDepartment is "All Departments", the total number of courses is returned.
    * If the selectedDepartment is not found in the departments array, 0 is returned.
@@ -721,7 +737,7 @@ export class CatalogPage extends React.Component<Props> {
         filteredCourses,
         this.renderCourseCatalogCard.bind(this)
       )
-    } else if (tabSelected === PROGRAMS_TAB) {
+    } else if (tabSelected === PROGRAMS_TAB && filteredPrograms.length > 0) {
       return this.renderCatalogRows(
         filteredPrograms,
         this.renderProgramCatalogCard.bind(this)

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -373,7 +373,6 @@ export class CatalogPage extends React.Component<Props> {
         )
       }
     }
-    console.log("changeSelectedTab")
     this.props.history.push(
       this.getUpdatedURL(selectTabName, this.state.selectedDepartment)
     )
@@ -419,7 +418,6 @@ export class CatalogPage extends React.Component<Props> {
     this.props.history.push(
       this.getUpdatedURL(this.state.tabSelected, selectedDepartment)
     )
-    console.log("changeSelectedDepartment")
     this.io = new window.IntersectionObserver(
       this.bottomOfLoadedCatalogCallback,
       { threshold: 1.0 }


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/3950

### Description (What does it do?)
Makes sure filteredPrograms is set earlier on the page to avoid the state where the programs don't show on load of /catalog/programs.
Added routing to update history on change to tab or department

### How can this be tested?
load /catalog/programs and programs should show
load /catalog/programs/department-name and department name should show
When you navigate by clicking a tab or department, the URL should update