### PR TITLE
Fix enrollment dialog default option

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -148,7 +148,7 @@ export class CourseProductDetailEnroll extends React.Component<
 
   hndSetCourseRun = (event: any) => {
     const { courseRuns } = this.props
-    if (event.target.value === "") {
+    if (event.target.value === "default") {
       this.setCurrentCourseRun(null)
       return
     }
@@ -203,7 +203,7 @@ export class CourseProductDetailEnroll extends React.Component<
           onChange={this.hndSetCourseRun.bind(this)}
           className="form-control"
         >
-          <option value="d" key="default-select">
+          <option value="default" key="default-select">
             Please Select
           </option>
           {courseRuns &&

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -23,6 +23,7 @@ import {
 
 import * as courseApi from "../lib/courseApi"
 import { makeUser, makeAnonymousUser } from "../factories/user"
+import { getDisabledProp } from "../lib/test_utils"
 
 describe("CourseProductDetailEnrollShallowRender", () => {
   let helper,
@@ -542,36 +543,23 @@ describe("CourseProductDetailEnrollShallowRender", () => {
             .at(0)
             .prop("disabled")
         )
-        assert.isTrue(
-          inner
-            .find("button.enroll-now-free")
-            .at(0)
-            .prop("disabled")
-        )
+        assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
         modal
           .find("select.form-control")
           .simulate("change", { target: { value: courseRun["id"] } })
         inner.update()
-        assert.isFalse(
-          inner
-            .find("button.enroll-now-free")
-            .at(0)
-            .prop("disabled")
-        )
-        assert.isFalse(
-          inner
-            .find("button.btn-upgrade")
-            .at(0)
-            .prop("disabled")
-        )
+        assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
+        assert.isFalse(getDisabledProp(inner, "button.btn-upgrade"))
+        // check if default selected it resets back
+        modal
+          .find("select.form-control")
+          .simulate("change", { target: { value: "default" } })
+        inner.update()
+        assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+        assert.isTrue(getDisabledProp(inner, "button.btn-upgrade"))
       } else {
         assert.isFalse(selectorControl.exists())
-        assert.isFalse(
-          inner
-            .find("button.enroll-now-free")
-            .at(0)
-            .prop("disabled")
-        )
+        assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
         assert.isFalse(
           upgradeForm
             .find("button.btn-upgrade")
@@ -604,22 +592,12 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
     const modal = inner.find(".upgrade-enrollment-modal")
     assert.isTrue(modal.find("select.form-control").exists())
-    assert.isTrue(
-      modal
-        .find("button.enroll-now-free")
-        .at(0)
-        .prop("disabled")
-    )
+    assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
     modal
       .find("select.form-control")
       .simulate("change", { target: { value: courseRun["id"] } })
     inner.update()
-    assert.isFalse(
-      inner
-        .find("button.enroll-now-free")
-        .at(0)
-        .prop("disabled")
-    )
+    assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
     assert.isFalse(inner.find("button.btn-upgrade").exists())
   })
   ;[
@@ -655,28 +633,15 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
       const modal = inner.find(".upgrade-enrollment-modal")
       assert.isTrue(modal.find("select.form-control").exists())
-      let upgradeBtnDisabledProp = inner
-        .find("button.btn-upgrade")
-        .at(0)
-        .prop("disabled")
-      assert.isTrue(
-        modal
-          .find("button.enroll-now-free")
-          .at(0)
-          .prop("disabled")
-      )
-      assert.isTrue(upgradeBtnDisabledProp)
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      assert.isTrue(getDisabledProp(inner, "button.btn-upgrade"))
       modal
         .find("select.form-control")
         .simulate("change", { target: { value: runWithMixedInfo["id"] } })
       inner.update()
       const certPricing = inner.find(".certificate-pricing").at(0)
-      upgradeBtnDisabledProp = inner
-        .find("button.btn-upgrade")
-        .at(0)
-        .prop("disabled")
       if (isUpgradable && hasProduct) {
-        assert.isFalse(upgradeBtnDisabledProp)
+        assert.isFalse(getDisabledProp(inner, "button.btn-upgrade"))
         assert.isTrue(certPricing.exists())
         assert.isTrue(
           certPricing
@@ -686,15 +651,10 @@ describe("CourseProductDetailEnrollShallowRender", () => {
             )
         )
       } else {
-        assert.isTrue(upgradeBtnDisabledProp)
+        assert.isTrue(getDisabledProp(inner, "button.btn-upgrade"))
         assert.isTrue(certPricing.text().includes("not available"))
       }
-      assert.isFalse(
-        inner
-          .find("button.enroll-now-free")
-          .at(0)
-          .prop("disabled")
-      )
+      assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
     })
   })
 

--- a/frontend/public/src/lib/test_utils.js
+++ b/frontend/public/src/lib/test_utils.js
@@ -30,6 +30,12 @@ export const findFormikErrorByName = (wrapper: any, name: string) =>
     .find("FormikConnect(ErrorMessageImpl)")
     .filterWhere(node => node.prop("name") === name)
 
+export const getDisabledProp = (inner: any, name: string) =>
+  inner
+    .find(`${name}`)
+    .at(0)
+    .prop("disabled")
+
 /**
  * This is here to support testing components that are wrapped with a
  * context consumer, e.g.:


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3944

### Description (What does it do?)
When selecting "Please select" again it should reset `currentCourseRun` and disable both upgrade and enroll buttons.

<img width="752" alt="Screenshot 2024-04-10 at 1 26 25 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/da084959-4e62-4333-813f-c8f984cb07ce">
