### PR TITLE
Update Browse link on Dashboard

### DIFF
--- a/frontend/public/src/components/EnrolledCourseList.js
+++ b/frontend/public/src/components/EnrolledCourseList.js
@@ -38,7 +38,7 @@ export class EnrolledCourseList extends React.Component<EnrolledCourseListProps>
           <h2>Enroll Now</h2>
           <p>
             You are not enrolled in any courses yet. Please{" "}
-            <a className="fw-bold" href={routes.root}>
+            <a className="fw-bold" href={routes.catalog}>
               browse our courses
             </a>
             .


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/3831

### Description (What does it do?)
Changed the route from root to catalog

### How can this be tested?
Log in as a user with no enrolled courses. The link in the middle of the page to "browse our courses" should link to the catalog, not the home page.