### PR TITLE
Course Product Page with no Runs

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -270,6 +270,11 @@ body.new-design {
           text-align: center;
         }
 
+        .btn-enrollment-button.disabled {
+          color: $white;
+          background-color: grey;
+        }
+
         button.btn-enrollment-button {
           color: $white;
         }

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -44,6 +44,18 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     )
   }
 
+  warningMessage(isArchived) {
+    const message = isArchived
+      ? "This course is no longer active, but you can still access selected content."
+      : "No sessions of this course are currently open for enrollment. More sessions may be added in the future."
+    return (
+      <div className="row d-flex align-self-stretch callout callout-warning course-archived-message">
+        <i className="material-symbols-outlined warning">error</i>
+        <p>{message}</p>
+      </div>
+    )
+  }
+
   render() {
     const { courses, courseRuns, enrollments } = this.props
 
@@ -55,9 +67,11 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     const run = getFirstRelevantRun(course, courseRuns)
     const product = run && run.products.length > 0 && run.products[0]
 
-    const isArchived =
-      moment().isAfter(run.end_date) &&
-      (moment().isBefore(run.enrollment_end) || emptyOrNil(run.enrollment_end))
+    const isArchived = run
+      ? moment().isAfter(run.end_date) &&
+        (moment().isBefore(run.enrollment_end) ||
+          emptyOrNil(run.enrollment_end))
+      : false
 
     const startDates = []
     const moreEnrollableCourseRuns = courseRuns && courseRuns.length > 1
@@ -82,41 +96,42 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     return (
       <>
         <div className="enrollment-info-box componentized">
-          {isArchived ? (
-            <div className="row d-flex align-self-stretch callout callout-warning course-archived-message">
-              <i className="material-symbols-outlined warning">error</i>
-              <p>
-                This course is no longer active, but you can still access
-                selected content.
-              </p>
+          {!run || isArchived ? this.warningMessage(isArchived) : null}
+          {run ? (
+            <div className="row d-flex align-items-center course-timing-message">
+              <div
+                className="enrollment-info-icon"
+                aria-level="3"
+                role="heading"
+              >
+                <img
+                  src="/static/images/products/start-date.png"
+                  alt="Course Timing"
+                />
+              </div>
+              <div className="enrollment-info-text">
+                {isArchived
+                  ? "Course content available anytime"
+                  : getStartDateText(run)}
+              </div>
+
+              {!isArchived && moreEnrollableCourseRuns ? (
+                <>
+                  <button
+                    className="more-enrollment-info"
+                    onClick={() => this.toggleShowMoreEnrollDates()}
+                  >
+                    {this.state.showMoreEnrollDates
+                      ? "Show Less"
+                      : "More Dates"}
+                  </button>
+                  {this.state.showMoreEnrollDates ? (
+                    <ul className="more-dates-enrollment-list">{startDates}</ul>
+                  ) : null}
+                </>
+              ) : null}
             </div>
           ) : null}
-          <div className="row d-flex align-items-center course-timing-message">
-            <div className="enrollment-info-icon" aria-level="3" role="heading">
-              <img
-                src="/static/images/products/start-date.png"
-                alt="Course Timing"
-              />
-            </div>
-            <div className="enrollment-info-text">
-              {isArchived
-                ? "Course content available anytime"
-                : getStartDateText(run)}
-            </div>
-            {!isArchived && moreEnrollableCourseRuns ? (
-              <>
-                <button
-                  className="more-enrollment-info"
-                  onClick={() => this.toggleShowMoreEnrollDates()}
-                >
-                  {this.state.showMoreEnrollDates ? "Show Less" : "More Dates"}
-                </button>
-                {this.state.showMoreEnrollDates ? (
-                  <ul className="more-dates-enrollment-list">{startDates}</ul>
-                ) : null}
-              </>
-            ) : null}
-          </div>
           {course && course.page ? (
             <div className="row d-flex align-items-top course-effort-message">
               <div
@@ -131,37 +146,41 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               </div>
               <div className="enrollment-info-text">
                 {course.page.length}
-                {isArchived ? (
-                  <>
-                    <span className="badge badge-pacing">ARCHIVED</span>
-                    <a
-                      className="pacing-faq-link float-right"
-                      href="https://mitxonline.zendesk.com/hc/en-us/articles/21995114519067-What-are-Archived-courses-on-MITx-Online-"
-                    >
-                      What's this?
-                    </a>
-                  </>
-                ) : run && run.is_self_paced ? (
-                  <>
-                    <span className="badge badge-pacing">SELF-PACED</span>
-                    <a
-                      className="pacing-faq-link float-right"
-                      href="https://mitxonline.zendesk.com/hc/en-us/articles/21994872904475-What-are-Self-Paced-courses-on-MITx-Online-"
-                    >
-                      What's this?
-                    </a>
-                  </>
-                ) : (
-                  <>
-                    <span className="badge badge-pacing">INSTRUCTOR-PACED</span>
-                    <a
-                      className="pacing-faq-link float-right"
-                      href="https://mitxonline.zendesk.com/hc/en-us/articles/21994938130075-What-are-Instructor-Paced-courses-on-MITx-Online-"
-                    >
-                      What's this?
-                    </a>
-                  </>
-                )}
+                {run ? (
+                  isArchived ? (
+                    <>
+                      <span className="badge badge-pacing">ARCHIVED</span>
+                      <a
+                        className="pacing-faq-link float-right"
+                        href="https://mitxonline.zendesk.com/hc/en-us/articles/21995114519067-What-are-Archived-courses-on-MITx-Online-"
+                      >
+                        What's this?
+                      </a>
+                    </>
+                  ) : run.is_self_paced ? (
+                    <>
+                      <span className="badge badge-pacing">SELF-PACED</span>
+                      <a
+                        className="pacing-faq-link float-right"
+                        href="https://mitxonline.zendesk.com/hc/en-us/articles/21994872904475-What-are-Self-Paced-courses-on-MITx-Online-"
+                      >
+                        What's this?
+                      </a>
+                    </>
+                  ) : (
+                    <>
+                      <span className="badge badge-pacing">
+                        INSTRUCTOR-PACED
+                      </span>
+                      <a
+                        className="pacing-faq-link float-right"
+                        href="https://mitxonline.zendesk.com/hc/en-us/articles/21994938130075-What-are-Instructor-Paced-courses-on-MITx-Online-"
+                      >
+                        What's this?
+                      </a>
+                    </>
+                  )
+                ) : null}
 
                 {course.page.effort ? (
                   <>
@@ -189,7 +208,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
               />
             </div>
             <div className="enrollment-info-text">
-              {product && !isArchived ? (
+              {run && product && !isArchived ? (
                 <>
                   Certificate track:{" "}
                   {formatLocalePrice(getFlexiblePriceForProduct(product))}

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -433,8 +433,7 @@ export class CourseProductDetailEnroll extends React.Component<
   }
 
   renderEnrollLoginButton() {
-    const { currentUser } = this.props
-    return !currentUser || !currentUser.id ? (
+    return (
       <h2>
         <a
           href={`${routes.login}?next=${encodeURIComponent(
@@ -445,43 +444,55 @@ export class CourseProductDetailEnroll extends React.Component<
           Enroll now
         </a>
       </h2>
-    ) : null
+    )
+  }
+
+  renderAccessCourseButton() {
+    return (
+      <h2>
+        <a
+          href={`${routes.login}?next=${encodeURIComponent(
+            window.location.pathname
+          )}`}
+          className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight"
+        >
+          Access Course Materials
+        </a>
+      </h2>
+    )
   }
 
   renderEnrollNowButton(
     run: EnrollmentFlaggedCourseRun,
     product: Product | null
   ) {
-    const { currentUser, courseRuns } = this.props
+    const { courseRuns } = this.props
     const csrfToken = getCookie("csrftoken")
-    return currentUser &&
-      currentUser.id &&
-      run &&
-      isWithinEnrollmentPeriod(run) ? (
-        <h2>
-          {(product && run.is_upgradable) ||
+    return run && isWithinEnrollmentPeriod(run) ? (
+      <h2>
+        {(product && run.is_upgradable) ||
         (courseRuns && courseRuns.length > 1) ? (
-              <button
-                id="upgradeEnrollBtn"
-                className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
-                onClick={() => this.toggleUpgradeDialogVisibility()}
-              >
+            <button
+              id="upgradeEnrollBtn"
+              className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
+              onClick={() => this.toggleUpgradeDialogVisibility()}
+            >
             Enroll now
-              </button>
-            ) : (
-              <form action="/enrollments/" method="post">
-                <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
-                <input type="hidden" name="run" value={run ? run.id : ""} />
-                <button
-                  type="submit"
-                  className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
-                >
+            </button>
+          ) : (
+            <form action="/enrollments/" method="post">
+              <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
+              <input type="hidden" name="run" value={run ? run.id : ""} />
+              <button
+                type="submit"
+                className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
+              >
               Enroll now
-                </button>
-              </form>
-            )}
-        </h2>
-      ) : null
+              </button>
+            </form>
+          )}
+      </h2>
+    ) : null
   }
 
   render() {
@@ -506,16 +517,19 @@ export class CourseProductDetailEnroll extends React.Component<
       }
     }
 
-    return run ? (
+    return (
       <>
         {
           // $FlowFixMe: isLoading null or undefined
           <Loader key="product_detail_enroll_loader" isLoading={isLoading}>
             <>
-              {this.renderEnrollLoginButton()}
-              {this.renderEnrollNowButton(run, product)}
+              {run
+                ? currentUser && currentUser.id
+                  ? this.renderEnrollNowButton(run, product)
+                  : this.renderEnrollLoginButton()
+                : this.renderAccessCourseButton()}
 
-              {currentUser ? this.renderAddlProfileFieldsModal() : null}
+              {run && currentUser ? this.renderAddlProfileFieldsModal() : null}
               {run ? this.renderUpgradeEnrollmentDialog(run) : null}
             </>
           </Loader>
@@ -541,7 +555,7 @@ export class CourseProductDetailEnroll extends React.Component<
           }
         </>
       </>
-    ) : null
+    )
   }
 }
 

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -454,7 +454,7 @@ export class CourseProductDetailEnroll extends React.Component<
           href={`${routes.login}?next=${encodeURIComponent(
             window.location.pathname
           )}`}
-          className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight"
+          className="btn btn-primary btn-enrollment-button btn-lg highlight disabled"
         >
           Access Course Materials
         </a>


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3430

### Description (What does it do?)
Updates the Course info box to still show info when no active run is available.

### Screenshots (if appropriate):
<img width="399" alt="Screenshot 2024-04-16 at 3 28 28 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/d6be442a-8b32-4dfb-aa8d-62c5b01a0af9">

To test this make sure you have a course that has no runs that are open for enrollment. The go to that course page, for exapmle: http://mitxonline.odl.local:8013/courses/w-course-29/
Make sure nothing else breaks.