### PR TITLE
Adding end date info to the CourseInfoBox

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -340,6 +340,8 @@ body.new-design {
           .enrollment-info-text {
             width: auto;
             flex-grow: 1;
+            color: #58585A;
+
 
             .pacing-faq-link {
               color: $home-page-dark-blue;
@@ -364,12 +366,14 @@ body.new-design {
           }
           .more-enrollment-info {
             width: auto;
-            color: $brand-darker-bg;
+            color: $home-page-header-blue;
             font-size: 12px;
             text-decoration-line: underline;
             border-color: transparent;
             background-color: transparent;
             padding-right: 0;
+            height: fit-content;
+            line-height: normal;
           }
           .more-dates-enrollment-list{
             list-style: none;

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -330,17 +330,18 @@ body.new-design {
 
           .enrollment-info-icon {
             max-width: 20px;
-            margin-right: 12px;
+            margin-right: 8px;
+            padding-left: 0;
 
             img {
-              max-width: 20px;
+              max-width: 18px;
             }
           }
 
           .enrollment-info-text {
             width: auto;
             flex-grow: 1;
-            color: #58585A;
+            color: $helptext-grey;
 
 
             .pacing-faq-link {
@@ -374,11 +375,20 @@ body.new-design {
             padding-right: 0;
             height: fit-content;
             line-height: normal;
+
+            &:hover {
+              text-decoration-line: none;
+              color: $brand-darker-bg;
+            }
           }
           .more-dates-enrollment-list{
             list-style: none;
+            font-size: 14px;
+            color: $helptext-grey;
+            margin-top: 5px;
+            margin-bottom: 0;
             li {
-              padding-left: 36px;
+              padding-left: 29px;
             }
             button.more-dates-link {
               font-size: 14px;

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -34,7 +34,7 @@ type CourseInfoBoxProps = {
 const getCourseDates = (run, isMoreDates = false) => {
   let startDate = isMoreDates
     ? formatPrettyShortDate(parseDateString(run.start_date))
-    : formatPrettyDate(parseDateString(run.end_date))
+    : formatPrettyDate(parseDateString(run.start_date))
   if (run.is_self_paced && moment(run.start_date).isBefore(moment())) {
     startDate = "Anytime"
   }

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -4,7 +4,8 @@ import {
   emptyOrNil,
   getFlexiblePriceForProduct,
   formatLocalePrice,
-  parseDateString
+  parseDateString,
+  formatPrettyShortDate
 } from "../lib/util"
 import { getFirstRelevantRun } from "../lib/courseApi"
 import moment from "moment-timezone"
@@ -21,15 +22,33 @@ type CourseInfoBoxProps = {
   toggleUpgradeDialogVisibility: () => Promise<any>,
   setCurrentCourseRun: (run: EnrollmentFlaggedCourseRun) => Promise<any>
 }
+
+/**
+ * This constructs the Date section for a given run
+ * If the run is under the toggle "More Dates" the format is inline and month
+ * is shortened to 3 letters.
+ * @param {EnrollmentFlaggedCourseRun} run
+ * @param {boolean} isMoreDates true if this run is going to show up under the More Dates toggle
+ * */
+
 const getCourseDates = (run, isMoreDates = false) => {
-  let startDate = formatPrettyDate(parseDateString(run.start_date))
+  let startDate = isMoreDates
+    ? formatPrettyShortDate(parseDateString(run.start_date))
+    : formatPrettyDate(parseDateString(run.end_date))
   if (run.is_self_paced && moment(run.start_date).isBefore(moment())) {
     startDate = "Anytime"
   }
   return (
     <>
       <b>Start:</b> {startDate} {isMoreDates ? null : <br />}
-      <b>End:</b> {formatPrettyDate(parseDateString(run.end_date))}
+      {run.end_date ? (
+        <>
+          <b>End:</b>{" "}
+          {isMoreDates
+            ? formatPrettyShortDate(parseDateString(run.end_date))
+            : formatPrettyDate(parseDateString(run.end_date))}
+        </>
+      ) : null}
     </>
   )
 }

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -22,13 +22,13 @@ type CourseInfoBoxProps = {
   toggleUpgradeDialogVisibility: () => Promise<any>,
   setCurrentCourseRun: (run: EnrollmentFlaggedCourseRun) => Promise<any>
 }
-const getCourseDates = run => {
+const getCourseDates = (run, isMoreDates = false) => {
   let startDate = formatPrettyDate(parseDateString(run.start_date))
   if (run.is_self_paced && moment(run.start_date).isBefore(moment())) {
-    startDate = "Start Anytime"
+    startDate = "Anytime"
   }
   return <>
-    <b>Start:</b>{" "}{startDate}<br/>
+    <b>Start:</b>{" "}{startDate}{" "}{isMoreDates ? null : (<br/>)}
     <b>End:</b>{" "}{formatPrettyDate(parseDateString(run.end_date))}
   </>
 }
@@ -83,7 +83,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
         if (courseRun.id !== run.id) {
           startDates.push(
             <li key={index}>
-              {getStartDateText(courseRun)}
+              {getCourseDates(courseRun, true)}
             </li>
           )
         }

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -4,7 +4,7 @@ import {
   emptyOrNil,
   getFlexiblePriceForProduct,
   formatLocalePrice,
-  getStartDateText, compareCourseRunStartDates, parseDateString
+  parseDateString
 } from "../lib/util"
 import { getFirstRelevantRun } from "../lib/courseApi"
 import moment from "moment-timezone"
@@ -12,7 +12,6 @@ import moment from "moment-timezone"
 import type { BaseCourseRun } from "../flow/courseTypes"
 import { EnrollmentFlaggedCourseRun, RunEnrollment } from "../flow/courseTypes"
 import type { CurrentUser } from "../flow/authTypes"
-import {CourseDetailWithRuns} from "../flow/courseTypes";
 
 type CourseInfoBoxProps = {
   courses: Array<BaseCourseRun>,
@@ -27,10 +26,12 @@ const getCourseDates = (run, isMoreDates = false) => {
   if (run.is_self_paced && moment(run.start_date).isBefore(moment())) {
     startDate = "Anytime"
   }
-  return <>
-    <b>Start:</b>{" "}{startDate}{" "}{isMoreDates ? null : (<br/>)}
-    <b>End:</b>{" "}{formatPrettyDate(parseDateString(run.end_date))}
-  </>
+  return (
+    <>
+      <b>Start:</b> {startDate} {isMoreDates ? null : <br />}
+      <b>End:</b> {formatPrettyDate(parseDateString(run.end_date))}
+    </>
+  )
 }
 
 export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProps> {
@@ -60,7 +61,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
   }
 
   render() {
-    const { courses, courseRuns, enrollments } = this.props
+    const { courses, courseRuns } = this.props
 
     if (!courses || courses.length < 1) {
       return null
@@ -82,9 +83,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
       courseRuns.forEach((courseRun, index) => {
         if (courseRun.id !== run.id) {
           startDates.push(
-            <li key={index}>
-              {getCourseDates(courseRun, true)}
-            </li>
+            <li key={index}>{getCourseDates(courseRun, true)}</li>
           )
         }
       })

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -731,7 +731,9 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     ["instructor-paced", true],
     ["instructor-paced", false]
   ].forEach(([courseMode, startInFuture]) => {
-    it(`CourseInfoBox renders the course start and end dates when the course is ${courseMode} and ${startInFuture}`, async () => {
+    it(`CourseInfoBox renders the course start and end dates when the course is ${courseMode} and has ${
+      startInFuture ? "future" : "past"
+    } start date`, async () => {
       if (courseMode === "self-paced") {
         courseRun = {
           ...makeCourseRunDetail(),

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -236,7 +236,7 @@ export const getFirstRelevantRun = (
    Returns: CourseRunDetail
   */
 
-  if (course.courseruns.length === 0 || courseRuns.length === 0) {
+  if (course.courseruns.length === 0 || courseRuns === null || courseRuns.length === 0) {
     return null
   }
 

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -236,7 +236,11 @@ export const getFirstRelevantRun = (
    Returns: CourseRunDetail
   */
 
-  if (course.courseruns.length === 0 || courseRuns === null || courseRuns.length === 0) {
+  if (
+    course.courseruns.length === 0 ||
+    courseRuns === null ||
+    courseRuns.length === 0
+  ) {
     return null
   }
 

--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -148,6 +148,10 @@ export const objectToFormData = (object: Object) => {
 export const formatPrettyDate = (momentDate: Moment) =>
   momentDate.format("MMMM D, YYYY")
 
+// Example return values: "Jan 1, 2019", "Dec 31, 2019"
+export const formatPrettyShortDate = (momentDate: Moment) =>
+  momentDate.format("MMM D, YYYY")
+
 export const formatPrettyDateUtc = (momentDate: Moment) =>
   momentDate.tz("UTC").format("MMMM D, YYYY")
 


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/2833 
Related to https://github.com/mitodl/hq/issues/2834
### Description (What does it do?)
Updates the course info box to show:
- end dates for all active course runs
- The More Dates button is now dark blue and when you hover becomes red
- updates the styles and text of the icons and the text for information about start and ends dates for all the runs.

**This PR only addresses the Course Start and End dates section not the whole info box.**
### Screenshots (if appropriate):
<img width="378" alt="Screenshot 2024-04-19 at 7 40 41 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/9f2084eb-7bcb-4f2d-9641-a4035e353a3f">


### How can this be tested?
Have a course with multiple active course runs (enrollment open). Go to the the course product page and verify that the functionality is still there and the design is as [described here.](https://www.figma.com/proto/Gs4zIhOFv5gVvafawwl6PF/MITx-Online?node-id=4792-207)
