### PR TITLE
Remove react-swipeable dependency

### DIFF
--- a/frontend/public/package.json
+++ b/frontend/public/package.json
@@ -96,7 +96,6 @@
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "react-select": "3.2.0",
-    "react-swipeable": "7.0.0",
     "react-test-renderer": "16.14.0",
     "react-zendesk": "0.1.13",
     "reactstrap": "9.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15268,7 +15268,6 @@ __metadata:
     react-router: 4.3.1
     react-router-dom: 4.3.1
     react-select: 3.2.0
-    react-swipeable: 7.0.0
     react-test-renderer: 16.14.0
     react-zendesk: 0.1.13
     reactstrap: 9.1.6
@@ -19141,15 +19140,6 @@ __metadata:
   peerDependencies:
     react: ^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0
   checksum: f84c99bc13999f632c7d341b2fe5e1a6cfbf1708ce10e80624535a5296a37359e8cb94c3cde5a3506dbe151fc712896132fae4f856e079fded638b0cb5a4a00e
-  languageName: node
-  linkType: hard
-
-"react-swipeable@npm:7.0.0":
-  version: 7.0.0
-  resolution: "react-swipeable@npm:7.0.0"
-  peerDependencies:
-    react: ^16.8.3 || ^17 || ^18
-  checksum: 54d15933483f7aea8f69e6a9930e220fb3bd98f314cae89a8b797e8a3bb959b68e777fe199cd7729edfe65edfcb5d933c7312ea08626f1613a6fd5d30e646598
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mitxonline/pull/2167

### Description (What does it do?)
Removes the react-swipeable dependency which is not used.
