### PR TITLE
Update duplicate enrollment meassage

### DIFF
--- a/frontend/public/src/lib/notificationsApi.js
+++ b/frontend/public/src/lib/notificationsApi.js
@@ -65,7 +65,7 @@ export function parseStoredUserMessage(
     break
   case USER_MSG_TYPE_ENROLL_DUPLICATED:
     alertType = ALERT_TYPE_DANGER
-    msgText = `You have already enrolled and paid for this course. If this is unexpected, please contact customer support at ${SETTINGS.support_email}.`
+    msgText = `You have already enrolled in this course. If this is unexpected, please contact customer support at ${SETTINGS.support_email}.`
     break
   case USER_MSG_TYPE_COMPLETED_AUTH:
     alertType = ALERT_TYPE_SUCCESS


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/3982

### Description (What does it do?)
updates a notification message when a user tries to enroll second time.

### How can this be tested?
enroll in an existing course run, then try to enroll again you should get a red notification with the updated message.