### PR TITLE
4137: mitx online course and program count on catalog page is incorrect in mobile view

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -604,11 +604,17 @@ export class CatalogPage extends React.Component<Props> {
    * If the selectedDepartment is not found in the departments array, 0 is returned.
    * @returns {number} the number of courses or programs associated with the department matching
    * the selectedDepartment state variable.
+   *
+   * @param {string} tabSelected The tab name for which the item count should be based on.  Optional.  If not defined, this.state.tabSelected is used.
    */
-  renderNumberOfCatalogItems() {
+  renderNumberOfCatalogItems(tabSelected: string) {
     const { departments } = this.props
+    let tabSelectedValue = tabSelected
+    if (typeof tabSelectedValue === "undefined") {
+      tabSelectedValue = this.state.tabSelected
+    }
     if (this.state.selectedDepartment === ALL_DEPARTMENTS) {
-      return this.state.tabSelected === COURSES_TAB
+      return tabSelectedValue === COURSES_TAB
         ? this.state.allCoursesCount
         : this.state.allProgramsCount
     } else if (!departments) return 0
@@ -618,7 +624,7 @@ export class CatalogPage extends React.Component<Props> {
     if (!departmentSlugs.includes(this.state.selectedDepartment)) {
       return 0
     } else {
-      if (this.state.tabSelected === COURSES_TAB) {
+      if (tabSelectedValue === COURSES_TAB) {
         return this.state.filteredDepartments.find(
           department => department.slug === this.state.selectedDepartment
         ).course_ids.length
@@ -841,7 +847,7 @@ export class CatalogPage extends React.Component<Props> {
                             >
                               Courses{" "}
                               <div className="product-number d-inline-block d-sm-none">
-                                ({this.renderNumberOfCatalogItems()})
+                                ({this.renderNumberOfCatalogItems(COURSES_TAB)})
                               </div>
                             </button>
                           </div>
@@ -861,7 +867,7 @@ export class CatalogPage extends React.Component<Props> {
                             >
                               Programs{" "}
                               <div className="product-number d-inline-block d-sm-none">
-                                ({this.renderNumberOfCatalogItems()})
+                                ({this.renderNumberOfCatalogItems(PROGRAMS_TAB)})
                               </div>
                             </button>
                           </div>

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -592,8 +592,8 @@ export class CatalogPage extends React.Component<Props> {
   }
 
   /**
-   * Returns the number of catalog items based on the selectedDepartment
-   * and the selectedTabName state variables.
+   * Returns the number of catalog items that are associated with the value of selectedDepartment
+   * and tabSelected.
    * If the selectedDepartment is "All Departments" and selectedTabName is equal to COURSES_TAB,
    * then total number of courses is returned.
    * If the selectedDepartment is "All Departments" and selectedTabName is equal not equal to
@@ -867,7 +867,8 @@ export class CatalogPage extends React.Component<Props> {
                             >
                               Programs{" "}
                               <div className="product-number d-inline-block d-sm-none">
-                                ({this.renderNumberOfCatalogItems(PROGRAMS_TAB)})
+                                ({this.renderNumberOfCatalogItems(PROGRAMS_TAB)}
+                                )
                               </div>
                             </button>
                           </div>

--- a/frontend/public/src/containers/pages/CatalogPage_test.js
+++ b/frontend/public/src/containers/pages/CatalogPage_test.js
@@ -489,6 +489,56 @@ describe("CatalogPage", function() {
     expect(programsFilteredByDepartment.length).equals(3)
   })
 
+  it("renders catalog course and program count based on selected department", async () => {
+    // The mobile catalog view displays both the course and program count at the same time.
+    // This test ensures that renderNumberOfCatalogItems can determine the course and program
+    // count.
+    courses = [displayedCourse]
+    programs = [displayedProgram]
+    const { inner } = await renderPage(
+      {
+        queries: {
+          courses: {
+            isPending: false,
+            status:    200
+          },
+          programs: {
+            isPending: false,
+            status:    200
+          },
+          departments: {
+            isPending: false,
+            status:    200
+          }
+        },
+        entities: {
+          courses: {
+            count:   3,
+            results: courses,
+            next:    "http://fake.com/api/courses/?page=2"
+          },
+          programs: {
+            count:   4,
+            results: programs,
+            next:    "http://fake.com/api/courses/?page=2"
+          },
+          departments: [
+            {
+              name:        "History",
+              course_ids:  [1],
+              program_ids: [1]
+            }
+          ]
+        }
+      },
+      {}
+    )
+    inner.instance().componentDidUpdate({}, {})
+    // Number of catalog items should match the number of visible courses.
+    expect(inner.instance().renderNumberOfCatalogItems("courses")).equals(3)
+    expect(inner.instance().renderNumberOfCatalogItems("programs")).equals(4)
+  })
+
   it("renders catalog courses based on selected department", async () => {
     const course1 = JSON.parse(JSON.stringify(displayedCourse))
     course1.departments = [{ name: "Math" }]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4137

### Description
Fixes an issue when displaying the course and program counts on the catalog page when viewing with a mobile display.

### Screenshots:
![Screenshot 2024-05-02 at 10 09 59 AM](https://github.com/mitodl/mitxonline/assets/8311573/ec16d454-eaaa-497f-a2da-1b60f59c9b7a)


### How can this be tested?

1. Use this branch with a instance of MITx Online which has a few courses and programs.  There should be a different number of course and programs - ex. 3 courses and 2 programs.
2. Visit the MITx Online catalog page (http://mitxonline.odl.local:8013/catalog/) using a mobile display.
3. Verify that the issue is resolved.
