### PR TITLE
Course format pacing info popup

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -456,6 +456,16 @@ body.new-design {
     }
   }
 
+  .pacing-info-dialog {
+    max-width: 500px;
+    .modal-header {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+    .modal-content {
+      padding: 5px 14px;
+    }
+  }
 
   .upgrade-enrollment-modal {
     max-width: 750px;

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -458,6 +458,7 @@ body.new-design {
 
   .pacing-info-dialog {
     max-width: 500px;
+
     .modal-header {
       border-bottom: none;
       padding-bottom: 0;

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -19,7 +19,6 @@ type CourseInfoBoxProps = {
   courseRuns: ?Array<EnrollmentFlaggedCourseRun>,
   enrollments: ?Array<RunEnrollment>,
   currentUser: CurrentUser,
-  toggleUpgradeDialogVisibility: () => Promise<any>,
   setCurrentCourseRun: (run: EnrollmentFlaggedCourseRun) => Promise<any>
 }
 
@@ -71,10 +70,6 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     this.setState({
       showMoreEnrollDates: !this.state.showMoreEnrollDates
     })
-  }
-  setRunEnrollDialog(run: EnrollmentFlaggedCourseRun) {
-    this.props.setCurrentCourseRun(run)
-    this.props.toggleUpgradeDialogVisibility()
   }
 
   warningMessage(isArchived) {

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -229,7 +229,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                   <>
                     Self-paced
                     <button
-                      className="info-link more-info"
+                      className="info-link more-info explain-format-btn"
                       onClick={() => this.togglePacingInfoDialogVisibility()}
                     >
                       What's this?
@@ -239,7 +239,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                   <>
                     Instructor-paced
                     <button
-                      className="info-link more-info"
+                      className="info-link more-info explain-format-btn"
                       onClick={() => this.togglePacingInfoDialogVisibility()}
                     >
                       What's this?

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -13,6 +13,7 @@ import moment from "moment-timezone"
 import type { BaseCourseRun } from "../flow/courseTypes"
 import { EnrollmentFlaggedCourseRun, RunEnrollment } from "../flow/courseTypes"
 import type { CurrentUser } from "../flow/authTypes"
+import { Modal, ModalBody, ModalHeader } from "reactstrap"
 
 type CourseInfoBoxProps = {
   courses: Array<BaseCourseRun>,
@@ -64,11 +65,18 @@ const getCourseDates = (run, isArchived = false, isMoreDates = false) => {
 
 export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProps> {
   state = {
-    showMoreEnrollDates: false
+    showMoreEnrollDates:        false,
+    pacingInfoDialogVisibility: false
   }
   toggleShowMoreEnrollDates() {
     this.setState({
       showMoreEnrollDates: !this.state.showMoreEnrollDates
+    })
+  }
+
+  togglePacingInfoDialogVisibility() {
+    this.setState({
+      pacingInfoDialogVisibility: !this.state.pacingInfoDialogVisibility
     })
   }
 
@@ -81,6 +89,45 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
         <i className="material-symbols-outlined warning">error</i>
         <p>{message}</p>
       </div>
+    )
+  }
+
+  renderPacingInfoDialog(pacing) {
+    const { pacingInfoDialogVisibility } = this.state
+    return (
+      <Modal
+        id={`pacing-info-dialog`}
+        className="pacing-info-dialog"
+        isOpen={pacingInfoDialogVisibility}
+        toggle={() => this.togglePacingInfoDialogVisibility()}
+        centered
+      >
+        <ModalHeader toggle={() => this.togglePacingInfoDialogVisibility()}>
+          What are {pacing} courses?
+        </ModalHeader>
+        <ModalBody>
+          {pacing === "Self-Paced" ? (
+            <p>
+              Flexible learning. Enroll at any time and progress at your own
+              speed. All course materials available immediately. Adaptable due
+              dates and extended timelines. Earn your certificate as soon as you
+              pass the course.{" "}
+              <a href="https://mitxonline.zendesk.com/hc/en-us/articles/21995114519067-What-are-Archived-courses-on-MITx-Online-">
+                Learn More
+              </a>
+            </p>
+          ) : (
+            <p>
+              Guided learning. Follow a set schedule with specific due dates for
+              assignments and exams. Course materials released on a schedule.
+              Earn your certificate shortly after the course ends.{" "}
+              <a href="https://mitxonline.zendesk.com/hc/en-us/articles/21994938130075-What-are-Instructor-Paced-courses-on-MITx-Online-">
+                Learn More
+              </a>
+            </p>
+          )}
+        </ModalBody>
+      </Modal>
     )
   }
 
@@ -181,22 +228,22 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                 {isArchived || run.is_self_paced ? (
                   <>
                     Self-paced
-                    <a
+                    <button
                       className="info-link more-info"
-                      href="https://mitxonline.zendesk.com/hc/en-us/articles/21995114519067-What-are-Archived-courses-on-MITx-Online-"
+                      onClick={() => this.togglePacingInfoDialogVisibility()}
                     >
                       What's this?
-                    </a>
+                    </button>
                   </>
                 ) : (
                   <>
                     Instructor-paced
-                    <a
+                    <button
                       className="info-link more-info"
-                      href="https://mitxonline.zendesk.com/hc/en-us/articles/21994938130075-What-are-Instructor-Paced-courses-on-MITx-Online-"
+                      onClick={() => this.togglePacingInfoDialogVisibility()}
                     >
                       What's this?
-                    </a>
+                    </button>
                   </>
                 )}
               </div>
@@ -266,6 +313,11 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
             </div>
           </div>
         </div>
+        {run
+          ? this.renderPacingInfoDialog(
+            run.is_self_paced ? "Self-Paced" : "Instructor-Paced"
+          )
+          : null}
         {course && course.programs && course.programs.length > 0 ? (
           <div className="program-info-box">
             <div className="related-programs-info">

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -548,9 +548,6 @@ export class CourseProductDetailEnroll extends React.Component<
                 courses={courses}
                 courseRuns={courseRuns}
                 currentUser={currentUser}
-                toggleUpgradeDialogVisibility={
-                  this.toggleUpgradeDialogVisibility
-                }
                 setCurrentCourseRun={this.setCurrentCourseRun}
                 enrollments={enrollments}
               ></CourseInfoBox>

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -333,8 +333,8 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       )
       assert.include(
         infobox
-          .find(".modal-title")
-          .at(0)
+          .find("ModalHeader")
+          .dive()
           .text(),
         `What are ${pacing} courses?`
       )

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -292,7 +292,49 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       }
     })
   })
-
+  ;[["Self-Paced"], ["Instructor-Paced"]].forEach(([pacing]) => {
+    it(`shows the Whats This? link to explain format for the course run`, async () => {
+      if (pacing === "Self-Paced") {
+        courseRun = {
+          ...makeCourseRunDetail(),
+          is_self_paced:  true,
+          enrollment_end: moment()
+            .add(7, "months")
+            .toISOString(),
+          enrollment_start: moment()
+            .subtract(1, "years")
+            .toISOString(),
+          end_date: moment()
+            .add(1, "years")
+            .toISOString()
+        }
+      } else {
+        courseRun['is_self_paced'] = false
+      }
+      const courseRuns = [courseRun]
+      const entities = {
+        currentUser: currentUser,
+        enrollments: [],
+        courseRuns:  courseRuns
+      }
+      const { inner } = await renderPage({
+        entities: entities
+      })
+      assert.isTrue(inner.exists())
+      const infobox = inner.find("CourseInfoBox").dive()
+      assert.isTrue(infobox.exists())
+      const pacingBtn = infobox.find(".explain-format-btn").at(0)
+      await pacingBtn.prop("onClick")()
+      assert.isTrue(infobox.find(".pacing-info-dialog").at(0).exists())
+      assert.include(
+        infobox
+          .find(".modal-title")
+          .at(0)
+          .text(),
+        `What are ${pacing} courses?`
+      )
+    })
+  })
   it("CourseInfoBox renders the archived message if the course is archived", async () => {
     const courseRun = {
       ...makeCourseRunDetail(),

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -309,7 +309,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
             .toISOString()
         }
       } else {
-        courseRun['is_self_paced'] = false
+        courseRun["is_self_paced"] = false
       }
       const courseRuns = [courseRun]
       const entities = {
@@ -325,7 +325,12 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       assert.isTrue(infobox.exists())
       const pacingBtn = infobox.find(".explain-format-btn").at(0)
       await pacingBtn.prop("onClick")()
-      assert.isTrue(infobox.find(".pacing-info-dialog").at(0).exists())
+      assert.isTrue(
+        infobox
+          .find(".pacing-info-dialog")
+          .at(0)
+          .exists()
+      )
       assert.include(
         infobox
           .find(".modal-title")


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/4122

### Description (What does it do?)
Adds a popup with explanation of the course format.

### Screenshots (if appropriate):
<img width="531" alt="Screenshot 2024-05-02 at 2 47 19 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/b5535025-41b5-47dc-9dbd-99a430ba365f">


### How can this be tested?
Go to course product page and click the "Learn More" link in front of course format.