### PR TITLE
Update styles for warning message on course product page

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -337,7 +337,6 @@ body.new-design {
               font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
               color: $warning;
               padding: 0;
-              margin-top: .25rem;
               width: fit-content;
             }
             p{
@@ -347,7 +346,7 @@ body.new-design {
               font-family: Inter, sans-serif;
               line-height: 15px;
               margin: 0;
-              padding: 0 10px 0 0;
+              padding: 0 10px 0 10px;
             }
           }
           .callout-warning{


### PR DESCRIPTION
### What are the relevant tickets?
None
### Description (What does it do?)
Fixing a spacing issue for the warning message for archived and no run courses:
Before:

<img width="405" alt="Screenshot 2024-05-02 at 3 23 51 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/a5a010f8-6093-4454-9dc2-c3071438ee4e">

After:


<img width="407" alt="Screenshot 2024-05-02 at 3 22 14 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/3709f77a-cf41-4644-8b65-1da7d98dee97">
