### PR TITLE
Adding a Learn More link to Archived message

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -87,12 +87,22 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     return (
       <div className="row d-flex align-self-stretch callout callout-warning course-status-message">
         <i className="material-symbols-outlined warning">error</i>
-        <p>{message}</p>
+        <p>
+          {message}{" "}
+          {isArchived ? (
+            <button
+              className="info-link more-info float-none explain-format-btn"
+              onClick={() => this.togglePacingInfoDialogVisibility()}
+            >
+              Learn More
+            </button>
+          ) : null}
+        </p>
       </div>
     )
   }
 
-  renderPacingInfoDialog(pacing) {
+  renderPacingInfoDialog(pacing, isArchived = false) {
     const { pacingInfoDialogVisibility } = this.state
     return (
       <Modal
@@ -103,16 +113,25 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
         centered
       >
         <ModalHeader toggle={() => this.togglePacingInfoDialogVisibility()}>
-          What are {pacing} courses?
+          What are {isArchived ? "Archived" : pacing} courses?
         </ModalHeader>
         <ModalBody>
-          {pacing === "Self-Paced" ? (
+          {isArchived ? (
+            <p>
+              Access lectures and readings beyond the official end date. Some
+              course assignments and exams may be unavailable. No support in
+              course discussion forums. Cannot earn a Course Certificate.{" "}
+              <a href="https://mitxonline.zendesk.com/hc/en-us/articles/21995114519067-What-are-Archived-courses-on-MITx-Online-">
+                Learn More
+              </a>
+            </p>
+          ) : pacing === "Self-Paced" ? (
             <p>
               Flexible learning. Enroll at any time and progress at your own
               speed. All course materials available immediately. Adaptable due
               dates and extended timelines. Earn your certificate as soon as you
               pass the course.{" "}
-              <a href="https://mitxonline.zendesk.com/hc/en-us/articles/21995114519067-What-are-Archived-courses-on-MITx-Online-">
+              <a href="https://mitxonline.zendesk.com/hc/en-us/articles/21994872904475-What-are-Self-Paced-courses-on-MITx-Online">
                 Learn More
               </a>
             </p>
@@ -315,7 +334,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
         </div>
         {run
           ? this.renderPacingInfoDialog(
-            run.is_self_paced ? "Self-Paced" : "Instructor-Paced"
+            run.is_self_paced ? "Self-Paced" : "Instructor-Paced", isArchived
           )
           : null}
         {course && course.programs && course.programs.length > 0 ? (

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -97,7 +97,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
           {message}{" "}
           {isArchived ? (
             <button
-              className="info-link more-info float-none explain-format-btn"
+              className="info-link more-info float-none explain-archived-btn"
               onClick={() => this.togglePacingInfoDialogVisibility("Archived")}
             >
               Learn More
@@ -256,7 +256,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     <button
                       className="info-link more-info explain-format-btn"
                       onClick={() =>
-                        this.togglePacingInfoDialogVisibility("Self-paced")
+                        this.togglePacingInfoDialogVisibility("Self-Paced")
                       }
                     >
                       What's this?
@@ -269,7 +269,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                       className="info-link more-info explain-format-btn"
                       onClick={() =>
                         this.togglePacingInfoDialogVisibility(
-                          "Instructor-paced"
+                          "Instructor-Paced"
                         )
                       }
                     >

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -66,7 +66,8 @@ const getCourseDates = (run, isArchived = false, isMoreDates = false) => {
 export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProps> {
   state = {
     showMoreEnrollDates:        false,
-    pacingInfoDialogVisibility: false
+    pacingInfoDialogVisibility: false,
+    pacingDialogState:          ""
   }
   toggleShowMoreEnrollDates() {
     this.setState({
@@ -74,7 +75,12 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     })
   }
 
-  togglePacingInfoDialogVisibility() {
+  togglePacingInfoDialogVisibility(pacingDialogState = "") {
+    if (pacingDialogState) {
+      this.setState({
+        pacingDialogState: pacingDialogState
+      })
+    }
     this.setState({
       pacingInfoDialogVisibility: !this.state.pacingInfoDialogVisibility
     })
@@ -92,7 +98,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
           {isArchived ? (
             <button
               className="info-link more-info float-none explain-format-btn"
-              onClick={() => this.togglePacingInfoDialogVisibility()}
+              onClick={() => this.togglePacingInfoDialogVisibility("Archived")}
             >
               Learn More
             </button>
@@ -102,9 +108,9 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     )
   }
 
-  renderPacingInfoDialog(pacing, isArchived = false) {
-    const { pacingInfoDialogVisibility } = this.state
-    return (
+  renderPacingInfoDialog() {
+    const { pacingInfoDialogVisibility, pacingDialogState } = this.state
+    return pacingDialogState ? (
       <Modal
         id={`pacing-info-dialog`}
         className="pacing-info-dialog"
@@ -113,10 +119,10 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
         centered
       >
         <ModalHeader toggle={() => this.togglePacingInfoDialogVisibility()}>
-          What are {isArchived ? "Archived" : pacing} courses?
+          What are {pacingDialogState} courses?
         </ModalHeader>
         <ModalBody>
-          {isArchived ? (
+          {pacingDialogState === "Archived" ? (
             <p>
               Access lectures and readings beyond the official end date. Some
               course assignments and exams may be unavailable. No support in
@@ -125,7 +131,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                 Learn More
               </a>
             </p>
-          ) : pacing === "Self-Paced" ? (
+          ) : pacingDialogState === "Self-Paced" ? (
             <p>
               Flexible learning. Enroll at any time and progress at your own
               speed. All course materials available immediately. Adaptable due
@@ -147,7 +153,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
           )}
         </ModalBody>
       </Modal>
-    )
+    ) : null
   }
 
   render() {
@@ -249,7 +255,9 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     Self-paced
                     <button
                       className="info-link more-info explain-format-btn"
-                      onClick={() => this.togglePacingInfoDialogVisibility()}
+                      onClick={() =>
+                        this.togglePacingInfoDialogVisibility("Self-paced")
+                      }
                     >
                       What's this?
                     </button>
@@ -259,7 +267,11 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
                     Instructor-paced
                     <button
                       className="info-link more-info explain-format-btn"
-                      onClick={() => this.togglePacingInfoDialogVisibility()}
+                      onClick={() =>
+                        this.togglePacingInfoDialogVisibility(
+                          "Instructor-paced"
+                        )
+                      }
                     >
                       What's this?
                     </button>
@@ -332,11 +344,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
             </div>
           </div>
         </div>
-        {run
-          ? this.renderPacingInfoDialog(
-            run.is_self_paced ? "Self-Paced" : "Instructor-Paced", isArchived
-          )
-          : null}
+        {run ? this.renderPacingInfoDialog() : null}
         {course && course.programs && course.programs.length > 0 ? (
           <div className="program-info-box">
             <div className="related-programs-info">

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -389,6 +389,21 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         .text()
         .includes("Course content available anytime")
     )
+    const archivedLearnMoreBtn = infobox.find(".explain-archived-btn").at(0)
+    await archivedLearnMoreBtn.prop("onClick")()
+    assert.isTrue(
+      infobox
+        .find(".pacing-info-dialog")
+        .at(0)
+        .exists()
+    )
+    assert.include(
+      infobox
+        .find("ModalHeader")
+        .dive()
+        .text(),
+      `What are Archived courses?`
+    )
   })
 
   it(`shows form based enrollment button when upgrade deadline has passed but course is within enrollment period`, async () => {


### PR DESCRIPTION
### What are the relevant tickets?
related to https://github.com/mitodl/mitxonline/pull/2187

### Description (What does it do?)
Adds a "Learn More" link
This link opens a popup dialog with info and a link to explanation page.

### Screenshots (if appropriate):
<img width="408" alt="Screenshot 2024-05-07 at 12 30 34 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/d054bfbb-1ddd-4775-97e0-748f51a419b1">


### How can this be tested?
Go to an archived course, you should see a yellow warning message. It should have a "Learn More" link that opens a dialog with more info.
Make sure that the Course Format link still works correctly, showing Self-Paced or Instructor-Paced popup info.