### PR TITLE
Give priority to enrollable runs

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -537,7 +537,7 @@ def defer_enrollment(  # noqa: C901
         raise ValidationError(
             f"Cannot defer to the same course run (run: {to_run.courseware_id})"  # noqa: EM102
         )
-    if not force and not to_run.is_not_beyond_enrollment:
+    if not force and not to_run.is_enrollable:
         raise ValidationError(
             f"Cannot defer to a course run that is outside of its enrollment period (run: {to_run.courseware_id})."  # noqa: EM102
         )

--- a/courses/models.py
+++ b/courses/models.py
@@ -706,7 +706,7 @@ class CourseRun(TimestampedModel):
         return self.end_date < now_in_utc()
 
     @property
-    def is_not_beyond_enrollment(self):
+    def is_enrollable(self):
         """
         Checks if the course is not beyond its enrollment period
 
@@ -716,8 +716,7 @@ class CourseRun(TimestampedModel):
         """
         now = now_in_utc()
         return (
-            (self.end_date is None or self.end_date > now)
-            and (self.enrollment_end is None or self.enrollment_end > now)
+            (self.enrollment_end is None or self.enrollment_end > now)
             and (self.enrollment_start is None or self.enrollment_start <= now)
         )
 
@@ -729,7 +728,7 @@ class CourseRun(TimestampedModel):
         Returns:
             boolean: True if course is not expired
         """
-        return not self.is_past and self.is_not_beyond_enrollment
+        return not self.is_past and self.is_enrollable
 
     @property
     def is_in_progress(self) -> bool:

--- a/courses/models.py
+++ b/courses/models.py
@@ -715,9 +715,8 @@ class CourseRun(TimestampedModel):
             boolean: True if enrollment period has begun but not ended
         """
         now = now_in_utc()
-        return (
-            (self.enrollment_end is None or self.enrollment_end > now)
-            and (self.enrollment_start is None or self.enrollment_start <= now)
+        return (self.enrollment_end is None or self.enrollment_end > now) and (
+            self.enrollment_start is None or self.enrollment_start <= now
         )
 
     @property

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -174,7 +174,7 @@ def test_course_run_not_beyond_enrollment(
             end_date=end_date,
             enrollment_end=enr_end_date,
             enrollment_start=enr_start_date,
-        ).is_not_beyond_enrollment
+        ).is_enrollable
         is expected
     )
 

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -148,13 +148,13 @@ def test_course_run_invalid_expiration_date(start_delta, end_delta, expiration_d
         [None, None, 1, True],  # noqa: PT007
         [None, None, -1, False],  # noqa: PT007
         [1, None, None, True],  # noqa: PT007
-        [-1, None, None, False],  # noqa: PT007
+        [-1, None, None, True],  # noqa: PT007
         [1, None, -1, False],  # noqa: PT007
         [None, 1, None, False],  # noqa: PT007
         [None, -1, None, True],  # noqa: PT007
     ],
 )
-def test_course_run_not_beyond_enrollment(
+def test_course_run_is_enrollable(
     end_days, enroll_start_days, enroll_end_days, expected
 ):
     """

--- a/courses/serializers/v1/base.py
+++ b/courses/serializers/v1/base.py
@@ -50,6 +50,7 @@ class BaseCourseRunSerializer(serializers.ModelSerializer):
             "certificate_available_date",
             "upgrade_deadline",
             "is_upgradable",
+            "is_enrollable",
             "is_self_paced",
             "run_tag",
             "id",

--- a/courses/serializers/v1/courses_test.py
+++ b/courses/serializers/v1/courses_test.py
@@ -137,6 +137,7 @@ def test_serialize_course_run():
             "expiration_date": drf_datetime(course_run.expiration_date),
             "upgrade_deadline": drf_datetime(course_run.upgrade_deadline),
             "is_upgradable": course_run.is_upgradable,
+            "is_enrollable": course_run.is_enrollable,
             "id": course_run.id,
             "products": [],
             "approved_flexible_price_exists": False,
@@ -171,6 +172,7 @@ def test_serialize_course_run_with_course():
             course_run.certificate_available_date
         ),
         "is_upgradable": course_run.is_upgradable,
+        "is_enrollable": course_run.is_enrollable,
         "is_self_paced": False,
         "id": course_run.id,
         "products": BaseProductSerializer(course_run.products, many=True).data,

--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -291,9 +291,9 @@ body.new-design {
           text-align: center;
         }
 
-        .btn-enrollment-button:disabled {
+        .btn-enrollment-button:disabled, .btn-gradient-red:disabled {
           color: $white;
-          background-color: $dashboard-tab-inactive;
+          background: $dashboard-tab-inactive !important;
           border-color: $dashboard-tab-inactive;
         }
 

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -30,8 +30,9 @@ import {
 import { formatPrettyDate, emptyOrNil } from "../lib/util"
 import moment from "moment-timezone"
 import {
-  getFirstRelevantRun, isEnrollmentFuture,
-  isFinancialAssistanceAvailable,
+  getFirstRelevantRun,
+  isEnrollmentFuture,
+  isFinancialAssistanceAvailable
 } from "../lib/courseApi"
 import { getCookie } from "../lib/api"
 import users, { currentUserSelector } from "../lib/queries/users"
@@ -511,7 +512,10 @@ export class CourseProductDetailEnroll extends React.Component<
       <>
         {
           // $FlowFixMe: isLoading null or undefined
-          <Loader key="product_detail_enroll_loader" isLoading={courseIsLoading}>
+          <Loader
+            key="product_detail_enroll_loader"
+            isLoading={courseIsLoading}
+          >
             <>
               {run
                 ? currentUser && currentUser.id

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -460,7 +460,7 @@ export class CourseProductDetailEnroll extends React.Component<
   ) {
     const { courseRuns } = this.props
     const csrfToken = getCookie("csrftoken")
-    return run && run.is_enrollable ? (
+    return run ? (
       <h2>
         {(product && run.is_upgradable) ||
         (courseRuns && courseRuns.length > 1) ? (
@@ -468,6 +468,7 @@ export class CourseProductDetailEnroll extends React.Component<
               id="upgradeEnrollBtn"
               className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red highlight enroll-now"
               onClick={() => this.toggleUpgradeDialogVisibility()}
+              disabled={!run.is_enrollable}
             >
             Enroll now
             </button>
@@ -478,6 +479,7 @@ export class CourseProductDetailEnroll extends React.Component<
               <button
                 type="submit"
                 className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
+                disabled={!run.is_enrollable}
               >
               Enroll now
               </button>
@@ -514,7 +516,7 @@ export class CourseProductDetailEnroll extends React.Component<
           // $FlowFixMe: isLoading null or undefined
           <Loader
             key="product_detail_enroll_loader"
-            isLoading={courseIsLoading}
+            isLoading={courseIsLoading || enrollmentsIsLoading}
           >
             <>
               {run

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -218,7 +218,7 @@ export class CourseProductDetailEnroll extends React.Component<
         <button
           type="submit"
           className="btn enroll-now enroll-now-free"
-          disabled={!run || isEnrollmentFuture(run)}
+          disabled={!run || !run.is_enrollable}
         >
           <strong>Enroll for Free</strong> without a certificate
         </button>

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -119,6 +119,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
   it("checks for enroll now button should not appear if enrollment start in future", async () => {
     const courseRun = makeCourseRunDetail()
+    courseRun["is_enrollable"] = false
     const { inner } = await renderPage(
       {
         entities: {
@@ -819,6 +820,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
             .toISOString()
         }
       }
+      console.log(courseMode)
       if (startInFuture) {
         courseRun["start_date"] = moment()
           .add(10, "months")
@@ -843,6 +845,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       assert.isTrue(inner.exists())
       const infobox = inner.find("CourseInfoBox").dive()
       assert.isTrue(infobox.exists())
+
       if (courseMode === "self-paced" && !startInFuture) {
         assert.include(
           infobox

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -820,7 +820,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
             .toISOString()
         }
       }
-      console.log(courseMode)
       if (startInFuture) {
         courseRun["start_date"] = moment()
           .add(10, "months")

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -134,11 +134,17 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       },
       {}
     )
-    assert.isNotOk(
+    assert.isTrue(
       inner
         .find(".enroll-now")
         .at(0)
         .exists()
+    )
+    assert.isTrue(
+      inner
+        .find(".enroll-now")
+        .at(0)
+        .prop("disabled")
     )
   })
 

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -572,17 +572,17 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     it(`${showsQualifier} the course run selector for a course with ${runsQualifier} active run${
       multiples ? "s" : ""
     } and enables enroll buttons on selection`, async () => {
-      courseRun["products"] = [
-        {
-          id:                     1,
-          price:                  10,
-          is_upgradable:          true,
-          product_flexible_price: {
-            amount:        10,
-            discount_type: DISCOUNT_TYPE_PERCENT_OFF
-          }
-        }
-      ]
+      // courseRun["products"] = [
+      //   {
+      //     id:                     1,
+      //     price:                  10,
+      //     is_upgradable:          true,
+      //     product_flexible_price: {
+      //       amount:        10,
+      //       discount_type: DISCOUNT_TYPE_PERCENT_OFF
+      //     }
+      //   }
+      // ]
       const courseRuns = [courseRun]
       if (multiples) {
         courseRuns.push(courseRun)

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -30,7 +30,6 @@ import { formatPrettyDate, parseDateString } from "../lib/util"
 describe("CourseProductDetailEnrollShallowRender", () => {
   let helper,
     renderPage,
-    isWithinEnrollmentPeriodStub,
     isFinancialAssistanceAvailableStub,
     courseRun,
     course,
@@ -70,11 +69,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       courseApi,
       "isFinancialAssistanceAvailable"
     )
-
-    isWithinEnrollmentPeriodStub = helper.sandbox.stub(
-      courseApi,
-      "isWithinEnrollmentPeriod"
-    )
   })
 
   afterEach(() => {
@@ -99,7 +93,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
   it("checks for enroll now button", async () => {
     const courseRun = makeCourseRunDetail()
-    isWithinEnrollmentPeriodStub.returns(true)
     const { inner } = await renderPage(
       {
         entities: {
@@ -126,7 +119,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
   it("checks for enroll now button should not appear if enrollment start in future", async () => {
     const courseRun = makeCourseRunDetail()
-    isWithinEnrollmentPeriodStub.returns(false)
     const { inner } = await renderPage(
       {
         entities: {
@@ -151,7 +143,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
   it("checks for enroll now button should appear if enrollment start not in future", async () => {
     const courseRun = makeCourseRunDetail()
-    isWithinEnrollmentPeriodStub.returns(true)
     const { inner } = await renderPage(
       {
         entities: {
@@ -178,7 +169,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
   it("checks for form-based enrollment form if there is no product", async () => {
     const courseRun = makeCourseRunDetail()
-    isWithinEnrollmentPeriodStub.returns(true)
     const { inner } = await renderPage(
       {
         entities: {
@@ -273,7 +263,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
           financial_assistance_form_url: "google.com"
         }
       }
-      isWithinEnrollmentPeriodStub.returns(true)
       isFinancialAssistanceAvailableStub.returns(true)
       const { inner } = await renderPage()
       inner.setState({ currentCourseRun: courseRun })
@@ -407,7 +396,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
   })
 
   it(`shows form based enrollment button when upgrade deadline has passed but course is within enrollment period`, async () => {
-    isWithinEnrollmentPeriodStub.returns(true)
     courseRun.is_upgradable = false
     course.next_run_id = courseRun.id
 
@@ -449,7 +437,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
           }
         }
       ]
-      isWithinEnrollmentPeriodStub.returns(true)
       const { inner } = await renderPage()
 
       const enrollBtn = inner.find(".enroll-now").at(0)
@@ -481,7 +468,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
           }
         }
       ]
-      isWithinEnrollmentPeriodStub.returns(true)
       const { inner } = await renderPage()
       const enrollBtn = inner.find(".enroll-now").at(0)
       assert.isTrue(enrollBtn.exists())
@@ -513,7 +499,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
           }
         }
       ]
-      isWithinEnrollmentPeriodStub.returns(true)
       isFinancialAssistanceAvailableStub.returns(false)
       const { inner } = await renderPage()
       const enrollBtn = inner.find(".enroll-now").at(0)
@@ -539,7 +524,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
 
   it(`shows the disabled enroll button and warning message when no active runs`, async () => {
     course = makeCourseDetailNoRuns()
-    isWithinEnrollmentPeriodStub.returns(false)
 
     const { inner } = await renderPage(
       {
@@ -573,7 +557,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         product_flexible_price: {}
       }
     ]
-    isWithinEnrollmentPeriodStub.returns(true)
 
     const { inner } = await renderPage()
 
@@ -604,7 +587,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         courseRuns.push(courseRun)
       }
 
-      isWithinEnrollmentPeriodStub.returns(true)
       const { inner } = await renderPage({
         entities: {
           courseRuns:  courseRuns,
@@ -668,7 +650,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     const courseRuns = [courseRun]
     courseRuns.push(courseRun)
 
-    isWithinEnrollmentPeriodStub.returns(true)
     const { inner } = await renderPage({
       entities: {
         courseRuns:  courseRuns,
@@ -709,7 +690,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       const courseRuns = [courseRun]
       courseRuns.push(runWithMixedInfo)
 
-      isWithinEnrollmentPeriodStub.returns(true)
       const { inner } = await renderPage({
         entities: {
           courseRuns:  courseRuns,
@@ -795,7 +775,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       currentUser: currentUser
     }
 
-    isWithinEnrollmentPeriodStub.returns(true)
     const { inner } = await renderPage({
       entities: entities
     })

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -1,5 +1,6 @@
 // @flow
 import casual from "casual-browserify"
+import moment from "moment-timezone"
 
 import { incrementer } from "./util"
 
@@ -46,40 +47,35 @@ export const makeCoursePage = (): CoursePage => ({
   effort:                        casual.text
 })
 
-export const makeCourseRun = (): CourseRun => ({
-  title:            casual.text,
-  start_date:       casual.moment.add(2, "M").format(),
-  end_date:         casual.moment.add(4, "M").format(),
-  enrollment_start: casual.moment.add(-1, "M").format(),
-  enrollment_end:   casual.moment.add(3, "M").format(),
-  upgrade_deadline: casual.moment.add(4, "M").format(),
-  courseware_url:   casual.url,
-  courseware_id:    casual.word.concat(genCoursewareId.next().value),
-  run_tag:          casual.word.concat(genRunTagNumber.next().value),
-  is_enrollable:    true,
-  // $FlowFixMe
-  id:               genCourseRunId.next().value,
-  course_number:    casual.word,
-  products:         [],
-  departments:      [makeDepartment()],
-  live:             true
-})
+export const makeCourseRun = (): CourseRun => {
+  const now = moment()
+  return {
+    title:            casual.text,
+    start_date:       now.add(2, "M").format(),
+    end_date:         now.add(4, "M").format(),
+    enrollment_start: now.add(-1, "M").format(),
+    enrollment_end:   now.add(3, "M").format(),
+    upgrade_deadline: casual.moment.add(4, "M").format(),
+    courseware_url:   casual.url,
+    courseware_id:    casual.word.concat(genCoursewareId.next().value),
+    run_tag:          casual.word.concat(genRunTagNumber.next().value),
+    is_enrollable:    true,
+    // $FlowFixMe
+    id:               genCourseRunId.next().value,
+    course_number:    casual.word,
+    products:         [],
+    departments:      [makeDepartment()],
+    live:             true
+  }
+}
 
 export const makeCourseRunWithProduct = (): CourseRun => ({
-  title:            casual.text,
-  start_date:       casual.moment.add(2, "M").format(),
-  end_date:         casual.moment.add(4, "M").format(),
-  enrollment_start: casual.moment.add(-1, "M").format(),
-  enrollment_end:   casual.moment.add(3, "M").format(),
-  upgrade_deadline: casual.moment.add(4, "M").format(),
-  courseware_url:   casual.url,
-  courseware_id:    casual.word.concat(genCoursewareId.next().value),
-  run_tag:          casual.word.concat(genRunTagNumber.next().value),
-  // $FlowFixMe
-  id:               genCourseRunId.next().value,
-  course_number:    casual.word,
-  is_upgradable:    true,
-  products:         [
+  ...makeCourseRun(),
+  upgrade_deadline: moment()
+    .add(4, "M")
+    .format(),
+  is_upgradable: true,
+  products:      [
     {
       description:            casual.text,
       id:                     genProductId.next().value,

--- a/frontend/public/src/factories/course.js
+++ b/frontend/public/src/factories/course.js
@@ -56,6 +56,7 @@ export const makeCourseRun = (): CourseRun => ({
   courseware_url:   casual.url,
   courseware_id:    casual.word.concat(genCoursewareId.next().value),
   run_tag:          casual.word.concat(genRunTagNumber.next().value),
+  is_enrollable:    true,
   // $FlowFixMe
   id:               genCourseRunId.next().value,
   course_number:    casual.word,

--- a/frontend/public/src/flow/courseTypes.js
+++ b/frontend/public/src/flow/courseTypes.js
@@ -18,6 +18,7 @@ export type BaseCourseRun = {
   upgrade_deadline: ?string,
   certificate_available_date: ?string,
   is_upgradable: boolean,
+  is_enrollable: boolean,
   is_self_paced: boolean,
   courseware_url: ?string,
   courseware_id: string,

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -37,10 +37,7 @@ export const isLinkableCourseRun = (
 
 export const isEnrollmentFuture = (run: CourseRunDetail): boolean => {
   const enrollStart = run.enrollment_start ? moment(run.enrollment_start) : null
-  return (
-    !!enrollStart &&
-    moment().isBefore(enrollStart)
-  )
+  return !!enrollStart && moment().isBefore(enrollStart)
 }
 
 export const courseRunStatusMessage = (run: CourseRun) => {

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -243,26 +243,37 @@ export const getFirstRelevantRun = (
 
   const now = moment()
   const enrollableRuns = courseRuns.filter(run => run.is_enrollable)
-  if (enrollableRuns.length === 0) {
-    return null
-  }
-  if (
-    enrollableRuns.some(
-      run => run.start_date && moment(run.start_date).isSameOrAfter(now)
-    )
-  ) {
-    return enrollableRuns
-      .filter(
+  if (enrollableRuns.length > 0) {
+    if (
+      enrollableRuns.some(
         run => run.start_date && moment(run.start_date).isSameOrAfter(now)
       )
+    ) {
+      return enrollableRuns
+        .filter(
+          run => run.start_date && moment(run.start_date).isSameOrAfter(now)
+        )
+        .reduce((prev, curr) =>
+          moment(curr.start_date).isBefore(moment(prev.start_date))
+            ? curr
+            : prev
+        )
+    }
+
+    return enrollableRuns
+      .filter(run => run.start_date && moment(run.start_date).isBefore(now))
       .reduce((prev, curr) =>
-        moment(curr.start_date).isBefore(moment(prev.start_date)) ? curr : prev
+        moment(curr.start_date).isBefore(moment(prev.start_date)) ? prev : curr
       )
   }
-
-  return courseRuns
-    .filter(run => run.start_date && moment(run.start_date).isBefore(now))
-    .reduce((prev, curr) =>
-      moment(curr.start_date).isBefore(moment(prev.start_date)) ? prev : curr
+  // no enrollable runs, then check for future runs
+  const futureRuns = courseRuns.filter(
+    run => run.start_date && moment(run.start_date).isSameOrAfter(now)
+  )
+  if (futureRuns.length > 0) {
+    return futureRuns.reduce((prev, curr) =>
+      moment(curr.start_date).isBefore(moment(prev.start_date)) ? curr : prev
     )
+  }
+  return null
 }

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -35,15 +35,11 @@ export const isLinkableCourseRun = (
   return notNil(run.start_date) && moment(run.start_date).isBefore(now)
 }
 
-export const isWithinEnrollmentPeriod = (run: CourseRunDetail): boolean => {
+export const isEnrollmentFuture = (run: CourseRunDetail): boolean => {
   const enrollStart = run.enrollment_start ? moment(run.enrollment_start) : null
-  const enrollEnd = run.enrollment_end ? moment(run.enrollment_end) : null
-  const now = moment()
-
   return (
     !!enrollStart &&
-    now.isAfter(enrollStart) &&
-    (isNil(enrollEnd) || now.isBefore(enrollEnd))
+    moment().isBefore(enrollStart)
   )
 }
 
@@ -255,13 +251,16 @@ export const getFirstRelevantRun = (
       run => run.start_date && moment(run.start_date).isSameOrAfter(now)
     )
   ) {
-    return courseRuns
+    const relevantRun = courseRuns
       .filter(
         run => run.start_date && moment(run.start_date).isSameOrAfter(now)
       )
       .reduce((prev, curr) =>
         moment(curr.start_date).isBefore(moment(prev.start_date)) ? curr : prev
       )
+    if (relevantRun.is_enrollable) {
+      return relevantRun
+    }
   }
 
   return courseRuns

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -242,22 +242,22 @@ export const getFirstRelevantRun = (
   }
 
   const now = moment()
-
+  const enrollableRuns = courseRuns.filter(run => run.is_enrollable)
+  if (enrollableRuns.length === 0) {
+    return null
+  }
   if (
-    courseRuns.some(
+    enrollableRuns.some(
       run => run.start_date && moment(run.start_date).isSameOrAfter(now)
     )
   ) {
-    const relevantRun = courseRuns
+    return enrollableRuns
       .filter(
         run => run.start_date && moment(run.start_date).isSameOrAfter(now)
       )
       .reduce((prev, curr) =>
         moment(curr.start_date).isBefore(moment(prev.start_date)) ? curr : prev
       )
-    if (relevantRun.is_enrollable) {
-      return relevantRun
-    }
   }
 
   return courseRuns

--- a/frontend/public/src/lib/courseApi_test.js
+++ b/frontend/public/src/lib/courseApi_test.js
@@ -1,7 +1,6 @@
 // @flow
 import {
   isLinkableCourseRun,
-  isWithinEnrollmentPeriod,
   generateStartDateText,
   isFinancialAssistanceAvailable,
   learnerProgramIsCompleted,
@@ -86,22 +85,6 @@ describe("Course API", () => {
         })
       }
     )
-  })
-
-  describe("isWithinEnrollmentPeriod", () => {
-    [
-      [past, future, "active enrollment period", true],
-      [past, null, "active enrollment period with no end", true],
-      [null, null, "null enrollment start", false],
-      [farPast, past, "past enrollment period", false],
-      [future, farFuture, "future enrollment period", false]
-    ].forEach(([enrollStart, enrollEnd, desc, expResult]) => {
-      it(`returns ${String(expResult)} with ${desc}`, () => {
-        courseRun.enrollment_start = enrollStart
-        courseRun.enrollment_end = enrollEnd
-        assert.equal(isWithinEnrollmentPeriod(courseRun), expResult)
-      })
-    })
   })
 
   describe("generateStartDateText", () => {


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/4146, https://github.com/mitodl/hq/issues/4197, https://github.com/mitodl/hq/issues/4199

### Description (What does it do?)
When only archived run is enrollable it has priority of coming up future runs.

This PR changes the logic for firstRelevantRun:
1. If there are enrollble runs - choose the one that is closest to now, giving preference to runs that start in the future.
2. If there are no currently enrollable runs, then return a run that will be enrollable in future
3. If there are no enrollable now and enrollable in future runs than return null. When this happens the "Enroll Now" button will be grey and disabled with the text "Access Course Materials".

### Screenshots (if appropriate):
<img width="1301" alt="Screenshot 2024-05-10 at 7 45 08 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/0590c16a-c83f-4cc7-a159-5317f1cbea52">

<img width="770" alt="Screenshot 2024-05-09 at 1 07 24 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/ef0379af-b522-49aa-a769-967605f8b1c9">

### How can this be tested?
Create a run the has an enrollable archived course and a run in the future like this course in production: https://mitxonline.mit.edu/courses/course-v1:MITxT+24.10x/ (you must be logged in to see that the enroll button is missing)

When you change to this branch the enroll now button should show up and open a dialog when clicked.