### PR TITLE
restrict duplicate enrollment only if user is verified

### DIFF
--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -256,7 +256,7 @@ def _validate_enrollment_post_request(
             user=user,
             run=run,
             change_status=None,
-            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
         ).exists()
     ):
         resp = redirect_with_user_message(

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -74,6 +74,7 @@ from openedx.api import (
     sync_enrollments_with_edx,
     unsubscribe_from_edx_course_emails,
 )
+from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
 from openedx.exceptions import (
     EdxApiEmailSettingsErrorException,
     NoEdxApiAuthError,
@@ -252,7 +253,7 @@ def _validate_enrollment_post_request(
     if (
         PaidCourseRun.fulfilled_paid_course_run_exists(user, run)
         or CourseRunEnrollment.objects.filter(
-            user=user, run=run, change_status=None
+            user=user, run=run, change_status=None, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
         ).exists()
     ):
         resp = redirect_with_user_message(

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -253,7 +253,10 @@ def _validate_enrollment_post_request(
     if (
         PaidCourseRun.fulfilled_paid_course_run_exists(user, run)
         or CourseRunEnrollment.objects.filter(
-            user=user, run=run, change_status=None, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+            user=user,
+            run=run,
+            change_status=None,
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
         ).exists()
     ):
         resp = redirect_with_user_message(


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/4210
### Description (What does it do?)
We had a problem where a user was downgrading their enrollment by enrolling again.
So we restricted duplicate enrollments.
However, this caused the issue above.

This PR restricts duplicate enrollment only if user is verified in that course.

### How can this be tested?
Enroll for free in a course run.
Then try to pay for it.
The payment should be successful, and you should see your enrollment in the dashboard.