### PR TITLE
Add task for creating featured items in cache

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -193,7 +193,7 @@
         "filename": "main/settings.py",
         "hashed_secret": "09edaaba587f94f60fbb5cee2234507bcb883cc2",
         "is_verified": false,
-        "line_number": 939
+        "line_number": 954
       }
     ],
     "pants": [
@@ -247,5 +247,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-01T20:58:31Z"
+  "generated_at": "2024-05-13T13:11:36Z"
 }

--- a/app.json
+++ b/app.json
@@ -146,12 +146,12 @@
       "description": "The name of the review app",
       "required": false
     },
-    "HUBSPOT_HOME_PAGE_FORM_GUID": {
-      "description": "Hubspot ID for the home page contact form",
-      "required": false
-    },
     "HOST_IP": {
       "description": "This server's host IP",
+      "required": false
+    },
+    "HUBSPOT_HOME_PAGE_FORM_GUID": {
+      "description": "Hubspot ID for the home page contact form",
       "required": false
     },
     "HUBSPOT_MAX_CONCURRENT_TASKS": {
@@ -553,6 +553,10 @@
     },
     "REDIS_URL": {
       "description": "Redis URL for non-production use",
+      "required": false
+    },
+    "REFRESH_FEATURED_HOMEPAGE_ITEMS_FREQ": {
+      "description": "How many seconds between checking for featured items for the homepage in the local in memory cache",
       "required": false
     },
     "REPAIR_OPENEDX_USERS_FREQUENCY": {

--- a/main/settings.py
+++ b/main/settings.py
@@ -823,6 +823,14 @@ REPAIR_OPENEDX_USERS_FREQUENCY = get_int(
 )
 REPAIR_OPENEDX_USERS_OFFSET = int(REPAIR_OPENEDX_USERS_FREQUENCY / 2)
 
+REFRESH_FEATURED_HOMEPAGE_ITEMS_FREQ = get_int(
+    name="REFRESH_FEATURED_HOMEPAGE_ITEMS_FREQ",
+    default=60,
+    description="How many seconds between checking for featured items for the homepage in the local in memory cache",
+)
+
+REFRESH_FEATURED_HOMEPAGE_ITEMS_OFFSET = int(REFRESH_FEATURED_HOMEPAGE_ITEMS_FREQ / 2)
+
 CELERY_BEAT_SCHEDULE = {
     "retry-failed-edx-enrollments": {
         "task": "openedx.tasks.retry_failed_edx_enrollments",
@@ -861,6 +869,13 @@ CELERY_BEAT_SCHEDULE = {
             day_of_week=CRON_COURSE_CERTIFICATES_DAYS,
             day_of_month="*",
             month_of_year="*",
+        ),
+    },
+    "refresh-featured-homepage-items": {
+        "task": "cms.tasks.refresh_featured_homepage_items",
+        "schedule": OffsettingSchedule(
+            run_every=timedelta(seconds=REFRESH_FEATURED_HOMEPAGE_ITEMS_FREQ),
+            offset=timedelta(seconds=REFRESH_FEATURED_HOMEPAGE_ITEMS_OFFSET),
         ),
     },
 }


### PR DESCRIPTION
### What are the relevant tickets?
Updates https://github.com/mitodl/hq/issues/4029

### Description (What does it do?)
Adds an offset, single run  cron task that runs every minute to check if the items exist and update if not. This is offset by 30 seconds so it gives some space for the similar google sheets task.

### How can this be tested?
Run the app and see that the cron is running in the celery logs. There should be adequate logging to view this manually.
