### PR TITLE
Admin: filtering certificates by course and program

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -436,7 +436,6 @@ class CourseRunCertificateAdmin(TimestampedModelAdmin):
         "user",
         "course_run",
         "get_revoked_state",
-        "certificate_page_revision",
     ]
     search_fields = [
         "course_run__courseware_id",
@@ -444,6 +443,7 @@ class CourseRunCertificateAdmin(TimestampedModelAdmin):
         "user__username",
         "user__email",
     ]
+    list_filter = ["is_revoked", "course_run__course"]
     raw_id_fields = ("user",)
 
     def get_revoked_state(self, obj):
@@ -469,7 +469,6 @@ class ProgramCertificateAdmin(TimestampedModelAdmin):
         "user",
         "program",
         "get_revoked_state",
-        "certificate_page_revision",
     ]
     search_fields = [
         "program__readable_id",
@@ -477,6 +476,7 @@ class ProgramCertificateAdmin(TimestampedModelAdmin):
         "user__username",
         "user__email",
     ]
+    list_filter = ["program__title", "is_revoked"]
     raw_id_fields = ("user",)
 
     def get_revoked_state(self, obj):


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Adding the ability to filter certificates which make it easy to track if certificates for a particular course or a program.
Also removing `certificate_page_revision` from the list view since it too long and not that important. If you need to check the certificate version then just view the individual certificate.
<img width="351" alt="Screenshot 2024-05-20 at 1 48 02 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/d57f049c-3981-4367-ad09-c81573887058">
