### PR TITLE
Fix flaky test: test_create_featured_courses

### DIFF
--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -359,6 +359,10 @@ def test_create_featured_items():
         live=True,
         in_progress=True,
     )
+    in_progress_course.enrollment_start = further_past_date
+    in_progress_course.start_date = past_date
+    in_progress_course.enrollment_end = future_date
+    in_progress_course.end_date = further_future_date
 
     unenrollable_course = CourseFactory.create(page=None, live=False)
     CoursePageFactory.create(course=unenrollable_course, live=False)
@@ -370,10 +374,12 @@ def test_create_featured_items():
     cache_value = redis_cache.get("CMS_homepage_featured_courses")
 
     assert len(cache_value) == 4
-    assert enrollable_future_course in cache_value
-    assert enrollable_other_future_course in cache_value
-    assert enrollable_self_paced_course in cache_value
-    assert in_progress_course in cache_value
+    assert set(cache_value) == {
+        enrollable_future_course,
+        enrollable_other_future_course,
+        enrollable_self_paced_course,
+        in_progress_course,
+    }
 
     assert cache_value[0] == enrollable_self_paced_course
     assert cache_value[1] == enrollable_future_course


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/4308

### Description (What does it do?)
test_create_featured_courses performs fine when the dates align, but when the factory produces a random date sometimes that date doesn't align as one would expect. To combat this, I set the dates based on one on another and based on "now" to keep the results consistent.  This was already in place for the future courses since their dates determined their order, but I have also now done this for the in_progress course.  I also made the check that they're all in place into one statement instead of 4 using sets.

### How can this be tested?
Check my logic and run the test... a lot.