### PR TITLE
Renaming enroll now button for archived courses

### DIFF
--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -1,7 +1,6 @@
 import React from "react"
 import {
   formatPrettyDate,
-  emptyOrNil,
   getFlexiblePriceForProduct,
   formatLocalePrice,
   parseDateString,

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -7,7 +7,7 @@ import {
   parseDateString,
   formatPrettyShortDate
 } from "../lib/util"
-import { getFirstRelevantRun } from "../lib/courseApi"
+import { getFirstRelevantRun, isRunArchived } from "../lib/courseApi"
 import moment from "moment-timezone"
 
 import type { BaseCourseRun } from "../flow/courseTypes"
@@ -166,11 +166,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     const course = courses[0]
     const run = getFirstRelevantRun(course, courseRuns)
     const product = run && run.products.length > 0 && run.products[0]
-    const isArchived = run
-      ? moment().isAfter(run.end_date) &&
-        (moment().isBefore(run.enrollment_end) ||
-          emptyOrNil(run.enrollment_end))
-      : false
+    const isArchived = isRunArchived(run)
 
     const startDates = []
     const moreEnrollableCourseRuns = courseRuns && courseRuns.length > 1

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -30,7 +30,8 @@ import {
 import { formatPrettyDate, emptyOrNil } from "../lib/util"
 import moment from "moment-timezone"
 import {
-  getFirstRelevantRun, isRunArchived,
+  getFirstRelevantRun,
+  isRunArchived,
   isEnrollmentFuture,
   isFinancialAssistanceAvailable
 } from "../lib/courseApi"

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -30,7 +30,7 @@ import {
 import { formatPrettyDate, emptyOrNil } from "../lib/util"
 import moment from "moment-timezone"
 import {
-  getFirstRelevantRun,
+  getFirstRelevantRun, isRunArchived,
   isEnrollmentFuture,
   isFinancialAssistanceAvailable
 } from "../lib/courseApi"
@@ -481,7 +481,7 @@ export class CourseProductDetailEnroll extends React.Component<
                 className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
                 disabled={!run.is_enrollable}
               >
-              Enroll now
+                {isRunArchived(run) ? "Enroll now" : "Access Course Materials"}
               </button>
             </form>
           )}

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -481,7 +481,7 @@ export class CourseProductDetailEnroll extends React.Component<
                 className="btn btn-primary btn-enrollment-button btn-gradient-red highlight enroll-now"
                 disabled={!run.is_enrollable}
               >
-                {isRunArchived(run) ? "Enroll now" : "Access Course Materials"}
+                {isRunArchived(run) ? "Access Course Materials" : "Enroll Now"}
               </button>
             </form>
           )}

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -113,11 +113,11 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         .find(".enroll-now")
         .at(0)
         .text(),
-      "Enroll now"
+      "Enroll Now"
     )
   })
 
-  it("checks for enroll now button should not appear if enrollment start in future", async () => {
+  it("checks for enroll now button should appear disabled if enrollment start in future", async () => {
     const courseRun = makeCourseRunDetail()
     courseRun["is_enrollable"] = false
     const { inner } = await renderPage(
@@ -170,7 +170,52 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         .find(".enroll-now")
         .at(0)
         .text(),
-      "Enroll now"
+      "Enroll Now"
+    )
+  })
+
+  it("checks for access course materials button should appear if course is archived", async () => {
+    const courseRun = {
+      ...makeCourseRunDetail(),
+      enrollment_end:   null,
+      enrollment_start: moment()
+        .subtract(1, "years")
+        .toISOString(),
+      start_date: moment()
+        .subtract(10, "months")
+        .toISOString(),
+      end_date: moment()
+        .subtract(7, "months")
+        .toISOString(),
+      upgrade_deadline: null
+    }
+    const { inner } = await renderPage(
+      {
+        entities: {
+          courseRuns: [courseRun]
+        },
+        queries: {
+          courseRuns: {
+            isPending: false,
+            status:    200
+          }
+        }
+      },
+      {}
+    )
+
+    assert.equal(
+      inner
+        .find(".enroll-now")
+        .at(0)
+        .text(),
+      "Access Course Materials"
+    )
+    assert.isFalse(
+      inner
+        .find(".enroll-now")
+        .at(0)
+        .prop("disabled")
     )
   })
 
@@ -196,7 +241,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         .find("form > button.enroll-now")
         .at(0)
         .text(),
-      "Enroll now"
+      "Enroll Now"
     )
   })
   ;[

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -3,7 +3,7 @@ import React from "react"
 import moment from "moment"
 import { isNil } from "ramda"
 
-import { notNil, parseDateString, formatPrettyDateTimeAmPmTz } from "./util"
+import {notNil, parseDateString, formatPrettyDateTimeAmPmTz, emptyOrNil} from "./util"
 
 import { NODETYPE_OPERATOR, NODETYPE_COURSE, NODEOPER_ALL } from "../constants"
 
@@ -209,6 +209,12 @@ export const learnerProgramIsCompleted = (learnerRecord: LearnerRecord) => {
   const electivesDone = walkNodes(electiveCourses, learnerRecord)
 
   return requirementsDone && electivesDone
+}
+export const isRunArchived = (run: CourseRunDetail) => {
+  return run ? moment().isAfter(run.end_date) &&
+        (moment().isBefore(run.enrollment_end) ||
+          emptyOrNil(run.enrollment_end))
+    : false
 }
 
 export const getFirstRelevantRun = (

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -3,7 +3,12 @@ import React from "react"
 import moment from "moment"
 import { isNil } from "ramda"
 
-import {notNil, parseDateString, formatPrettyDateTimeAmPmTz, emptyOrNil} from "./util"
+import {
+  notNil,
+  parseDateString,
+  formatPrettyDateTimeAmPmTz,
+  emptyOrNil
+} from "./util"
 
 import { NODETYPE_OPERATOR, NODETYPE_COURSE, NODEOPER_ALL } from "../constants"
 
@@ -211,7 +216,8 @@ export const learnerProgramIsCompleted = (learnerRecord: LearnerRecord) => {
   return requirementsDone && electivesDone
 }
 export const isRunArchived = (run: CourseRunDetail) => {
-  return run ? moment().isAfter(run.end_date) &&
+  return run
+    ? moment().isAfter(run.end_date) &&
         (moment().isBefore(run.enrollment_end) ||
           emptyOrNil(run.enrollment_end))
     : false


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.mit.edu/mitxonline/mitxonline-issues/issues/671

### Description (What does it do?)
Renaming enroll now button for archived courses

### Screenshots (if appropriate):
<img width="407" alt="Screenshot 2024-05-28 at 3 35 16 PM" src="https://github.com/mitodl/mitxonline/assets/7574259/b518cfea-7721-4f81-a46a-997b14619c5f">

