### PR TITLE
Adding topics to course and program api

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -231,6 +231,7 @@ class CourseRunEnrollmentAdmin(AuditableModelAdmin):
         "get_run_courseware_id",
         "enrollment_mode",
         "change_status",
+        "created_on",
     )
     raw_id_fields = (
         "user",

--- a/courses/serializers/v1/courses_test.py
+++ b/courses/serializers/v1/courses_test.py
@@ -9,7 +9,7 @@ from courses.factories import (
     CourseRunFactory,
     CourseRunGradeFactory,
 )
-from courses.models import Department
+from courses.models import Department, CoursesTopic
 from courses.serializers.v1.base import BaseCourseSerializer, CourseRunGradeSerializer
 from courses.serializers.v1.courses import (
     CourseRunEnrollmentSerializer,
@@ -43,6 +43,8 @@ def test_serialize_course(mocker, mock_context, is_anonymous, all_runs, settings
     course = courseRun1.course
     department = "a course departments"
     course.departments.set([Department.objects.create(name=department)])
+    topic = "a course topic"
+    course.topics.set([CoursesTopic.objects.create(name=topic)])
 
     CourseRunEnrollmentFactory.create(
         run=courseRun1, **({} if is_anonymous else {"user": user})
@@ -61,6 +63,7 @@ def test_serialize_course(mocker, mock_context, is_anonymous, all_runs, settings
                 CourseRunSerializer(courseRun2).data,
             ],
             "next_run_id": course.first_unexpired_run.id,
+            "topics": [{"name": topic}],
             "departments": [{"name": department}],
             "page": CoursePageSerializer(course.page).data,
             "programs": ProgramSerializer(course.programs, many=True).data

--- a/courses/serializers/v1/courses_test.py
+++ b/courses/serializers/v1/courses_test.py
@@ -9,7 +9,7 @@ from courses.factories import (
     CourseRunFactory,
     CourseRunGradeFactory,
 )
-from courses.models import Department, CoursesTopic
+from courses.models import Department
 from courses.serializers.v1.base import BaseCourseSerializer, CourseRunGradeSerializer
 from courses.serializers.v1.courses import (
     CourseRunEnrollmentSerializer,

--- a/courses/serializers/v1/courses_test.py
+++ b/courses/serializers/v1/courses_test.py
@@ -43,8 +43,6 @@ def test_serialize_course(mocker, mock_context, is_anonymous, all_runs, settings
     course = courseRun1.course
     department = "a course departments"
     course.departments.set([Department.objects.create(name=department)])
-    topic = "a course topic"
-    course.topics.set([CoursesTopic.objects.create(name=topic)])
 
     CourseRunEnrollmentFactory.create(
         run=courseRun1, **({} if is_anonymous else {"user": user})
@@ -63,7 +61,6 @@ def test_serialize_course(mocker, mock_context, is_anonymous, all_runs, settings
                 CourseRunSerializer(courseRun2).data,
             ],
             "next_run_id": course.first_unexpired_run.id,
-            "topics": [{"name": topic}],
             "departments": [{"name": department}],
             "page": CoursePageSerializer(course.page).data,
             "programs": ProgramSerializer(course.programs, many=True).data

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -30,6 +30,7 @@ class CourseSerializer(BaseCourseSerializer):
     next_run_id = serializers.SerializerMethodField()
     page = BaseCoursePageSerializer(read_only=True)
     programs = serializers.SerializerMethodField()
+    topics = serializers.SerializerMethodField()
 
     def get_next_run_id(self, instance):
         """Get next run id"""
@@ -44,6 +45,15 @@ class CourseSerializer(BaseCourseSerializer):
 
         return None
 
+    def get_topics(self, instance):
+        """List topics of a course"""
+        if instance.page:
+            return sorted(
+                [{"name": topic.name} for topic in instance.page.topics.all()],
+                key=lambda topic: topic["name"],
+            )
+        return []
+
     class Meta:
         model = models.Course
         fields = [
@@ -54,6 +64,7 @@ class CourseSerializer(BaseCourseSerializer):
             "departments",
             "page",
             "programs",
+            "topics",
         ]
 
 

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -3,7 +3,7 @@ import logging
 from rest_framework import serializers
 
 from cms.serializers import ProgramPageSerializer
-from courses.models import Program, ProgramRequirementNodeType
+from courses.models import Program, ProgramRequirementNodeType, CoursesTopic
 from courses.serializers.base import (
     BaseProgramRequirementTreeSerializer,
     get_thumbnail_url,
@@ -21,6 +21,7 @@ class ProgramSerializer(serializers.ModelSerializer):
     req_tree = serializers.SerializerMethodField()
     page = serializers.SerializerMethodField()
     departments = serializers.StringRelatedField(many=True, read_only=True)
+    topics = serializers.SerializerMethodField()
 
     def get_courses(self, instance):
         return [course[0].id for course in instance.courses if course[0].live]
@@ -45,6 +46,15 @@ class ProgramSerializer(serializers.ModelSerializer):
         else:
             return {"feature_image_src": get_thumbnail_url(None)}
 
+    def get_topics(self, instance):
+        """List all topics in all courses in the program"""
+        topics = (
+            CoursesTopic.objects.filter(course__program=instance)
+            .values("name")
+            .distinct("name")
+        )
+        return list(topics)
+
     class Meta:
         model = Program
         fields = [
@@ -58,6 +68,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "program_type",
             "departments",
             "live",
+            "topics",
         ]
 
 

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -48,12 +48,13 @@ class ProgramSerializer(serializers.ModelSerializer):
 
     def get_topics(self, instance):
         """List all topics in all courses in the program"""
-        topics = (
-            CoursesTopic.objects.filter(course__program=instance)
-            .values("name")
-            .distinct("name")
+        topics = set(  # noqa: C401
+            topic.name
+            for course in instance.courses
+            if course[0].page
+            for topic in course[0].page.topics.all()
         )
-        return list(topics)
+        return [{"name": topic} for topic in sorted(topics)]
 
     class Meta:
         model = Program

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -3,7 +3,7 @@ import logging
 from rest_framework import serializers
 
 from cms.serializers import ProgramPageSerializer
-from courses.models import Program, ProgramRequirementNodeType, CoursesTopic
+from courses.models import Program, ProgramRequirementNodeType
 from courses.serializers.base import (
     BaseProgramRequirementTreeSerializer,
     get_thumbnail_url,

--- a/courses/serializers/v2/programs_test.py
+++ b/courses/serializers/v2/programs_test.py
@@ -9,7 +9,7 @@ from courses.factories import (  # noqa: F401
     CourseRunFactory,
     program_with_empty_requirements,
 )
-from courses.models import Department, CoursesTopic
+from courses.models import CoursesTopic, Department
 from courses.serializers.v2.programs import (
     ProgramRequirementTreeSerializer,
     ProgramSerializer,

--- a/courses/serializers/v2/programs_test.py
+++ b/courses/serializers/v2/programs_test.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import pytest
 from django.utils.timezone import now
 
+from cms.factories import CoursePageFactory
 from cms.serializers import ProgramPageSerializer
 from courses.factories import (  # noqa: F401
     CourseRunFactory,
@@ -29,11 +30,13 @@ def test_serialize_program(mock_context, remove_tree, program_with_empty_require
         start_date=now() + timedelta(hours=1),
     )
     course1 = run1.course
+    CoursePageFactory.create(course=run1.course)
     run2 = CourseRunFactory.create(
         course__page=None,
         start_date=now() + timedelta(hours=2),
     )
     course2 = run2.course
+    CoursePageFactory.create(course=run2.course)
     departments = [
         Department.objects.create(name=f"department{num}") for num in range(3)
     ]
@@ -42,6 +45,7 @@ def test_serialize_program(mock_context, remove_tree, program_with_empty_require
 
     formatted_reqs = {"required": [], "electives": []}
 
+    topics = []
     if not remove_tree:
         program_with_empty_requirements.add_requirement(course1)
         program_with_empty_requirements.add_requirement(course2)
@@ -51,9 +55,11 @@ def test_serialize_program(mock_context, remove_tree, program_with_empty_require
         formatted_reqs["electives"] = [
             course.id for course in program_with_empty_requirements.elective_courses
         ]
-    topics = [CoursesTopic.objects.create(name=f"topic{num}") for num in range(3)]
-    course1.topics.set([topics[0], topics[1]])
-    course2.topics.set([topics[1], topics[2]])
+        topics = [CoursesTopic.objects.create(name=f"topic{num}") for num in range(3)]
+        course1.page.topics.set([topics[0], topics[1]])
+        course2.page.topics.set([topics[1], topics[2]])
+        course1.page.save()
+        course2.page.save()
 
     data = ProgramSerializer(
         instance=program_with_empty_requirements, context=mock_context

--- a/courses/serializers/v2/programs_test.py
+++ b/courses/serializers/v2/programs_test.py
@@ -8,7 +8,7 @@ from courses.factories import (  # noqa: F401
     CourseRunFactory,
     program_with_empty_requirements,
 )
-from courses.models import Department
+from courses.models import Department, CoursesTopic
 from courses.serializers.v2.programs import (
     ProgramRequirementTreeSerializer,
     ProgramSerializer,
@@ -51,6 +51,9 @@ def test_serialize_program(mock_context, remove_tree, program_with_empty_require
         formatted_reqs["electives"] = [
             course.id for course in program_with_empty_requirements.elective_courses
         ]
+    topics = [CoursesTopic.objects.create(name=f"topic{num}") for num in range(3)]
+    course1.topics.set([topics[0], topics[1]])
+    course2.topics.set([topics[1], topics[2]])
 
     data = ProgramSerializer(
         instance=program_with_empty_requirements, context=mock_context
@@ -73,5 +76,6 @@ def test_serialize_program(mock_context, remove_tree, program_with_empty_require
             "program_type": "Series",
             "departments": [],
             "live": True,
+            "topics": [{"name": topic.name} for topic in topics],
         },
     )

--- a/courses/views/test_utils.py
+++ b/courses/views/test_utils.py
@@ -54,7 +54,7 @@ def num_queries_from_programs(programs, version="v1"):
                 num_queries += num_queries_from_course(course)
             num_queries += 4 + (6 * num_courses) + 1
         if version == "v2":
-            num_queries += 6 + (12 * num_courses) + 1
+            num_queries += 6 + (17 * num_courses) + 1
     return num_queries
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Checks off second box https://github.com/mitodl/hq/issues/4110

### Description (What does it do?)

Adding course topics to course and program api
### Screenshots (if appropriate):
<img width="749" alt="Screenshot 2024-05-30 at 10 01 22 AM" src="https://github.com/mitodl/mitxonline/assets/7574259/75e585a6-401d-4459-9081-27b4f8c1e5eb">

### How can this be tested?
Go to http://mitxonline.odl.local:8013/api/v2/courses/
http://mitxonline.odl.local:8013/api/v2/programs/