### PR TITLE
Fixing CoursePage related name overlap

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -549,9 +549,9 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
         return self.readable_id.split("+")[-1]
 
     @cached_property
-    def course_page(self):
+    def page(self):
         """Gets the associated CoursePage"""
-        return getattr(self, "page", None)
+        return getattr(self, "coursepage", None)
 
     @cached_property
     def active_products(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -549,9 +549,9 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
         return self.readable_id.split("+")[-1]
 
     @cached_property
-    def page(self):
+    def course_page(self):
         """Gets the associated CoursePage"""
-        return getattr(self, "coursepage", None)
+        return getattr(self, "page", None)
 
     @cached_property
     def active_products(self):

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -47,9 +47,9 @@ class CourseSerializer(BaseCourseSerializer):
 
     def get_topics(self, instance):
         """List topics of a course"""
-        if instance.page:
+        if instance.course_page:
             return sorted(
-                [{"name": topic.name} for topic in instance.page.topics.all()],
+                [{"name": topic.name} for topic in instance.course_page.topics.all()],
                 key=lambda topic: topic["name"],
             )
         return []

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -47,9 +47,9 @@ class CourseSerializer(BaseCourseSerializer):
 
     def get_topics(self, instance):
         """List topics of a course"""
-        if instance.course_page:
+        if hasattr(instance, "page") and instance.page is not None:
             return sorted(
-                [{"name": topic.name} for topic in instance.course_page.topics.all()],
+                [{"name": topic.name} for topic in instance.page.topics.all()],
                 key=lambda topic: topic["name"],
             )
         return []

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -51,7 +51,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         topics = set(  # noqa: C401
             topic.name
             for course in instance.courses
-            if course[0].page
+            if hasattr(course[0], "page") and course[0].page is not None
             for topic in course[0].page.topics.all()
         )
         return [{"name": topic} for topic in sorted(topics)]


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mitxonline/pull/2228

### Description (What does it do?)
Fixing naming overlap between `Course.page` as property and as a related name to `CoursePage`

### How can this be tested?
Create a course without a course page.
Go to `http://mitxonline.odl.local:8013/api/v2/courses/`. Make sure it works.