### PR TITLE
Use hasattr() rather than directly referencing the property when checking for course.page

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -549,9 +549,9 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
         return self.readable_id.split("+")[-1]
 
     @cached_property
-    def course_page(self):
+    def page(self):
         """Gets the associated CoursePage"""
-        return getattr(self, "page", None)
+        return getattr(self, "coursepage", None)
 
     @cached_property
     def active_products(self):

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -47,9 +47,9 @@ class CourseSerializer(BaseCourseSerializer):
 
     def get_topics(self, instance):
         """List topics of a course"""
-        if instance.course_page:
+        if hasattr(instance, "page") and instance.page is not None:
             return sorted(
-                [{"name": topic.name} for topic in instance.course_page.topics.all()],
+                [{"name": topic.name} for topic in instance.page.topics.all()],
                 key=lambda topic: topic["name"],
             )
         return []

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -47,7 +47,7 @@ class CourseSerializer(BaseCourseSerializer):
 
     def get_topics(self, instance):
         """List topics of a course"""
-        if hasattr(instance, "page", None) and instance.page is not None:
+        if hasattr(instance, "page") and instance.page is not None:
             return sorted(
                 [{"name": topic.name} for topic in instance.page.topics.all()],
                 key=lambda topic: topic["name"],

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -47,7 +47,7 @@ class CourseSerializer(BaseCourseSerializer):
 
     def get_topics(self, instance):
         """List topics of a course"""
-        if hasattr(instance, "page") and instance.page is not None:
+        if hasattr(instance, "page", None) and instance.page is not None:
             return sorted(
                 [{"name": topic.name} for topic in instance.page.topics.all()],
                 key=lambda topic: topic["name"],

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -51,7 +51,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         topics = set(  # noqa: C401
             topic.name
             for course in instance.courses
-            if course[0].page
+            if course[0].page is not None
             for topic in course[0].page.topics.all()
         )
         return [{"name": topic} for topic in sorted(topics)]

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -51,7 +51,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         topics = set(  # noqa: C401
             topic.name
             for course in instance.courses
-            if hasattr(course[0], "page", None) and course[0].page is not None
+            if hasattr(course[0], "page") and course[0].page is not None
             for topic in course[0].page.topics.all()
         )
         return [{"name": topic} for topic in sorted(topics)]

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -51,7 +51,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         topics = set(  # noqa: C401
             topic.name
             for course in instance.courses
-            if course[0].page is not None
+            if hasattr(course[0], "page", None) and course[0].page is not None
             for topic in course[0].page.topics.all()
         )
         return [{"name": topic} for topic in sorted(topics)]


### PR DESCRIPTION
### What are the relevant tickets?

In response to https://github.com/mitodl/mitxonline/pull/2235 which is a fix for issues with the deploy of https://github.com/mitodl/mitxonline/pull/2228

### Why?

Since the deploy of the above pull request in RC, you'll see a 500 on the API and the catalog page will not load due to a `RelatedObjectDoesNotExist`  error.  There was a PR put up to fix this, but I found a couple of issues so I put up this PR as a response. This PR is meant to address the 500 errors without disrupting other parts of the application and to fully address the issue as the other PR only covered the courses API and the programs API is seeing the same issue.

### Description (What does it do?)

I reverted the change to the property on the Course model and instead I changed the `get_topics` function in the serializers to use `if hasattr(instance, "page") and instance.page is not None:` rather than `instance.page` as it's possible there is no page and invoking the property without it existing causes the error in question, but since `hasattr` actually retrieves the attribute via `getattr` and checks for an exception, it does the check more gracefully. An alternative would be to try/catch in its place, but it's technically the same operation.

### How can this be tested?

Prior to pulling the branch, on your local instance, remove the CoursePage of one course that is presently available for enrollment.  This can be accomplished in the CMS, admin, or database. The pages area of the CMS is fairly quick, navigate to courses, find a course that you would like to remove the page for, click the button with three dots and select the delete option.
Navigate to the following:
http://mitxonline.odl.local:8013/api/v2/courses/
http://mitxonline.odl.local:8013/api/v2/programs/
http://mitxonline.odl.local:8013/
http://mitxonline.odl.local:8013/catalog
and anywhere else that might be affected by changes to courses, coursepages, and topics.

You will see blank pages and/or 500 errors.  If you look at logs you will see a `RelatedObjectDoesNotExist` error

Pull the branch, and with no changes to your data, revisit those same locations. Things should now work.
Put the course page for the course back and double check that things still work once this has been restored.