### PR TITLE
4341: Color contrast low on "Access Course Materials" button

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -289,16 +289,13 @@ body.new-design {
           width: 100%;
           padding: 0!important;
           text-align: center;
+          color: $white;
         }
 
         .btn-enrollment-button:disabled, .btn-gradient-red:disabled {
-          color: $white;
-          background: $dashboard-tab-inactive !important;
-          border-color: $dashboard-tab-inactive;
-        }
-
-        button.btn-enrollment-button {
-          color: $white;
+          background: #6F7175 !important;
+          border-color: #6F7175;
+          opacity: 1;
         }
 
         button.btn-enrollment-button:hover {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4341

### Description (What does it do?)
Addresses contrast issue on disabled enrollment button.

### Screenshots (if appropriate):
![Screenshot 2024-06-06 at 12 19 52 PM](https://github.com/mitodl/mitxonline/assets/8311573/14d171e8-4de0-43cd-97d6-b0c64ce97977)

### How can this be tested?

1. Create an archived course run: https://docs.google.com/document/d/1F0e-laruWOgCAe_NOA-MENcjh4_SECdGUJ_q-yTJS50/edit#heading=h.38hb48f8hdc7 with the enrollment end date in the past.
2. Create a Course page in the CMS.
3. Visit the course about page, and verify that there is a button showing "Access Course Materials" with text and background color matching what is spec'd in the linked issue.  The button should be disabled.
4. Modify the course run start date, end date, enrollment start date, and enrollment end date to all be in the future.
5. Visit the course about page, and verify that there is a button showing "Enroll now" with text and background color matching what is spec'd in the linked issue.  The button should be disabled.
