### PR TITLE
Populate profile form occupation checkbox with saved data from user profile

### DIFF
--- a/frontend/public/src/components/forms/EditProfileForm.js
+++ b/frontend/public/src/components/forms/EditProfileForm.js
@@ -38,7 +38,15 @@ const getInitialValues = (user: User) => ({
       (user.user_profile && user.user_profile.leadership_level) || "",
     year_of_birth:    (user.user_profile && user.user_profile.year_of_birth) || "",
     years_experience:
-      (user.user_profile && user.user_profile.years_experience) || undefined
+      (user.user_profile && user.user_profile.years_experience) || undefined,
+    type_is_professional:
+      (user.user_profile && user.user_profile.type_is_professional) || false,
+    type_is_student:
+      (user.user_profile && user.user_profile.type_is_student) || false,
+    type_is_educator:
+      (user.user_profile && user.user_profile.type_is_educator) || false,
+    type_is_other:
+      (user.user_profile && user.user_profile.type_is_other) || false
   }
 })
 


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
This PR fixes an issue on the edit profile and additional details forms where the "Are you a" checkboxes were not being populated with the user's saved profile information.  The form would still save the form correctly.

### How can this be tested?
Visit the edit profile page or additional details form, documented here: https://docs.google.com/document/d/1W7jYty8HjkaYxSFXoUMF9ZYTOp8eJ4ssmINfgLhQ61Q/edit?pli=1#heading=h.hi2minfkuu1y
Check or uncheck one of the checkboxes on the form.  Submit the form.  After the page reloads, verify that the changed checkbox represents the change made prior to submitting the form.