### PR TITLE
Adding TTL check and coursepage

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -328,9 +328,15 @@ def create_featured_items():
     now = now_in_utc()
     end_of_day = now + timedelta(days=1)
 
+    valid_coursepages = cms_models.CoursePage.objects.filter(live=True).values_list(
+        "course_id", flat=True
+    )
+
     enrollable_courseruns = get_enrollable_courseruns_qs(
         end_of_day,
-        Course.objects.select_related("page").filter(page__live=True, live=True),
+        Course.objects.select_related("page").filter(
+            id__in=valid_coursepages, live=True
+        ),
     )
 
     # Figure out which courses are self-paced and select 2 at random

--- a/cms/constants.py
+++ b/cms/constants.py
@@ -7,3 +7,5 @@ PROGRAM_INDEX_SLUG = "programs"
 CERTIFICATE_INDEX_SLUG = "certificate"
 SIGNATORY_INDEX_SLUG = "signatories"
 INSTRUCTOR_INDEX_SLUG = "instructors"
+
+ONE_MINUTE = 60

--- a/cms/models.py
+++ b/cms/models.py
@@ -731,7 +731,7 @@ class HomePage(VideoPlayerConfigMixin):
         now = now_in_utc()
         redis_cache = caches["redis"]
         cached_featured_products = redis_cache.get("CMS_homepage_featured_courses")
-        if len(cached_featured_products) > 0:
+        if cached_featured_products:
             featured_product_ids = [course.id for course in cached_featured_products]
             relevant_run_course_ids = (
                 CourseRun.objects.filter(live=True)

--- a/cms/models.py
+++ b/cms/models.py
@@ -731,7 +731,7 @@ class HomePage(VideoPlayerConfigMixin):
         now = now_in_utc()
         redis_cache = caches["redis"]
         cached_featured_products = redis_cache.get("CMS_homepage_featured_courses")
-        if cached_featured_products:
+        if cached_featured_products and len(cached_featured_products) > 0:
             featured_product_ids = [course.id for course in cached_featured_products]
             relevant_run_course_ids = (
                 CourseRun.objects.filter(live=True)

--- a/cms/tasks.py
+++ b/cms/tasks.py
@@ -6,6 +6,7 @@ from django.core.cache import cache
 from mitol.common.decorators import single_task
 
 from cms.api import create_featured_items
+from cms.constants import ONE_MINUTE
 from cms.models import Page
 from main.celery import app
 from main.settings import (
@@ -108,8 +109,9 @@ def refresh_featured_homepage_items():
     """
     logger = logging.getLogger("refresh_featured_homepage_items__task")
     logger.info("Refreshing featured homepage items...")
-    featured_courses = cache.get("CMS_homepage_featured_courses")
-    if featured_courses is not None:
+    # if the key is not found, the ttl will be 0 per their docs
+    # https://github.com/jazzband/django-redis?tab=readme-ov-file#get-ttl-time-to-live-from-key
+    if cache.ttl("CMS_homepage_featured_courses") > ONE_MINUTE:
         logger.info("Featured courses found in cache, moving on")
         return
     logger.info("No featured courses found in cache, refreshing")

--- a/cms/tasks.py
+++ b/cms/tasks.py
@@ -111,7 +111,7 @@ def refresh_featured_homepage_items():
     logger.info("Refreshing featured homepage items...")
     # if the key is not found, the ttl will be 0 per their docs
     # https://github.com/jazzband/django-redis?tab=readme-ov-file#get-ttl-time-to-live-from-key
-    if cache.ttl("CMS_homepage_featured_courses") > ONE_MINUTE:
+    if cache.ttl("CMS_homepage_featured_courses") > (10 * ONE_MINUTE):
         logger.info("Featured courses found in cache, moving on")
         return
     logger.info("No featured courses found in cache, refreshing")


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/4615

### Description (What does it do?)
modifies the function that checks for a key in the cache to also check the TTL to reset the cached list a little prior to expiration so we don't see it break

### How can this be tested?
Manually set a key to be cached for under 10 minutes instead of 24 hours, next time the task runs (every minute)), you should see it replace the key even though TTL is not 0. 
Also, if there's nothing in the cache, the homepage shouldn't be disrupted, just empty in that area.
