### PR TITLE
Fix Django Admin search for Products

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -48,9 +48,9 @@ class ProductAdmin(VersionAdmin):
     model = Product
     search_fields = (
         "description",
-        "courseruns__title",
+        "courserunproducts__title",
         "programruns__program__title",
-        "courseruns__courseware_id",
+        "courserunproducts__courseware_id",
         "programruns__program__readable_id",
     )
     list_display = ("id", "content_object", "description", "price", "is_active")


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/2201
https://github.com/mitodl/mitxonline/issues/1895

### Description (What does it do?)
Fixes the Django Admin search for Products

### How can this be tested?

1. Have an instance of MITx Online with a Product created. 
2. Visit mitxonline.odl.local:8013/admin/ecommerce/product/
3. Use the search bar to search for your Product.  Verify that your Product is displayed if the search matches.
4. Use the search bar to search for a non-existing Product (random string that doesn't match any Product string).  Verify that your Product is not displayed.
