### PR TITLE
docs: replaced mitxpro-openedx-extensions with openedx-companion-auth in readme

### DIFF
--- a/docs/source/configuration/open_edx.rst
+++ b/docs/source/configuration/open_edx.rst
@@ -73,7 +73,7 @@ Install from local Build
 
   * To update to a new development version without having to actually bump the package version, simply ``pip uninstall social-auth-mitxpro``, then install again
 
-Install ``mitxpro-openedx-extensions`` in LMS
+Install ``openedx-companion-auth`` in LMS
 ---------------------------------------------
 
 There are two options for this:
@@ -83,16 +83,16 @@ Install via pip
 
 .. code-block:: shell
 
-    pip install mitxpro-openedx-extensions
+    pip install openedx-companion-auth
 
 Install from local Build
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Checkout the `mitxpro-openedx-extensions <https://github.com/mitodl/mitxpro-openedx-extensions>`_ project and build the package per the project instructions
-* Copy the ``mitxpro-openedx-extensions-$VERSION.tar.gz`` file into devstack's ``edx-platform`` directory
-* In devstack, run ``make lms-shell`` and within that shell ``pip install mitxpro-openedx-extensions-$VERSION.tar.gz``
+* Checkout the `open-edx-plugins <https://github.com/mitodl/open-edx-plugins>`_ project and build the package per the project instructions
+* Copy the ``openedx-companion-auth-$VERSION.tar.gz`` file into devstack's ``edx-platform`` directory
+* In devstack, run ``make lms-shell`` and within that shell ``pip install openedx-companion-auth-$VERSION.tar.gz``
 
-  * To update to a new development version without having to actually bump the package version, simply ``pip uninstall -y mitxpro-openedx-extensions``, then install again
+  * To update to a new development version without having to actually bump the package version, simply ``pip uninstall -y openedx-companion-auth``, then install again
 
 Configure MITx Online as a OAuth provider for Open edX
 ######################################################

--- a/docs/source/configuration/open_edx.rst
+++ b/docs/source/configuration/open_edx.rst
@@ -88,8 +88,8 @@ Install via pip
 Install from local Build
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Checkout the `open-edx-plugins <https://github.com/mitodl/open-edx-plugins>`_ project and build the package per the project instructions
-* Copy the ``openedx-companion-auth-$VERSION.tar.gz`` file into devstack's ``edx-platform`` directory
+* Checkout the `openedx-companion-auth <https://github.com/mitodl/open-edx-plugins/tree/main/src/openedx_companion_auth>`_ project and build the package per the project instructions
+* Copy the ``openedx-companion-auth-$VERSION.tar.gz`` file from the ``dist`` folder into devstack's ``edx-platform`` directory
 * In devstack, run ``make lms-shell`` and within that shell ``pip install openedx-companion-auth-$VERSION.tar.gz``
 
   * To update to a new development version without having to actually bump the package version, simply ``pip uninstall -y openedx-companion-auth``, then install again

--- a/docs/source/configuration/tutor.rst
+++ b/docs/source/configuration/tutor.rst
@@ -124,7 +124,7 @@ These steps will also disable the AuthN SSO MFE, so from here on you'll get norm
 #. Create a ``env/build/openedx/requirements/private.txt`` with the required extensions::
 
       social-auth-mitxpro
-      mitxpro-openedx-extensions
+      openedx-companion-auth
 
 #. Edit the ``env/apps/openedx/config/lms.env.yml`` file and add::
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4416

### Description (What does it do?)
This PR replaces `mitxpro-openedx-extensions `with `openedx-companion-auth` in the readme file. More details in the ticket

### How can this be tested?
- Validate the changes in [open_edx.rst](https://github.com/mitodl/mitxonline/blob/anas/update-readme/docs/source/configuration/open_edx.rst) and [tutor.rst](https://github.com/mitodl/mitxonline/blob/anas/update-readme/docs/source/configuration/tutor.rst)