### PR TITLE
Fix hover color for red blue button

### DIFF
--- a/frontend/public/scss/cards.scss
+++ b/frontend/public/scss/cards.scss
@@ -344,6 +344,7 @@ button.btn.btn-gradient-red-to-blue, a.btn.btn-gradient-red-to-blue {
 button.btn.btn-gradient-red-to-blue:hover, a.btn.btn-gradient-red-to-blue:hover {
     border-color: $home-page-header-blue;
     background: $home-page-header-blue !important;
+    color: white !important;
 }
 
 div.std-card-body, div.enrolled-item, div.cart-helptext {


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
Fixes the text color when hovering on a button with btn-gradient-red-to-blue

### Screenshots (if appropriate):
![Screenshot 2024-06-13 at 10 37 46 AM](https://github.com/mitodl/mitxonline/assets/8311573/261c87a9-d4fa-4ca4-9dcc-64e2d52e5900)


### How can this be tested?
Visit the sign in page and verify that the "Continue" button text is white when hovering.
