### PR TITLE
Include course instructors in V2 API results

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -6,7 +6,7 @@ from mitol.olposthog.features import is_enabled
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from cms.serializers import BaseCoursePageSerializer
+from cms.serializers import CoursePageSerializer
 from courses import models
 from courses.api import create_run_enrollments
 from courses.serializers.v1.base import (
@@ -28,7 +28,7 @@ class CourseSerializer(BaseCourseSerializer):
 
     departments = DepartmentSerializer(many=True, read_only=True)
     next_run_id = serializers.SerializerMethodField()
-    page = BaseCoursePageSerializer(read_only=True)
+    page = CoursePageSerializer(read_only=True)
     programs = serializers.SerializerMethodField()
     topics = serializers.SerializerMethodField()
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4575

### Description
Adds the Instructor name and description to the Courses API v2 for all Instructors associated with a Course Page.

### How can this be tested?

1. Run the configure_instance command.
2. Create an Instructor page in the CMS.  Add the instructor to the Course page.
3. Visit http://mitxonline.odl.local:8013/api/v2/courses/<COURSE_NUMBER> and verify that the instructor added to the Course Page is included in the API response.
