### PR TITLE
Set time limit for task process_google_sheet_requests

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -781,7 +781,7 @@ CRON_COURSERUN_SYNC_DAYS = get_string(
 )
 CRON_PROCESS_REFUND_REQUESTS_MINUTES = get_string(
     name="CRON_PROCESS_REFUND_REQUESTS_MINUTES",
-    default="*",
+    default="*/5",
     description="minute value for scheduled task to process refund requests",
 )
 CRON_COURSE_CERTIFICATES_HOURS = get_string(
@@ -859,7 +859,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "process-google-sheets-requests": {
         "task": "sheets.tasks.process_google_sheets_requests",
-        "schedule": crontab(minute=CRON_PROCESS_REFUND_REQUESTS_MINUTES),
+        "schedule": crontab(minute=CRON_PROCESS_REFUND_REQUESTS_MINUTES, hour='8-22'),
     },
     "generate-course-certificate": {
         "task": "courses.tasks.generate_course_certificates",

--- a/main/settings.py
+++ b/main/settings.py
@@ -781,7 +781,7 @@ CRON_COURSERUN_SYNC_DAYS = get_string(
 )
 CRON_PROCESS_REFUND_REQUESTS_MINUTES = get_string(
     name="CRON_PROCESS_REFUND_REQUESTS_MINUTES",
-    default="*/5",
+    default="*",
     description="minute value for scheduled task to process refund requests",
 )
 CRON_COURSE_CERTIFICATES_HOURS = get_string(
@@ -859,7 +859,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "process-google-sheets-requests": {
         "task": "sheets.tasks.process_google_sheets_requests",
-        "schedule": crontab(minute=CRON_PROCESS_REFUND_REQUESTS_MINUTES, hour='8-22'),
+        "schedule": crontab(minute=CRON_PROCESS_REFUND_REQUESTS_MINUTES, hour="6-22"),
     },
     "generate-course-certificate": {
         "task": "courses.tasks.generate_course_certificates",

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -1,54 +1,25 @@
 import logging
-from django.core.cache import cache
+from celery.exceptions import SoftTimeLimitExceeded
 from mitol.google_sheets_deferrals.api import DeferralRequestHandler
 from mitol.google_sheets_refunds.api import RefundRequestHandler
 
 from main.celery import app
-from redis import Redis
-from django.conf import settings
-
 log = logging.getLogger(__name__)
 
 
-@app.task(bind=True)
+@app.task(time_limit=120, soft_time_limit=60)
 def process_google_sheets_requests(self):
     """
     Task to process refund and deferral requests from Google sheets
     """
-    # revoke all previously scheduled tasks
-    import time
-    time.sleep(120)
-    log.info(self.name)
-    log.info(app.signature(self.name))
+    try:
+        refund_request_handler = RefundRequestHandler()
+        deferral_request_handler = DeferralRequestHandler()
+        if refund_request_handler.is_configured():
+            refund_request_handler.process_sheet()
 
+        if deferral_request_handler.is_configured():
+            deferral_request_handler.process_sheet()
+    except SoftTimeLimitExceeded:
+        log.info(f"Google sheets requests exceeded time limit")
 
-    redis_client = Redis.from_url(settings.CELERY_BROKER_URL, socket_connect_timeout=3)
-    print(redis_client.llen(app.default_app.conf.task_default_queue))
-
-
-    import base64
-    import json
-
-    with app.pool.acquire(block=True) as conn:
-        tasks = conn.default_channel.client.lrange('celery', 0, -1)
-        print(tasks)
-
-    decoded_tasks = []
-
-    for task in tasks:
-        j = json.loads(task)
-        body = json.loads(base64.b64decode(j['body']))
-        decoded_tasks.append(body)
-
-    print(decoded_tasks)
-    query = app.events.state.tasks_by_type(self.name)
-    for uuid, task in query:
-        app.control.revoke(uuid)
-
-    refund_request_handler = RefundRequestHandler()
-    deferral_request_handler = DeferralRequestHandler()
-    if refund_request_handler.is_configured():
-        refund_request_handler.process_sheet()
-
-    if deferral_request_handler.is_configured():
-        deferral_request_handler.process_sheet()

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 @app.task(time_limit=120, soft_time_limit=60)
-def process_google_sheets_requests(self):
+def process_google_sheets_requests():
     """
     Task to process refund and deferral requests from Google sheets
     """

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -23,4 +23,4 @@ def process_google_sheets_requests():
         if deferral_request_handler.is_configured():
             deferral_request_handler.process_sheet()
     except SoftTimeLimitExceeded:
-        log.info(f"Google sheets requests exceeded time limit")
+        log.info("Google sheets requests exceeded time limit")

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -1,5 +1,5 @@
 import logging
-
+from django.core.cache import cache
 from mitol.google_sheets_deferrals.api import DeferralRequestHandler
 from mitol.google_sheets_refunds.api import RefundRequestHandler
 
@@ -7,12 +7,38 @@ from main.celery import app
 
 log = logging.getLogger(__name__)
 
+LOCK_EXPIRE = 60 * 10  # Lock expires in 10 minutes
 
-@app.task
+@contextmanager
+def memcache_lock(lock_id, oid):
+    timeout_at = time.monotonic() + LOCK_EXPIRE - 3
+    # cache.add fails if the key already exists
+    status = cache.add(lock_id, oid, LOCK_EXPIRE)
+    try:
+        yield status
+    finally:
+        # memcache delete is very slow, but we have to use it to take
+        # advantage of using add() for atomic locking
+        if time.monotonic() < timeout_at and status:
+            # don't release the lock if we exceeded the timeout
+            # to lessen the chance of releasing an expired lock
+            # owned by someone else
+            # also don't release the lock if we didn't acquire it
+            cache.delete(lock_id)
+
+@app.task(bind=True)
 def process_google_sheets_requests():
     """
     Task to process refund and deferral requests from Google sheets
     """
+    feed_url_hexdigest = md5(feed_url).hexdigest()
+    lock_id = '{0}-lock-{1}'.format(self.name, feed_url_hexdigest)
+    logger.debug('Importing feed: %s', feed_url)
+    with memcache_lock(lock_id, self.app.oid) as acquired:
+        if acquired:
+            return Feed.objects.import_feed(feed_url).url
+    logger.debug(
+        'Feed %s is already being imported by another worker', feed_url)
     refund_request_handler = RefundRequestHandler()
     deferral_request_handler = DeferralRequestHandler()
     if refund_request_handler.is_configured():

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -4,6 +4,8 @@ from mitol.google_sheets_deferrals.api import DeferralRequestHandler
 from mitol.google_sheets_refunds.api import RefundRequestHandler
 
 from main.celery import app
+from redis import Redis
+from django.conf import settings
 
 log = logging.getLogger(__name__)
 
@@ -14,8 +16,31 @@ def process_google_sheets_requests(self):
     Task to process refund and deferral requests from Google sheets
     """
     # revoke all previously scheduled tasks
-    # log.info(self.name)
-    # log.info(app.signature(self.name))
+    import time
+    time.sleep(120)
+    log.info(self.name)
+    log.info(app.signature(self.name))
+
+
+    redis_client = Redis.from_url(settings.CELERY_BROKER_URL, socket_connect_timeout=3)
+    print(redis_client.llen(app.default_app.conf.task_default_queue))
+
+
+    import base64
+    import json
+
+    with app.pool.acquire(block=True) as conn:
+        tasks = conn.default_channel.client.lrange('celery', 0, -1)
+        print(tasks)
+
+    decoded_tasks = []
+
+    for task in tasks:
+        j = json.loads(task)
+        body = json.loads(base64.b64decode(j['body']))
+        decoded_tasks.append(body)
+
+    print(decoded_tasks)
     query = app.events.state.tasks_by_type(self.name)
     for uuid, task in query:
         app.control.revoke(uuid)

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -7,38 +7,19 @@ from main.celery import app
 
 log = logging.getLogger(__name__)
 
-LOCK_EXPIRE = 60 * 10  # Lock expires in 10 minutes
-
-@contextmanager
-def memcache_lock(lock_id, oid):
-    timeout_at = time.monotonic() + LOCK_EXPIRE - 3
-    # cache.add fails if the key already exists
-    status = cache.add(lock_id, oid, LOCK_EXPIRE)
-    try:
-        yield status
-    finally:
-        # memcache delete is very slow, but we have to use it to take
-        # advantage of using add() for atomic locking
-        if time.monotonic() < timeout_at and status:
-            # don't release the lock if we exceeded the timeout
-            # to lessen the chance of releasing an expired lock
-            # owned by someone else
-            # also don't release the lock if we didn't acquire it
-            cache.delete(lock_id)
 
 @app.task(bind=True)
-def process_google_sheets_requests():
+def process_google_sheets_requests(self):
     """
     Task to process refund and deferral requests from Google sheets
     """
-    feed_url_hexdigest = md5(feed_url).hexdigest()
-    lock_id = '{0}-lock-{1}'.format(self.name, feed_url_hexdigest)
-    logger.debug('Importing feed: %s', feed_url)
-    with memcache_lock(lock_id, self.app.oid) as acquired:
-        if acquired:
-            return Feed.objects.import_feed(feed_url).url
-    logger.debug(
-        'Feed %s is already being imported by another worker', feed_url)
+    # revoke all previously scheduled tasks
+    # log.info(self.name)
+    # log.info(app.signature(self.name))
+    query = app.events.state.tasks_by_type(self.name)
+    for uuid, task in query:
+        app.control.revoke(uuid)
+
     refund_request_handler = RefundRequestHandler()
     deferral_request_handler = DeferralRequestHandler()
     if refund_request_handler.is_configured():

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -1,9 +1,11 @@
 import logging
+
 from celery.exceptions import SoftTimeLimitExceeded
 from mitol.google_sheets_deferrals.api import DeferralRequestHandler
 from mitol.google_sheets_refunds.api import RefundRequestHandler
 
 from main.celery import app
+
 log = logging.getLogger(__name__)
 
 
@@ -22,4 +24,3 @@ def process_google_sheets_requests():
             deferral_request_handler.process_sheet()
     except SoftTimeLimitExceeded:
         log.info(f"Google sheets requests exceeded time limit")
-


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4550

I looked at the logs for June 6th and this task was taking up to 4 minutes, and the schedule was set to run every minute.

### Description (What does it do?)
sets a time limit on the task and sets the schedule to every 5 min.
I am not sure what would be the best way to abort the task if it has exceeded the time limit.

### How can this be tested?
Add this to the task and watch the logs:
```
 import time
 time.sleep(130) 
```