### PR TITLE
Change the cache from memcache to redis in the task as well as it is in util func

### DIFF
--- a/cms/tasks.py
+++ b/cms/tasks.py
@@ -2,7 +2,7 @@ import logging
 from urllib.parse import urljoin, urlparse
 
 import requests
-from django.core.cache import cache
+from django.core.cache import caches
 from mitol.common.decorators import single_task
 
 from cms.api import create_featured_items
@@ -105,13 +105,14 @@ def queue_fastly_full_purge():
 @single_task(10)
 def refresh_featured_homepage_items():
     """
-    Refresh the featured homepage items in the memcached cache.
+    Refresh the featured homepage items in the redis cache.
     """
     logger = logging.getLogger("refresh_featured_homepage_items__task")
     logger.info("Refreshing featured homepage items...")
     # if the key is not found, the ttl will be 0 per their docs
     # https://github.com/jazzband/django-redis?tab=readme-ov-file#get-ttl-time-to-live-from-key
-    if cache.ttl("CMS_homepage_featured_courses") > (10 * ONE_MINUTE):
+    redis_cache = caches["redis"]
+    if redis_cache.ttl("CMS_homepage_featured_courses") > (10 * ONE_MINUTE):
         logger.info("Featured courses found in cache, moving on")
         return
     logger.info("No featured courses found in cache, refreshing")


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/4651

### Description (What does it do?)
Fixes the task to use the correct cache when checking ttl for the featured courses

### How can this be tested?

Delete your local featured items :

```
from django.core.cache import caches
redis_cache.get("CMS_homepage_featured_courses") // should return a list if you have any set
redis_cache = caches["redis"]
redis_cache.delete("CMS_homepage_featured_courses")
redis_cache.get("CMS_homepage_featured_courses") // should return nothing 
```

Wait for the task to run on celery, every minute, at :30.  You should see successful output in terminal and running `.get` again should return a new list

A good next test would be to set ttl for the line to under 10 minutes (so less than 600 seconds) manually, after it has run successfully:

```
from django.core.cache import caches
redis_cache = caches["redis"]
redis_cache.get("CMS_homepage_featured_courses") // Should return current list. If there are none, can run `cms.api.create_featured_items()`
redis_cache.ttl("CMS_homepage_featured_courses") // should return current value (about 24 hours from now)
redis_cache.expire("CMS_homepage_featured_courses", 300) 
redis_cache.ttl("CMS_homepage_featured_courses") // should return a value slightly less than 300
```

Next time task runs, it should successfully check ttl and run again - changing the output of `redis_cache.get("CMS_homepage_featured_courses")`
