### PR TITLE
Program enroll button text does not appear on about page

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -290,6 +290,9 @@ body.new-design {
           padding: 0!important;
           text-align: center;
           color: $white;
+          background: $primary;
+          font-size: 20px;
+          font-weight: 700;
         }
 
         .btn-enrollment-button:disabled, .btn-gradient-red:disabled {

--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -405,7 +405,7 @@ export class ProgramProductDetailEnroll extends React.Component<
               {enrollment ? (
                 <Fragment>
                   <div
-                    className={`btn btn-primary btn-enrollment-button highlight outline`}
+                    className={`btn btn-enrollment-button highlight`}
                   >
                     Enrolled &#10003;
                   </div>

--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -404,9 +404,7 @@ export class ProgramProductDetailEnroll extends React.Component<
             <>
               {enrollment ? (
                 <Fragment>
-                  <div
-                    className={`btn btn-enrollment-button highlight`}
-                  >
+                  <div className={`btn btn-enrollment-button highlight`}>
                     Enrolled &#10003;
                   </div>
                 </Fragment>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4662

### Description (What does it do?)
Fixes a styling issue where the text of the "Enrolled" button on the Program about page was white on a white background, when the learner is enrolled in the Program.

### Screenshots (if appropriate):
![Screenshot 2024-06-20 at 11 38 37 AM](https://github.com/mitodl/mitxonline/assets/8311573/60363e70-179b-4cb1-98d6-e2ac8de8bf0e)


### How can this be tested?

1. Enroll into a Program.
2. Visit the Program's about page.
3. Verify that the "Enrolled" button has white text on a red background and does not change when hovered.
