### PR TITLE
Fix invalid compose project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,3 +180,4 @@ volumes:
   npm-cache: {}
   django_media: {}
   yarn-cache: {}
+  db-data: {}


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mitxonline/pull/2240/commits/948d9559d2814074d5d4b1c07393bd395d83ebc0#r1633562871

### Description (What does it do?)
Throws error
```
service "db" refers to undefined volume db-data: invalid compose project
```
### How can this be tested?
Should run docker compose build and up with no error.