### PR TITLE
4548 dashboard dont display course detail link when the course about page is not published

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -469,7 +469,7 @@ export class EnrolledItemCard extends React.Component<
     const startDateDescription = generateStartDateText(enrollment.run)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
-    const pageLocation = enrollment.run.course.page
+    const pageLocation = enrollment.run.course.page.live ? enrollment.run.course.page : null
     const menuTitle = `Course options for ${enrollment.run.course.title}`
 
     const courseRunStatusMessageText = courseRunStatusMessage(enrollment.run)

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -35,7 +35,6 @@ import GetCertificateButton from "./GetCertificateButton"
 import {
   isFinancialAssistanceAvailable,
   isLinkableCourseRun,
-  generateStartDateText,
   courseRunStatusMessage
 } from "../lib/courseApi"
 import { isSuccessResponse } from "../lib/util"
@@ -468,7 +467,9 @@ export class EnrolledItemCard extends React.Component<
 
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
-    const pageLocation = enrollment.run.course.page.live ? enrollment.run.course.page : null
+    const pageLocation = enrollment.run.course.page.live
+      ? enrollment.run.course.page
+      : null
     const menuTitle = `Course options for ${enrollment.run.course.title}`
 
     const courseRunStatusMessageText = courseRunStatusMessage(enrollment.run)

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -466,7 +466,6 @@ export class EnrolledItemCard extends React.Component<
           </div>
         ) : null
 
-    const startDateDescription = generateStartDateText(enrollment.run)
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
     const pageLocation = enrollment.run.course.page.live ? enrollment.run.course.page : null
@@ -554,7 +553,6 @@ export class EnrolledItemCard extends React.Component<
             </div>
             <div className="detail">
               {courseId}
-              {startDateDescription === null}
               {courseRunStatusMessageText}
               <div className="enrollment-extra-links d-flex">
                 {pageLocation ? (
@@ -606,7 +604,6 @@ export class EnrolledItemCard extends React.Component<
     const { menuVisibility } = this.state
 
     const title = enrollment.program.title
-    const startDateDescription = null
     const certificateLinks = null
     const pageLocation = null
     const courseRunStatusMessageText = null
@@ -676,7 +673,6 @@ export class EnrolledItemCard extends React.Component<
               {this.renderProgramUnenrollmentModal(enrollment)}
             </div>
             <div className="detail detail-program">
-              {startDateDescription === null}
               {courseRunStatusMessageText}
               <div className="enrollment-extra-links d-flex pe-2">
                 <a

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -219,22 +219,22 @@ describe("EnrolledItemCard", () => {
   it("Course detail does not display course details (about page) link if course page is not published", async () => {
     enrollmentCardProps.enrollment.run.course.page.live = false
     const inner = await renderedCard()
-    const enrollmentExtraLinks = inner.find(".enrolled-item").find(".enrollment-extra-links")
+    const enrollmentExtraLinks = inner
+      .find(".enrolled-item")
+      .find(".enrollment-extra-links")
     assert.isTrue(enrollmentExtraLinks.exists())
-    const courseDetailsPageLink = enrollmentExtraLinks
-      .find("a")
-      .at(0)
+    const courseDetailsPageLink = enrollmentExtraLinks.find("a").at(0)
     assert.isFalse(courseDetailsPageLink.exists())
   })
 
   it("Course detail does display course details (about page) link if course page is published", async () => {
     enrollmentCardProps.enrollment.run.course.page.live = true
     const inner = await renderedCard()
-    const enrollmentExtraLinks = inner.find(".enrolled-item").find(".enrollment-extra-links")
+    const enrollmentExtraLinks = inner
+      .find(".enrolled-item")
+      .find(".enrollment-extra-links")
     assert.isTrue(enrollmentExtraLinks.exists())
-    const courseDetailsPageLink = enrollmentExtraLinks
-      .find("a")
-      .at(0)
+    const courseDetailsPageLink = enrollmentExtraLinks.find("a").at(0)
     assert.isTrue(courseDetailsPageLink.exists())
   })
 

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -216,6 +216,28 @@ describe("EnrolledItemCard", () => {
     assert.isTrue(detailText.startsWith(" | Ended"))
   })
 
+  it("Course detail does not display course details (about page) link if course page is not published", async () => {
+    enrollmentCardProps.enrollment.run.course.page.live = false
+    const inner = await renderedCard()
+    const enrollmentExtraLinks = inner.find(".enrolled-item").find(".enrollment-extra-links")
+    assert.isTrue(enrollmentExtraLinks.exists())
+    const courseDetailsPageLink = enrollmentExtraLinks
+      .find("a")
+      .at(0)
+    assert.isFalse(courseDetailsPageLink.exists())
+  })
+
+  it("Course detail does display course details (about page) link if course page is published", async () => {
+    enrollmentCardProps.enrollment.run.course.page.live = true
+    const inner = await renderedCard()
+    const enrollmentExtraLinks = inner.find(".enrolled-item").find(".enrollment-extra-links")
+    assert.isTrue(enrollmentExtraLinks.exists())
+    const courseDetailsPageLink = enrollmentExtraLinks
+      .find("a")
+      .at(0)
+    assert.isTrue(courseDetailsPageLink.exists())
+  })
+
   it("renders the unenrollment verification modal", async () => {
     const inner = await renderedCard()
     const modalId = `run-unenrollment-${userEnrollment.id}-modal`


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4548

### Description (What does it do?)
Removes the "Course details" link on the course cards shown on a learner's dashboard if the course does not have a published CMS page.

### How can this be tested?

1. CReate course with a drafted CMS page.
2. Enroll user in course
3. Visit user's dashboard.
4. Verify that the "Course details" link is not displayed on the course card.
