### PR TITLE
Preliminary Test-More-Dates "No Sessions" design: Exclamation point icon - low contrast and spacing

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -333,25 +333,27 @@ body.new-design {
           }
 
           .callout {
-            padding: 0.9375rem;
             flex-wrap: nowrap;
+            padding: 15px;
             i.warning {
               font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-              color: $warning;
-              padding: 0;
+              color: #B87A00;
+              padding-right: 10px;
               width: fit-content;
+              padding-left: 0;
             }
-            p{
-              width: 95%;
-              font-size: 0.875rem;
-              color: $home-page-header-blue;
+            p {
               font-family: Inter, sans-serif;
-              line-height: 15px;
+              font-size: 13px;
+              font-weight: 400;
+              line-height: 15.73px;
+              text-align: left;
+              color: $home-page-header-blue;
               margin: 0;
-              padding: 0 10px 0 10px;
+              flex-shrink: 1;
             }
           }
-          .callout-warning{
+          .callout-warning {
             border: 1px solid rgba(255, 171, 0, 0.30);
             border-left: 2px solid $warning;
             background: #FFF3CC;

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -90,9 +90,9 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
       ? "This course is no longer active, but you can still access selected content."
       : "No sessions of this course are currently open for enrollment. More sessions may be added in the future."
     return (
-      <div className="row d-flex align-self-stretch callout callout-warning course-status-message">
+      <div className="row d-flex callout callout-warning course-status-message">
         <i className="material-symbols-outlined warning">error</i>
-        <p>
+        <p className="p-0">
           {message}{" "}
           {isArchived ? (
             <button


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4152

### Description (What does it do?)
Fixes the spacing and contrast of the icon element on course about pages which have no course runs that are enrollable in the future.

### Screenshots (if appropriate):
![Screenshot 2024-07-10 at 9 26 35 AM](https://github.com/mitodl/mitxonline/assets/8311573/f35e11a3-c9d9-4ef2-97de-3aa2ad69e7b1)


### How can this be tested?

1. Create or update a course run that is not enrollable based on the defintion here https://docs.google.com/document/d/1F0e-laruWOgCAe_NOA-MENcjh4_SECdGUJ_q-yTJS50/edit#heading=h.1hrid43inzkv
2. visit the Course's about page and verify that spacing and color of the icon.
