### PR TITLE
Enrollment in a course run without a course page crashes the dashboard

### DIFF
--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -460,7 +460,8 @@ export class EnrolledItemCard extends React.Component<
 
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
-    const pageLocation = enrollment.run.course.page.live ?
+    console.log(enrollment.run.course.page)
+    const pageLocation = enrollment.run.course.page && enrollment.run.course.page.live ?
       enrollment.run.course.page :
       null
     const menuTitle = `Course options for ${enrollment.run.course.title}`

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -460,7 +460,6 @@ export class EnrolledItemCard extends React.Component<
 
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
-    console.log(enrollment.run.course.page)
     const pageLocation =
       enrollment.run.course.page && enrollment.run.course.page.live ?
         enrollment.run.course.page :

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -461,9 +461,10 @@ export class EnrolledItemCard extends React.Component<
     const onUnenrollClick = partial(this.onDeactivate.bind(this), [enrollment])
     const courseId = enrollment.run.course_number
     console.log(enrollment.run.course.page)
-    const pageLocation = enrollment.run.course.page && enrollment.run.course.page.live ?
-      enrollment.run.course.page :
-      null
+    const pageLocation =
+      enrollment.run.course.page && enrollment.run.course.page.live ?
+        enrollment.run.course.page :
+        null
     const menuTitle = `Course options for ${enrollment.run.course.title}`
 
     const courseRunStatusMessageText = courseRunStatusMessage(enrollment.run)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4913

### Description (What does it do?)
Fixes an issue caused when loading the dashboard while also enrolled in a course with no page.

### How can this be tested?

1. Enroll into a course run associated with a course that has no page.
2. Visit your dashboard.
3. Verify the dashboard loads and that the course is shown on the dashboard.