### PR TITLE
When creating enrollment set is_active explicitly in the enrollment api call

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -668,6 +668,7 @@ def enroll_in_edx_course_runs(
                     mode=mode,
                     username=username,
                     force_enrollment=force_enrollment,
+                    enrollment_attributes={"is_active": True},
                 )
             results.append(enrollment)
         except HTTPError as exc:  # noqa: PERF203

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -668,8 +668,14 @@ def enroll_in_edx_course_runs(
                     mode=mode,
                     username=username,
                     force_enrollment=force_enrollment,
-                    enrollment_attributes={"name": "is_active", "value": True},
                 )
+                if not enrollment.is_active:
+                    enrollment = edx_client.enrollments.create_student_enrollment(
+                        course_run.courseware_id,
+                        mode=mode,
+                        username=username,
+                        force_enrollment=force_enrollment,
+                    )
             results.append(enrollment)
         except HTTPError as exc:  # noqa: PERF203
             raise EdxApiEnrollErrorException(user, course_run, exc) from exc

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -668,7 +668,7 @@ def enroll_in_edx_course_runs(
                     mode=mode,
                     username=username,
                     force_enrollment=force_enrollment,
-                    enrollment_attributes={"is_active": True},
+                    enrollment_attributes={"name": "is_active", "value": True},
                 )
             results.append(enrollment)
         except HTTPError as exc:  # noqa: PERF203

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -669,7 +669,8 @@ def enroll_in_edx_course_runs(
                     username=username,
                     force_enrollment=force_enrollment,
                 )
-                if not enrollment.is_active:
+                print(enrollment)
+                if not enrollment["is_active"]:
                     enrollment = edx_client.enrollments.create_student_enrollment(
                         course_run.courseware_id,
                         mode=mode,

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -669,7 +669,7 @@ def enroll_in_edx_course_runs(
                     username=username,
                     force_enrollment=force_enrollment,
                 )
-                if not enrollment["is_active"]:
+                if not enrollment.is_active:
                     enrollment = edx_client.enrollments.create_student_enrollment(
                         course_run.courseware_id,
                         mode=mode,

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -669,7 +669,6 @@ def enroll_in_edx_course_runs(
                     username=username,
                     force_enrollment=force_enrollment,
                 )
-                print(enrollment)
                 if not enrollment["is_active"]:
                     enrollment = edx_client.enrollments.create_student_enrollment(
                         course_run.courseware_id,

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -447,8 +447,14 @@ def test_enroll_in_edx_course_runs(settings, mocker, user):
     """Tests that enroll_in_edx_course_runs uses the EdxApi client to enroll in course runs"""
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "mock_api_token"  # noqa: S105
     mock_client = mocker.MagicMock()
-    enroll_return_values = [mocker.Mock(is_active=True), mocker.Mock(is_active=False), mocker.Mock(is_active=True)]
-    mock_client.enrollments.create_student_enrollment = mocker.Mock(side_effect=enroll_return_values)
+    enroll_return_values = [
+        mocker.Mock(is_active=True),
+        mocker.Mock(is_active=False),
+        mocker.Mock(is_active=True),
+    ]
+    mock_client.enrollments.create_student_enrollment = mocker.Mock(
+        side_effect=enroll_return_values
+    )
     mocker.patch("openedx.api.get_edx_api_client", return_value=mock_client)
     mocker.patch("openedx.api.get_edx_api_service_client", return_value=mock_client)
     course_runs = CourseRunFactory.build_batch(2)

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -447,7 +447,7 @@ def test_enroll_in_edx_course_runs(settings, mocker, user):
     """Tests that enroll_in_edx_course_runs uses the EdxApi client to enroll in course runs"""
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "mock_api_token"  # noqa: S105
     mock_client = mocker.MagicMock()
-    enroll_return_values = ["result1", "result2"]
+    enroll_return_values = [{"is_active": True}, {"is_active": False}, {"is_active": True}]
     mock_client.enrollments.create_student_enrollment = mocker.Mock(
         side_effect=enroll_return_values
     )
@@ -467,7 +467,7 @@ def test_enroll_in_edx_course_runs(settings, mocker, user):
         username=user.username,
         force_enrollment=True,
     )
-    assert enroll_results == enroll_return_values
+    assert enroll_results == [{"is_active": True}, {"is_active": True}]
 
 
 def test_enroll_api_fail(mocker, user):

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -447,10 +447,8 @@ def test_enroll_in_edx_course_runs(settings, mocker, user):
     """Tests that enroll_in_edx_course_runs uses the EdxApi client to enroll in course runs"""
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "mock_api_token"  # noqa: S105
     mock_client = mocker.MagicMock()
-    enroll_return_values = [{"is_active": True}, {"is_active": False}, {"is_active": True}]
-    mock_client.enrollments.create_student_enrollment = mocker.Mock(
-        side_effect=enroll_return_values
-    )
+    enroll_return_values = [mocker.Mock(is_active=True), mocker.Mock(is_active=False), mocker.Mock(is_active=True)]
+    mock_client.enrollments.create_student_enrollment = mocker.Mock(side_effect=enroll_return_values)
     mocker.patch("openedx.api.get_edx_api_client", return_value=mock_client)
     mocker.patch("openedx.api.get_edx_api_service_client", return_value=mock_client)
     course_runs = CourseRunFactory.build_batch(2)
@@ -467,7 +465,7 @@ def test_enroll_in_edx_course_runs(settings, mocker, user):
         username=user.username,
         force_enrollment=True,
     )
-    assert enroll_results == [{"is_active": True}, {"is_active": True}]
+    assert enroll_results == [enroll_return_values[0], enroll_return_values[2]]
 
 
 def test_enroll_api_fail(mocker, user):


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/mitxonline/issues/2225 and https://github.com/mitodl/mitxonline/issues/1797

### Description (What does it do?)
If use enrolls, unenrolls, and enrolls again, the course run enrollment in edx should be active, otherwise the user can't access the course on edx, just like it happened for this user https://github.com/mitodl/hq/issues/4367.

On open edx `is_active = False` is equivalent to being unenrolled.


### How can this be tested?
Locally you can test if by enrolling in a course for an audit track, then unenrolling, then paying again. You can pay with a coupon too.
The api would get called again. This double call of create enrollment api is going to set is_active to true on repeated call.