### PR TITLE
Show only enrollable runs in the enrollment dialog

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -32,7 +32,6 @@ import moment from "moment-timezone"
 import {
   getFirstRelevantRun,
   isRunArchived,
-  isEnrollmentFuture,
   isFinancialAssistanceAvailable
 } from "../lib/courseApi"
 import { getCookie } from "../lib/api"
@@ -178,7 +177,11 @@ export class CourseProductDetailEnroll extends React.Component<
 
   renderRunSelectorButtons() {
     const { courseRuns } = this.props
-
+    const enrollableCourseRuns = courseRuns ?
+      courseRuns.filter(
+        (run: EnrollmentFlaggedCourseRun) => run.is_enrollable
+      ) :
+      []
     return (
       <>
         {courseRuns && courseRuns.length > 1 ? (
@@ -195,13 +198,12 @@ export class CourseProductDetailEnroll extends React.Component<
           <option value="default" key="default-select">
             Please Select
           </option>
-          {courseRuns &&
-            courseRuns.map((elem: EnrollmentFlaggedCourseRun) => (
+          {enrollableCourseRuns &&
+            enrollableCourseRuns.map((elem: EnrollmentFlaggedCourseRun) => (
               <option value={elem.id} key={`courserun-selection-${elem.id}`}>
                 {formatPrettyDate(moment(new Date(elem.start_date)))} -{" "}
                 {formatPrettyDate(moment(new Date(elem.end_date)))}{" "}
                 {elem.is_upgradable ? "" : "(no certificate available)"}
-                {isEnrollmentFuture(elem) ? "(enrollment opens soon)" : ""}
               </option>
             ))}
         </select>

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -537,17 +537,6 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     it(`${showsQualifier} the course run selector for a course with ${runsQualifier} active run${
       multiples ? "s" : ""
     } and enables enroll buttons on selection`, async () => {
-      // courseRun["products"] = [
-      //   {
-      //     id:                     1,
-      //     price:                  10,
-      //     is_upgradable:          true,
-      //     product_flexible_price: {
-      //       amount:        10,
-      //       discount_type: DISCOUNT_TYPE_PERCENT_OFF
-      //     }
-      //   }
-      // ]
       const courseRuns = [courseRun]
       if (multiples) {
         courseRuns.push(courseRun)

--- a/frontend/public/src/lib/courseApi.js
+++ b/frontend/public/src/lib/courseApi.js
@@ -40,11 +40,6 @@ export const isLinkableCourseRun = (
   return notNil(run.start_date) && moment(run.start_date).isBefore(now)
 }
 
-export const isEnrollmentFuture = (run: CourseRunDetail): boolean => {
-  const enrollStart = run.enrollment_start ? moment(run.enrollment_start) : null
-  return !!enrollStart && moment().isBefore(enrollStart)
-}
-
 export const courseRunStatusMessage = (run: CourseRun) => {
   const startDateDescription = generateStartDateText(run)
   if (startDateDescription !== null) {


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/4877
### Description (What does it do?)
Filters course runs for enrollment in the enrollment dialog.

### Screenshots (if appropriate):
<img width="736" alt="Screenshot 2024-07-23 at 7 42 44 AM" src="https://github.com/user-attachments/assets/8a53a718-8f86-4683-8842-3929262a6e2d">


### How can this be tested?
Create at least two or three course runs. Make one of them with future enrollment. Go to the product page and open the enrollment dialog. The future course run should not show up in the options.