### PR TITLE
Add certificate_type to courses and programs serializer

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -31,6 +31,7 @@ class CourseSerializer(BaseCourseSerializer):
     page = CoursePageSerializer(read_only=True)
     programs = serializers.SerializerMethodField()
     topics = serializers.SerializerMethodField()
+    certificate_type = serializers.SerializerMethodField()
 
     def get_next_run_id(self, instance):
         """Get next run id"""
@@ -54,6 +55,12 @@ class CourseSerializer(BaseCourseSerializer):
             )
         return []
 
+    def get_certificate_type(self, instance):
+        program = instance.programs[0]
+        if "MicroMasters" in program.program_type:
+            return "MicroMasters Credential"
+        return "Certificate of Completion"
+
     class Meta:
         model = models.Course
         fields = [
@@ -65,6 +72,7 @@ class CourseSerializer(BaseCourseSerializer):
             "page",
             "programs",
             "topics",
+            "certificate_type",
         ]
 
 

--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -22,6 +22,7 @@ class ProgramSerializer(serializers.ModelSerializer):
     page = serializers.SerializerMethodField()
     departments = serializers.StringRelatedField(many=True, read_only=True)
     topics = serializers.SerializerMethodField()
+    certificate_type = serializers.SerializerMethodField()
 
     def get_courses(self, instance):
         return [course[0].id for course in instance.courses if course[0].live]
@@ -56,6 +57,11 @@ class ProgramSerializer(serializers.ModelSerializer):
         )
         return [{"name": topic} for topic in sorted(topics)]
 
+    def get_certificate_type(self, instance):
+        if "MicroMasters" in instance.program_type:
+            return "MicroMasters Credential"
+        return "Certificate of Completion"
+
     class Meta:
         model = Program
         fields = [
@@ -67,6 +73,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "req_tree",
             "page",
             "program_type",
+            "certificate_type",
             "departments",
             "live",
             "topics",


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/4945

### Description (What does it do?)
Add certificate_type to courses and programs serializer


### How can this be tested?
go to http://mitxonline.odl.local:8013/api/v2/courses/ and make sure you see certificate type.