### PR TITLE
Add availability to Courses API endpoint

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -100,7 +100,7 @@ class CourseSerializer(BaseCourseSerializer):
     def get_availability(self, instance):
         """Get course availability"""
         archived_course_runs = get_archived_courseruns(
-            instance.courseruns(is_self_paced=False)
+            instance.courseruns.filter(is_self_paced=False)
         )
         if archived_course_runs.count() == 0:
             return "dated"

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -16,6 +16,7 @@ from courses.serializers.v1.base import (
     ProductRelatedField,
 )
 from courses.serializers.v1.departments import DepartmentSerializer
+from courses.utils import get_archived_courseruns
 from flexiblepricing.api import is_courseware_flexible_price_approved
 from main import features
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
@@ -32,6 +33,7 @@ class CourseSerializer(BaseCourseSerializer):
     programs = serializers.SerializerMethodField()
     topics = serializers.SerializerMethodField()
     certificate_type = serializers.SerializerMethodField()
+    availability = serializers.SerializerMethodField()
     required_prerequisites = serializers.SerializerMethodField()
     duration = serializers.SerializerMethodField()
     time_commitment = serializers.SerializerMethodField()
@@ -95,6 +97,15 @@ class CourseSerializer(BaseCourseSerializer):
                 return "MicroMasters Credential"
         return "Certificate of Completion"
 
+    def get_availability(self, instance):
+        """Get course availability"""
+        archived_course_runs = get_archived_courseruns(
+            instance.courseruns(is_self_paced=False)
+        )
+        if archived_course_runs.count() == 0:
+            return "dated"
+        return "anytime"
+
     class Meta:
         model = models.Course
         fields = [
@@ -110,6 +121,7 @@ class CourseSerializer(BaseCourseSerializer):
             "required_prerequisites",
             "duration",
             "time_commitment",
+            "availability",
         ]
 
 

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -66,6 +66,7 @@ def test_serialize_course(
             "departments": [{"name": department}],
             "page": CoursePageSerializer(course.page).data,
             "certificate_type": certificate_type,
+            "availability": "dated",
             "topics": [{"name": topic.name} for topic in topics],
             "required_prerequisites": True,
             "duration": course.page.length,

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -106,6 +106,7 @@ def test_serialize_course_required_prerequisites(
             "page": CoursePageSerializer(course.page).data,
             "certificate_type": "Certificate of Completion",
             "topics": [],
+            "availability": "dated",
             "required_prerequisites": expected_required_prerequisites,
             "duration": course.page.length,
             "time_commitment": course.page.effort,

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -187,6 +187,7 @@ def get_archived_courseruns(queryset):
     """
     now = now_in_utc()
     return queryset.filter(
-        Q(end_date__lt=now)
+        get_enrollable_course_run_filter(now)
+        & Q(end_date__lt=now)
         & (Q(enrollment_end__isnull=True) | Q(enrollment_end__gt=now))
     )

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -173,3 +173,20 @@ def get_unenrollable_courses(queryset):
         .filter(courseruns__id__in=courseruns_qs.values_list("id", flat=True))
         .distinct()
     )
+
+
+def get_archived_courseruns(queryset):
+    """
+    Returns course runs that are archived. This is defined as:
+    - The course run end date has passed
+    - The course run enrollment date is in the future or None
+    This logic is set to match the logic found in frontend/public/src/lib/courseApi.js isRunArchived
+
+    Args:
+        queryset: Queryset of CourseRun objects
+    """
+    now = now_in_utc()
+    return queryset.filter(
+        Q(end_date__lt=now)
+        & (Q(enrollment_start__isnull=True) | Q(enrollment_start__gt=now))
+    )

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -179,7 +179,7 @@ def get_archived_courseruns(queryset):
     """
     Returns course runs that are archived. This is defined as:
     - The course run end date has passed
-    - The course run enrollment date is in the future or None
+    - The course run enrollment end date is in the future or None.
     This logic is set to match the logic found in frontend/public/src/lib/courseApi.js isRunArchived
 
     Args:
@@ -188,5 +188,5 @@ def get_archived_courseruns(queryset):
     now = now_in_utc()
     return queryset.filter(
         Q(end_date__lt=now)
-        & (Q(enrollment_start__isnull=True) | Q(enrollment_start__gt=now))
+        & (Q(enrollment_end__isnull=True) | Q(enrollment_end__gt=now))
     )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4994

### Description (What does it do?)
Adds availability to the courses API endpoint. If a course has any dated run open for enrollment, API will show `dated` for that course. If there are only self paced courses, it will show `anytime`

### How can this be tested?
Hit the endpoint with courses with multiple courseruns. Some good date variability would be to have some runs open for enrollment and some not. Having variability in whether or not they are self-paced will show if the changes meet the need as well.