### PR TITLE
Fixing discount code payload generation for Google Analytics

### DIFF
--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -738,7 +738,7 @@ class CheckoutInterstitialView(LoginRequiredMixin, TemplateView):
         }
         if order.discounts.count() > 0:
             ga_purchase_payload["coupon"] = ",".join(
-                [discount.discount_code for discount in order.discounts]
+                [discount.discount_code for discount in order.discounts.all()]
             )
         return ga_purchase_payload
 

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -738,7 +738,10 @@ class CheckoutInterstitialView(LoginRequiredMixin, TemplateView):
         }
         if order.discounts.count() > 0:
             ga_purchase_payload["coupon"] = ",".join(
-                [discount.redeemed_discount.discount_code for discount in order.discounts.all()]
+                [
+                    discount.redeemed_discount.discount_code
+                    for discount in order.discounts.all()
+                ]
             )
         return ga_purchase_payload
 

--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -738,7 +738,7 @@ class CheckoutInterstitialView(LoginRequiredMixin, TemplateView):
         }
         if order.discounts.count() > 0:
             ga_purchase_payload["coupon"] = ",".join(
-                [discount.discount_code for discount in order.discounts.all()]
+                [discount.redeemed_discount.discount_code for discount in order.discounts.all()]
             )
         return ga_purchase_payload
 


### PR DESCRIPTION
### What are the relevant tickets?

n/a but a relevant Sentry error is here: https://mit-office-of-digital-learning.sentry.io/issues/5647502284/?project=5864687&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0

### Description (What does it do?)

There's code in the checkout interstitial that generates a context for Google Analytics, and includes discount info if there is any. This fixes a minor issue with it that was causing 500 errors.

### How can this be tested?

Create an order with a discount code, and then checkout. _Don't use a zero-value code._ If the discount brings your order to $0, you won't get routed through CyberSource. But, checkout should work fine.
