### PR TITLE
Updated URL for program cert track

### DIFF
--- a/frontend/public/src/components/ProgramInfoBox.js
+++ b/frontend/public/src/components/ProgramInfoBox.js
@@ -182,7 +182,7 @@ export default class ProgramInfoBox extends React.PureComponent<ProgramInfoBoxPr
                 <>
                   Certificate track: {program.page.price}
                   <div>
-                    <a target="_blank" rel="noreferrer" href="#">
+                    <a target="_blank" rel="noreferrer" href="https://mitxonline.zendesk.com/hc/en-us/articles/16928404973979-Does-MITx-Online-offer-free-certificates">
                       What's the certificate track?
                     </a>
                   </div>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3822

### Description (What does it do?)
Updates the URL on programs about pages with courses that can be paid for.

### How can this be tested?
Create a program with paid courses.  Visit the program about page.  Verify the link described in the issue redirects to the correct URL.
