### PR TITLE
Make the enrollment alert read by screen reader

### DIFF
--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -76,7 +76,11 @@ export class NotificationContainer extends React.Component<Props, State> {
     const { hiddenNotifications } = this.state
 
     return (
-      <div className="notifications order-2" id="notifications-container" ref={this.headingRef}>
+      <div
+        className="notifications order-2"
+        id="notifications-container"
+        ref={this.headingRef}
+      >
         {Object.keys(userNotifications).map((notificationKey, i) => {
           const dismiss = partial(this.onDismiss, [notificationKey])
           const notification = userNotifications[notificationKey]

--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -31,7 +31,7 @@ type State = {
 }
 
 export class NotificationContainer extends React.Component<Props, State> {
-  headingRef: { current: null | HTMLHeadingElement }
+  headingRef: { current: null | HTMLDivElement }
 
   constructor(props: Props) {
     super(props)

--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -74,7 +74,6 @@ export class NotificationContainer extends React.Component<Props, State> {
   render() {
     const { userNotifications } = this.props
     const { hiddenNotifications } = this.state
-    console.log(userNotifications)
 
     return (
       <div className="notifications order-2" id="notifications-container" ref={this.headingRef}>

--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -31,8 +31,25 @@ type State = {
 }
 
 export class NotificationContainer extends React.Component<Props, State> {
+  headingRef: { current: null | HTMLHeadingElement }
+
+  constructor(props: Props) {
+    super(props)
+    this.headingRef = React.createRef()
+  }
   state = {
     hiddenNotifications: new Set()
+  }
+
+  componentDidMount() {
+    if (this.headingRef.current) {
+      this.headingRef.current.focus()
+    }
+  }
+  componentDidUpdate() {
+    if (this.headingRef.current) {
+      this.headingRef.current.focus()
+    }
   }
 
   onDismiss = (notificationKey: string) => {
@@ -57,9 +74,10 @@ export class NotificationContainer extends React.Component<Props, State> {
   render() {
     const { userNotifications } = this.props
     const { hiddenNotifications } = this.state
+    console.log(userNotifications)
 
     return (
-      <div className="notifications order-2" id="notifications-container">
+      <div className="notifications order-2" id="notifications-container" ref={this.headingRef}>
         {Object.keys(userNotifications).map((notificationKey, i) => {
           const dismiss = partial(this.onDismiss, [notificationKey])
           const notification = userNotifications[notificationKey]
@@ -81,6 +99,7 @@ export class NotificationContainer extends React.Component<Props, State> {
               toggle={dismiss}
               fade={true}
               closeClassName="btn-close-white"
+              closeAriaLabel="Close Enrollment Notification Button"
             >
               <AlertBodyComponent dismiss={dismiss} {...notification.props} />
             </Alert>


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/715

### Description (What does it do?)
Makes the alert/notification at the top of the page get read by the screen reader when it appears on the screen.


### How can this be tested?
Turn on the screen reader then try to enroll or/and unenroll from a course. the screen reader should read the alert message when it comes up.

