### PR TITLE
MITx Online receipt displays wrong date

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -427,6 +427,7 @@ class OrderHistorySerializer(serializers.ModelSerializer):
             "lines",
             "created_on",
             "titles",
+            "updated_on",
         ]
         model = models.Order
         depth = 1

--- a/frontend/public/src/containers/pages/checkout/OrderHistory.js
+++ b/frontend/public/src/containers/pages/checkout/OrderHistory.js
@@ -73,7 +73,7 @@ export class OrderHistory extends React.Component<Props> {
     const orderTitle =
       order.titles.length > 0 ? order.titles.join("<br />") : <em>No Items</em>
     const orderDate = formatPrettyDateTimeAmPmTz(
-      parseDateString(order.created_on)
+      parseDateString(order.updated_on)
     )
     return (
       <tr scope="row" key={`ordercard_${order.id}`}>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5106

### Description (What does it do?)
Changes the order page to display the datetime for orders using the update_on value instead of the created_on value for the associated order.

### How can this be tested?

1. Begin to purchase a Course.
2. Take a minute or two to complete the payment steps.
3. Verify the order page displays the update_on value which should be equal to the time when you completed the payment steps and were redirected back to MITx Online.
