### PR TITLE
Filtering only enrollable runs on the product page

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -581,7 +581,9 @@ class Course(TimestampedModel, ValidateOnSaveMixin):
         """
         course_runs = self.courseruns.all()
         eligible_course_runs = [
-            course_run for course_run in course_runs if (course_run.is_enrollable and not course_run.is_past)
+            course_run
+            for course_run in course_runs
+            if (course_run.is_enrollable and not course_run.is_past)
         ]
         if len(eligible_course_runs) < 1:
             # check for archived courses

--- a/frontend/public/src/components/CourseInfoBox.js
+++ b/frontend/public/src/components/CourseInfoBox.js
@@ -17,6 +17,7 @@ import { Modal, ModalBody, ModalHeader } from "reactstrap"
 type CourseInfoBoxProps = {
   courses: Array<BaseCourseRun>,
   currentUser: CurrentUser,
+  enrollableCourseRuns: Array<EnrollmentFlaggedCourseRun>,
   setCurrentCourseRun: (run: EnrollmentFlaggedCourseRun) => Promise<any>
 }
 
@@ -154,7 +155,7 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
   }
 
   render() {
-    const { courses } = this.props
+    const { courses, enrollableCourseRuns } = this.props
 
     if (!courses || courses.length < 1) {
       return null
@@ -166,10 +167,9 @@ export default class CourseInfoBox extends React.PureComponent<CourseInfoBoxProp
     const isArchived = isRunArchived(run)
 
     const startDates = []
-    const moreEnrollableCourseRuns =
-      course.courseruns && course.courseruns.length > 1
+    const moreEnrollableCourseRuns = enrollableCourseRuns.length > 1
     if (moreEnrollableCourseRuns) {
-      course.courseruns.forEach((courseRun, index) => {
+      enrollableCourseRuns.forEach((courseRun, index) => {
         if (courseRun.id !== run.id) {
           startDates.push(
             <li key={index}>{getCourseDates(courseRun, isArchived, true)}</li>

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -160,7 +160,9 @@ export class CourseProductDetailEnroll extends React.Component<
     })
   }
 
-  renderRunSelectorButtons(enrollableCourseRuns: Array<EnrollmentFlaggedCourseRun>) {
+  renderRunSelectorButtons(
+    enrollableCourseRuns: Array<EnrollmentFlaggedCourseRun>
+  ) {
     return (
       <>
         {enrollableCourseRuns && enrollableCourseRuns.length > 1 ? (
@@ -228,7 +230,9 @@ export class CourseProductDetailEnroll extends React.Component<
         (run: EnrollmentFlaggedCourseRun) => run.is_enrollable
       ) :
       []
-    const upgradableCourseRuns = enrollableCourseRuns.filter((run: EnrollmentFlaggedCourseRun) => run.is_upgradable)
+    const upgradableCourseRuns = enrollableCourseRuns.filter(
+      (run: EnrollmentFlaggedCourseRun) => run.is_upgradable
+    )
     if (upgradableCourseRuns.length < 1 && enrollableCourseRuns.length < 1) {
       return null
     }
@@ -253,118 +257,119 @@ export class CourseProductDetailEnroll extends React.Component<
     const { upgradeEnrollmentDialogVisibility } = this.state
     const product = run && run.products ? run.products[0] : null
     const canUpgrade = !!(run && run.is_upgradable && product)
-    return upgradableCourseRuns.length > 0 || enrollableCourseRuns.length > 1 ? (
-      <Modal
-        id={`upgrade-enrollment-dialog`}
-        className="upgrade-enrollment-modal"
-        isOpen={upgradeEnrollmentDialogVisibility}
-        toggle={() => this.cancelEnrollment()}
-        centered
-      >
-        <ModalHeader toggle={() => this.cancelEnrollment()}>
-          {course && course.title}
-        </ModalHeader>
-        <ModalBody>
-          {enrollableCourseRuns.length > 0 ? (
-            <div className="row date-selector-button-bar">
-              <div className="col-12">
-                <div>{this.renderRunSelectorButtons(enrollableCourseRuns)}</div>
+    return upgradableCourseRuns.length > 0 ||
+      enrollableCourseRuns.length > 1 ? (
+        <Modal
+          id={`upgrade-enrollment-dialog`}
+          className="upgrade-enrollment-modal"
+          isOpen={upgradeEnrollmentDialogVisibility}
+          toggle={() => this.cancelEnrollment()}
+          centered
+        >
+          <ModalHeader toggle={() => this.cancelEnrollment()}>
+            {course && course.title}
+          </ModalHeader>
+          <ModalBody>
+            {enrollableCourseRuns.length > 0 ? (
+              <div className="row date-selector-button-bar">
+                <div className="col-12">
+                  <div>{this.renderRunSelectorButtons(enrollableCourseRuns)}</div>
+                </div>
               </div>
-            </div>
-          ) : null}
+            ) : null}
 
-          {upgradableCourseRuns.length > 0 ? (
-            <>
-              <div className="row upsell-messaging-header">
-                <div className="col-12 p-0 font-weight-bold">
+            {upgradableCourseRuns.length > 0 ? (
+              <>
+                <div className="row upsell-messaging-header">
+                  <div className="col-12 p-0 font-weight-bold">
                   Do you want to earn a certificate?
+                  </div>
                 </div>
-              </div>
-              <div className="row d-sm-flex flex-md-row flex-sm-column">
-                <div className="col-md-6 col-sm-12">
-                  <ul>
-                    <li> Certificate is signed by MIT faculty</li>
-                    <li>
-                      {" "}
+                <div className="row d-sm-flex flex-md-row flex-sm-column">
+                  <div className="col-md-6 col-sm-12">
+                    <ul>
+                      <li> Certificate is signed by MIT faculty</li>
+                      <li>
+                        {" "}
                       Demonstrates knowledge and skills taught in this course
-                    </li>
-                    <li> Enhance your college &amp; earn a promotion</li>
-                  </ul>
-                </div>
-                <div className="col-md-6 col-sm-12">
-                  <ul>
-                    <li>Highlight on your resume/CV</li>
-                    <li>Share on your social channels &amp; LinkedIn</li>
-                    <li>
+                      </li>
+                      <li> Enhance your college &amp; earn a promotion</li>
+                    </ul>
+                  </div>
+                  <div className="col-md-6 col-sm-12">
+                    <ul>
+                      <li>Highlight on your resume/CV</li>
+                      <li>Share on your social channels &amp; LinkedIn</li>
+                      <li>
                       Enhance your college application with an earned
                       certificate from MIT
-                    </li>
-                  </ul>
-                </div>
-              </div>
-              <div className="row certificate-pricing-row d-sm-flex flex-md-row flex-sm-column">
-                <div
-                  className={`col-md-6 col-sm-12 certificate-pricing d-flex align-items-center ${
-                    run ? "" : "opacity-50"
-                  }`}
-                >
-                  <div className="certificate-pricing-logo">
-                    <img src="/static/images/certificates/certificate-logo.svg" />
+                      </li>
+                    </ul>
                   </div>
-                  <p>
+                </div>
+                <div className="row certificate-pricing-row d-sm-flex flex-md-row flex-sm-column">
+                  <div
+                    className={`col-md-6 col-sm-12 certificate-pricing d-flex align-items-center ${
+                      run ? "" : "opacity-50"
+                    }`}
+                  >
+                    <div className="certificate-pricing-logo">
+                      <img src="/static/images/certificates/certificate-logo.svg" />
+                    </div>
+                    <p>
                     Certificate track:{" "}
-                    <strong id="certificate-price-info">
-                      {product &&
+                      <strong id="certificate-price-info">
+                        {product &&
                         run.is_upgradable &&
                         formatLocalePrice(getFlexiblePriceForProduct(product))}
-                    </strong>
-                    <>
-                      <br />
-                      {canUpgrade ? (
-                        <span className="text-danger">
+                      </strong>
+                      <>
+                        <br />
+                        {canUpgrade ? (
+                          <span className="text-danger">
                           Payment date:{" "}
-                          {formatPrettyDate(moment(run.upgrade_deadline))}
-                        </span>
-                      ) : (
-                        <strong id="certificate-price-info">
+                            {formatPrettyDate(moment(run.upgrade_deadline))}
+                          </span>
+                        ) : (
+                          <strong id="certificate-price-info">
                           not available
-                        </strong>
-                      )}
-                    </>
-                  </p>
-                </div>
-                <div className="col-md-6 col-sm-12 pr-0 enroll-and-pay">
-                  <form
-                    action="/cart/add/"
-                    method="get"
-                    className="text-center"
-                  >
-                    <input
-                      type="hidden"
-                      name="product_id"
-                      value={(product && product.id) || ""}
-                    />
-                    <button
-                      type="submit"
-                      className="btn btn-upgrade"
-                      disabled={!canUpgrade}
+                          </strong>
+                        )}
+                      </>
+                    </p>
+                  </div>
+                  <div className="col-md-6 col-sm-12 pr-0 enroll-and-pay">
+                    <form
+                      action="/cart/add/"
+                      method="get"
+                      className="text-center"
                     >
-                      <strong>Enroll and Pay</strong>
-                      <br />
-                      <span>for the certificate track</span>
-                    </button>
-                  </form>
+                      <input
+                        type="hidden"
+                        name="product_id"
+                        value={(product && product.id) || ""}
+                      />
+                      <button
+                        type="submit"
+                        className="btn btn-upgrade"
+                        disabled={!canUpgrade}
+                      >
+                        <strong>Enroll and Pay</strong>
+                        <br />
+                        <span>for the certificate track</span>
+                      </button>
+                    </form>
+                  </div>
                 </div>
-              </div>
-            </>
-          ) : null}
-          <div className="row upgrade-options-row">
-            <div>{needFinancialAssistanceLink}</div>
-            <div>{this.getEnrollmentForm(run)}</div>
-          </div>
-        </ModalBody>
-      </Modal>
-    ) : null
+              </>
+            ) : null}
+            <div className="row upgrade-options-row">
+              <div>{needFinancialAssistanceLink}</div>
+              <div>{this.getEnrollmentForm(run)}</div>
+            </div>
+          </ModalBody>
+        </Modal>
+      ) : null
   }
 
   renderAddlProfileFieldsModal() {
@@ -447,34 +452,35 @@ export class CourseProductDetailEnroll extends React.Component<
     return run ? (
       <h2>
         {(product && run.is_upgradable) || hasMultipleEnrollableRuns ? (
+          <button
+            id="upgradeEnrollBtn"
+            className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red-to-blue highlight enroll-now"
+            onClick={() => this.toggleUpgradeDialogVisibility()}
+            disabled={!run.is_enrollable}
+          >
+            Enroll now
+          </button>
+        ) : (
+          <form action="/enrollments/" method="post">
+            <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
+            <input type="hidden" name="run" value={run ? run.id : ""} />
             <button
-              id="upgradeEnrollBtn"
-              className="btn btn-primary btn-enrollment-button btn-lg btn-gradient-red-to-blue highlight enroll-now"
-              onClick={() => this.toggleUpgradeDialogVisibility()}
+              type="submit"
+              className="btn btn-primary btn-enrollment-button btn-gradient-red-to-blue highlight enroll-now"
               disabled={!run.is_enrollable}
             >
-            Enroll now
+              {isRunArchived(run) ? "Access Course Materials" : "Enroll Now"}
             </button>
-          ) : (
-            <form action="/enrollments/" method="post">
-              <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
-              <input type="hidden" name="run" value={run ? run.id : ""} />
-              <button
-                type="submit"
-                className="btn btn-primary btn-enrollment-button btn-gradient-red-to-blue highlight enroll-now"
-                disabled={!run.is_enrollable}
-              >
-                {isRunArchived(run) ? "Access Course Materials" : "Enroll Now"}
-              </button>
-            </form>
-          )}
+          </form>
+        )}
       </h2>
     ) : null
   }
 
   render() {
     const { courses, courseIsLoading, currentUser } = this.props
-    let run, product = null
+    let run,
+      product = null
     const courseRuns = courses && courses[0] ? courses[0].courseruns : null
     const enrollableCourseRuns = courseRuns ?
       courseRuns.filter(
@@ -489,8 +495,8 @@ export class CourseProductDetailEnroll extends React.Component<
         this.updateDate(run)
       }
     }
-    const hasMultipleEnrollableRuns = enrollableCourseRuns && enrollableCourseRuns.length > 1
-
+    const hasMultipleEnrollableRuns =
+      enrollableCourseRuns && enrollableCourseRuns.length > 1
 
     return (
       <>
@@ -503,7 +509,11 @@ export class CourseProductDetailEnroll extends React.Component<
             <>
               {run ?
                 currentUser && currentUser.id ?
-                  this.renderEnrollNowButton(run, hasMultipleEnrollableRuns, product) :
+                  this.renderEnrollNowButton(
+                    run,
+                    hasMultipleEnrollableRuns,
+                    product
+                  ) :
                   this.renderEnrollLoginButton(run) :
                 this.renderAccessCourseButton()}
 

--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -487,7 +487,7 @@ export class CourseProductDetailEnroll extends React.Component<
         (run: EnrollmentFlaggedCourseRun) => run.is_enrollable
       ) :
       []
-    if (courseRuns) {
+    if (courses && courseRuns) {
       run = getFirstRelevantRun(courses[0], courseRuns)
 
       if (run) {

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -316,7 +316,7 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         courseRun.products[0].id
       )
 
-      const flexiblePricingLink = modal.find(".financial-assistance-link").at(0)
+      const flexiblePricingLink = inner.find(".financial-assistance-link").at(0)
       if (flexPriceApproved) {
         assert.isFalse(flexiblePricingLink.exists())
       } else {

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -311,8 +311,10 @@ describe("CourseProductDetailEnrollShallowRender", () => {
         .simulate("change", { target: { value: courseRun["id"] } })
       inner.update()
 
-      assert.equal(inner.find("input[type='hidden']").at(0).prop("value"), courseRun.products[0].id)
-
+      assert.equal(
+        inner.find("input[type='hidden']").at(0).prop("value"),
+        courseRun.products[0].id
+      )
 
       const flexiblePricingLink = modal.find(".financial-assistance-link").at(0)
       if (flexPriceApproved) {

--- a/frontend/public/src/components/CourseProductDetailEnroll_test.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll_test.js
@@ -302,6 +302,17 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       await enrollBtn.prop("onClick")()
 
       const modal = inner.find(".upgrade-enrollment-modal")
+      const selectorControl = modal.find(".date-selector-button-bar").at(0)
+      const selectorControlItems = selectorControl.find("option")
+      assert.isTrue(selectorControlItems.at(0).text() === "Please Select")
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      modal
+        .find("select.form-control")
+        .simulate("change", { target: { value: courseRun["id"] } })
+      inner.update()
+
+      assert.equal(inner.find("input[type='hidden']").at(0).prop("value"), courseRun.products[0].id)
+
 
       const flexiblePricingLink = modal.find(".financial-assistance-link").at(0)
       if (flexPriceApproved) {
@@ -456,10 +467,16 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       enrollBtn.prop("onClick")()
 
       const modal = inner.find(".upgrade-enrollment-modal")
-      const upgradeForm = modal.find("form").at(0)
-      assert.isTrue(upgradeForm.exists())
+      const selectorControl = modal.find(".date-selector-button-bar").at(0)
+      const selectorControlItems = selectorControl.find("option")
+      assert.isTrue(selectorControlItems.at(0).text() === "Please Select")
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      modal
+        .find("select.form-control")
+        .simulate("change", { target: { value: courseRun["id"] } })
+      inner.update()
 
-      assert.equal(upgradeForm.find("input[type='hidden']").prop("value"), "1")
+      assert.equal(inner.find("input[type='hidden']").at(0).prop("value"), "1")
 
       assert.equal(inner.find("#certificate-price-info").at(0).text(), "$9.00")
     })
@@ -494,10 +511,16 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       await enrollBtn.prop("onClick")()
 
       const modal = inner.find(".upgrade-enrollment-modal")
-      const upgradeForm = modal.find("form").at(0)
-      assert.isTrue(upgradeForm.exists())
+      const selectorControl = modal.find(".date-selector-button-bar").at(0)
+      const selectorControlItems = selectorControl.find("option")
+      assert.isTrue(selectorControlItems.at(0).text() === "Please Select")
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      modal
+        .find("select.form-control")
+        .simulate("change", { target: { value: courseRun["id"] } })
+      inner.update()
 
-      assert.equal(upgradeForm.find("input[type='hidden']").prop("value"), "1")
+      assert.equal(inner.find("input[type='hidden']").at(0).prop("value"), "1")
 
       assert.equal(
         inner.find("#certificate-price-info").at(0).text().at(1),
@@ -539,12 +562,33 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       const upgradeForm = modal.find("form").at(0)
       assert.isTrue(upgradeForm.exists())
 
-      assert.equal(upgradeForm.find("input[type='hidden']").prop("value"), "1")
-
+      const selectorControl = modal.find(".date-selector-button-bar").at(0)
+      assert.isTrue(selectorControl.exists())
+      const selectorControlItems = selectorControl.find("option")
+      assert.isTrue(selectorControlItems.at(0).text() === "Please Select")
+      assert.isTrue(
+        upgradeForm.find("button.btn-upgrade").at(0).prop("disabled")
+      )
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      modal
+        .find("select.form-control")
+        .simulate("change", { target: { value: courseRun["id"] } })
+      inner.update()
+      assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
+      assert.isFalse(getDisabledProp(inner, "button.btn-upgrade"))
+      assert.equal(inner.find("input[type='hidden']").at(0).prop("value"), "1")
       assert.equal(
         inner.find("#certificate-price-info").at(0).text().at(1),
         "9"
       )
+
+      // check if default selected it resets back
+      modal
+        .find("select.form-control")
+        .simulate("change", { target: { value: "default" } })
+      inner.update()
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      assert.isTrue(getDisabledProp(inner, "button.btn-upgrade"))
     })
   })
 
@@ -604,10 +648,10 @@ describe("CourseProductDetailEnrollShallowRender", () => {
     await enrollBtn.prop("onClick")()
   })
   ;[
-    ["does not show", "one", false],
-    ["shows", "multiple", true]
-  ].forEach(([showsQualifier, runsQualifier, multiples]) => {
-    it(`${showsQualifier} the course run selector for a course with ${runsQualifier} active run${
+    ["one", false],
+    ["multiple", true]
+  ].forEach(([runsQualifier, multiples]) => {
+    it(`shows the course run selector for a course with ${runsQualifier} active run${
       multiples ? "s" : ""
     } and enables enroll buttons on selection`, async () => {
       const courseRuns = [courseRun]
@@ -632,35 +676,31 @@ describe("CourseProductDetailEnrollShallowRender", () => {
       assert.isTrue(upgradeForm.exists())
 
       const selectorControl = modal.find(".date-selector-button-bar").at(0)
+      assert.isTrue(selectorControl.exists())
+      const selectorControlItems = selectorControl.find("option")
+      assert.isTrue(selectorControlItems.at(0).text() === "Please Select")
+      assert.isTrue(
+        upgradeForm.find("button.btn-upgrade").at(0).prop("disabled")
+      )
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      modal
+        .find("select.form-control")
+        .simulate("change", { target: { value: courseRun["id"] } })
+      inner.update()
+      assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
+      assert.isFalse(getDisabledProp(inner, "button.btn-upgrade"))
+      // check if default selected it resets back
+      modal
+        .find("select.form-control")
+        .simulate("change", { target: { value: "default" } })
+      inner.update()
+      assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
+      assert.isTrue(getDisabledProp(inner, "button.btn-upgrade"))
 
       if (multiples) {
-        assert.isTrue(selectorControl.exists())
-        const selectorControlItems = selectorControl.find("option")
         assert.isTrue(selectorControlItems.length === 3)
-        assert.isTrue(selectorControlItems.at(0).text() === "Please Select")
-        assert.isTrue(
-          upgradeForm.find("button.btn-upgrade").at(0).prop("disabled")
-        )
-        assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
-        modal
-          .find("select.form-control")
-          .simulate("change", { target: { value: courseRun["id"] } })
-        inner.update()
-        assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
-        assert.isFalse(getDisabledProp(inner, "button.btn-upgrade"))
-        // check if default selected it resets back
-        modal
-          .find("select.form-control")
-          .simulate("change", { target: { value: "default" } })
-        inner.update()
-        assert.isTrue(getDisabledProp(inner, "button.enroll-now-free"))
-        assert.isTrue(getDisabledProp(inner, "button.btn-upgrade"))
       } else {
-        assert.isFalse(selectorControl.exists())
-        assert.isFalse(getDisabledProp(inner, "button.enroll-now-free"))
-        assert.isFalse(
-          upgradeForm.find("button.btn-upgrade").at(0).prop("disabled")
-        )
+        assert.isTrue(selectorControlItems.length === 2)
       }
     })
   })


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/5098

### Description (What does it do?)
In terms of logic there are three places where this is important:
1) I n deciding which "Enroll Now" button to show, (open a dialog or just submit a form)
2) in rendering the enrollment dialog drop down for selecting a run
3) Displaying "more dates" section

Everything should function as usual except for:
1. If there is only one run that is open for enrollment and is upgradable the Enroll Now button open a dialog where the user still has a select dropdown (instead of no dropdown). This makes the choice deliberate and makes the course dates visible.
2. An archived course is not chosen as `next_run_id` if there are other enrollable runs
3. Only enrollable runs show up in the "More Dates" section.
### How can this be tested?

Make sure the "Enroll now" button, the enrollment dialog and "more dates" behaves in a way that is expected.