### PR TITLE
Add time_commitment and durations to the courses api

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -33,6 +33,8 @@ class CourseSerializer(BaseCourseSerializer):
     topics = serializers.SerializerMethodField()
     certificate_type = serializers.SerializerMethodField()
     required_prerequisites = serializers.SerializerMethodField()
+    duration = serializers.SerializerMethodField()
+    time_commitment = serializers.SerializerMethodField()
 
     def get_required_prerequisites(self, instance):
         """
@@ -45,6 +47,24 @@ class CourseSerializer(BaseCourseSerializer):
             and hasattr(instance.page, "prerequisites")
             and instance.page.prerequisites != ""
         )
+
+    def get_duration(self, instance):
+        """
+        Get the duration of the course from the course page CMS.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "length"):
+            return instance.page.length
+
+        return None
+
+    def get_time_commitment(self, instance):
+        """
+        Get the time commitment of the course from the course page CMS.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "effort"):
+            return instance.page.effort
+
+        return None
 
     def get_next_run_id(self, instance):
         """Get next run id"""
@@ -88,6 +108,8 @@ class CourseSerializer(BaseCourseSerializer):
             "topics",
             "certificate_type",
             "required_prerequisites",
+            "duration",
+            "time_commitment",
         ]
 
 

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -68,6 +68,8 @@ def test_serialize_course(
             "certificate_type": certificate_type,
             "topics": [{"name": topic.name} for topic in topics],
             "required_prerequisites": True,
+            "duration": course.page.length,
+            "time_commitment": course.page.effort,
             "programs": BaseProgramSerializer(course.programs, many=True).data
             if all_runs
             else None,
@@ -104,6 +106,8 @@ def test_serialize_course_required_prerequisites(
             "certificate_type": "Certificate of Completion",
             "topics": [],
             "required_prerequisites": expected_required_prerequisites,
+            "duration": course.page.length,
+            "time_commitment": course.page.effort,
             "programs": None,
         },
     )


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/5176 and https://github.com/mitodl/hq/issues/5177

### Description (What does it do?)
time_commitment and durations to the courses api



### How can this be tested?
Go to http://mitxonline.odl.local:8013/api/v2/courses/ and make sure  that time_commitment and durations show the values you entered in the cms.