### PR TITLE
Styling Course Info Box when no program

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -309,7 +309,8 @@ body.new-design {
 
         .enrollment-info-box, .program-info-box {
           margin: 10px 0;
-          padding: 0;
+          padding-top: 10px;
+          border-top: 1px solid #d1d1d1;
 
           .related-programs-info {
             font-size: 16px;
@@ -322,11 +323,7 @@ body.new-design {
         }
 
         .enrollment-info-box {
-          border: 1px solid #d1d1d1;
-          border-left: none;
-          border-right: none;
           font-size: 15px;
-          padding-top: 10px;
 
           .row {
             margin: 0 0 20px 0;


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fix Style of the course info box when there is no program listed:
Before: 
<img width="470" alt="Screenshot 2024-08-07 at 7 59 33 AM" src="https://github.com/user-attachments/assets/c7c16d1f-5e57-41cb-bdd8-a0d98caf13e4">
