### PR TITLE
Generate certificates twice a day

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -786,7 +786,7 @@ CRON_PROCESS_REFUND_REQUESTS_MINUTES = get_string(
 )
 CRON_COURSE_CERTIFICATES_HOURS = get_string(
     name="CRON_COURSE_CERTIFICATES_HOURS",
-    default=0,
+    default="0,12",
     description="'hours' value for the 'generate-course-certificate' scheduled task (defaults to midnight)",
 )
 CRON_COURSE_CERTIFICATES_DAYS = get_string(


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/4956

### Description (What does it do?)
Adjust the schedule of `courses.tasks.generate_course_certificates` to run twice a day.

### How can this be tested?
Nothing should break.