### PR TITLE
Revert "Update redis Docker tag to v6.2.14"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - db-data:/var/lib/postgresql/data
 
   redis:
-    image: redis:6.2.14
+    image: redis:6.0.5
     ports:
       - "6379"
 


### PR DESCRIPTION
Reverts mitodl/mitxonline#2346

Throws Error 503 Backend fetch failed
