### PR TITLE
Add get_dated_courseruns function for availability to check for dated courses

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -16,7 +16,7 @@ from courses.serializers.v1.base import (
     ProductRelatedField,
 )
 from courses.serializers.v1.departments import DepartmentSerializer
-from courses.utils import get_archived_courseruns
+from courses.utils import get_dated_courseruns
 from flexiblepricing.api import is_courseware_flexible_price_approved
 from main import features
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
@@ -99,12 +99,10 @@ class CourseSerializer(BaseCourseSerializer):
 
     def get_availability(self, instance):
         """Get course availability"""
-        archived_course_runs = get_archived_courseruns(
-            instance.courseruns.filter(is_self_paced=False)
-        )
-        if archived_course_runs.count() == 0:
-            return "dated"
-        return "anytime"
+        dated_courseruns = get_dated_courseruns(instance.courseruns)
+        if dated_courseruns.count() == 0:
+            return "anytime"
+        return "dated"
 
     class Meta:
         model = models.Course

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -106,7 +106,7 @@ def test_serialize_course_required_prerequisites(
             "page": CoursePageSerializer(course.page).data,
             "certificate_type": "Certificate of Completion",
             "topics": [],
-            "availability": "dated",
+            "availability": "anytime",
             "required_prerequisites": expected_required_prerequisites,
             "duration": course.page.length,
             "time_commitment": course.page.effort,

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -201,11 +201,7 @@ def get_dated_courseruns(queryset):
     - End date can be dated and greater than now or null
     - Enrollable (enrollment start is in the past and enrollment end is in the future or null)
     """
-    now = now_in_utc()
-    return queryset.filter(
-        Q(is_self_paced=False)
-        & Q(start_date__isnull=False)
-        & (Q(end_date__isnull=True) | Q(end_date__gt=now))
-        & (Q(enrollment_end__isnull=True) | Q(enrollment_end__gt=now))
-        & Q(enrollment_start__lt=now)
+    return queryset.filter(get_enrollable_course_run_filter()
+        & Q(is_self_paced=False)
+        & Q(enrollment_end__isnull=False)
     )

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -191,3 +191,21 @@ def get_archived_courseruns(queryset):
         & Q(end_date__lt=now)
         & (Q(enrollment_end__isnull=True) | Q(enrollment_end__gt=now))
     )
+
+
+def get_dated_courseruns(queryset):
+    """
+    Returns course runs that are dated meaning they are
+    - Not self-paced
+    - Have a start date
+    - End date can be dated and greater than now or null
+    - Enrollable (enrollment start is in the past and enrollment end is in the future or null)
+    """
+    now = now_in_utc()
+    return queryset.filter(
+        Q(is_self_paced=False)
+        & Q(start_date__isnull=False)
+        & (Q(end_date__isnull=True) | Q(end_date__gt=now))
+        & (Q(enrollment_end__isnull=True) | Q(enrollment_end__gt=now))
+        & Q(enrollment_start__lt=now)
+    )

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -201,7 +201,8 @@ def get_dated_courseruns(queryset):
     - End date can be dated and greater than now or null
     - Enrollable (enrollment start is in the past and enrollment end is in the future or null)
     """
-    return queryset.filter(get_enrollable_course_run_filter()
+    return queryset.filter(
+        get_enrollable_course_run_filter()
         & Q(is_self_paced=False)
         & Q(enrollment_end__isnull=False)
     )

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -268,6 +268,7 @@ def test_get_unenrollable_courses():
     assert unenrollable_course in unenrollable_courses
     assert enrollable_course not in unenrollable_courses
 
+
 @pytest.mark.django_db
 def test_get_dated_courseruns():
     """

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -268,7 +268,7 @@ def test_get_unenrollable_courses():
     assert unenrollable_course in unenrollable_courses
     assert enrollable_course not in unenrollable_courses
 
-
+@pytest.mark.django_db
 def test_get_dated_courseruns():
     """
     Test get_dated_courseruns
@@ -296,7 +296,7 @@ def test_get_dated_courseruns():
     self_paced_courserun = CourseRunFactory.create(
         course=self_paced_course,
         live=True,
-        self_paced=True,
+        is_self_paced=True,
         start_date=now,
         enrollment_start=past_date,
         enrollment_end=future_date,


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/5260

### Description (What does it do?)
Rather than relying on the adverse, this PR adds a gunction, get_dated_courseruns, to get any dated, enrollable courseruns for the course being serialized.  I've also added a test to this effect. This will generate the correct availability as we defined dated as having 1 or more dated courseruns, regardless of whether they also had archived or self-paced courses.

### How can this be tested?
Create courseruns that are both enrollable and not, self-paced and not and you should still see dated as long as one is both enrollable and not self-paced.

