### PR TITLE
Updating styles for program info box

### DIFF
--- a/frontend/public/scss/product-page/product-details.scss
+++ b/frontend/public/scss/product-page/product-details.scss
@@ -366,6 +366,10 @@ body.new-design {
               max-width: 18px;
             }
           }
+          .enrollment-info-text.pacing-badge-position {
+            width: min-content;
+            text-align: right;
+          }
 
           .enrollment-info-text {
             width: auto;
@@ -374,6 +378,9 @@ body.new-design {
             padding-left: 10px;
             padding-right: 0;
 
+            .enrollment-length-info {
+              max-width: 165px;
+            }
             span {
               font-weight: 700;
               color: black;
@@ -385,9 +392,9 @@ body.new-design {
             }
 
             .badge-pacing {
+              display: inline-flex;
               background-color: $black;
               text-transform: uppercase;
-              margin-left: .5rem;
               padding: 3px;
               font-weight: normal;
               color: white;
@@ -409,6 +416,7 @@ body.new-design {
             }
           }
           .more-info {
+            display: inline-flex;
             width: auto;
             border-color: transparent;
             background-color: transparent;

--- a/frontend/public/src/components/ProgramInfoBox.js
+++ b/frontend/public/src/components/ProgramInfoBox.js
@@ -130,7 +130,18 @@ export default class ProgramInfoBox extends React.PureComponent<ProgramInfoBoxPr
                 />
               </div>
               <div className="enrollment-info-text">
-                {program.page.length}{" "}
+                <div className="enrollment-length-info">
+                  {program.page.length}{" "}
+                </div>
+                {program.page.effort ? (
+                  <>
+                    <div className="enrollment-effort">
+                      {program.page.effort}
+                    </div>
+                  </>
+                ) : null}
+              </div>
+              <div className="enrollment-info-text pacing-badge-position">
                 {run && run.is_self_paced ? (
                   <>
                     <span className="badge badge-pacing">SELF-PACED</span>{" "}
@@ -152,13 +163,6 @@ export default class ProgramInfoBox extends React.PureComponent<ProgramInfoBoxPr
                     </a>
                   </>
                 )}
-                {program.page.effort ? (
-                  <>
-                    <div className="enrollment-effort">
-                      {program.page.effort}
-                    </div>
-                  </>
-                ) : null}
               </div>
             </div>
           ) : null}


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/4491

### Description (What does it do?)
Updates the section for duration and required effort to allow longer text.

### Screenshots (if appropriate):
<img width="448" alt="Screenshot 2024-08-21 at 2 16 21 PM" src="https://github.com/user-attachments/assets/177a7f9f-2d72-4d32-80ce-5ec2efa982b8">
<img width="449" alt="Screenshot 2024-08-21 at 2 16 52 PM" src="https://github.com/user-attachments/assets/585b5a64-8453-4d58-b5a7-307088afcc84">
<img width="442" alt="Screenshot 2024-08-21 at 2 17 59 PM" src="https://github.com/user-attachments/assets/28145927-e18b-4522-9e22-3fef5ebb3e63">
