### PR TITLE
Fix typo in unenrollment email

### DIFF
--- a/courses/templates/mail/course_run_unenrollment/body.html
+++ b/courses/templates/mail/course_run_unenrollment/body.html
@@ -9,7 +9,7 @@
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
                       <p style="margin: 0 0 10px;">
-                        You have been unenrolled in
+                        You have been unenrolled from
                         {% if enrollment.run.start_date %}
                           {{ enrollment.run.course_number }} {{ enrollment.run.course.title }} starting {{ enrollment.run.start_date|date:"F j, Y"}}.
                         {% else %}

--- a/courses/templates/mail/course_run_unenrollment/subject.txt
+++ b/courses/templates/mail/course_run_unenrollment/subject.txt
@@ -1,1 +1,1 @@
-You have been unenrolled in {{ enrollment.run.course_number }} {{ enrollment.run.course.title }}.
+You have been unenrolled from {{ enrollment.run.course_number }} {{ enrollment.run.course.title }}.


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3832

### Description (What does it do?)
Fixes typo in the unerollment email

### How can this be tested?
unenroll from a course and ensure that the typos are corrected in the email subject line and body.

