### PR TITLE
Fix description for POSTHOG_ENABLED variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -536,7 +536,7 @@
       "required": false
     },
     "POSTHOG_ENABLED": {
-      "description": "API host for PostHog",
+      "description": "Whether PostHog is enabled",
       "required": false
     },
     "POSTHOG_FEATURE_FLAG_REQUEST_TIMEOUT_MS": {

--- a/main/settings.py
+++ b/main/settings.py
@@ -1177,7 +1177,7 @@ POSTHOG_MAX_RETRIES = get_int(
 POSTHOG_ENABLED = get_bool(
     name="POSTHOG_ENABLED",
     default=False,
-    description="API host for PostHog",
+    description="Whether PostHog is enabled",
 )
 
 # HomePage Hubspot Form Settings


### PR DESCRIPTION
### What are the relevant tickets?
N/A; variable description fix.

### Description (What does it do?)
This PR fixes the description for the `POSTHOG_ENABLED` variable, which appears to have been inadvertently copied from the description for the `POSTHOG_API_HOST` variable.

### How can this be tested?
There are no functional changes, just an update to a variable description.
