### PR TITLE
Make post_save CourseRunCertificate signal work

### DIFF
--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1462,9 +1462,6 @@ def test_generate_program_certificate_failure_not_all_passed_nested_elective_sti
     courses = CourseFactory.create_batch(3)
     course_runs = CourseRunFactory.create_batch(3, course=factory.Iterator(courses))
     mocker.patch(
-      "hubspot_sync.task_helpers.sync_hubspot_user",
-    )
-    mocker.patch(
         "hubspot_sync.management.commands.configure_hubspot_properties._upsert_custom_properties",
     )
     # Create Program

--- a/courses/apps.py
+++ b/courses/apps.py
@@ -11,4 +11,7 @@ class CoursesConfig(AppConfig):
     name = "courses"
 
     def ready(self):
-        pass
+        """
+        Ready handler. Import signals.
+        """
+        import courses.signals  # noqa: F401

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -414,10 +414,13 @@ def test_course_course_number():
     assert course.course_number == "Test101"
 
 
-def test_course_run_certificate_start_end_dates_and_page_revision():
+def test_course_run_certificate_start_end_dates_and_page_revision(mocker):
     """
     Test that the CourseRunCertificate start_end_dates property works properly
     """
+    mocker.patch(
+        "hubspot_sync.management.commands.configure_hubspot_properties._upsert_custom_properties",
+    )
     certificate = CourseRunCertificateFactory.create(
         course_run__course__page__certificate_page__product_name="product_name"
     )
@@ -430,12 +433,15 @@ def test_course_run_certificate_start_end_dates_and_page_revision():
     )
 
 
-def test_program_certificate_start_end_dates_and_page_revision(user):
+def test_program_certificate_start_end_dates_and_page_revision(user, mocker):
     """
     Test that the ProgramCertificate start_end_dates property works properly.
     The start date is the start date of the first course run passed.
     The end date is the date the user received the program certificate.
     """
+    mocker.patch(
+        "hubspot_sync.management.commands.configure_hubspot_properties._upsert_custom_properties",
+    )
     now = now_in_utc()
     start_date = now + timedelta(days=1)
     end_date = now + timedelta(days=100)

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -2,6 +2,7 @@
 Signals for mitxonline course certificates
 """
 
+from django.core.management import call_command
 from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -11,6 +12,7 @@ from courses.models import (
     CourseRunCertificate,
     Program,
 )
+from hubspot_sync.task_helpers import sync_hubspot_user
 
 
 @receiver(
@@ -39,3 +41,5 @@ def handle_create_course_run_certificate(
             transaction.on_commit(
                 lambda: generate_multiple_programs_certificate(user, programs)
             )
+        call_command("configure_hubspot_properties")
+        sync_hubspot_user(instance.user)

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -2,7 +2,6 @@
 Signals for mitxonline course certificates
 """
 
-from django.core.management import call_command
 from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -12,7 +11,6 @@ from courses.models import (
     CourseRunCertificate,
     Program,
 )
-from hubspot_sync.task_helpers import sync_hubspot_user
 
 
 @receiver(
@@ -41,5 +39,3 @@ def handle_create_course_run_certificate(
             transaction.on_commit(
                 lambda: generate_multiple_programs_certificate(user, programs)
             )
-        call_command("configure_hubspot_properties")
-        sync_hubspot_user(instance.user)


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/mitxonline/issues/2365

### Description (What does it do?)
Imports signals courses config.

### How can this be tested?
create all required course run certificates for your program. A program certificate should get created automatically .

