### PR TITLE
Ignore revoked program certificates for now

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -864,7 +864,7 @@ def generate_program_certificate(user, program, force_create=False):  # noqa: FB
     """
     from hubspot_sync.task_helpers import sync_hubspot_user
 
-    existing_cert_queryset = ProgramCertificate.objects.filter(
+    existing_cert_queryset = ProgramCertificate.all_objects.filter(
         user=user, program=program
     )
     if existing_cert_queryset.exists():


### PR DESCRIPTION
### What are the relevant tickets?
Fix #https://github.com/mitodl/hq/issues/5643

### Description (What does it do?)
If the user has a revoked program certificate, it's a special case, just skip them for now.


Create a user with a revoked program certificate that has met all program requirements. The call `generate_program_certificate(user, program)`. It should not error.