### PR TITLE
fix custom 404 template

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -193,7 +193,7 @@
         "filename": "main/settings.py",
         "hashed_secret": "09edaaba587f94f60fbb5cee2234507bcb883cc2",
         "is_verified": false,
-        "line_number": 955
+        "line_number": 954
       }
     ],
     "pants": [
@@ -240,5 +240,5 @@
       }
     ]
   },
-  "generated_at": "2024-09-16T18:23:36Z"
+  "generated_at": "2024-10-03T19:08:49Z"
 }

--- a/main/settings.py
+++ b/main/settings.py
@@ -178,8 +178,6 @@ INSTALLED_APPS = (
     "wagtail",
     "modelcluster",
     "taggit",
-    # django-fsm-admin
-    "viewflow",
     # django-robots
     "robots",
     # django-reversion
@@ -215,6 +213,7 @@ INSTALLED_APPS = (
     "mitol.payment_gateway.apps.PaymentGatewayApp",
     "mitol.olposthog.apps.OlPosthog",
     # "mitol.oauth_toolkit_extensions.apps.OAuthToolkitExtensionsApp",
+    "viewflow",
 )
 # Only include the seed data app if this isn't running in prod
 # if ENVIRONMENT not in ("production", "prod"):

--- a/main/urls.py
+++ b/main/urls.py
@@ -26,9 +26,6 @@ from wagtail.documents import urls as wagtaildocs_urls
 from cms.views import instructor_page
 from main.views import cms_signin_redirect_to_site_signin, index, refine
 
-handler500 = "main.views.handler500"
-handler404 = "main.views.handler404"
-
 urlpatterns = [
     # NOTE: we only bring in base_urlpatterns so applications can only be created via django-admin
     path(
@@ -93,6 +90,9 @@ urlpatterns = [
     static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 )
+
+handler500 = "main.views.handler500"
+handler404 = "main.views.handler404"
 
 if settings.DEBUG:
     import debug_toolbar  # pylint: disable=wrong-import-position, wrong-import-order


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/orgs/mitodl/projects/21/views/6?pane=issue&itemId=81655244

### Description (What does it do?)
Viewflow was overriding the 404 error page which then overrided our custom 404 error page.  This PR move the viewflow library lower in on the list of installed apps in the settings.py file, which will allow for our custom 404 error page to take precedence over the 404 error page provided by viewflow. 

### How can this be tested?
Set `DEBUG` equal to `False` in your .env file as well as the docker-compose.yml file.
Restart your application and visit a page like http://mitxonline.odl.local:8013/fake.
Verify that the MITx Online custom 404 page is displayed and not the 404 page from viewflow (you can currently see the 404 page from viewflow if you visit https://rc.mitxonline.mit.edu/fake.
