### PR TITLE
Validate user email on account creation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -236,9 +236,9 @@
         "filename": "users/serializers.py",
         "hashed_secret": "ab90d9d736f9e0909b62d0922e0482e4b827449f",
         "is_verified": false,
-        "line_number": 234
+        "line_number": 238
       }
     ]
   },
-  "generated_at": "2024-10-03T19:08:49Z"
+  "generated_at": "2024-11-05T12:32:12Z"
 }

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -289,7 +289,7 @@ def test_create_user_via_email(
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
-        json={"validation_decisions": {"username": ""}},
+        json={"validation_decisions": {"username": "", "email": ""}},
         status=status.HTTP_200_OK,
     )
     email = "user@example.com"

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -158,7 +158,7 @@ class AuthStateMachine(RuleBasedStateMachine):
     )
     mock_edx_username_patcher = patch(
         "users.serializers.validate_username_email_with_edx",
-        return_value="",
+        return_value={"username": "", "email": ""},
     )
     openedx_api_patcher = patch("authentication.pipeline.user.openedx_api")
     openedx_tasks_patcher = patch("authentication.pipeline.user.openedx_tasks")

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -157,7 +157,7 @@ class AuthStateMachine(RuleBasedStateMachine):
         return_value="dummy-username",
     )
     mock_edx_username_patcher = patch(
-        "users.serializers.validate_username_with_edx",
+        "users.serializers.validate_username_email_with_edx",
         return_value="",
     )
     openedx_api_patcher = patch("authentication.pipeline.user.openedx_api")

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -886,7 +886,7 @@ def unsubscribe_from_edx_course_emails(user, course_run):
     return result
 
 
-def validate_username_with_edx(username, email):
+def validate_username_email_with_edx(username, email):
     """
     Returns validation message after validating it with edX.
 

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -886,12 +886,13 @@ def unsubscribe_from_edx_course_emails(user, course_run):
     return result
 
 
-def validate_username_with_edx(username):
+def validate_username_with_edx(username, email):
     """
     Returns validation message after validating it with edX.
 
     Args:
         username (str): the username
+        email (str): the email
 
     Raises:
         EdxApiRegistrationValidationException: Raised if response status is not OK.
@@ -905,6 +906,7 @@ def validate_username_with_edx(username):
         edx_url(OPENEDX_REGISTRATION_VALIDATION_PATH),
         data=dict(  # noqa: C408
             username=username,
+            email=email,
         ),
     )
     if resp.status_code != status.HTTP_200_OK:

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -912,7 +912,7 @@ def validate_username_email_with_edx(username, email):
     if resp.status_code != status.HTTP_200_OK:
         raise EdxApiRegistrationValidationException(username, resp)
     result = resp.json()
-    return result["validation_decisions"]["username"]
+    return result["validation_decisions"]
 
 
 def bulk_retire_edx_users(usernames):

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -40,7 +40,7 @@ from openedx.api import (
     unsubscribe_from_edx_course_emails,
     update_edx_user_email,
     update_edx_user_name,
-    validate_username_with_edx,
+    validate_username_email_with_edx,
 )
 from openedx.constants import (
     EDX_DEFAULT_ENROLLMENT_MODE,
@@ -229,15 +229,15 @@ def test_create_edx_user_for_user_not_synced_with_edx(
 
 @responses.activate
 def test_validate_edx_username_conflict(settings, user):
-    """Test that validate_username_with_edx handles a username validation conflict"""
+    """Test that validate_username_email_with_edx handles a username validation conflict"""
     edx_username_validation_response_mock(True, settings)  # noqa: FBT003
 
-    assert validate_username_with_edx(user.username)
+    assert validate_username_email_with_edx(user.username)
 
 
 @responses.activate
 def test_validate_edx_username_conflict(settings, user):  # noqa: F811
-    """Test that validate_username_with_edx raises an exception for non-200 response"""
+    """Test that validate_username_email_with_edx raises an exception for non-200 response"""
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
@@ -249,7 +249,7 @@ def test_validate_edx_username_conflict(settings, user):  # noqa: F811
         status=status.HTTP_400_BAD_REQUEST,
     )
     with pytest.raises(EdxApiRegistrationValidationException):
-        validate_username_with_edx(user.username)
+        validate_username_email_with_edx(user.username)
 
 
 @responses.activate

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -232,7 +232,7 @@ def test_validate_edx_username_conflict(settings, user):
     """Test that validate_username_email_with_edx handles a username validation conflict"""
     edx_username_validation_response_mock(True, settings)  # noqa: FBT003
 
-    assert validate_username_email_with_edx(user.username)
+    assert validate_username_email_with_edx(user.username, "example@mit.edu")
 
 
 @responses.activate
@@ -249,7 +249,7 @@ def test_validate_edx_username_conflict(settings, user):  # noqa: F811
         status=status.HTTP_400_BAD_REQUEST,
     )
     with pytest.raises(EdxApiRegistrationValidationException):
-        validate_username_email_with_edx(user.username)
+        validate_username_email_with_edx(user.username, "example@mit.edu")
 
 
 @responses.activate

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -241,7 +241,9 @@ class UserSerializer(serializers.ModelSerializer):
         email = data.get("email")
         if username:
             try:
-                openedx_validation_msg_dict = validate_username_email_with_edx(username, email)
+                openedx_validation_msg_dict = validate_username_email_with_edx(
+                    username, email
+                )
             except (
                 HTTPError,
                 RequestsConnectionError,
@@ -249,7 +251,10 @@ class UserSerializer(serializers.ModelSerializer):
             ) as exc:
                 log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
                 raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
-            if openedx_validation_msg_dict["username"] or openedx_validation_msg_dict["email"]:
+            if (
+                openedx_validation_msg_dict["username"]
+                or openedx_validation_msg_dict["email"]
+            ):
                 raise serializers.ValidationError(openedx_validation_msg_dict)
 
         return data

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -42,7 +42,7 @@ USERNAME_ALREADY_EXISTS_MSG = (
     "A user already exists with this username. Please try a different one."
 )
 EMAIL_CONFLICT_MSG = (
-    "This email is already associated with an existing account"
+    "This email is associated with an existing account. Please try a different one."
 )
 
 OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP = {
@@ -261,7 +261,7 @@ class UserSerializer(serializers.ModelSerializer):
                             OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP.get(openedx_validation_msg_dict['username'])})
             if openedx_validation_msg_dict["email"]:
                 # there is no email form field at this point, but we are still validating the email address
-                raise serializers.ValidationError({"username": openedx_validation_msg_dict['email']})
+                raise serializers.ValidationError(openedx_validation_msg_dict['email'])
         return data
 
     def create(self, validated_data):

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -41,14 +41,7 @@ USERNAME_ERROR_MSG = "Username can only contain letters, numbers, spaces, and th
 USERNAME_ALREADY_EXISTS_MSG = (
     "A user already exists with this username. Please try a different one."
 )
-EMAIL_CONFLICT_MSG = "This email is already associated with an existing account"
-RETIRED_EMAIL_MSG = "This email is associated to a retired account."
 
-OPENEDX_VALIDATION_MSGS_MAP = {
-    "It looks like this username is already taken": USERNAME_ALREADY_EXISTS_MSG,
-    "This email is already associated with an existing account": EMAIL_CONFLICT_MSG,
-    "This email is associated to a retired account.": RETIRED_EMAIL_MSG,
-}
 
 EMAIL_ERROR_MSG = "Email address already exists in the system."
 
@@ -248,10 +241,7 @@ class UserSerializer(serializers.ModelSerializer):
         email = data.get("email")
         if username:
             try:
-                openedx_validation_msg = validate_username_email_with_edx(username, email)
-                openedx_validation_msg = OPENEDX_VALIDATION_MSGS_MAP.get(
-                    openedx_validation_msg, openedx_validation_msg
-                )
+                openedx_validation_msg_dict = validate_username_email_with_edx(username, email)
             except (
                 HTTPError,
                 RequestsConnectionError,
@@ -260,8 +250,8 @@ class UserSerializer(serializers.ModelSerializer):
                 log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
                 raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
 
-            if openedx_validation_msg:
-                raise serializers.ValidationError(openedx_validation_msg)
+            if openedx_validation_msg_dict:
+                raise serializers.ValidationError(openedx_validation_msg_dict)
 
         return data
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -47,7 +47,7 @@ EMAIL_CONFLICT_MSG = (
 
 OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP = {
     "It looks like this username is already taken": USERNAME_ALREADY_EXISTS_MSG,
-    "This email is already associated with an existing account": EMAIL_CONFLICT_MSG
+    "This email is already associated with an existing account": EMAIL_CONFLICT_MSG,
 }
 
 EMAIL_ERROR_MSG = "Email address already exists in the system."
@@ -257,11 +257,16 @@ class UserSerializer(serializers.ModelSerializer):
                 log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
                 raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
             if openedx_validation_msg_dict["username"]:
-                raise serializers.ValidationError({"username":
-                            OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP.get(openedx_validation_msg_dict['username'])})
+                raise serializers.ValidationError(
+                    {
+                        "username": OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP.get(
+                            openedx_validation_msg_dict["username"]
+                        )
+                    }
+                )
             if openedx_validation_msg_dict["email"]:
                 # there is no email form field at this point, but we are still validating the email address
-                raise serializers.ValidationError(openedx_validation_msg_dict['email'])
+                raise serializers.ValidationError(openedx_validation_msg_dict["email"])
         return data
 
     def create(self, validated_data):

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -249,8 +249,7 @@ class UserSerializer(serializers.ModelSerializer):
             ) as exc:
                 log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
                 raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
-
-            if openedx_validation_msg_dict:
+            if openedx_validation_msg_dict["username"] or openedx_validation_msg_dict["email"]:
                 raise serializers.ValidationError(openedx_validation_msg_dict)
 
         return data

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -41,11 +41,8 @@ USERNAME_ERROR_MSG = "Username can only contain letters, numbers, spaces, and th
 USERNAME_ALREADY_EXISTS_MSG = (
     "A user already exists with this username. Please try a different one."
 )
-EMAIL_CONFLICT_MSG = (
-    "This email is already associated with an existing account")
-RETIRED_EMAIL_MSG = (
-    "This email is associated to a retired account."
-)
+EMAIL_CONFLICT_MSG = "This email is already associated with an existing account"
+RETIRED_EMAIL_MSG = "This email is associated to a retired account."
 
 OPENEDX_VALIDATION_MSGS_MAP = {
     "It looks like this username is already taken": USERNAME_ALREADY_EXISTS_MSG,
@@ -245,9 +242,7 @@ class UserSerializer(serializers.ModelSerializer):
                     {"username": "This field is required."}
                 )
             if not data.get("email"):
-                raise serializers.ValidationError(
-                    {"email": "This field is required."}
-                )
+                raise serializers.ValidationError({"email": "This field is required."})
 
         username = data.get("username")
         email = data.get("email")

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -227,6 +227,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         request = self.context.get("request", None)
+        print("Validate Email and username")
         # Certain fields are required only if a new User is being created (i.e.: the request method is POST)
         if request is not None and request.method == "POST":
             if not data.get("password"):
@@ -237,11 +238,16 @@ class UserSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {"username": "This field is required."}
                 )
+            if not data.get("email"):
+                raise serializers.ValidationError(
+                    {"email": "This field is required."}
+                )
 
         username = data.get("username")
+        email = data.get("email")
         if username:
             try:
-                openedx_validation_msg = validate_username_with_edx(username)
+                openedx_validation_msg = validate_username_with_edx(username, email)
                 openedx_validation_msg = OPENEDX_USERNAME_VALIDATION_MSGS_MAP.get(
                     openedx_validation_msg, openedx_validation_msg
                 )

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -17,7 +17,7 @@ from hubspot_sync.task_helpers import sync_hubspot_user
 from mail import verification_api
 from main.constants import USER_REGISTRATION_FAILED_MSG
 from main.serializers import WriteableSerializerMethodField
-from openedx.api import validate_username_with_edx, validate_username_email_with_edx
+from openedx.api import validate_username_email_with_edx
 from openedx.exceptions import EdxApiRegistrationValidationException
 from openedx.tasks import change_edx_user_email_async
 from users.models import ChangeEmailRequest, LegalAddress, User, UserProfile

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -267,7 +267,7 @@ def test_username_validation_connection_exception(
     UserSerializer should raise a RequestsConnectionError or HTTPError if the connection to OpenEdx
     fails.  The serializer should raise a validation error.
     """
-    mocker.patch("openedx.api.validate_username_with_edx", side_effect=exception_raised)
+    mocker.patch("openedx.api.validate_username_email_with_edx", side_effect=exception_raised)
 
     serializer = UserSerializer(
         data={

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -96,7 +96,7 @@ def test_create_user_serializer(settings, valid_address_dict, test_case_dup):
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
-        json={"validation_decisions": {"username": ""}},
+        json={"validation_decisions": {"username": "", "email": ""}},
         status=status.HTTP_200_OK,
     )
     serializer = UserSerializer(
@@ -202,7 +202,7 @@ def test_username_validation(
     responses.add(
         responses.POST,
         settings.OPENEDX_API_BASE_URL + OPENEDX_REGISTRATION_VALIDATION_PATH,
-        json={"validation_decisions": {"username": ""}},
+        json={"validation_decisions": {"username": "", "email": ""}},
         status=status.HTTP_200_OK,
     )
     # Seed an initial user with a constant username

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -267,7 +267,9 @@ def test_username_validation_connection_exception(
     UserSerializer should raise a RequestsConnectionError or HTTPError if the connection to OpenEdx
     fails.  The serializer should raise a validation error.
     """
-    mocker.patch("openedx.api.validate_username_email_with_edx", side_effect=exception_raised)
+    mocker.patch(
+        "openedx.api.validate_username_email_with_edx", side_effect=exception_raised
+    )
 
     serializer = UserSerializer(
         data={


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/5642, https://github.com/mitodl/hq/issues/5931

### Description (What does it do?)
Adds email as one of the fields to validate.

### How can this be tested? 

Retire an existing user, then try to create an account with the same email address but different username.

