### PR TITLE
add duration and time_commitment to program API

### DIFF
--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -25,6 +25,8 @@ class ProgramSerializer(serializers.ModelSerializer):
     topics = serializers.SerializerMethodField()
     certificate_type = serializers.SerializerMethodField()
     required_prerequisites = serializers.SerializerMethodField()
+    duration = serializers.SerializerMethodField()
+    time_commitment = serializers.SerializerMethodField()
 
     def get_courses(self, instance):
         return [course[0].id for course in instance.courses if course[0].live]
@@ -44,6 +46,24 @@ class ProgramSerializer(serializers.ModelSerializer):
             and hasattr(instance.page, "prerequisites")
             and instance.page.prerequisites != ""
         )
+
+    def get_duration(self, instance):
+        """
+        Get the length/duration field from the program page CMS.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "length"):
+            return instance.page.length
+
+        return None
+
+    def get_time_commitment(self, instance):
+        """
+        Get the effort/time_commitment field from the program page CMS.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "effort"):
+            return instance.page.effort
+
+        return None
 
     def get_req_tree(self, instance):
         req_root = instance.get_requirements_root()
@@ -95,6 +115,8 @@ class ProgramSerializer(serializers.ModelSerializer):
             "enrollment_start",
             "enrollment_end",
             "required_prerequisites",
+            "duration",
+            "time_commitment",
         ]
 
 

--- a/courses/serializers/v2/programs_test.py
+++ b/courses/serializers/v2/programs_test.py
@@ -105,5 +105,7 @@ def test_serialize_program(
             "enrollment_start": program_with_empty_requirements.enrollment_start,
             "enrollment_end": program_with_empty_requirements.enrollment_end,
             "required_prerequisites": required_prerequisites,
+            "duration": program_with_empty_requirements.page.length,
+            "time_commitment": program_with_empty_requirements.page.effort,
         },
     )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5698

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `duration` and `time_commitment` to the program API 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Create a program and populate the length/duration and effort/time_commitment in the program CMS page. These fields should be populated via the endpoint /api/v2/programs/
