### PR TITLE
revert postgres upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
     services:
       db:
-        image: postgres:16.4
+        image: postgres:15.8
         # Health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ x-extra-hosts:
 
 services:
   db:
-    image: postgres:16.4
+    image: postgres:15.8
     ports:
       - "5432"
     environment:
@@ -67,8 +67,10 @@ services:
       << : *py-environment
       PORT: 8011
     env_file: .env
-    links:
+    depends_on:
       - db
+    links:
+      - db:db
       - redis
       # these are links instead of `depends_on`
       # because if we just want a shell for `web` we don't want to run these

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,10 +67,8 @@ services:
       << : *py-environment
       PORT: 8011
     env_file: .env
-    depends_on:
-      - db
     links:
-      - db:db
+      - db
       - redis
       # these are links instead of `depends_on`
       # because if we just want a shell for `web` we don't want to run these


### PR DESCRIPTION
### What are the relevant tickets?
Reverts https://github.com/mitodl/mitxonline/pull/2329/files

### Description (What does it do?)
I initially thought the postgres upgrade worked fine but my local was caching things or something weird.  Anyway, upgrading to Postgres v16 without any modifications to our data does not work, so this PR reverts that upgrade.

