### PR TITLE
Notifications set tab-index to -1

### DIFF
--- a/frontend/public/src/components/NotificationContainer.js
+++ b/frontend/public/src/components/NotificationContainer.js
@@ -80,6 +80,7 @@ export class NotificationContainer extends React.Component<Props, State> {
         className="notifications order-2"
         id="notifications-container"
         ref={this.headingRef}
+        tabIndex="-1"
       >
         {Object.keys(userNotifications).map((notificationKey, i) => {
           const dismiss = partial(this.onDismiss, [notificationKey])


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/715

### Description (What does it do?)
Set tab index to -1

### How can this be tested?
Trigger a notification through enrollments or failiure of enrollment and make sure that the notifications dic is set to tab-index: -1.

