### PR TITLE
fix flaky test ordering

### DIFF
--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -287,7 +287,9 @@ def test_product_managers():
     active_products = ProductFactory.create_batch(2, is_active=True)
 
     assert list(Product.objects.all().order_by("id")) == list(active_products)
-    assert list(Product.all_objects.all().order_by("id")) == list(inactive_products + active_products)
+    assert list(Product.all_objects.all().order_by("id")) == list(
+        inactive_products + active_products
+    )
 
 
 def test_product_multiple_active_for_single_purchasable_object():


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
Fixes a flaky test that has delayed deployments.  The fix is done by ordering the items in the unit test to ensure that the lists are compared equally.

### How can this be tested?
Tests should pass.
