### PR TITLE
add css to refine dashboard after refine-antd upgrades to v4

### DIFF
--- a/frontend/staff-dashboard/src/styles/antd.less
+++ b/frontend/staff-dashboard/src/styles/antd.less
@@ -6,6 +6,27 @@
 
 @primary-color: #A31F34;
 
+.ant-btn-primary{
+  background-color: @primary-color;
+  &:hover {
+    background-color: @primary-color !important;
+    border-color: @primary-color !important;
+    opacity: 0.9
+  }
+}
+
+.ant-menu-item-selected {
+  color: @primary-color !important;
+  background-color: #e3d5d5 !important;
+}
+
+.ant-btn-default{
+   &:hover {
+     border-color: @primary-color !important;
+     color: @primary-color !important;
+   }
+}
+
 .income-usd {
   max-width: 150px;
   overflow-y: auto;


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
refine-antd upgrades to v4 in https://github.com/mitodl/mitxonline/pull/2399 (I didn't notice the button color changed when testing the PR)

### Description (What does it do?)
<!--- Describe your changes in detail -->
Apply custom CSS to the staff dashboard after the package `refine-antd` is upgraded to v4, the primary button's color has changed to blue in v4, which doesn't match with https://rc.mitxonline.mit.edu/staff-dashboard/. 

Since https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less no longer exists in `refine-antd v4`, this PR is to add some CSS to match the button color with the existing staff dashboard.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

![image](https://github.com/user-attachments/assets/e0170ca9-5b72-4897-a293-293a25baad0a)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker-compose build
docker-compose up
Go to staff dashboard http://mitxonline.odl.local:8013/staff-dashboard/flexible_pricing and compare to RC

