### PR TITLE
Fix font size of course name on Course certificate

### DIFF
--- a/frontend/public/scss/certificates/certificate.scss
+++ b/frontend/public/scss/certificates/certificate.scss
@@ -127,10 +127,13 @@ $blue: #355b6b;
       .degree-text {
         display: block;
         font-size: 38px;
-        font-size: 7vw;
         line-height: 45px;
         font-weight: 600;
         margin: 0 0 10px;
+
+        @media (max-width: 768px) {
+          font-size: 7vw;
+        }
       }
 
       .success-text {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5844

### Description (What does it do?)
Updates the sizing of the course name font.

### Screenshots (if appropriate):
<img width="398" alt="Screenshot 2024-11-01 at 3 36 39 PM" src="https://github.com/user-attachments/assets/75d1ce1d-2f8f-4eb0-be7e-6fffdf1fb40f">


### How can this be tested?

1. Enroll yourself into a course.
2. Create a Signatory and Course certificate page in the CMS for the course from step 1.
3. Enter Django Admin and create yourself a course certificate for the course in step 1.
4. Go to your MITx Online Dashboard.  Click on view certificate.
5. Resize the browser window so that it matches the size in the issue or attached screenshot.
