### PR TITLE
adding validation to email confirmation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -236,9 +236,9 @@
         "filename": "users/serializers.py",
         "hashed_secret": "ab90d9d736f9e0909b62d0922e0482e4b827449f",
         "is_verified": false,
-        "line_number": 238
+        "line_number": 214
       }
     ]
   },
-  "generated_at": "2024-11-05T12:32:12Z"
+  "generated_at": "2024-11-12T15:43:01Z"
 }

--- a/mail/verification_api.py
+++ b/mail/verification_api.py
@@ -1,15 +1,20 @@
 """API for email verifications"""
 
+import logging
 from urllib.parse import quote_plus
 
 from django.urls import reverse
 
-from authentication import serializers
+from rest_framework import serializers
+
 from mail import api
 from mail.constants import EMAIL_CHANGE_EMAIL, EMAIL_VERIFICATION
+from main.constants import USER_REGISTRATION_FAILED_MSG
 from openedx.api import validate_username_email_with_edx
 from openedx.exceptions import EdxApiRegistrationValidationException
 from users.serializers import OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP
+
+log = logging.getLogger()
 
 
 def send_verification_email(strategy, backend, code, partial_token):  # pylint: disable=unused-argument  # noqa: ARG001
@@ -22,8 +27,8 @@ def send_verification_email(strategy, backend, code, partial_token):  # pylint: 
         code (social_django.models.Code): the confirmation code used to confirm the email address
         partial_token (str): token used to resume a halted pipeline
     """
-    print("hello")
     email = strategy.request_data()["email"]
+    validate_email_with_edx_api(email)
 
     url = "{}?verification_code={}&partial_token={}".format(
         strategy.build_absolute_uri(reverse("register-confirm")),
@@ -39,21 +44,28 @@ def send_verification_email(strategy, backend, code, partial_token):  # pylint: 
         )
     )
 
+
 def validate_email_with_edx_api(email):
-        try:
-            openedx_validation_msg_dict = validate_username_email_with_edx({'email': email})
-        except (
-            EdxApiRegistrationValidationException,
-        ) as exc:
-            log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
-            raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
-        if openedx_validation_msg_dict["email"]:
-            # there is no email form field at this point, but we are still validating the email address
-            raise serializers.ValidationError({
-                    "email": OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP.get(
-                        openedx_validation_msg_dict["email"]
-                    )
-                })
+    """
+    Validate an email with edx api before sending a verification email
+
+    Args:
+        email (str): the email to validate
+    """
+    try:
+        openedx_validation_msg_dict = validate_username_email_with_edx({'email': email})
+    except (
+        EdxApiRegistrationValidationException,
+    ) as exc:
+        log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
+        raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
+    if openedx_validation_msg_dict["email"]:
+        # there is no email form field at this point, but we are still validating the email address
+        raise serializers.ValidationError({
+                "email": OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP.get(
+                    openedx_validation_msg_dict["email"]
+                )
+            })
 
 
 def send_verify_email_change_email(request, change_request):

--- a/mail/verification_api.py
+++ b/mail/verification_api.py
@@ -4,7 +4,6 @@ import logging
 from urllib.parse import quote_plus
 
 from django.urls import reverse
-
 from rest_framework import serializers
 
 from mail import api
@@ -53,19 +52,19 @@ def validate_email_with_edx_api(email):
         email (str): the email to validate
     """
     try:
-        openedx_validation_msg_dict = validate_username_email_with_edx({'email': email})
-    except (
-        EdxApiRegistrationValidationException,
-    ) as exc:
+        openedx_validation_msg_dict = validate_username_email_with_edx({"email": email})
+    except EdxApiRegistrationValidationException as exc:
         log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
         raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
     if openedx_validation_msg_dict["email"]:
         # there is no email form field at this point, but we are still validating the email address
-        raise serializers.ValidationError({
+        raise serializers.ValidationError(
+            {
                 "email": OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP.get(
                     openedx_validation_msg_dict["email"]
                 )
-            })
+            }
+        )
 
 
 def send_verify_email_change_email(request, change_request):

--- a/mail/verification_api.py
+++ b/mail/verification_api.py
@@ -12,7 +12,7 @@ from mail.constants import EMAIL_CHANGE_EMAIL, EMAIL_VERIFICATION
 from main.constants import USER_REGISTRATION_FAILED_MSG
 from openedx.api import validate_username_email_with_edx
 from openedx.exceptions import EdxApiRegistrationValidationException
-from users.serializers import OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP
+from users.constants import OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP
 
 log = logging.getLogger()
 

--- a/mail/verification_api.py
+++ b/mail/verification_api.py
@@ -4,8 +4,12 @@ from urllib.parse import quote_plus
 
 from django.urls import reverse
 
+from authentication import serializers
 from mail import api
 from mail.constants import EMAIL_CHANGE_EMAIL, EMAIL_VERIFICATION
+from openedx.api import validate_username_email_with_edx
+from openedx.exceptions import EdxApiRegistrationValidationException
+from users.serializers import OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP
 
 
 def send_verification_email(strategy, backend, code, partial_token):  # pylint: disable=unused-argument  # noqa: ARG001
@@ -18,6 +22,9 @@ def send_verification_email(strategy, backend, code, partial_token):  # pylint: 
         code (social_django.models.Code): the confirmation code used to confirm the email address
         partial_token (str): token used to resume a halted pipeline
     """
+    print("hello")
+    email = strategy.request_data()["email"]
+
     url = "{}?verification_code={}&partial_token={}".format(
         strategy.build_absolute_uri(reverse("register-confirm")),
         quote_plus(code.code),
@@ -31,6 +38,22 @@ def send_verification_email(strategy, backend, code, partial_token):  # pylint: 
             EMAIL_VERIFICATION,
         )
     )
+
+def validate_email_with_edx_api(email):
+        try:
+            openedx_validation_msg_dict = validate_username_email_with_edx({'email': email})
+        except (
+            EdxApiRegistrationValidationException,
+        ) as exc:
+            log.exception("Unable to create user account", exc)  # noqa: PLE1205, TRY401
+            raise serializers.ValidationError(USER_REGISTRATION_FAILED_MSG)  # noqa: B904
+        if openedx_validation_msg_dict["email"]:
+            # there is no email form field at this point, but we are still validating the email address
+            raise serializers.ValidationError({
+                    "email": OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP.get(
+                        openedx_validation_msg_dict["email"]
+                    )
+                })
 
 
 def send_verify_email_change_email(request, change_request):

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -886,7 +886,7 @@ def unsubscribe_from_edx_course_emails(user, course_run):
     return result
 
 
-def validate_username_email_with_edx(username, email):
+def validate_username_email_with_edx(validation_dict):
     """
     Returns validation message after validating it with edX.
 
@@ -905,12 +905,11 @@ def validate_username_email_with_edx(username, email):
     resp = req_session.post(
         edx_url(OPENEDX_REGISTRATION_VALIDATION_PATH),
         data=dict(  # noqa: C408
-            username=username,
-            email=email,
+            **validation_dict
         ),
     )
     if resp.status_code != status.HTTP_200_OK:
-        raise EdxApiRegistrationValidationException(username, resp)
+        raise EdxApiRegistrationValidationException(validation_dict, resp)
     result = resp.json()
     return result["validation_decisions"]
 

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -904,7 +904,7 @@ def validate_username_email_with_edx(validation_dict):
     )
     resp = req_session.post(
         edx_url(OPENEDX_REGISTRATION_VALIDATION_PATH),
-        data=dict(  # noqa: C408
+        data=dict(
             **validation_dict
         ),
     )

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -232,7 +232,9 @@ def test_validate_edx_username_conflict(settings, user):
     """Test that validate_username_email_with_edx handles a username validation conflict"""
     edx_username_validation_response_mock(True, settings)  # noqa: FBT003
 
-    assert validate_username_email_with_edx({"username": user.username, "email": "example@mit.edu"})
+    assert validate_username_email_with_edx(
+        {"username": user.username, "email": "example@mit.edu"}
+    )
 
 
 @responses.activate
@@ -249,7 +251,9 @@ def test_validate_edx_username_conflict(settings, user):  # noqa: F811
         status=status.HTTP_400_BAD_REQUEST,
     )
     with pytest.raises(EdxApiRegistrationValidationException):
-        validate_username_email_with_edx({"username": user.username, "email": "example@mit.edu"})
+        validate_username_email_with_edx(
+            {"username": user.username, "email": "example@mit.edu"}
+        )
 
 
 @responses.activate

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -232,7 +232,7 @@ def test_validate_edx_username_conflict(settings, user):
     """Test that validate_username_email_with_edx handles a username validation conflict"""
     edx_username_validation_response_mock(True, settings)  # noqa: FBT003
 
-    assert validate_username_email_with_edx(user.username, "example@mit.edu")
+    assert validate_username_email_with_edx({"username": user.username, "email": "example@mit.edu"})
 
 
 @responses.activate
@@ -249,7 +249,7 @@ def test_validate_edx_username_conflict(settings, user):  # noqa: F811
         status=status.HTTP_400_BAD_REQUEST,
     )
     with pytest.raises(EdxApiRegistrationValidationException):
-        validate_username_email_with_edx(user.username, "example@mit.edu")
+        validate_username_email_with_edx({"username": user.username, "email": "example@mit.edu"})
 
 
 @responses.activate

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -110,17 +110,17 @@ class UnknownEdxApiEmailSettingsException(Exception):  # noqa: N818
 class EdxApiRegistrationValidationException(Exception):  # noqa: N818
     """An edX Registration Validation API call resulted in an error response"""
 
-    def __init__(self, username, response, msg=None):
+    def __init__(self, values, response, msg=None):
         """
         Sets exception properties and adds a default message
 
         Args:
-            username (str): The username being compared for uniqueness
+            values (str): The values being compared for uniqueness
             response (requests.Response): edX response for username validation
         """
-        self.username = username
+        self.values = values
         self.response = response
         if msg is None:
             # Set some default useful error message
-            msg = f"EdX API error validating registration username {self.username}.\n{get_error_response_summary(self.response)}"
+            msg = f"EdX API error validating registration username or email {self.values}.\n{get_error_response_summary(self.response)}"
         super().__init__(msg)

--- a/users/constants.py
+++ b/users/constants.py
@@ -1,3 +1,33 @@
 """User constants"""
 
+import re
+
 USERNAME_MAX_LEN = 30
+
+US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
+CA_POSTAL_RE = re.compile(r"[A-Z]\d[A-Z] \d[A-Z]\d$", flags=re.I)
+USER_GIVEN_NAME_RE = re.compile(
+    r"""
+    ^                               # Start of string
+    (?![~!@&)(+:'.?/,`-]+)          # String should not start from character(s) in this set - They can exist in elsewhere
+    ([^/^$#*=\[\]`%_;<>{}\"|]+)     # String should not contain characters(s) from this set - All invalid characters
+    $                               # End of string
+    """,
+    flags=re.I | re.VERBOSE | re.MULTILINE,
+)
+USERNAME_RE_PARTIAL = r"[\w ._+-]+"
+USERNAME_RE = re.compile(rf"(?P<username>{USERNAME_RE_PARTIAL})")
+USERNAME_ERROR_MSG = "Username can only contain letters, numbers, spaces, and the following characters: _+-"
+USERNAME_ALREADY_EXISTS_MSG = (
+    "A user already exists with this username. Please try a different one."
+)
+EMAIL_CONFLICT_MSG = (
+    "This email is associated with an existing account. Please try a different one."
+)
+
+OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP = {
+    "It looks like this username is already taken": USERNAME_ALREADY_EXISTS_MSG,
+    "This email is already associated with an existing account": EMAIL_CONFLICT_MSG,
+}
+
+EMAIL_ERROR_MSG = "Email address already exists in the system."

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -20,13 +20,17 @@ from main.serializers import WriteableSerializerMethodField
 from openedx.api import validate_username_email_with_edx
 from openedx.exceptions import EdxApiRegistrationValidationException
 from openedx.tasks import change_edx_user_email_async
-from users.constants import USER_GIVEN_NAME_RE, USERNAME_ALREADY_EXISTS_MSG, EMAIL_ERROR_MSG, USERNAME_RE, \
-    USERNAME_ERROR_MSG, OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP
+from users.constants import (
+    EMAIL_ERROR_MSG,
+    OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP,
+    USER_GIVEN_NAME_RE,
+    USERNAME_ALREADY_EXISTS_MSG,
+    USERNAME_ERROR_MSG,
+    USERNAME_RE,
+)
 from users.models import ChangeEmailRequest, LegalAddress, User, UserProfile
 
 log = logging.getLogger()
-
-
 
 
 class UserProfileSerializer(serializers.ModelSerializer):
@@ -226,7 +230,7 @@ class UserSerializer(serializers.ModelSerializer):
                     {
                         "username": username,
                         "email": email,
-                     }
+                    }
                 )
             except (
                 HTTPError,

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -20,37 +20,13 @@ from main.serializers import WriteableSerializerMethodField
 from openedx.api import validate_username_email_with_edx
 from openedx.exceptions import EdxApiRegistrationValidationException
 from openedx.tasks import change_edx_user_email_async
+from users.constants import USER_GIVEN_NAME_RE, USERNAME_ALREADY_EXISTS_MSG, EMAIL_ERROR_MSG, USERNAME_RE, \
+    USERNAME_ERROR_MSG, OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP
 from users.models import ChangeEmailRequest, LegalAddress, User, UserProfile
 
 log = logging.getLogger()
 
-US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
-CA_POSTAL_RE = re.compile(r"[A-Z]\d[A-Z] \d[A-Z]\d$", flags=re.I)
-USER_GIVEN_NAME_RE = re.compile(
-    r"""
-    ^                               # Start of string
-    (?![~!@&)(+:'.?/,`-]+)          # String should not start from character(s) in this set - They can exist in elsewhere
-    ([^/^$#*=\[\]`%_;<>{}\"|]+)     # String should not contain characters(s) from this set - All invalid characters
-    $                               # End of string
-    """,
-    flags=re.I | re.VERBOSE | re.MULTILINE,
-)
-USERNAME_RE_PARTIAL = r"[\w ._+-]+"
-USERNAME_RE = re.compile(rf"(?P<username>{USERNAME_RE_PARTIAL})")
-USERNAME_ERROR_MSG = "Username can only contain letters, numbers, spaces, and the following characters: _+-"
-USERNAME_ALREADY_EXISTS_MSG = (
-    "A user already exists with this username. Please try a different one."
-)
-EMAIL_CONFLICT_MSG = (
-    "This email is associated with an existing account. Please try a different one."
-)
 
-OPENEDX_ACCOUNT_CREATION_VALIDATION_MSGS_MAP = {
-    "It looks like this username is already taken": USERNAME_ALREADY_EXISTS_MSG,
-    "This email is already associated with an existing account": EMAIL_CONFLICT_MSG,
-}
-
-EMAIL_ERROR_MSG = "Email address already exists in the system."
 
 
 class UserProfileSerializer(serializers.ModelSerializer):

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -223,7 +223,10 @@ class UserSerializer(serializers.ModelSerializer):
         if username:
             try:
                 openedx_validation_msg_dict = validate_username_email_with_edx(
-                    username, email
+                    {
+                        "username": username,
+                        "email": email,
+                     }
                 )
             except (
                 HTTPError,


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/6025

### Description (What does it do?)
Add email validation to the initial email confirmation 


### How can this be tested?
Create an account, then retire your account with this command:
./manage.py retire_users -u "username"

Then try to create an account again with the same email address