### PR TITLE
Add weekly hours

### DIFF
--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -27,6 +27,8 @@ class ProgramSerializer(serializers.ModelSerializer):
     required_prerequisites = serializers.SerializerMethodField()
     duration = serializers.SerializerMethodField()
     time_commitment = serializers.SerializerMethodField()
+    min_weekly_hours = serializers.SerializerMethodField()
+    max_weekly_hours = serializers.SerializerMethodField()
 
     def get_courses(self, instance):
         return [course[0].id for course in instance.courses if course[0].live]
@@ -94,6 +96,24 @@ class ProgramSerializer(serializers.ModelSerializer):
             return "MicroMasters Credential"
         return "Certificate of Completion"
 
+    def get_min_weekly_hours(self, instance):
+        """
+        Get the min weekly hours of the course from the course page CMS.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "min_weekly_hours"):
+            return instance.page.min_weekly_hours
+
+        return None
+
+    def get_max_weekly_hours(self, instance):
+        """
+        Get the max weekly hours of the course from the course page CMS.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "max_weekly_hours"):
+            return instance.page.max_weekly_hours
+
+        return None
+
     class Meta:
         model = Program
         fields = [
@@ -117,6 +137,8 @@ class ProgramSerializer(serializers.ModelSerializer):
             "required_prerequisites",
             "duration",
             "time_commitment",
+            "min_weekly_hours",
+            "max_weekly_hours",
         ]
 
 

--- a/courses/serializers/v2/programs_test.py
+++ b/courses/serializers/v2/programs_test.py
@@ -107,5 +107,7 @@ def test_serialize_program(
             "required_prerequisites": required_prerequisites,
             "duration": program_with_empty_requirements.page.length,
             "time_commitment": program_with_empty_requirements.page.effort,
+            "max_weekly_hours": program_with_empty_requirements.page.max_weekly_hours,
+            "min_weekly_hours": program_with_empty_requirements.page.min_weekly_hours,
         },
     )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5999

### Description (What does it do?)
Adds min and max weekly hours to the program CMS pages and programs V2 API.

### How can this be tested?

1. Update a program CMS page with min and max weekly hours.
2. Visit http://mitxonline.odl.local:8013/api/v2/programs/ and ensure that the min and max weekly hours are showing.

