### PR TITLE
Set change status on deferal request

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -185,6 +185,9 @@ def create_run_enrollments(  # noqa: C901
             if not created:
                 enrollment_mode_changed = mode != enrollment.enrollment_mode
                 enrollment.edx_enrolled = edx_request_success
+                if change_status is not None:
+                    enrollment.change_status = change_status
+                    enrollment.save_and_log()
                 # Case (Upgrade): When user was enrolled in free mode and now enrolls in paid mode (e.g. Verified)
                 # So, User has an active enrollment and the only changing thing is going to be enrollment mode
                 if enrollment.active and enrollment_mode_changed:


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/6097

### Description (What does it do?)
sets the change_status on enrollment when not created.

There are few options here:
1. the user enrolls again in the course run
2. refund or deferral request

### How can this be tested?
Will test this on RC, since google sheets are already setup there.