### PR TITLE
Enable tabbing through the department menu on mobile view

### DIFF
--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -295,6 +295,8 @@ export class CatalogPage extends React.Component<Props> {
    */
   toggleMobileFilterWindowExpanded = (expanded: boolean) => {
     this.setState({ mobileFilterWindowExpanded: expanded })
+    const inputs = [...document.getElementsByTagName("a")]
+    inputs.forEach(input => input.setAttribute('tabindex', expanded ? "-1" : "0"))
   }
 
   /**
@@ -773,7 +775,6 @@ export class CatalogPage extends React.Component<Props> {
     )
     return (
       <nav
-        className="sticky-top"
         id="department-sidebar"
         aria-label="department filters"
       >


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.mit.edu/mitxonline/mitxonline-issues/issues/760

### Description (What does it do?)
Enable tabbing through the department menu on mobile view


### How can this be tested?
Enlarge the screen to over 300%, and try navigating though the page with keyboard or mouse.

