### PR TITLE
add option to generate certificates for a program

### DIFF
--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -19,13 +19,15 @@ Check the usages of this command below:
 4. Un-Revoke a program certificate for a user
 ./mange.py manage_program_certificates -—unrevoke —-program=<program_readable_id> -—user=<username or email>
 
+5. Generate Program certificate for all enrolled users in the program who have earned it
+./mange.py manage_program_certificates --create -—program=<program_readable_id>
 """
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 
 from courses.api import generate_program_certificate, manage_program_certificate_access
-from courses.models import Program
+from courses.models import Program, ProgramEnrollment
 from users.api import fetch_user
 
 User = get_user_model()
@@ -45,7 +47,7 @@ class Command(BaseCommand):
             "--user",
             type=str,
             help="The id, email or username of the enrolled User",
-            required=True,
+            required=False,
         )
         parser.add_argument(
             "--program",
@@ -90,12 +92,13 @@ class Command(BaseCommand):
                 "The command needs a valid action e.g. --revoke, --unrevoke, --create."  # noqa: EM101
             )
 
-        try:
-            user = fetch_user(user)
-        except User.DoesNotExist:
-            raise CommandError(  # noqa: B904
-                f"Could not find a user with <username or email>={user}."  # noqa: EM102
-            )
+        if user:
+            try:
+                user = fetch_user(user)
+            except User.DoesNotExist:
+                raise CommandError(  # noqa: B904
+                    f"Could not find a user with <username or email>={user}."  # noqa: EM102
+                )
 
         # Unable to obtain a program object based on the provided program readable id
         try:
@@ -105,6 +108,8 @@ class Command(BaseCommand):
 
         # Handle revoke/un-revoke of a certificate
         if revoke or unrevoke:
+            if not user:
+                raise CommandError("If you want to revoke/unrevoke a user argument is required")
             revoke_status = manage_program_certificate_access(
                 user=user,
                 program=program,
@@ -125,27 +130,42 @@ class Command(BaseCommand):
 
         # Handle the creation of the program certificate.
         elif create:
-            # If -f or --force argument is provided, we'll forcefully generate the program certificate
-            certificate, created_cert = generate_program_certificate(
-                user=user, program=program, force_create=force_create
-            )
-            success_result = True
+            if user:
 
-            if created_cert:
-                cert_status = "created"
-            elif certificate and not created_cert:
-                cert_status = "already exists"
-            else:
-                success_result = False
-                cert_status = (
-                    "ignored, certificates for required courses are missing, use "
-                    "-f or --force argument to forcefully create a program certificate"
+                # If -f or --force argument is provided, we'll forcefully generate the program certificate
+                certificate, created_cert = generate_program_certificate(
+                    user=user, program=program, force_create=force_create
                 )
+                success_result = True
 
-            result_summary = f"Certificate: {cert_status}"
+                if created_cert:
+                    cert_status = "created"
+                elif certificate and not created_cert:
+                    cert_status = "already exists"
+                else:
+                    success_result = False
+                    cert_status = (
+                        "ignored, certificates for required courses are missing, use "
+                        "-f or --force argument to forcefully create a program certificate"
+                    )
 
-            result = f"Processed user {user.username} ({user.email}) in program {program.readable_id}. Result - {result_summary}"
-            result_output = self.style.SUCCESS(result)
-            if not success_result:
-                result_output = self.style.ERROR(result)
-            self.stdout.write(result_output)
+                result_summary = f"Certificate: {cert_status}"
+
+                result = f"Processed user {user.username} ({user.email}) in program {program.readable_id}. Result - {result_summary}"
+                result_output = self.style.SUCCESS(result)
+                if not success_result:
+                    result_output = self.style.ERROR(result)
+                self.stdout.write(result_output)
+            else:
+
+                # generate certificates for all enrolled users
+                enrollments = ProgramEnrollment.objects.filter(program=program)
+                cert_count = 0
+                for enrollment in enrollments:
+                    certificate, created_cert = generate_program_certificate(
+                        user=enrollment.user, program=program
+                    )
+                    if created_cert:
+                        cert_count += 1
+
+                self.stdout.write(f"Successfully created {cert_count} certificates for program {program.readable_id}")

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
 
         super().add_arguments(parser)
 
-    def handle(self, *args, **options):  # pylint: disable=too-many-locals  # noqa: ARG002
+    def handle(self, *args, **options):  # pylint: disable=too-many-locals  # noqa: ARG002, C901
         """Handle command execution"""
 
         revoke = options.get("revoke")
@@ -109,7 +109,7 @@ class Command(BaseCommand):
         # Handle revoke/un-revoke of a certificate
         if revoke or unrevoke:
             if not user:
-                raise CommandError("If you want to revoke/unrevoke a user argument is required")
+                raise CommandError("If you want to revoke/unrevoke a user argument is required")  # noqa: EM101
             revoke_status = manage_program_certificate_access(
                 user=user,
                 program=program,
@@ -168,4 +168,4 @@ class Command(BaseCommand):
                     if created_cert:
                         cert_count += 1
 
-                self.stdout.write(f"Successfully created {cert_count} certificates for program {program.readable_id}")
+                self.stdout.write(self.style.SUCCESS(f"Successfully created {cert_count} certificates for program {program.readable_id}"))

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -109,7 +109,9 @@ class Command(BaseCommand):
         # Handle revoke/un-revoke of a certificate
         if revoke or unrevoke:
             if not user:
-                raise CommandError("If you want to revoke/unrevoke a user argument is required")  # noqa: EM101
+                raise CommandError(
+                    "If you want to revoke/unrevoke a user argument is required"  # noqa: EM101
+                )
             revoke_status = manage_program_certificate_access(
                 user=user,
                 program=program,
@@ -131,7 +133,6 @@ class Command(BaseCommand):
         # Handle the creation of the program certificate.
         elif create:
             if user:
-
                 # If -f or --force argument is provided, we'll forcefully generate the program certificate
                 certificate, created_cert = generate_program_certificate(
                     user=user, program=program, force_create=force_create
@@ -157,7 +158,6 @@ class Command(BaseCommand):
                     result_output = self.style.ERROR(result)
                 self.stdout.write(result_output)
             else:
-
                 # generate certificates for all enrolled users
                 enrollments = ProgramEnrollment.objects.filter(program=program)
                 cert_count = 0
@@ -168,4 +168,8 @@ class Command(BaseCommand):
                     if created_cert:
                         cert_count += 1
 
-                self.stdout.write(self.style.SUCCESS(f"Successfully created {cert_count} certificates for program {program.readable_id}"))
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Successfully created {cert_count} certificates for program {program.readable_id}"
+                    )
+                )


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/6131

### Description (What does it do?)
add option to generate certificates for a program



### How can this be tested?
1. Have a user that has passed all required courses in your program. 
2. Make sure the program certificate is not there. If your program does not have a certificate child page created then the program certificates don't get generated.

3. Then created the certificate page and Signatories for the program
4. Then run the management command:
` ./manage.py manage_program_certificates --create -—program=<my_program_id>`
