### PR TITLE
Remove pagination for departments

### DIFF
--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -108,7 +108,6 @@ class DepartmentViewSet(viewsets.ReadOnlyModelViewSet):
     """API view set for Departments"""
 
     serializer_class = DepartmentWithCoursesAndProgramsSerializer
-    pagination_class = Pagination
     permission_classes = []
 
     def get_queryset(self):

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -49,7 +49,7 @@ def test_get_departments(
     ) as context:
         resp = user_drf_client.get(reverse("v2:departments_api-list"))
     duplicate_queries_check(context)
-    empty_departments_data = resp.json()["results"]
+    empty_departments_data = resp.json()
     assert_drf_json_equal(
         empty_departments_data, empty_departments_from_fixture, ignore_order=True
     )
@@ -64,7 +64,7 @@ def test_get_departments(
     ) as context:
         resp = user_drf_client.get(reverse("v2:departments_api-list"))
     duplicate_queries_check(context)
-    departments_data = resp.json()["results"]
+    departments_data = resp.json()
     departments_from_fixture = []
     for department in departments:
         departments_from_fixture.append(  # noqa: PERF401

--- a/frontend/public/src/lib/queries/departments.js
+++ b/frontend/public/src/lib/queries/departments.js
@@ -10,7 +10,7 @@ export const departmentsQuery = page => ({
   queryKey:  departmentsQueryKey,
   url:       `/api/v2/departments/?page=${page}`,
   transform: json => ({
-    departments: json.results
+    departments: json
   }),
   update: {
     departments: nextState


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/6308

### Description (What does it do?)
Remove pagination for departments api



### How can this be tested?
Create over 12 departments with courses. Go to http://mitxonline.odl.local:8013/api/v2/departments/
You should see all departments on one page.