### PR TITLE
Re-orders the title and start time of the course to be read in the proper order by the reader

### DIFF
--- a/frontend/public/scss/catalog.scss
+++ b/frontend/public/scss/catalog.scss
@@ -416,6 +416,7 @@
                     }
 
                     .catalog-item-description {
+                        height: 85px;
                         display: flex;
                         padding: 15px;
                         flex-direction: column;
@@ -435,7 +436,6 @@
                         }
 
                         .item-title {
-                            height: 36px;
                             align-self: stretch;
                             color: rgba(3, 21, 45, 0.85);
                             /* Add elipses after 2 lines of title text */

--- a/frontend/public/scss/catalog.scss
+++ b/frontend/public/scss/catalog.scss
@@ -416,6 +416,9 @@
                     }
 
                     .catalog-item-description {
+                        display: -webkit-flex;
+                        -webkit-flex-flow: column;
+                        flex-flow: column;
                         height: 85px;
                         display: flex;
                         padding: 15px;
@@ -425,6 +428,8 @@
                         align-self: stretch;
 
                         .start-date-description {
+                            -webkit-order: 1;
+                            order: 1;
                             align-self: stretch;
                             overflow: hidden;
                             color: var(--grey-text, #6F7175);
@@ -436,6 +441,8 @@
                         }
 
                         .item-title {
+                            -webkit-order: 2;
+                            order: 2;
                             align-self: stretch;
                             color: rgba(3, 21, 45, 0.85);
                             /* Add elipses after 2 lines of title text */

--- a/frontend/public/src/containers/pages/CatalogPage.js
+++ b/frontend/public/src/containers/pages/CatalogPage.js
@@ -669,10 +669,10 @@ export class CatalogPage extends React.Component<Props> {
               alt=""
             />
             <div className="catalog-item-description">
+              <div className="item-title">{course.title}</div>
               <div className="start-date-description">
                 {getStartDateText(course)}
               </div>
-              <div className="item-title">{course.title}</div>
             </div>
           </div>
         </a>


### PR DESCRIPTION
### What are the relevant tickets?
Fix Partially https://github.com/mitodl/hq/issues/3478

### Description (What does it do?)
Re-orders the title and start time of the course to be read in the proper order by the reader.

### Screenshots (if appropriate):
Everything should look the same.

### How can this be tested?
Using voiceOver.