### PR TITLE
Enrolled Course Item dropdown menu accessibility 

### DIFF
--- a/frontend/public/scss/dashboard.scss
+++ b/frontend/public/scss/dashboard.scss
@@ -138,6 +138,20 @@ $enrolled-passed-fg: #ffffff;
     }
   }
 
+  .dropdown-toggle.menu-button {
+    height: fit-content;
+    border-color: transparent;
+    background-color: inherit;
+
+    span {
+      vertical-align: -webkit-baseline-middle;
+    }
+  }
+
+  .dropdown-toggle.menu-button::after {
+    display: none;
+  }
+
   .no-enrollments h2 {
     font-size: 25px !important;
     margin-bottom: 30px !important;

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -8,10 +8,6 @@ import {
 } from "../lib/util"
 import { Formik, Form, Field } from "formik"
 import {
-  Dropdown,
-  DropdownToggle,
-  DropdownMenu,
-  DropdownItem,
   Button,
   Modal,
   ModalHeader,

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -424,9 +424,6 @@ export class EnrolledItemCard extends React.Component<
   renderCourseEnrollment() {
     const { enrollment, currentUser, isProgramCard, redirectToCourseHomepage } =
       this.props
-
-    const { menuVisibility } = this.state
-
     const financialAssistanceLink =
       isFinancialAssistanceAvailable(enrollment.run) &&
       !enrollment.approved_flexible_price_exists ? (

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -72,8 +72,7 @@ type EnrolledItemCardState = {
   submittingEnrollmentId: number | null,
   emailSettingsModalVisibility: boolean,
   runUnenrollmentModalVisibility: boolean,
-  programUnenrollmentModalVisibility: boolean,
-  menuVisibility: boolean
+  programUnenrollmentModalVisibility: boolean
 }
 
 export class EnrolledItemCard extends React.Component<
@@ -84,8 +83,7 @@ export class EnrolledItemCard extends React.Component<
     submittingEnrollmentId:             null,
     emailSettingsModalVisibility:       false,
     runUnenrollmentModalVisibility:     false,
-    programUnenrollmentModalVisibility: false,
-    menuVisibility:                     false
+    programUnenrollmentModalVisibility: false
   }
 
   toggleEmailSettingsModalVisibility = () => {
@@ -106,13 +104,6 @@ export class EnrolledItemCard extends React.Component<
     const { runUnenrollmentModalVisibility } = this.state
     this.setState({
       runUnenrollmentModalVisibility: !runUnenrollmentModalVisibility
-    })
-  }
-
-  toggleMenuVisibility = () => {
-    const { menuVisibility } = this.state
-    this.setState({
-      menuVisibility: !menuVisibility
     })
   }
 
@@ -632,7 +623,6 @@ export class EnrolledItemCard extends React.Component<
 
   renderProgramEnrollment() {
     const { enrollment } = this.props
-    const { menuVisibility } = this.state
 
     const title = enrollment.program.title
     const certificateLinks = null
@@ -675,32 +665,30 @@ export class EnrolledItemCard extends React.Component<
                   </a>
                 </h2>
               </div>
-              <Dropdown
-                isOpen={menuVisibility}
-                toggle={this.toggleMenuVisibility.bind(this)}
-                id={`programEnrollmentDropdown-${enrollment.id}`}
+              <button
+                className="dropdown-toggle menu-button"
+                data-bs-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+                type="button"
+                id={`enrollmentDropdown-${enrollment.id}`}
               >
-                <DropdownToggle
-                  className="d-inline-flex unstyled dot-menu"
-                  aria-label={menuTitle}
-                >
-                  <span className="material-icons" title={menuTitle}>
-                    more_vert
-                  </span>
-                </DropdownToggle>
-                <DropdownMenu end>
-                  <span id={`unenrollButtonWrapper-${enrollment.id}`}>
-                    <DropdownItem
-                      className="unstyled d-block"
-                      onClick={() =>
-                        this.toggleProgramUnenrollmentModalVisibility()
-                      }
-                    >
-                      Unenroll
-                    </DropdownItem>
-                  </span>
-                </DropdownMenu>
-              </Dropdown>
+                <span className="material-icons" title={menuTitle}>
+                  more_vert
+                </span>
+              </button>
+              <ul className="dropdown-menu dropdown-menu-end">
+                <li className="dropdown-item">
+                  <button
+                    className="unenroll-btn unstyled d-block"
+                    onClick={() =>
+                      this.toggleProgramUnenrollmentModalVisibility()
+                    }
+                  >
+                    Unenroll
+                  </button>
+                </li>
+              </ul>
               {this.renderProgramUnenrollmentModal(enrollment)}
             </div>
             <div className="detail detail-program">

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -564,7 +564,7 @@ export class EnrolledItemCard extends React.Component<
               <ul className="dropdown-menu dropdown-menu-end">
                 <li className="dropdown-item">
                   <button
-                    className="unstyled d-block"
+                    className="unenroll-btn unstyled d-block"
                     onClick={onUnenrollClick}
                   >
                     Unenroll

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -7,12 +7,7 @@ import {
   formatPrettyMonthDate
 } from "../lib/util"
 import { Formik, Form, Field } from "formik"
-import {
-  Button,
-  Modal,
-  ModalHeader,
-  ModalBody
-} from "reactstrap"
+import { Button, Modal, ModalHeader, ModalBody } from "reactstrap"
 import { partial, pathOr } from "ramda"
 import { createStructuredSelector } from "reselect"
 import { compose } from "redux"

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -553,7 +553,7 @@ export class EnrolledItemCard extends React.Component<
                 )}
               </div>
               <button
-                className="dropdown-toggle user-menu-button"
+                className="dropdown-toggle menu-button"
                 data-bs-toggle="dropdown"
                 aria-haspopup="true"
                 aria-expanded="false"

--- a/frontend/public/src/components/EnrolledItemCard.js
+++ b/frontend/public/src/components/EnrolledItemCard.js
@@ -552,38 +552,36 @@ export class EnrolledItemCard extends React.Component<
                   </a>
                 )}
               </div>
-              <Dropdown
-                isOpen={menuVisibility}
-                toggle={this.toggleMenuVisibility.bind(this)}
+              <button
+                className="dropdown-toggle user-menu-button"
+                data-bs-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+                type="button"
                 id={`enrollmentDropdown-${enrollment.id}`}
               >
-                <DropdownToggle
-                  className="d-inline-flex unstyled dot-menu"
-                  aria-label={menuTitle}
-                >
-                  <span className="material-icons" title={menuTitle}>
-                    more_vert
-                  </span>
-                </DropdownToggle>
-                <DropdownMenu end>
-                  <span id={`unenrollButtonWrapper-${enrollment.id}`}>
-                    <DropdownItem
-                      className="unstyled d-block"
-                      onClick={onUnenrollClick}
-                    >
-                      Unenroll
-                    </DropdownItem>
-                  </span>
-                  <span id="subscribeButtonWrapper">
-                    <DropdownItem
-                      className="unstyled d-block"
-                      onClick={() => this.toggleEmailSettingsModalVisibility()}
-                    >
-                      Email Settings
-                    </DropdownItem>
-                  </span>
-                </DropdownMenu>
-              </Dropdown>
+                <span className="material-icons" title={menuTitle}>
+                  more_vert
+                </span>
+              </button>
+              <ul className="dropdown-menu dropdown-menu-end">
+                <li className="dropdown-item">
+                  <button
+                    className="unstyled d-block"
+                    onClick={onUnenrollClick}
+                  >
+                    Unenroll
+                  </button>
+                </li>
+                <li className="dropdown-item">
+                  <button
+                    className="unstyled d-block"
+                    onClick={() => this.toggleEmailSettingsModalVisibility()}
+                  >
+                    Email Settings
+                  </button>
+                </li>
+              </ul>
               {this.renderRunUnenrollmentModal(enrollment)}
               {this.renderEmailSettingsDialog(enrollment)}
             </div>

--- a/frontend/public/src/components/EnrolledItemCard_test.js
+++ b/frontend/public/src/components/EnrolledItemCard_test.js
@@ -236,7 +236,7 @@ describe("EnrolledItemCard", () => {
     )} activate the unenrollment verification modal if the enrollment type is ${enrollmentType}`, async () => {
       enrollmentCardProps.enrollment.enrollment_mode = enrollmentType
       const inner = await renderedCard()
-      const unenrollButton = inner.find("Dropdown DropdownItem").at(0)
+      const unenrollButton = inner.find(".unenroll-btn").at(0)
 
       assert.isTrue(unenrollButton.exists())
       await unenrollButton.prop("onClick")()


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/6344

### Description (What does it do?)
Make dropdown menu same as in the header.
for course items and program items.

### Screenshots (if appropriate):

<img width="407" alt="Screenshot 2025-01-22 at 8 22 09 AM" src="https://github.com/user-attachments/assets/23c4e9c6-b1da-46e8-a26a-35d740d16b7e" />

<img width="1150" alt="Screenshot 2025-01-22 at 8 46 30 AM" src="https://github.com/user-attachments/assets/859fb5bd-acc7-4442-8b92-db387b58f320" />


### How can this be tested?
Go to the student dashboard and make sure the dropdown menu looks good and works.