### PR TITLE
Add support for round-tripping the user through Unified Ecommerce on login

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "frontend/public/src/lib/auth.js",
         "hashed_secret": "e3c328a97de7239b3f60eecda765a69535205744",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 25
       }
     ],
     "frontend/public/src/lib/test_constants.js": [
@@ -240,5 +240,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-05T12:32:12Z"
+  "generated_at": "2025-01-22T20:35:24Z"
 }

--- a/app.json
+++ b/app.json
@@ -612,6 +612,10 @@
       "description": "Token to access the status API.",
       "required": false
     },
+    "UNIFIED_ECOMMERCE_URL": {
+      "description": "The base URL for Unified Ecommerce.",
+      "required": false
+    },
     "USE_X_FORWARDED_HOST": {
       "description": "Set HOST header to original domain accessed by user",
       "required": false

--- a/frontend/public/src/flow/declarations.js
+++ b/frontend/public/src/flow/declarations.js
@@ -21,7 +21,8 @@ declare type Settings = {
   digital_credentials: boolean,
   digital_credentials_supported_runs: Array<string>,
   posthog_api_token: ?string,
-  posthog_api_host: ?string
+  posthog_api_host: ?string,
+  unified_ecommerce_url: ?string,
 }
 declare var SETTINGS: Settings
 

--- a/frontend/public/src/lib/auth.js
+++ b/frontend/public/src/lib/auth.js
@@ -81,7 +81,10 @@ export const handleAuthResponse = (
   const { state, redirect_url, partial_token, errors, field_errors } = response
   // This is pre-login so we won't be able to flag this out for individual users.
   // The use of "anonymousUser" is historical - see usage in PR #2064 for instance
-  const sendThruEcommerce = checkFeatureFlag("enable_unified_ecommerce", "anonymousUser");
+  const sendThruEcommerce = checkFeatureFlag(
+    "enable_unified_ecommerce",
+    "anonymousUser"
+  )
 
   // If a specific handler function was passed in for this response state, invoke it
   if (has(state, handlers)) {

--- a/frontend/public/src/lib/auth.js
+++ b/frontend/public/src/lib/auth.js
@@ -1,8 +1,10 @@
 // @flow
+/* global SETTINGS: false */
 import qs from "query-string"
 import { isEmpty, includes, has } from "ramda"
 
 import { routes } from "../lib/urls"
+import { checkFeatureFlag } from "../lib/util"
 
 import type { RouterHistory } from "react-router"
 import type { AuthResponse, AuthStates } from "../flow/authTypes"
@@ -77,6 +79,9 @@ export const handleAuthResponse = (
 ) => {
   /* eslint-disable camelcase */
   const { state, redirect_url, partial_token, errors, field_errors } = response
+  // This is pre-login so we won't be able to flag this out for individual users.
+  // The use of "anonymousUser" is historical - see usage in PR #2064 for instance
+  const sendThruEcommerce = checkFeatureFlag("enable_unified_ecommerce", "anonymousUser");
 
   // If a specific handler function was passed in for this response state, invoke it
   if (has(state, handlers)) {
@@ -84,7 +89,18 @@ export const handleAuthResponse = (
   }
 
   if (state === STATE_SUCCESS) {
-    window.location = redirect_url || routes.dashboard
+    const end_location = redirect_url || routes.dashboard
+    if (SETTINGS.unified_ecommerce_url && sendThruEcommerce) {
+      const ecommerce = new URL(`${SETTINGS.unified_ecommerce_url}`)
+
+      ecommerce.pathname = "establish_session/"
+      ecommerce.searchParams.set("next", end_location)
+      ecommerce.searchParams.set("system", "mitxonline")
+
+      window.location = ecommerce.href
+    } else {
+      window.location = end_location
+    }
   } else if (state === STATE_LOGIN_PASSWORD) {
     history.push(routes.login.password)
   } else if (state === STATE_REGISTER_DETAILS) {

--- a/frontend/public/src/lib/auth_test.js
+++ b/frontend/public/src/lib/auth_test.js
@@ -57,7 +57,7 @@ describe("auth lib function", () => {
           state:        "success",
           redirect_url: "/"
         })
-        const handlers = []
+        const handlers = {}
         global.SETTINGS = {
           unified_ecommerce_url: "http://ecommerce"
         }

--- a/frontend/public/src/lib/auth_test.js
+++ b/frontend/public/src/lib/auth_test.js
@@ -11,7 +11,6 @@ import {
 import { routes } from "../lib/urls"
 import { makeRegisterAuthResponse } from "../factories/auth"
 
-
 const util = require("../lib/util")
 
 describe("auth lib function", () => {
@@ -50,22 +49,30 @@ describe("auth lib function", () => {
         sinon.assert.calledWith(handler, response)
       })
     })
-
     ;[true, false].forEach(flagState => {
-      it(`redirects through Unified Ecommerce properly if the feature flag is ${flagState ? "enabled" : "disabled"}`, () => {
-        const response = makeRegisterAuthResponse({ state: "success", redirect_url: "/" })
+      it(`redirects through Unified Ecommerce properly if the feature flag is ${
+        flagState ? "enabled" : "disabled"
+      }`, () => {
+        const response = makeRegisterAuthResponse({
+          state:        "success",
+          redirect_url: "/"
+        })
         const handlers = []
         global.SETTINGS = {
           unified_ecommerce_url: "http://ecommerce"
         }
 
-        sandbox.stub(util, 'checkFeatureFlag').returns(flagState)
+        sandbox.stub(util, "checkFeatureFlag").returns(flagState)
 
-        assert.equal(util.checkFeatureFlag("enable_unified_ecommerce", "anonymousUser"), flagState)
+        assert.equal(
+          util.checkFeatureFlag("enable_unified_ecommerce", "anonymousUser"),
+          flagState
+        )
 
         handleAuthResponse(history, response, handlers)
 
         assert.equal(window.location.hostname, flagState ? "ecommerce" : "fake")
       })
-    })})
+    })
+  })
 })

--- a/main/settings.py
+++ b/main/settings.py
@@ -1199,3 +1199,11 @@ HUBSPOT_PORTAL_ID = get_string(
     default="",
     description="Hubspot Portal ID",
 )
+
+# Unified Ecommerce integration
+
+UNIFIED_ECOMMERCE_URL = get_string(
+    name="UNIFIED_ECOMMERCE_URL",
+    default="http://ue.odl.local:9080/",
+    description="The base URL for Unified Ecommerce.",
+)

--- a/main/utils.py
+++ b/main/utils.py
@@ -52,6 +52,7 @@ def get_js_settings(request: HttpRequest):  # noqa: ARG001
         "features": {},
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,
         "posthog_api_host": settings.POSTHOG_API_HOST,
+        "unified_ecommerce_url": settings.UNIFIED_ECOMMERCE_URL,
     }
 
 

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -51,6 +51,7 @@ def test_get_js_settings(settings, rf):
         "features": {},
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,
         "posthog_api_host": settings.POSTHOG_API_HOST,
+        "unified_ecommerce_url": settings.UNIFIED_ECOMMERCE_URL,
     }
 
 


### PR DESCRIPTION
### What are the relevant tickets?

mitodl/hq#6520

### Description (What does it do?)

After login, this throws the user to the Unified Ecommerce session start endpoint, which will start up a session for the user there and then send them back to MITx Online. This ensures the user can interact with the cart while in MITx Online (to get cart status, add items, etc.). 

### How can this be tested?

The code for this is feature flagged out. Ensure `enable_unified_ecommerce` is configured in PostHog to test this. It needs to be Enabled. (Additionally, you should have your MITx Online setup configured to use PostHog, and ideally a project that you control rather than one of the regular OL ones.) 

You'll need a Unified Ecommerce instance set up. Specifically, it will need to be set up and tracking jkachel/6520-add-updates-to-establish-session so you have the other side of the equation (unless https://github.com/mitodl/unified-ecommerce/pull/200 is merged when you test). The instructions for setting up Unified Ecommerce are in the README and README-keycloak files.

In the `.env` file, optionally set `UNIFIED_ECOMMERCE_URL` to the URL you have set up for the UE API. The default is `http://ue.odl.local:9080/' - if you've set the hostnames up differently, then you should set this appropriately. Do not set this to the port for the frontend (8072 usually).

In Unified Ecommerce, you should have an Integrated System set up with a slug named "mitxonline". The homepage URL should be set to the root URL for your MITx Online instance. 

Ensure you have a Web Inspector pulled up into the Network tab, and enable Preserve Log. Then, log into the system. Once you've entered your password, you should see that you're being thrown to Unified Ecommerce. You'll likely have to log into Keycloak, and then you should be thrown back to MITx Online.

If you start somewhere that redirects you into login (like, from clicking Enroll on a course while logged out), you should be sent back to the proper page.

Note that if you have a Keycloak session already - in other words, you logged into Unified Ecommerce before MITx Online - you won't be prompted to log in again. We don't expose a logout from the UI, but you can log out of Unified Ecommerce by going to `http://ue.odl.local:9080/logout`. This will destroy your UE session and your Keycloak session, so you'll have a blank slate.

### Additional Context

The learner needs a UE session so that they can interact with the API (i.e. get cart status, add things to cart, etc.). Doing this by throwing the user to UE once they've logged into MITx Online seemed like a reasonable way to do this. 

Once MITx Online auths through Keycloak, UE will pick up the existing Keycloak session and start its own session up using that. Since these will share the same underlying Keycloak instance, the sessions should all be the same.

The feature flag check happens before the learner logs in, so we will be limited in our ability to conditionally enable the flag. We can limit the flag via the client's IP address, but we should be careful to check/clear these as we're testing because IP addresses often change on consumer-grade Internet connections. 