### PR TITLE
Adding cart items info to the header

### DIFF
--- a/ecommerce/views/v0/__init__.py
+++ b/ecommerce/views/v0/__init__.py
@@ -205,6 +205,27 @@ class BasketViewSet(
     def get_queryset(self):
         return Basket.objects.filter(user=self.request.user).all()
 
+    @action(
+        detail=False,
+        methods=["get"],
+        name="Basket Items Count",
+        url_name="basket_items_count",
+    )
+    def get_items_in_basket(self):
+        basket, _ = Basket.objects.get_or_create(user=self.request.user)
+        print(basket.get_products())
+        print(basket.get_products().count())
+
+        print(basket.get_basket_items())
+        print(basket.products.all())
+        return Response(
+            {
+                "message": "Discount applied",
+                "cartItemsCount": 5,
+            }
+        )
+
+
 
 class BasketItemViewSet(
     NestedViewSetMixin, ListCreateAPIView, mixins.DestroyModelMixin, GenericViewSet

--- a/frontend/public/src/components/TopBar.js
+++ b/frontend/public/src/components/TopBar.js
@@ -35,7 +35,7 @@ const TopBar = ({ currentUser }: Props) => {
       currentUser.id :
       "anonymousUser"
   )
-  const cartItemCount = 0
+  const cartItemCount = 1
   return (
     <header className="site-header d-flex d-flex flex-column">
       {showComponent ? (

--- a/frontend/public/src/containers/App.js
+++ b/frontend/public/src/containers/App.js
@@ -32,11 +32,19 @@ import CatalogPage from "./pages/CatalogPage"
 
 import type { Match, Location } from "react-router"
 import type { CurrentUser } from "../flow/authTypes"
+import {pathOr} from "ramda"
+import {
+  cartItemsCountQuery,
+  cartItemsCountQueryKey,
+  cartItemsCountSelector,
+  coursesQuery
+} from "../lib/queries/courseRuns"
 
 type Props = {
   match: Match,
   location: Location,
   currentUser: ?CurrentUser,
+  cartItemsCount: number,
   addUserNotification: Function
 }
 
@@ -135,15 +143,18 @@ export class App extends React.Component<Props, void> {
 }
 
 const mapStateToProps = createStructuredSelector({
-  currentUser: currentUserSelector
+  currentUser:    currentUserSelector,
+  cartItemsCount: cartItemsCountSelector,
 })
 
 const mapDispatchToProps = {
   addUserNotification
 }
 
-const mapPropsToConfig = () => [users.currentUserQuery()]
-
+const mapPropsToConfig = props => [
+  cartItemsCountQuery(props.courseId),
+  users.currentUserQuery()
+]
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   connectRequest(mapPropsToConfig)

--- a/frontend/public/src/lib/queries/courseRuns.js
+++ b/frontend/public/src/lib/queries/courseRuns.js
@@ -4,6 +4,7 @@ import { nextState } from "./util"
 
 export const courseRunsSelector = pathOr(null, ["entities", "courseRuns"])
 export const coursesSelector = pathOr(null, ["entities", "courses"])
+export const cartItemsCountSelector = pathOr(null, ["entities", "cartItemsCount"])
 export const programsSelector = pathOr(null, ["entities", "programs"])
 
 export const courseRunsQueryKey = "courseRuns"
@@ -31,6 +32,18 @@ export const coursesQuery = (courseKey: string = "") => ({
     courses: nextState
   }
 })
+
+export const cartItemsCountQuery = () => ({
+  queryKey:  "cartItemsCount",
+  url:       `/api/baskets/basket_items_count/`,
+  transform: json => ({
+    cartItemsCount: json
+  }),
+  update: {
+    cartItemsCount: nextState
+  }
+})
+
 
 // This will need to be updated to v2 once we get the courses endpoint to allow for multiple ID query
 export const programsQuery = (programKey: string = "") => ({


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5662

### Description (What does it do?)
Adds an api call for cart items count in the header component.

### Screenshots (if appropriate):
<img width="446" alt="Screenshot 2025-01-23 at 2 40 34 PM" src="https://github.com/user-attachments/assets/f4b9f975-ee82-4655-b91e-31c3a9d28fbb" />


### How can this be tested?
Add a product to your cart , you should see the cart have a label with a number at the header.