### PR TITLE
removing order from InstructorPageLink

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1105,7 +1105,7 @@ class ProductPage(VideoPlayerConfigMixin, MetadataPageMixin):
         InlinePanel(
             "linked_instructors",
             label="Faculty Members",
-            help_text="If you need to change the order of faculty members, please delete and add them in the correct order, instead of re-choosing"),
+        )
     ]
 
     subpage_types = ["FlexiblePricingRequestForm", "CertificatePage"]

--- a/cms/models.py
+++ b/cms/models.py
@@ -14,7 +14,7 @@ from django.core.cache import caches
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.forms import ChoiceField, DecimalField, TextInput
+from django.forms import ChoiceField, DecimalField
 from django.http import Http404
 from django.template.response import TemplateResponse
 from django.urls import reverse

--- a/cms/models.py
+++ b/cms/models.py
@@ -637,7 +637,9 @@ class InstructorPageLink(models.Model):  # noqa: DJ008
     )
     order = models.SmallIntegerField(default=1, null=True, blank=True)
 
+    readonly_fields= ("order",)
     panels = [
+        FieldPanel('order'),
         PageChooserPanel("linked_instructor_page", "cms.InstructorPage"),
     ]
 
@@ -1102,7 +1104,10 @@ class ProductPage(VideoPlayerConfigMixin, MetadataPageMixin):
         FieldPanel("feature_image"),
         FieldPanel("video_url"),
         FieldPanel("faculty_section_title"),
-        InlinePanel("linked_instructors", label="Faculty Members"),
+        InlinePanel(
+            "linked_instructors",
+            label="Faculty Members",
+            help_text="If you need to change the order of faculty members, please delete and add them in the correct order, instead of re-choosing"),
     ]
 
     subpage_types = ["FlexiblePricingRequestForm", "CertificatePage"]

--- a/cms/models.py
+++ b/cms/models.py
@@ -14,7 +14,7 @@ from django.core.cache import caches
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.forms import ChoiceField, DecimalField
+from django.forms import ChoiceField, DecimalField, TextInput
 from django.http import Http404
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -637,9 +637,7 @@ class InstructorPageLink(models.Model):  # noqa: DJ008
     )
     order = models.SmallIntegerField(default=1, null=True, blank=True)
 
-    readonly_fields= ("order",)
     panels = [
-        FieldPanel('order'),
         PageChooserPanel("linked_instructor_page", "cms.InstructorPage"),
     ]
 
@@ -1145,7 +1143,7 @@ class ProductPage(VideoPlayerConfigMixin, MetadataPageMixin):
     def get_context(self, request, *args, **kwargs):  # noqa: ARG002
         instructors = [
             member.linked_instructor_page
-            for member in self.linked_instructors.order_by("order").all()
+            for member in self.linked_instructors.all()
         ]
 
         return {

--- a/cms/models.py
+++ b/cms/models.py
@@ -1105,7 +1105,7 @@ class ProductPage(VideoPlayerConfigMixin, MetadataPageMixin):
         InlinePanel(
             "linked_instructors",
             label="Faculty Members",
-        )
+        ),
     ]
 
     subpage_types = ["FlexiblePricingRequestForm", "CertificatePage"]
@@ -1142,8 +1142,7 @@ class ProductPage(VideoPlayerConfigMixin, MetadataPageMixin):
 
     def get_context(self, request, *args, **kwargs):  # noqa: ARG002
         instructors = [
-            member.linked_instructor_page
-            for member in self.linked_instructors.all()
+            member.linked_instructor_page for member in self.linked_instructors.all()
         ]
 
         return {


### PR DESCRIPTION
### What are the relevant tickets?
fix https://github.com/mitodl/hq/issues/6415

### Description (What does it do?)
Removing the ordering of instructor link page. It doesn't do anything useful.

When the admin re-chooses instructors the order is unpredictable, or at least was unpredictable.


### How can this be tested?
1. Go to cms page. Start editing a course page by adding a bunch of instructors to the page. Check the order on the page.
2. Then go ahead and change some of the selection to another instructor. Check the order of instructors on the page again. (this used to mess up the order)

3. Then try deleting and adding them in the desired order.
Check that the order is as expected.




