### PR TITLE
docs yml correct python version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install ghp-import
         run: pip install ghp-import
       - name: Build documentation


### PR DESCRIPTION
### What are the relevant tickets?
Fix this error 
`The version '3.1' with architecture 'x64' was not found for Ubuntu 22.04`
### Description (What does it do?)
puts 3.10 in quotes.

