### PR TITLE
Prevent linking existing user if uid is different

### DIFF
--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -61,6 +61,22 @@ def get_username(strategy, backend, user=None, *args, **kwargs):  # pylint: disa
     return {"username": None if not user else strategy.storage.user.get_username(user)}
 
 
+def limit_one_auth_per_backend(strategy, backend, user, uid, **kwargs):  # pylint: disable=unused-argument
+    """Limit the user to one social auth account per backend"""
+    if not user:
+        return {}
+
+    user_storage = strategy.storage.user
+    social_auths = user_storage.get_social_auth_for_user(user, backend.name)
+
+    # if there's at least one social auth and any of them don't match the incoming uid
+    # we have or are trying to add mutltiple accounts
+    if social_auths and any(auth.uid != uid for auth in social_auths):
+        raise AuthException(backend.name, "Another edX account is already linked to your MITxOnline account.")
+
+    return {}
+
+
 @partial
 def create_user_via_email(
     strategy,

--- a/main/settings.py
+++ b/main/settings.py
@@ -367,6 +367,7 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.social_user",
     # Associates the current social details with another user account with the same email address.
     "social_core.pipeline.social_auth.associate_by_email",
+    "authentication.pipeline.user.limit_one_auth_per_backend",
     # validate an incoming email auth request
     "authentication.pipeline.user.validate_email_auth_request",
     # validate the user's email either it is blocked or not.


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/6588

### Description (What does it do?)
If a user is currently logged in under email address, social auth should reject an attempt to link the accounts.

### How can this be tested?
