### PR TITLE
Allow to defer enrollment without to_run

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -343,7 +343,7 @@ def defer_enrollment(  # noqa: C901
             keep_failed_enrollments=keep_failed_enrollments,
             mode=EDX_ENROLLMENT_AUDIT_MODE,
         )
-        return downgraded_enrollments, None
+        return first_or_none(downgraded_enrollments), None
 
     if not force and not from_enrollment.active:
         raise ValidationError(

--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -34,7 +34,6 @@ class Command(EnrollmentChangeCommand):
             "--to-run",
             type=str,
             help="The 'courseware_id' value for the CourseRun that you are deferring to",
-            required=True,
         )
         parser.add_argument(
             "-k",
@@ -71,16 +70,11 @@ class Command(EnrollmentChangeCommand):
             raise CommandError(f"Invalid enrollment deferral - {exc}")  # noqa: B904, EM102
         except Exception as exc:  # noqa: BLE001
             raise CommandError(f"{exc}")  # noqa: B904, EM102
-        else:
-            if not to_enrollment:
-                raise CommandError(
-                    f"Failed to create/update the target enrollment ({to_courseware_id})"  # noqa: EM102
-                )
 
         self.stdout.write(
             self.style.SUCCESS(
                 f"Deferred enrollment for user: {user}\n"
                 f"Enrollment deactivated: {enrollment_summary(from_enrollment)}\n"
-                f"Enrollment created/updated: {enrollment_summary(to_enrollment)}"
+                f"Enrollment created/updated: {enrollment_summary(to_enrollment) if to_enrollment else 'N/A'}"
             )
         )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Awhile ago we added the possibility to defer enrollments without providing a course run to defer to. Now I the management command can do that too.

Try to run the management command:
`./manage.py defer_enrollment --user example@mit.edu --from-run  course-v1:MITxT+18.01.1x+1T2025
`
you should get 
```
Deferred enrollment for user: User username=username email=example@mit.edu
Enrollment deactivated: <CourseRunEnrollment: id=2, run=course-v1:MITxT+18.01.1x+1T2025, mode=audit>
Enrollment created/updated: N/A
```

