### PR TITLE
No emails for downgrading enrollment

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -198,7 +198,11 @@ def create_run_enrollments(  # noqa: C901
                 if enrollment.active and enrollment_mode_changed:
                     enrollment.update_mode_and_save(mode=mode)
 
-                if not enrollment.active and enrollment_mode_changed and mode == EDX_ENROLLMENT_AUDIT_MODE:
+                if (
+                    not enrollment.active
+                    and enrollment_mode_changed
+                    and mode == EDX_ENROLLMENT_AUDIT_MODE
+                ):
                     is_enrollment_downgraded = True
 
                 elif not enrollment.active:

--- a/courses/api.py
+++ b/courses/api.py
@@ -220,6 +220,7 @@ def create_run_enrollments(  # noqa: C901
         else:
             successful_enrollments.append(enrollment)
             if enrollment.edx_enrolled and not is_enrollment_downgraded:
+                # Do not send enrollment email if the user was downgraded.
                 mail_api.send_course_run_enrollment_email(enrollment)
     return successful_enrollments, edx_request_success
 

--- a/courses/api.py
+++ b/courses/api.py
@@ -105,7 +105,9 @@ def create_run_enrollments(  # noqa: C901
 ):
     """
     Creates local records of a user's enrollment in course runs, and attempts to enroll them
-    in edX via API
+    in edX via API.
+    Updates the enrollment mode and change_status if the user is already enrolled in the course run
+    and now is changing the enrollment mode, (e.g. pays or re-enrolls again or getting deferred)
 
     Args:
         user (User): The user to enroll
@@ -168,6 +170,7 @@ def create_run_enrollments(  # noqa: C901
     else:
         edx_request_success = True
 
+    is_enrollment_downgraded = False
     for run in runs:
         try:
             enrollment, created = CourseRunEnrollment.all_objects.get_or_create(
@@ -189,9 +192,14 @@ def create_run_enrollments(  # noqa: C901
                     enrollment.change_status = change_status
                     enrollment.save_and_log(None)
                 # Case (Upgrade): When user was enrolled in free mode and now enrolls in paid mode (e.g. Verified)
+                # Case (Downgrade): When user was enrolled in paid mode and downgrades to a free mode in case
+                # of deferral(e.g. Audit)
                 # So, User has an active enrollment and the only changing thing is going to be enrollment mode
                 if enrollment.active and enrollment_mode_changed:
                     enrollment.update_mode_and_save(mode=mode)
+
+                if not enrollment.active and enrollment_mode_changed and mode == EDX_ENROLLMENT_AUDIT_MODE:
+                    is_enrollment_downgraded = True
 
                 elif not enrollment.active:
                     if enrollment_mode_changed:
@@ -207,7 +215,7 @@ def create_run_enrollments(  # noqa: C901
             )
         else:
             successful_enrollments.append(enrollment)
-            if enrollment.edx_enrolled:
+            if enrollment.edx_enrolled and not is_enrollment_downgraded:
                 mail_api.send_course_run_enrollment_email(enrollment)
     return successful_enrollments, edx_request_success
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Currently, if a user gets downgrades from verified to audit they get dent an email about enrolling in the course run.
We should not send email about enrollment in a course if the user got downgraded from "Verified" to "Audit".

### How can this be tested?

You can use a management command to defer your enrollment. The enrollment should be set to "audit" and "deferred" And you should not receive and email about enrolling in an audit mode for the course run.

`./manage.py defer_enrollment --user example@mit.edu --from-run course-v1:MITxT+14.73x+1T2026`