### PR TITLE
making downgrade not send email

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -196,14 +196,10 @@ def create_run_enrollments(  # noqa: C901
                 # of deferral(e.g. Audit)
                 # So, User has an active enrollment and the only changing thing is going to be enrollment mode
                 if enrollment.active and enrollment_mode_changed:
+                    if mode == EDX_ENROLLMENT_AUDIT_MODE and enrollment.enrollment_mode == EDX_ENROLLMENT_VERIFIED_MODE:
+                        # Downgrade the enrollment
+                        is_enrollment_downgraded = True
                     enrollment.update_mode_and_save(mode=mode)
-
-                if (
-                    not enrollment.active
-                    and enrollment_mode_changed
-                    and mode == EDX_ENROLLMENT_AUDIT_MODE
-                ):
-                    is_enrollment_downgraded = True
 
                 elif not enrollment.active:
                     if enrollment_mode_changed:

--- a/courses/api.py
+++ b/courses/api.py
@@ -196,7 +196,10 @@ def create_run_enrollments(  # noqa: C901
                 # of deferral(e.g. Audit)
                 # So, User has an active enrollment and the only changing thing is going to be enrollment mode
                 if enrollment.active and enrollment_mode_changed:
-                    if mode == EDX_ENROLLMENT_AUDIT_MODE and enrollment.enrollment_mode == EDX_ENROLLMENT_VERIFIED_MODE:
+                    if (
+                        mode == EDX_ENROLLMENT_AUDIT_MODE
+                        and enrollment.enrollment_mode == EDX_ENROLLMENT_VERIFIED_MODE
+                    ):
                         # Downgrade the enrollment
                         is_enrollment_downgraded = True
                     enrollment.update_mode_and_save(mode=mode)


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Don't send email when downgrading enrollment.

### How can this be tested?
You can use a management command to defer your enrollment. The enrollment should be set to "audit" and "deferred" And you should not receive and email about enrolling in an audit mode for the course run.

./manage.py defer_enrollment --user example@mit.edu --from-run course-v1:MITxT+14.73x+1T2026