### PR TITLE
Remove duplicated course topics

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -107,15 +107,15 @@ class CourseSerializer(BaseCourseSerializer):
     def get_topics(self, instance):
         """List topics of a course"""
         if hasattr(instance, "page") and instance.page is not None:
-            all_topics = []
             course_topics = instance.page.topics.all()
             parent_topics = CoursesTopic.objects.filter(
-                child_topics__in=all_topics
+                child_topics__in=course_topics
             ).distinct()
             all_topics = sorted(
                 [{"name": topic.name} for topic in course_topics],
                 key=lambda topic: topic["name"],
             )
+
             for parent_topic in parent_topics:
                 all_topics.append({"name": parent_topic.name})
             return all_topics

--- a/courses/wagtail_hooks.py
+++ b/courses/wagtail_hooks.py
@@ -12,8 +12,3 @@ def register_viewset():
     Register `CourseTopicViewSet` in wagtail
     """
     return CourseTopicViewSet("topics")
-
-
-@hooks.register("register_admin_menu_item")
-def register_calendar_menu_item():
-    return MenuItem("Course Topics", "/cms/topics", icon_name="desktop")

--- a/courses/wagtail_hooks.py
+++ b/courses/wagtail_hooks.py
@@ -1,7 +1,6 @@
 """Wagtail hooks for courses app"""
 
 from wagtail import hooks
-from wagtail.admin.menu import MenuItem
 
 from courses.wagtail_views import CourseTopicViewSet
 

--- a/courses/wagtail_views.py
+++ b/courses/wagtail_views.py
@@ -13,4 +13,4 @@ class CourseTopicViewSet(ModelViewSet):
     search_fields = ["name"]
     form_fields = ["parent", "name"]
     list_display = ["name", "parent"]
-    add_to_admin_menu = True
+    add_to_admin_menu = False


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5432

### Description (What does it do?)
Removes the Course topics menu items in the admin view in the cms.
The topics are still available at http://mitxonline.odl.local:8013/cms/topics/.
Adds parent topic for each child topic in the api.

### How can this be tested?
Take a look at the cms admin side bar.
Take a look at https://mitxonline.mit.edu/api/v2/courses/ and make sure that the parent topic appears.
