### PR TITLE
Reset change_status on all requests to create_run_enrollment

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -108,6 +108,10 @@ def create_run_enrollments(  # noqa: C901
     in edX via API.
     Updates the enrollment mode and change_status if the user is already enrolled in the course run
     and now is changing the enrollment mode, (e.g. pays or re-enrolls again or getting deferred)
+    Possible cases are:
+    1. Downgrade: Verified to Audit via a deferral
+    2. Upgrade: Audit to Verified via a payment
+    3. Reactivation: Audit to Audit or Verified to Verified via a re-enrollment
 
     Args:
         user (User): The user to enroll
@@ -188,9 +192,9 @@ def create_run_enrollments(  # noqa: C901
             if not created:
                 enrollment_mode_changed = mode != enrollment.enrollment_mode
                 enrollment.edx_enrolled = edx_request_success
-                if change_status is not None:
-                    enrollment.change_status = change_status
-                    enrollment.save_and_log(None)
+                # This resets the change_status if the enrollment was reactivated or Upgraded/Downgraded
+                enrollment.change_status = change_status
+                enrollment.save_and_log(None)
                 # Case (Upgrade): When user was enrolled in free mode and now enrolls in paid mode (e.g. Verified)
                 # Case (Downgrade): When user was enrolled in paid mode and downgrades to a free mode in case
                 # of deferral(e.g. Audit)


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/6927

### Description (What does it do?)
This effects not just deferrals, but all requests that are modifying an enrollment through this method:

The change status will be set to the provided value or to the default value. Rather then setting it only when the mode was anything else than None.

This allows to reset an active enrollment to a clean state.

This allows for a previously deferred run to get "un-deferred".


### How can this be tested?
You can test it with the management command.
`./manage.py defer_enrollment --user example@mit.edu --from-run  course-v1:MITxT+18.01.1x+1T2025 --to-run course-v1:MITxT+18.01.1x+2T2025`
And then reverse it back
`./manage.py defer_enrollment --user annagav@mit.edu --from-run  course-v1:MITxT+18.01.1x+2T2025 --to-run course-v1:MITxT+18.01.1x+1T2025`