### PR TITLE
automatically create cache table

### DIFF
--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -4,6 +4,7 @@
 
 python3 manage.py collectstatic --noinput --clear
 python3 manage.py migrate --noinput
+python3 manage.py createcachetable
 python3 manage.py configure_wagtail
 
 health_urls=(


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR runs `./manage.py createcachetable` as part of setup.

### How can this be tested?
If you want to test this, you probably need a fairly clean install of mitxonline. After running migrations, you'll get a 500 error `relation "durable_cache" does not exist`. This fixes it. 

In lieu of starting with a fresh db, you could just check that `docker compose up` still works.