### PR TITLE
Fix varnish config for arbitrary hostnames

### DIFF
--- a/config/default.vcl
+++ b/config/default.vcl
@@ -1,22 +1,7 @@
 # specify the VCL syntax version to use
 vcl 4.1;
 
-# import vmod_dynamic for better backend name resolution
-import dynamic;
-
-# we won't use any static backend, but Varnish still need a default one
-backend default none;
-
-# set up a dynamic director
-# for more info, see https://github.com/nigoroll/libvmod-dynamic/blob/master/src/vmod_dynamic.vcc
-sub vcl_init {
-        new d = dynamic.director(port = "8013");
-}
-
-sub vcl_recv {
-	# force the host header to match the backend (not all backends need it,
-	# but example.com does)
-	set req.http.host = "mitxonline.odl.local:8013";
-	# set the backend
-	set req.backend_hint = d.backend("mitxonline.odl.local");
+backend default {
+  .host = "nginx";
+  .port = "8013";
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,9 @@ services:
     environment:
       << : *py-environment
       PORT: 8011
+      # these are necessary to get the hostname from the varnish proxy
+      USE_X_FORWARDED_HOST: true
+      USE_X_FORWARDED_PORT: true
     env_file: .env
     links:
       - db
@@ -86,7 +89,7 @@ services:
     ports:
       - "8012:8012"
     environment:
-      PUBLIC_PATH: http://${MITX_ONLINE_HOSTNAME:-mitxonline.odl.local}:8012/
+      PUBLIC_PATH: ${MITX_ONLINE_WATCH_BASE_URL:-http://mitxonline.odl.local:8012/}
       NODE_ENV: ${NODE_ENV:-development}
       DOCKER_HOST: ${DOCKER_HOST:-missing}
       CONTAINER_NAME: 'watch'
@@ -128,7 +131,7 @@ services:
     ports:
        - "8016:8016"
     environment:
-      PUBLIC_PATH: http://${MITX_ONLINE_HOSTNAME:-mitxonline.odl.local}:8016/
+      PUBLIC_PATH: ${MITX_ONLINE_REFINE_BASE_URL:-http://mitxonline.odl.local:8016/}
       PORT: 8016
       NODE_ENV: ${NODE_ENV:-development}
     volumes:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This simplifies and fixes the varnish configuration so that it doesn't do the extra steps of setting a hardcoded host name.

Instead, the `docker-compse.yml` has been updated to use the forwarded host/port, which accomplishes the same result but will work for arbitrary url bases.

I also made a bit of a breaking change to the way that `PUBLIC_PATH` is set because I need to be able to override the entire string (e.g. `https://mitxonline.odl.local', different protocol and no port). This shouldn't be an issue for most people unless they doing something super custom.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to `docker compose up` and the app should function like normal.