### PR TITLE
Improve openapi schema for enrollments API

### DIFF
--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -73,6 +73,7 @@ from main.constants import (
     USER_MSG_TYPE_ENROLLED,
 )
 from main.utils import encode_json_cookie_value, redirect_with_user_message
+from openapi.utils import extend_schema_get_queryset
 from openedx.api import (
     subscribe_to_edx_course_emails,
     sync_enrollments_with_edx,
@@ -381,19 +382,6 @@ class CreateEnrollmentView(APIView):
         return resp
 
 
-@extend_schema(
-    request=CourseRunEnrollmentSerializer,
-    responses={200: CourseRunEnrollmentSerializer},
-    parameters=[
-        OpenApiParameter(
-            name="id",
-            type=OpenApiTypes.INT,
-            location=OpenApiParameter.PATH,
-            description="Course run enrollment ID",
-            required=True,
-        )
-    ],
-)
 class UserEnrollmentsApiViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
@@ -406,6 +394,7 @@ class UserEnrollmentsApiViewSet(
     serializer_class = CourseRunEnrollmentSerializer
     permission_classes = [IsAuthenticated]
 
+    @extend_schema_get_queryset(CourseRunEnrollment.objects.none())
     def get_queryset(self):
         return (
             CourseRunEnrollment.objects.filter(user=self.request.user)

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -153,13 +153,6 @@ paths:
     get:
       operationId: enrollments_list
       description: API view set for user enrollments
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: Course run enrollment ID
-        required: true
       tags:
       - enrollments
       responses:
@@ -174,13 +167,6 @@ paths:
     post:
       operationId: enrollments_create
       description: API view set for user enrollments
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: Course run enrollment ID
-        required: true
       tags:
       - enrollments
       requestBody:
@@ -196,7 +182,7 @@ paths:
               $ref: '#/components/schemas/CourseRunEnrollmentRequest'
         required: true
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
@@ -211,7 +197,7 @@ paths:
         name: id
         schema:
           type: integer
-        description: Course run enrollment ID
+        description: A unique integer value identifying this course run enrollment.
         required: true
       tags:
       - enrollments
@@ -242,7 +228,7 @@ paths:
         name: id
         schema:
           type: integer
-        description: Course run enrollment ID
+        description: A unique integer value identifying this course run enrollment.
         required: true
       tags:
       - enrollments
@@ -272,17 +258,13 @@ paths:
         name: id
         schema:
           type: integer
-        description: Course run enrollment ID
+        description: A unique integer value identifying this course run enrollment.
         required: true
       tags:
       - enrollments
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CourseRunEnrollment'
-          description: ''
+        '204':
+          description: No response body
   /api/v1/program_enrollments/:
     get:
       operationId: program_enrollments_list

--- a/openapi/utils.py
+++ b/openapi/utils.py
@@ -15,10 +15,10 @@ def extend_schema_get_queryset(queryset: QuerySet):
     """
 
     def decorate(get_queryset):
-        def decorated(self, *args, **kwrags):
+        def decorated(self, *args, **kwargs):
             if getattr(self, "swagger_fake_view", False):  # drf-yasg comp
                 return queryset
-            return get_queryset(self, *args, **kwrags)
+            return get_queryset(self, *args, **kwargs)
 
         return decorated
 

--- a/openapi/utils.py
+++ b/openapi/utils.py
@@ -1,0 +1,25 @@
+from django.db.models import QuerySet
+
+
+def extend_schema_get_queryset(queryset: QuerySet):
+    """
+    DRF Spectacular uses a ViewSet's queryset to generate parts of the schema
+    (for example, the type of the primary key).
+
+    If the queryset cannot be determined at schema generation time (e.g., it
+    requires an authenticated user) then this can be used to specify the
+    queryset.
+
+    See https://drf-spectacular.readthedocs.io/en/latest/faq.html#my-get-queryset-depends-on-some-attributes-not-available-at-schema-generation-time
+    for more information.
+    """
+
+    def decorate(get_queryset):
+        def decorated(self, *args, **kwrags):
+            if getattr(self, "swagger_fake_view", False):  # drf-yasg comp
+                return queryset
+            return get_queryset(self, *args, **kwrags)
+
+        return decorated
+
+    return decorate

--- a/scripts/test/openapi_spec_check.sh
+++ b/scripts/test/openapi_spec_check.sh
@@ -13,6 +13,6 @@ if [ $? -eq 0 ]; then
 	echo "OpenAPI spec is up to date!"
 	exit 0
 else
-	echo "OpenAPI spec is out of date. Please regenerate via ./scripts/generate_openapi.sh"
+	echo "OpenAPI spec is out of date. Please regenerate via ./manage.py generate_openapi_spec"
 	exit 1
 fi


### PR DESCRIPTION
### What are the relevant tickets?

Related to https://github.com/mitodl/hq/issues/7004

### Description (What does it do?)
Fixes some issues with the `api/v1/enrollments/` OpenAPI schema

### How can this be tested?
1. Tests should pass
2. http://mitxonline.odl.local:8013/dashboard/ should still show your enrollments
3. http://mitxonline.odl.local:8013/api/v1/enrollments/ should still show your enrollments
