### PR TITLE
Successfully enroll in test course runs without clalling edX

### DIFF
--- a/courses/management/commands/populate_course_data.py
+++ b/courses/management/commands/populate_course_data.py
@@ -15,13 +15,14 @@ User = get_user_model()
 
 COURSE_DATA_PATH = "courses/management/courses.json"
 FAKE_COURSE_DESC_PREFIX = "[FAKE] "
+FAKE_TAG_PREFIX = "fake-"
 
 
 def generate_run_defaults(run):
     """Generates default values for a CourseRun based on the provided run data"""
     now = now_in_utc()
     run_defaults = {
-        "run_tag": f"fake-{run['run_tag']}{now.year}",
+        "run_tag": f"{FAKE_TAG_PREFIX}{run['run_tag']}{now.year}",
         "live": True,
         "title": run["title"],
         "upgrade_deadline": f"{now.year}{run['upgrade_deadline']}",
@@ -39,7 +40,7 @@ def generate_run_defaults(run):
         run_defaults["end_date"] = f"{previous_year}{run['end_date']}"
         run_defaults["enrollment_start"] = f"{previous_year}{run['enrollment_start']}"
         run_defaults["enrollment_end"] = f"{now.year}{run['enrollment_end']}"
-        run_defaults["run_tag"] = f"fake-{run['run_tag']}{previous_year}"
+        run_defaults["run_tag"] = f"{FAKE_TAG_PREFIX}{run['run_tag']}{previous_year}"
 
     return run_defaults
 

--- a/courses/management/commands/populate_course_data.py
+++ b/courses/management/commands/populate_course_data.py
@@ -21,7 +21,7 @@ def generate_run_defaults(run):
     """Generates default values for a CourseRun based on the provided run data"""
     now = now_in_utc()
     run_defaults = {
-        "run_tag": f"{run['run_tag']}{now.year}",
+        "run_tag": f"fake-{run['run_tag']}{now.year}",
         "live": True,
         "title": run["title"],
         "upgrade_deadline": f"{now.year}{run['upgrade_deadline']}",
@@ -39,7 +39,7 @@ def generate_run_defaults(run):
         run_defaults["end_date"] = f"{previous_year}{run['end_date']}"
         run_defaults["enrollment_start"] = f"{previous_year}{run['enrollment_start']}"
         run_defaults["enrollment_end"] = f"{now.year}{run['enrollment_end']}"
-        run_defaults["run_tag"] = f"{run['run_tag']}{previous_year}"
+        run_defaults["run_tag"] = f"fake-{run['run_tag']}{previous_year}"
 
     return run_defaults
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -769,6 +769,13 @@ class CourseRun(TimestampedModel):
         )
 
     @property
+    def is_fake_course_run(self):
+        """
+        Checks if a course run is a fake course run
+        """
+        return self.run_tag.startswith("fake-")
+
+    @property
     def courseware_url(self):
         """
         Full URL for this CourseRun as it exists in the courseware

--- a/courses/models.py
+++ b/courses/models.py
@@ -30,6 +30,7 @@ from courses.constants import (
     ENROLLABLE_ITEM_ID_SEPARATOR,
     SYNCED_COURSE_RUN_FIELD_MSG,
 )
+from courses.management.commands.populate_course_data import FAKE_TAG_PREFIX
 from main.models import AuditableModel, AuditModel, ValidateOnSaveMixin
 from main.utils import serialize_model_object
 from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENTS_PAID_MODES
@@ -773,7 +774,7 @@ class CourseRun(TimestampedModel):
         """
         Checks if a course run is a fake course run
         """
-        return self.run_tag.startswith("fake-")
+        return self.run_tag.startswith(FAKE_TAG_PREFIX)
 
     @property
     def courseware_url(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -30,7 +30,6 @@ from courses.constants import (
     ENROLLABLE_ITEM_ID_SEPARATOR,
     SYNCED_COURSE_RUN_FIELD_MSG,
 )
-from courses.management.commands.populate_course_data import FAKE_TAG_PREFIX
 from main.models import AuditableModel, AuditModel, ValidateOnSaveMixin
 from main.utils import serialize_model_object
 from openedx.constants import EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENTS_PAID_MODES
@@ -774,7 +773,7 @@ class CourseRun(TimestampedModel):
         """
         Checks if a course run is a fake course run
         """
-        return self.run_tag.startswith(FAKE_TAG_PREFIX)
+        return self.run_tag.startswith("fake_")
 
     @property
     def courseware_url(self):


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5336

### Description (What does it do?)
Allows to enroll in test course runs without enrollment in edX.

### Screenshots (if appropriate):
<img width="1669" alt="Screenshot 2025-04-02 at 2 13 50 PM" src="https://github.com/user-attachments/assets/3d1d4aa6-09fb-4596-a19d-4f61c8f75d57" />

### How can this be tested?
In django shell run `./manage.py populate_course_data`

Enroll in one of the test courses named starting with "Case 1:"
Enroll in other courses make sure enrollment works.