### PR TITLE
Add xdist so tests can be run faster

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
           - ".*_test.js"
           - --exclude-files
           - "config/keycloak/*"
+        additional_dependencies: ["gibberish-detector"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.7.0"
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -84,6 +84,10 @@
       "min_level": 2
     },
     {
+      "path": "detect_secrets.filters.gibberish.should_exclude_secret",
+      "limit": 3.7
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -125,51 +129,6 @@
     }
   ],
   "results": {
-    ".github/workflows/new-issues.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/new-issues.yml",
-        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "authentication/utils.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "authentication/utils.py",
-        "hashed_secret": "e3c328a97de7239b3f60eecda765a69535205744",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    "docker-compose.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docker-compose.yml",
-        "hashed_secret": "965748b380ab0ab25d1846afc174a3d93a8ec06c",
-        "is_verified": false,
-        "line_number": 6
-      }
-    ],
-    "frontend/public/src/constants.js": [
-      {
-        "type": "Secret Keyword",
-        "filename": "frontend/public/src/constants.js",
-        "hashed_secret": "f99d98e85f9064a9b39c10c0d10fa2151df4a764",
-        "is_verified": false,
-        "line_number": 132
-      }
-    ],
-    "frontend/public/src/lib/auth.js": [
-      {
-        "type": "Secret Keyword",
-        "filename": "frontend/public/src/lib/auth.js",
-        "hashed_secret": "e3c328a97de7239b3f60eecda765a69535205744",
-        "is_verified": false,
-        "line_number": 25
-      }
-    ],
     "frontend/public/src/lib/test_constants.js": [
       {
         "type": "Base64 High Entropy String",
@@ -188,15 +147,6 @@
         "line_number": 24
       }
     ],
-    "main/settings.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "main/settings.py",
-        "hashed_secret": "09edaaba587f94f60fbb5cee2234507bcb883cc2",
-        "is_verified": false,
-        "line_number": 1014
-      }
-    ],
     "pants": [
       {
         "type": "Hex High Entropy String",
@@ -204,15 +154,6 @@
         "hashed_secret": "ed24096d9c520ce62fa2af60a0137a0f96facd73",
         "is_verified": false,
         "line_number": 39
-      }
-    ],
-    "pytest.ini": [
-      {
-        "type": "Secret Keyword",
-        "filename": "pytest.ini",
-        "hashed_secret": "b235838f76594bf21886c6eec9c06a207e9ec5ce",
-        "is_verified": false,
-        "line_number": 20
       }
     ],
     "users/api.py": [
@@ -230,16 +171,7 @@
         "is_verified": false,
         "line_number": 164
       }
-    ],
-    "users/serializers.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "users/serializers.py",
-        "hashed_secret": "ab90d9d736f9e0909b62d0922e0482e4b827449f",
-        "is_verified": false,
-        "line_number": 243
-      }
     ]
   },
-  "generated_at": "2025-03-18T15:57:12Z"
+  "generated_at": "2025-04-03T10:32:50Z"
 }

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 """Project conftest"""
 
+import uuid
 from types import SimpleNamespace  # noqa: F401
 
 import pytest
@@ -21,6 +22,13 @@ def default_settings(monkeypatch, settings):  # noqa: PT004
 def mocked_product_signal(mocker):  # noqa: PT004
     """Mock hubspot_sync signals"""
     mocker.patch("ecommerce.signals.sync_hubspot_product")
+
+
+@pytest.fixture(autouse=True)
+def payment_gateway_settings(settings):  # noqa: PT004
+    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY = "Test Security Key"
+    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY = "Test Access Key"
+    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID = uuid.uuid4()
 
 
 def pytest_addoption(parser):

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1,7 +1,6 @@
 """Tests for Ecommerce api"""
 
 import random
-import uuid
 from datetime import datetime
 
 import pytest
@@ -107,13 +106,6 @@ def products():
 def user(db):
     """Creates a user"""
     return UserFactory.create()
-
-
-@pytest.fixture(autouse=True)
-def payment_gateway_settings():  # noqa: PT004
-    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY = "Test Security Key"
-    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY = "Test Access Key"
-    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID = uuid.uuid4()
 
 
 @pytest.fixture(autouse=True)

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -315,22 +315,32 @@ def get_test_order_data(order, receipt_data):
             "street_address": [],
         },
         "receipt": {
-            "card_number": receipt_data["req_card_number"]  # noqa: SIM401
-            if "req_card_number" in receipt_data
-            else None,
-            "card_type": CYBERSOURCE_CARD_TYPES[receipt_data["req_card_type"]]
-            if "req_card_type" in receipt_data
-            else None,
-            "payment_method": receipt_data["req_payment_method"]  # noqa: SIM401
-            if "req_payment_method" in receipt_data
-            else None,
-            "bill_to_email": receipt_data["req_bill_to_email"]  # noqa: SIM401
-            if "req_bill_to_email" in receipt_data
-            else None,
-            "name": f"{receipt_data['req_bill_to_forename']} {receipt_data['req_bill_to_surname']}"
-            if "req_bill_to_forename" in receipt_data
-            or "req_bill_to_surname" in receipt_data
-            else None,
+            "card_number": (
+                receipt_data["req_card_number"]  # noqa: SIM401
+                if "req_card_number" in receipt_data
+                else None
+            ),
+            "card_type": (
+                CYBERSOURCE_CARD_TYPES[receipt_data["req_card_type"]]
+                if "req_card_type" in receipt_data
+                else None
+            ),
+            "payment_method": (
+                receipt_data["req_payment_method"]  # noqa: SIM401
+                if "req_payment_method" in receipt_data
+                else None
+            ),
+            "bill_to_email": (
+                receipt_data["req_bill_to_email"]  # noqa: SIM401
+                if "req_bill_to_email" in receipt_data
+                else None
+            ),
+            "name": (
+                f"{receipt_data['req_bill_to_forename']} {receipt_data['req_bill_to_surname']}"
+                if "req_bill_to_forename" in receipt_data
+                or "req_bill_to_surname" in receipt_data
+                else None
+            ),
         },
     }
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1,13 +1,11 @@
 import operator as op
 import random
-import uuid
 from datetime import datetime, timedelta
 
 import freezegun
 import pytest
 import pytz
 import reversion
-from django.conf import settings
 from django.forms.models import model_to_dict
 from django.urls import reverse
 from mitol.common.utils.datetime import now_in_utc
@@ -77,13 +75,6 @@ def discounts():
 def user(db):
     """Creates a user"""
     return UserFactory.create()
-
-
-@pytest.fixture(autouse=True)
-def payment_gateway_settings():  # noqa: PT004
-    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY = "Test Security Key"
-    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY = "Test Access Key"
-    settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID = uuid.uuid4()
 
 
 @pytest.fixture(autouse=True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1467,6 +1467,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "executing"
 version = "2.0.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -2885,6 +2899,29 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "psutil"
+version = "7.0.0"
+description = "Cross-platform lib for process and system monitoring in Python.  NOTE: the syntax of this script MUST be kept compatible with Python 2.7."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25"},
+    {file = "psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993"},
+    {file = "psutil-7.0.0-cp36-cp36m-win32.whl", hash = "sha256:84df4eb63e16849689f76b1ffcb36db7b8de703d1bc1fe41773db487621b6c17"},
+    {file = "psutil-7.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e"},
+    {file = "psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99"},
+    {file = "psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553"},
+    {file = "psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black (==24.10.0)", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
+test = ["pytest", "pytest-xdist", "setuptools"]
+
+[[package]]
 name = "psycopg2"
 version = "2.9.9"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
@@ -3308,6 +3345,27 @@ pytest = ">=5.0"
 
 [package.extras]
 dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+psutil = {version = ">=3.0", optional = true, markers = "extra == \"psutil\""}
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
 
 [[package]]
 name = "python-dateutil"
@@ -4402,4 +4460,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.16"
-content-hash = "71ce257c8fc6f55927abb2ecfb256a65868b061bd73244d4f112f04122b6d9d1"
+content-hash = "102014938b5082e0e9e02f4f9453c3c435cc6f3427d0a41cdd3500d9d844df7e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ responses = "^0.25.0"
 ruff = "^0.9"
 semantic-version = "^2.10.0"
 wagtail-factories = "^4.2"
+pytest-xdist = {extras = ["psutil"], version = "^3.6.1"}
 
 [tool.ruff]
 target-version = "py39"

--- a/scripts/test/python_tests.sh
+++ b/scripts/test/python_tests.sh
@@ -20,6 +20,6 @@ function run_test {
 run_test ./scripts/test/detect_missing_migrations.sh
 run_test ./scripts/test/no_auto_migrations.sh
 run_test ./scripts/test/openapi_spec_check.sh
-run_test pytest
+run_test pytest -n logical
 
 exit $status


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Python tests have been taking an increasing amount of time to run, definitely locally and I suspect github actions are suffering as well. This adds the plugin `pytest-xdist` which allows the tests to run in parallel. Each test worker gets its own db so they don't stomp on each other.

It also fixes the ecommerce tests which starting failing when run in parallel because some the settings fixture (moved to `conftest.py`) was setting the settings on the global django settings instead of the pytest `settings` fixture so it was leaking across test boundaries, but in such a way that it allowed other tests to pass that otherwise wouldn't have the correct configuration if they ran earlier.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You can run this a few ways (you don't need to test them all, but test at least one `-n` option):

- `pytest` - same as before, everything is run serially
- `pytest -n auto` - run 1 process per physical cpu
- `pytest -n logical` - run 1 process per logical cpu
- `pytest -n N` - run N processes