### PR TITLE
Check that if social auths already exist we dont create another

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -194,7 +194,7 @@
         "filename": "main/settings.py",
         "hashed_secret": "09edaaba587f94f60fbb5cee2234507bcb883cc2",
         "is_verified": false,
-        "line_number": 1014
+        "line_number": 1016
       }
     ],
     "pants": [
@@ -241,5 +241,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-18T15:57:12Z"
+  "generated_at": "2025-04-02T20:32:06Z"
 }

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -8,6 +8,7 @@ from social_core.backends.email import EmailAuth
 from social_core.exceptions import AuthException
 from social_core.pipeline.partial import partial
 from social_core.pipeline.user import create_user
+from social_django.models import UserSocialAuth
 
 from authentication.backends.ol_open_id_connect import OlOpenIdConnectAuth
 from authentication.exceptions import (
@@ -286,3 +287,29 @@ def create_openedx_user(strategy, backend, user=None, is_new=False, **kwargs):  
         )
 
     return {}
+
+
+def limit_one_auth_per_backend(strategy, backend, user, uid, **kwargs):  # pylint: disable=unused-argument # noqa: ARG001
+    """
+    Limit the user to one social auth account per backend
+    Args:
+        strategy (social_django.strategy.DjangoStrategy): the strategy used to authenticate
+        backend (social_core.backends.base.BaseAuth): the backend being used to authenticate
+        user (User): the current user
+        uid (str): the uid of the user
+    """
+    if not user:
+        return {}
+
+    social_auths = UserSocialAuth.objects.filter(user=user, provider=backend.name)
+
+    # if there's at least one social auth and any of them don't match the incoming uid
+    # we have or are trying to add multiple accounts
+    if social_auths and all(auth.uid != uid for auth in social_auths):
+        raise AuthException(
+            backend.name,
+            "Another account exists but is linked to a different MITxOnline account.",
+        )
+
+    return {}
+

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -312,4 +312,3 @@ def limit_one_auth_per_backend(strategy, backend, user, uid, **kwargs):  # pylin
         )
 
     return {}
-

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -10,9 +10,9 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError
 from rest_framework import status
 from social_core.backends.email import EmailAuth
-from social_django.utils import load_backend, load_strategy
 from social_core.exceptions import AuthException
 from social_django.models import UserSocialAuth
+from social_django.utils import load_backend, load_strategy
 
 from authentication.exceptions import (
     EmailBlockedException,
@@ -635,6 +635,7 @@ def test_create_ol_oidc_user(  # noqa: PLR0913
             assert not strategy.create_user.called
     else:
         assert response == {}
+
 
 def test_limit_one_auth_per_backend_no_user(mocker):
     """limit_one_auth_per_backend should not error if the user doesn't exist"""

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -11,6 +11,8 @@ from django.db import IntegrityError
 from rest_framework import status
 from social_core.backends.email import EmailAuth
 from social_django.utils import load_backend, load_strategy
+from social_core.exceptions import AuthException
+from social_django.models import UserSocialAuth
 
 from authentication.exceptions import (
     EmailBlockedException,
@@ -24,7 +26,7 @@ from authentication.exceptions import (
 from authentication.pipeline import user as user_actions
 from authentication.utils import SocialAuthState
 from openedx.api import OPENEDX_REGISTRATION_VALIDATION_PATH
-from users.factories import UserFactory
+from users.factories import UserFactory, UserSocialAuthFactory
 
 User = get_user_model()
 FAKE = faker.Faker()
@@ -633,3 +635,33 @@ def test_create_ol_oidc_user(  # noqa: PLR0913
             assert not strategy.create_user.called
     else:
         assert response == {}
+
+def test_limit_one_auth_per_backend_no_user(mocker):
+    """limit_one_auth_per_backend should not error if the user doesn't exist"""
+    mock_strategy = mocker.Mock()
+    mock_backend = mocker.Mock()
+    assert (
+        user_actions.limit_one_auth_per_backend(
+            strategy=mock_strategy, backend=mock_backend, user=None, uid=None
+        )
+        == {}
+    )
+
+
+@pytest.mark.django_db
+def test_limit_one_auth_per_backend_conflicting_auth(mocker, user):
+    """limit_one_auth_per_backend should error if the user already has an auth for that backend"""
+    mock_strategy = mocker.Mock()
+    mock_backend = mocker.Mock()
+    mock_backend.name = "email"
+    UserSocialAuthFactory.create(user=user, provider=mock_backend.name)
+
+    assert (
+        UserSocialAuth.objects.filter(user=user, provider=mock_backend.name).count()
+        == 1
+    )
+
+    with pytest.raises(AuthException):
+        user_actions.limit_one_auth_per_backend(
+            backend=mock_backend, user=user, strategy=mock_strategy, uid="non-matching"
+        )

--- a/main/settings.py
+++ b/main/settings.py
@@ -382,6 +382,8 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.social_user",
     # Associates the current social details with another user account with the same email address.
     "social_core.pipeline.social_auth.associate_by_email",
+    # Make sure we are not creating duplicate auth
+    "authentication.pipeline.user.limit_one_auth_per_backend",
     # validate an incoming email auth request
     "authentication.pipeline.user.validate_email_auth_request",
     # validate the user's email either it is blocked or not.


### PR DESCRIPTION
### What are the relevant tickets?
Similar to this reverted PR https://github.com/mitodl/mitxonline/pull/2546
But makes sure not to create extra auths going forward, rather than checking if multiple already exist (which plenty of them do)
### Description (What does it do?)
Makes sure not to create another social auth for same provider

### How can this be tested?
Try to create multiple auths for the same provider.
