### PR TITLE
add more scenarios

### DIFF
--- a/courses/management/commands/populate_course_data.py
+++ b/courses/management/commands/populate_course_data.py
@@ -26,6 +26,7 @@ def generate_run_defaults(run):
         "live": True,
         "title": run["title"],
         "upgrade_deadline": f"{now.year}{run['upgrade_deadline']}",
+        "is_self_paced": run["is_self_paced"],
     }
 
     if run["is_enrollable"]:

--- a/courses/management/courses.json
+++ b/courses/management/courses.json
@@ -149,5 +149,248 @@
                 "price": 100
             }
         ]
+    },
+    {
+        "title": "Case 5: Enroll Closed, Future Open, Upgrade Available for Both",
+        "readable_id": "course-v1:MITxT+0.005x",
+        "description": "This course is has one past run, future run open for enrollment, and has an upgrade option available for both.",
+        "topics": [],
+        "price": 100,
+        "min_weeks": null,
+        "max_weeks": null,
+        "min_weekly_hours": 3,
+        "max_weekly_hours": 6,
+        "length": "8 weeks",
+        "course_runs": [
+            {
+                "courseware_id": "course-v1:MITxT+0.005x+1T",
+                "title": "Case 5: Enroll Closed, Future Open, Upgrade Available for Both",
+                "upgrade_deadline": "-12-31T23:59:59Z",
+                "start_date": "-01-01T00:00:00Z",
+                "end_date": "-01-01T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-01-01T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": false,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "1T",
+                "live": true,
+                "price": 100
+            },
+            {
+                "courseware_id": "course-v1:MITxT+0.005x+2T",
+                "title": "Case 5: Enroll Closed, Future Open, Upgrade Available for Both",
+                "upgrade_deadline": "-12-31T23:59:59Z",
+                "start_date": "-12-31T00:00:00Z",
+                "end_date": "-12-31T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-12-31T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": true,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "2T",
+                "live": true,
+                "price": 100
+            }
+        ]
+    },
+    {
+        "title": "Case 6: Enroll Closed, Future Open, Upgrade Only Future",
+        "readable_id": "course-v1:MITxT+0.006x",
+        "description": "This course is has one past run, future run open for enrollment, and has an upgrade option available for the future run.",
+        "topics": [],
+        "price": 100,
+        "min_weeks": null,
+        "max_weeks": null,
+        "min_weekly_hours": 3,
+        "max_weekly_hours": 6,
+        "length": "8 weeks",
+        "course_runs": [
+            {
+                "courseware_id": "course-v1:MITxT+0.006x+1T",
+                "title": "Case 6: Enroll Closed, Future Open, Upgrade Only Future",
+                "upgrade_deadline": "-01-01T00:00:00Z",
+                "start_date": "-01-01T00:00:00Z",
+                "end_date": "-01-01T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-01-01T23:59:59Z",
+                "is_upgradable": false,
+                "is_enrollable": false,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "1T",
+                "live": true,
+                "price": 100
+            },
+            {
+                "courseware_id": "course-v1:MITxT+0.006x+2T",
+                "title": "Case 6: Enroll Closed, Future Open, Upgrade Only Future",
+                "upgrade_deadline": "-12-31T23:59:59Z",
+                "start_date": "-12-31T00:00:00Z",
+                "end_date": "-12-31T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-12-31T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": true,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "2T",
+                "live": true,
+                "price": 100
+            }
+        ]
+    },
+    {
+        "title": "Case 7: Enroll Closed, No Future Run, Upgrade Available",
+        "readable_id": "course-v1:MITxT+0.007x",
+        "description": "This course is has one past run, no future run, and is upgradable",
+        "topics": [],
+        "price": 100,
+        "min_weeks": null,
+        "max_weeks": null,
+        "min_weekly_hours": 3,
+        "max_weekly_hours": 6,
+        "length": "8 weeks",
+        "course_runs": [
+            {
+                "courseware_id": "course-v1:MITxT+0.007x+1T",
+                "title": "Case 7: Enroll Closed, No Future Run, Upgrade Available",
+                "upgrade_deadline": "-12-31T23:59:59Z",
+                "start_date": "-01-01T00:00:00Z",
+                "end_date": "-01-01T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-01-01T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": false,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "1T",
+                "live": true,
+                "price": 100
+            }
+        ]
+    },
+    {
+        "title": "Case 8: Enroll Closed, No Future Run, No Upgrade",
+        "readable_id": "course-v1:MITxT+0.008x",
+        "description": "This course is has one past run, no future run, and is not upgradable",
+        "topics": [],
+        "price": 100,
+        "min_weeks": null,
+        "max_weeks": null,
+        "min_weekly_hours": 3,
+        "max_weekly_hours": 6,
+        "length": "8 weeks",
+        "course_runs": [
+            {
+                "courseware_id": "course-v1:MITxT+0.008x+1T",
+                "title": "Case 8: Enroll Closed, No Future Run, No Upgrade",
+                "upgrade_deadline": "-01-01T23:59:59Z",
+                "start_date": "-01-01T00:00:00Z",
+                "end_date": "-01-01T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-01-01T23:59:59Z",
+                "is_upgradable": false,
+                "is_enrollable": false,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "1T",
+                "live": true,
+                "price": 100
+            }
+        ]
+    },
+    {
+        "title": "Case 9: Enroll Open, Future Not Yet Open, Upgrade Both",
+        "readable_id": "course-v1:MITxT+0.009x",
+        "description": "This course is has one current self-paced run, future run open for enrollment, and has an upgrade option available for the future run.",
+        "topics": [],
+        "price": 100,
+        "min_weeks": null,
+        "max_weeks": null,
+        "min_weekly_hours": 3,
+        "max_weekly_hours": 6,
+        "length": "8 weeks",
+        "course_runs": [
+            {
+                "courseware_id": "course-v1:MITxT+0.009x+1T",
+                "title": "Case 9: Enroll Open, Future Not Yet Open, Upgrade Both",
+                "upgrade_deadline": "-12-31T00:00:00Z",
+                "start_date": "-01-01T00:00:00Z",
+                "end_date": "-12-31T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-12-31T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": true,
+                "is_archived": false,
+                "is_self_paced": true,
+                "run_tag": "1T",
+                "live": true,
+                "price": 100
+            },
+            {
+                "courseware_id": "course-v1:MITxT+0.009x+2T",
+                "title": "Case 9: Enroll Open, Future Not Yet Open, Upgrade Both",
+                "upgrade_deadline": "-12-31T23:59:59Z",
+                "start_date": "-12-31T00:00:00Z",
+                "end_date": "-12-31T23:59:59Z",
+                "enrollment_start": "-12-31T23:59:59Z",
+                "enrollment_end": "-12-31T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": false,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "2T",
+                "live": true,
+                "price": 100
+            }
+        ]
+    },
+    {
+        "title": "Case 10: Run Archived Enrollable, Future Enrollment Open",
+        "readable_id": "course-v1:MITxT+0.010x",
+        "description": "One archived run with a start date that was closer to now, one future run open for enroll but the start date is further away from now.",
+        "topics": [],
+        "min_weeks": null,
+        "max_weeks": null,
+        "min_weekly_hours": 3,
+        "max_weekly_hours": 6,
+        "length": "8 weeks",
+        "course_runs": [
+            {
+                "courseware_id": "course-v1:MITxT+0.010x+1T",
+                "title": "Case 10: Run Archived Enrollable, Future Enrollment Open",
+                "upgrade_deadline": "-01-01T23:59:59Z",
+                "start_date": "-01-01T00:00:00Z",
+                "end_date": "-12-31T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-12-31T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": true,
+                "is_archived": true,
+                "is_self_paced": false,
+                "run_tag": "1T",
+                "live": true,
+                "price": 100
+            },
+            {
+                "courseware_id": "course-v1:MITxT+0.010x+2T",
+                "title": "Case 10: Run Archived Enrollable, Future Enrollment Open",
+                "upgrade_deadline": "-01-01T23:59:59Z",
+                "start_date": "-12-31T00:00:00Z",
+                "end_date": "-12-31T23:59:59Z",
+                "enrollment_start": "-01-01T00:00:00Z",
+                "enrollment_end": "-12-31T23:59:59Z",
+                "is_upgradable": true,
+                "is_enrollable": false,
+                "is_archived": false,
+                "is_self_paced": false,
+                "run_tag": "2T",
+                "live": true,
+                "price": 100
+            }
+        ]
     }
 ]


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5335
### Description (What does it do?)
<!--- Describe your changes in detail -->

Add more courses with different runs based on the issue https://github.com/mitodl/hq/issues/5335.

Run `./manage.py populate_course_data`

got to `http://mitxonline.odl.local:8013/catalog/courses/test-scenarios-department` to view them.
or http://mitxonline.odl.local:8013/courses/course-v1:MITxT+0.010x/