### PR TITLE
Small fix for the fake test course runs

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -773,7 +773,7 @@ class CourseRun(TimestampedModel):
         """
         Checks if a course run is a fake course run
         """
-        return self.run_tag.startswith("fake_")
+        return self.run_tag.startswith("fake")
 
     @property
     def courseware_url(self):


### PR DESCRIPTION
### What are the relevant tickets?
related to https://github.com/mitodl/mitxonline/pull/2584
I add a typo after resolving a circular import in the previous PR.

### Description (What does it do?)
Fixing a little typo


### How can this be tested?
Enrollment in test courses should succeed.