### PR TITLE
Make Preview certificate work in the CMS

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -422,8 +422,16 @@ class CertificatePage(CourseProgramChildPage):
         context = {}
 
         if request.is_preview:
+            is_program_certificate = False
+            if isinstance(self.parent, ProgramPage):
+                is_program_certificate = True
+                product_name = self.parent.program.title
+            else:
+                product_name = self.parent.course.title
             preview_context = {
+                "uuid": "fake-uuid",
                 "learner_name": "Anthony M. Stark",
+                "product_name": product_name,
                 "start_date": (
                     self.parent.product.first_unexpired_run.start_date
                     if self.parent.product.first_unexpired_run
@@ -435,6 +443,7 @@ class CertificatePage(CourseProgramChildPage):
                     else datetime.now() + timedelta(days=45)  # noqa: DTZ005
                 ),
                 "CEUs": self.CEUs,
+                "is_program_certificate": is_program_certificate,
             }
         elif self.certificate:
             # Verify that the certificate in fact is for this same course


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/7052#issuecomment-2787490264
### Description (What does it do?)
Make Preview certificate work in the CMS

### Screenshots (if appropriate):
<img width="1088" alt="Screenshot 2025-04-10 at 2 09 08 PM" src="https://github.com/user-attachments/assets/4c3e0def-4735-4e9f-95f5-e1687b086bda" />
<img width="1157" alt="Screenshot 2025-04-10 at 2 08 50 PM" src="https://github.com/user-attachments/assets/fbc569d2-3651-4c94-8b0b-67f05bba20cf" />


### How can this be tested?
Created a certificate page for a program or a course.
Create Signatories.
Preview the pages.
