### PR TITLE
Add a compose profile for apisix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,8 @@ services:
 
   api:
     image: apache/apisix:latest
+    profiles:
+      - apisix
     environment:
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-ol-local}
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-apisix}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The APISIX service is missing a `profile`, this adds it.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
By default the service should not start, add `apisix` to `COMPOSE_PROFILES` to have it start:

```COMPOSE_PROFILES=apisix docker compose up```