### PR TITLE
Make email settings more clear

### DIFF
--- a/app.json
+++ b/app.json
@@ -190,10 +190,6 @@
       "description": "Maximum number of emails to send in a batch",
       "required": false
     },
-    "MAILGUN_FROM_EMAIL": {
-      "description": "Email which mail comes from",
-      "required": false
-    },
     "MAILGUN_KEY": {
       "description": "The token for authenticating against the Mailgun API",
       "required": true
@@ -483,7 +479,7 @@
       "required": false
     },
     "MITX_ONLINE_SUPPORT_EMAIL": {
-      "description": "Email address listed for customer support",
+      "description": "Email address listed for customer support in the frontend. Not used for sending email.",
       "required": false
     },
     "MITX_ONLINE_USE_S3": {

--- a/main/settings.py
+++ b/main/settings.py
@@ -538,18 +538,19 @@ EMAIL_USE_TLS = get_bool(
     description="Outgoing e-mail TLS setting",
 )
 
-MITX_ONLINE_REPLY_TO_ADDRESS = get_string(
-    name="MITX_ONLINE_REPLY_TO_ADDRESS",
-    default="webmaster@localhost",
-    description="E-mail to use for reply-to address of emails",
-)
-
 DEFAULT_FROM_EMAIL = get_string(
     name="MITX_ONLINE_FROM_EMAIL",
     default="webmaster@localhost",
     description="E-mail to use for the from field",
 )
 
+MITX_ONLINE_REPLY_TO_ADDRESS = get_string(
+    name="MITX_ONLINE_REPLY_TO_ADDRESS",
+    default=DEFAULT_FROM_EMAIL,
+    description="E-mail to use for reply-to address of emails",
+)
+
+MAILGUN_FROM_EMAIL = DEFAULT_FROM_EMAIL
 MAILGUN_SENDER_DOMAIN = get_string(
     name="MAILGUN_SENDER_DOMAIN",
     default=None,
@@ -573,16 +574,11 @@ MAILGUN_RECIPIENT_OVERRIDE = get_string(
     dev_only=True,
     description="Override the recipient for outgoing email, development only",
 )
-MAILGUN_FROM_EMAIL = get_string(
-    name="MAILGUN_FROM_EMAIL",
-    default="no-reply@localhost",
-    description="Email which mail comes from",
-)
 
 EMAIL_SUPPORT = get_string(
     name="MITX_ONLINE_SUPPORT_EMAIL",
     default=MAILGUN_RECIPIENT_OVERRIDE or "support@localhost",
-    description="Email address listed for customer support",
+    description="Email address listed for customer support in the frontend. Not used for sending email.",
 )
 
 NOTIFICATION_EMAIL_BACKEND = get_string(


### PR DESCRIPTION
### What are the relevant tickets?

mitodl/hq#4051

### Description (What does it do?)

A handful of changes that make the email configuration settings more clear:

- Set the Mailgun From override to the `MITX_ONLINE_FROM_EMAIL` setting so we don't have >1 setting for this
- Set `MITX_ONLINE_REPLY_TO_ADDRESS` to default to `MITX_ONLINE_FROM_EMAIL` (since this seems like a reasonable choice)
- Update the description of `EMAIL_SUPPORT` to note that the setting is only a display setting

Following this, the only environment setting you really have to set will be `MITX_ONLINE_FROM_EMAIL`. (Mostly, this is just to make things slightly less confusing.)

### How can this be tested?

All tests should pass. If you have a usable Mailgun setup, you can try things that send email and see what you get back. There should be no functional changes.

### Additional Context

There will be a related PR to make sure the settings for deployment are correct too.