### PR TITLE
Fix some issues with Docker infra config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10.16-slim AS base
 
-LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
+LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
 WORKDIR /tmp
@@ -55,15 +55,15 @@ RUN python3 -m venv $VIRTUAL_ENV
 RUN poetry install
 
 
-FROM poetry as code
+FROM poetry AS code
 
 COPY . /src
 WORKDIR /src
 
 # Set pip cache folder, as it is breaking pip when it is on a shared volume
-ENV XDG_CACHE_HOME /tmp/.cache
+ENV XDG_CACHE_HOME=/tmp/.cache
 
-FROM node:17.9 as node
+FROM node:17.9 AS node
 
 COPY --from=code /src /src
 WORKDIR /src
@@ -71,17 +71,17 @@ WORKDIR /src
 RUN yarn workspace mitx-online-public install --immutable && \
     yarn workspace mitx-online-public run build
 
-FROM code as django-server
+FROM code AS django-server
 
 EXPOSE 8013
-ENV PORT 8013
-CMD uwsgi uwsgi.ini
+ENV PORT=8013
+CMD ["uwsgi", "uwsgi.ini"]
 
-FROM django-server as production
+FROM django-server AS production
 
-copy --from=node /src /src
+COPY --from=node /src /src
 
-FROM code as jupyter-notebook
+FROM code AS jupyter-notebook
 
 RUN pip install --force-reinstall jupyter
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,13 +124,13 @@ services:
       - db
       - redis
     volumes:
-      - .:/app
+      - .:/src
       - django_media:/var/media
     extra_hosts: *default-extra-hosts
 
   refine:
     image: node:17.9
-    working_dir: /app
+    working_dir: /src
     command: ["/bin/bash", "./scripts/run-refine-dev.sh"]
     ports:
        - "8016:8016"
@@ -139,7 +139,7 @@ services:
       PORT: 8016
       NODE_ENV: ${NODE_ENV:-development}
     volumes:
-      - .:/app
+      - .:/src
       - npm-cache:/root/.npm
     depends_on:
       # this doesn't really depend on watch but they step on each other if they start at the same time
@@ -159,7 +159,7 @@ services:
       target: jupyter-notebook
     profiles: ["notebook"]
     volumes:
-      - .:/app
+      - .:/src
     environment:
       << : *py-environment
     env_file: .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: django-server
-    command: ./scripts/run-django-dev.sh
+    command: ["/bin/bash", "./scripts/run-django-dev.sh"]
     stdin_open: true
     tty: true
     ports:
@@ -82,14 +82,14 @@ services:
       - watch
       - refine
     volumes:
-      - .:/app
+      - .:/src
       - django_media:/var/media
     extra_hosts: *default-extra-hosts
 
   watch:
     image: node:17.9
-    working_dir: /app
-    command: ./scripts/run-watch-dev.sh
+    working_dir: /src
+    command: ["/bin/bash", "./scripts/run-watch-dev.sh"]
     ports:
       - "8012:8012"
     environment:
@@ -100,7 +100,7 @@ services:
       PORT: 8012
     env_file: .env
     volumes:
-      - .:/app
+      - .:/src
       - yarn-cache:/home/mitodl/.cache/yarn
     healthcheck:
       test: curl -f http://watch:8012/health || exit 1
@@ -131,7 +131,7 @@ services:
   refine:
     image: node:17.9
     working_dir: /app
-    command: ./scripts/run-refine-dev.sh
+    command: ["/bin/bash", "./scripts/run-refine-dev.sh"]
     ports:
        - "8016:8016"
     environment:


### PR DESCRIPTION

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)

Fixes some issues with pathnames in the Docker Compose environment. For the Kubernetes deployment, the Dockerfile changed to put the app at `/src` in the image, not `/app` - but the mounts in the Compose file got missed, so it didn't seem like changes were being propagated into your running container. This fixes that. (The path change is to keep things in line with other EKS deployments.) 

Also fixes some smaller things:
- Commands now use json format - this is the preferred method - and scripts get run via `/bin/bash` instead of directly
- In some places, the case for Dockerfile commands wasn't correct, so fixed that
- `ENV` should use the `variable=value` syntax now. (Also, `LABEL`.)

### How can this be tested?

App should work normally. If you make changes, you should see them in the running container too.

### Additional Context

I didn't muck with the nginx settings. It still mounts the app in `/app`, which is fine for its purposes.

This does change the mounts in the watch and refine containers too, though, for consistency (since these are things we actually touch).

The script changes are more because I broke my file permissions locally, but it's also slightly better to be explicit.