### PR TITLE
Update the extra hosts section to include local.openedx.io

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ x-extra-hosts:
   &default-extra-hosts # pragma: allowlist secret
   - "edx.odl.local:${OPENEDX_IP:-172.22.0.1}"
   - "host.docker.internal:host-gateway"
-  - "local.edly.io:host-gateway"
   - "local.openedx.io:host-gateway"
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ x-extra-hosts:
   - "edx.odl.local:${OPENEDX_IP:-172.22.0.1}"
   - "host.docker.internal:host-gateway"
   - "local.edly.io:host-gateway"
+  - "local.openedx.io:host-gateway"
 
 services:
   db:


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

Just adds local.openedx.io to the `x-extra-hosts` section in the Compose file. Tutor defaults to this hostname now. You can certainly set up Tutor to use a different one, but we might as well have the default in there too.

### How can this be tested?

Ideally, you have a Tutor instance or can get one set up that uses the default `local.openedx.io` domain name. You should be able to use the MITx Online integration stuff with Tutor successfully.

Practically, the `web` and `celery` containers just need to be able to talk to a container that's outside the MITx Online network using the `local.openedx.io` hostname. Since we're aliasing this to `host-gateway`, this means the container can be anything that can respond on a port. You can just use the `nginx` container for this: `docker run --rm -p 80:80 nginx` Then, in a separate terminal, run `docker compose run --rm web curl -v http://local.openedx.io` - you should get a page back. This should also work if you swap `web` for `celery`. 
