### PR TITLE
fix: use host-gateway for local.openedx.io to fix Open edX API auth session creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ x-extra-hosts:
   &default-extra-hosts # pragma: allowlist secret
   - "edx.odl.local:${OPENEDX_IP:-172.22.0.1}"
   - "host.docker.internal:host-gateway"
-  - "local.edly.io:host-gateway"
+  - "local.openedx.io:host-gateway"
 
 services:
   db:

--- a/main/settings.py
+++ b/main/settings.py
@@ -1041,13 +1041,13 @@ MITOL_AUTHENTICATION_REPLY_TO_EMAIL = MITX_ONLINE_REPLY_TO_ADDRESS
 
 OPENEDX_OAUTH_PROVIDER = get_string(
     name="OPENEDX_OAUTH_PROVIDER",
-    default="mitxpro-oauth2",
+    default="ol-oauth2",
     description="Social auth provider backend name",
 )
 
 OPENEDX_SOCIAL_LOGIN_PATH = get_string(
     name="OPENEDX_SOCIAL_LOGIN_PATH",
-    default="/auth/login/mitxpro-oauth2/?auth_entry=login",
+    default="/auth/login/ol-oauth2/?auth_entry=login",
     description="Open edX social auth login url",
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
Fixes the social auth issue of not creating `OpenEdxApiAuth` with tutor

### Description (What does it do?)
This PR resolves an issue where social auth fails to create an `OpenEdxApiAuth` record when using Tutor.

Through investigation, I discovered that Tutor only preserves login sessions for requests coming from the `local.openedx.io` domain. If you attempt to log in from `localhost:8000`, authentication appears successful (no errors in the logs), but navigating to the dashboard reveals that the user is not actually logged in. The same issue occurs when requests originate from host.docker.internal.

During the `OpenEdxApiAuth` creation flow, the request is sent to edX with a session cookie, but the server treats it as anonymous and redirects to the login page rather than the intended redirect_uri.

To fix this, the PR maps the container's edX requests to local.openedx.io via Docker's host-gateway, ensuring that the session is preserved and authentication succeeds.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Checkout this branch and run: `docker-compose up -d`
- Once containers have restarted, follow the social auth integration steps from the [setup docs](https://mitodl.github.io/handbook/openedx/MITx-edx-integration-tutor.html).  
  Ensure that the `OPENEDX_API_BASE_URL` is set to `http://local.openedx.io:8000`.
- In a private/incognito window, register a new user.  
  Verify that a corresponding entry is created in the `http://mitxonline.odl.local:8053/admin/courseware/openedxapiauth/` admin page.
- Enroll the user in a course and open it in edX.  
  Confirm that the user is successfully enrolled on edX.
- For any existing users missing an `OpenEdxApiAuth` record, run the following inside the web container:  
  `python manage.py repair_missing_courseware_records`  
  There should be no errors, and the missing entries should be created.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Related PR: https://github.com/mitodl/mitxpro/pull/3470


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
