### PR TITLE
Fix username regression in openedx grade api

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -596,9 +596,7 @@ def get_edx_grades_with_users(course_run, user=None):
         all_grades = list(edx_course_grades.all_current_grades)
         for edx_grade in all_grades:
             try:
-                user = User.objects.get(
-                    openedx_users__edx_username=edx_grade.username
-                )
+                user = User.objects.get(openedx_users__edx_username=edx_grade.username)
             except User.DoesNotExist:  # noqa: PERF203
                 log.warning("User with username %s not found", edx_grade.username)
             else:


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/6576057829/?referrer=slack&notification_uuid=7f8edacf-3e9a-4aee-bb4e-69451d22098e&alert_rule_id=14636035&alert_type=issue

### Description (What does it do?)
I think this error was introduced in this PR: https://github.com/mitodl/mitxonline/pull/2594/
This PR just reverts that change introduced in that PR.
