### PR TITLE
Update edx user profile asynchronously

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -55,7 +55,7 @@ class CurrentUserRetrieveUpdateViewSet(
             update_result = super().update(request, *args, **kwargs)
             if user_name != request.data.get("name"):
                 tasks.change_edx_user_name_async.delay(request.user.id)
-            tasks.update_edx_user_profile(request.user.id)
+            tasks.update_edx_user_profile.delay(request.user.id)
             sync_hubspot_user(request.user)
             return update_result
 


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/7308

### Description (What does it do?)

Update edx user profile asynchronously

### How can this be tested?

Try to save profile while missing OpenEdxApiAuth
