### PR TITLE
Add API key for B2B data

### DIFF
--- a/b2b/models.py
+++ b/b2b/models.py
@@ -1,5 +1,6 @@
 """Models for B2B data."""
 
+from django.contrib.auth import get_user_model
 from django.db import models
 from django.http import Http404
 from django.utils.text import slugify
@@ -79,6 +80,17 @@ class OrganizationPage(Page):
         self.slug = slugify(f"org-{self.name}")
         Page.save(self, clean=clean, user=user, log_action=log_action, **kwargs)
 
+    def get_learners(self):
+        """Get the learners associated with this organization."""
+
+        return (
+            get_user_model()
+            .objects.filter(
+                b2b_contracts__organization=self,
+            )
+            .distinct()
+        )
+
 
 class ContractPage(Page):
     """Stores information about a contract with an organization."""
@@ -150,3 +162,14 @@ class ContractPage(Page):
 
         self.slug = slugify(f"contract-{self.organization.id}-{self.id}")
         Page.save(self, clean=clean, user=user, log_action=log_action, **kwargs)
+
+    def get_learners(self):
+        """Get the learners associated with this organization."""
+
+        return (
+            get_user_model()
+            .objects.filter(
+                b2b_contracts=self,
+            )
+            .distinct()
+        )

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -2,6 +2,7 @@
 
 from rest_framework import viewsets
 from rest_framework.permissions import IsAdminUser
+from rest_framework_api_key.permissions import HasAPIKey
 
 from b2b.models import ContractPage, OrganizationPage
 from b2b.serializers.v0 import ContractPageSerializer, OrganizationPageSerializer
@@ -14,7 +15,7 @@ class OrganizationPageViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = OrganizationPage.objects.all()
     serializer_class = OrganizationPageSerializer
-    permission_classes = [IsAdminUser]
+    permission_classes = [IsAdminUser | HasAPIKey]
     lookup_field = "slug"
     lookup_url_kwarg = "organization_slug"
 
@@ -26,6 +27,6 @@ class ContractPageViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = ContractPage.objects.all()
     serializer_class = ContractPageSerializer
-    permission_classes = [IsAdminUser]
+    permission_classes = [IsAdminUser | HasAPIKey]
     lookup_field = "slug"
     lookup_url_kwarg = "contract_slug"

--- a/main/settings.py
+++ b/main/settings.py
@@ -228,6 +228,7 @@ INSTALLED_APPS = (
     "health_check.contrib.celery_ping",
     "health_check.contrib.redis",
     "health_check.contrib.db_heartbeat",
+    "rest_framework_api_key",
 )
 # Only include the seed data app if this isn't running in prod
 # if ENVIRONMENT not in ("production", "prod"):

--- a/poetry.lock
+++ b/poetry.lock
@@ -203,18 +203,18 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.38.13"
+version = "1.38.15"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "boto3-1.38.13-py3-none-any.whl", hash = "sha256:668400d13889d2d2fcd66ce785cc0b0fc040681f58a9c7f67daa9149a52b6c63"},
-    {file = "boto3-1.38.13.tar.gz", hash = "sha256:6633bce2b73284acce1453ca85834c7c5a59e0dbcce1170be461cc079bdcdfcf"},
+    {file = "boto3-1.38.15-py3-none-any.whl", hash = "sha256:f2239b8c2816dd03a2a97297d33d5f7899f23be3a261db9a09ca691c32b7ddc2"},
+    {file = "boto3-1.38.15.tar.gz", hash = "sha256:dca60f7a3ead91c05cf471f7750e54d63b92bfc0e61fa122e2e3f5140e020a8d"},
 ]
 
 [package.dependencies]
-botocore = ">=1.38.13,<1.39.0"
+botocore = ">=1.38.15,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.12.0,<0.13.0"
 
@@ -223,14 +223,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.38.13"
+version = "1.38.15"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "botocore-1.38.13-py3-none-any.whl", hash = "sha256:de29fee43a1f02787fb5b3756ec09917d5661ed95b2b2d64797ab04196f69e14"},
-    {file = "botocore-1.38.13.tar.gz", hash = "sha256:22feee15753cd3f9f7179d041604078a1024701497d27b22be7c6707e8d13ccb"},
+    {file = "botocore-1.38.15-py3-none-any.whl", hash = "sha256:9cc149ef56c3b99aff5436f26b71ad9558a45e4ac6b25b7b7046b0889279e601"},
+    {file = "botocore-1.38.15.tar.gz", hash = "sha256:6adb3b1b0739153d5dc9758e5e06f7596290999c07ed8f9167ca62a1f97c6592"},
 ]
 
 [package.dependencies]
@@ -583,14 +583,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.2.0"
 description = "Composable command line interface toolkit"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+    {file = "click-8.2.0-py3-none-any.whl", hash = "sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c"},
+    {file = "click-8.2.0.tar.gz", hash = "sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d"},
 ]
 
 [package.dependencies]
@@ -1158,7 +1158,7 @@ test = ["boto3", "celery", "django-storages", "pytest", "pytest-cov", "pytest-dj
 [package.source]
 type = "git"
 url = "https://github.com/revsys/django-health-check"
-reference = "HEAD"
+reference = "9cfe2eaec5a15219513a36210b34875c03c64fe4"
 resolved_reference = "9cfe2eaec5a15219513a36210b34875c03c64fe4"
 
 [[package]]
@@ -1422,14 +1422,14 @@ user-agents = "*"
 
 [[package]]
 name = "django-viewflow"
-version = "2.2.10"
+version = "2.2.11"
 description = "Reusable library to build business applications fast"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "django_viewflow-2.2.10-py3-none-any.whl", hash = "sha256:8d5697ab3b174c03bdcfea8c4b3c7ddfe982f4a1ec917cc90e01358153a7acd8"},
-    {file = "django_viewflow-2.2.10.tar.gz", hash = "sha256:666990e279056c2aabbd43a2bd7411dba63978e5fd962d79f6408780d7c1794d"},
+    {file = "django-viewflow-2.2.11.tar.gz", hash = "sha256:d44241b912cefe11ec70dbd9f2712a7bc17f6691d37ffa5eb10dad0c534b5ca0"},
+    {file = "django_viewflow-2.2.11-py3-none-any.whl", hash = "sha256:518ec75be2e735881cbfaa31f03d40a41b8b2e5a066677dfbc27c210f95135b6"},
 ]
 
 [package.dependencies]
@@ -1462,6 +1462,21 @@ files = [
 
 [package.dependencies]
 django = ">=4.2"
+
+[[package]]
+name = "djangorestframework-api-key"
+version = "3.1.0"
+description = "API key permissions for the Django REST Framework"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "djangorestframework_api_key-3.1.0-py3-none-any.whl", hash = "sha256:1b6ed7d89308cf872b29084cf68f9b7171f7efd2b8f84f480c09aa4232f910c1"},
+    {file = "djangorestframework_api_key-3.1.0.tar.gz", hash = "sha256:7e9c88360933b3c46467d80645a50cf36697674c7856a737a1c674d570860ac9"},
+]
+
+[package.dependencies]
+packaging = "*"
 
 [[package]]
 name = "djangorestframework-simplejwt"
@@ -1646,16 +1661,19 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.2"
+version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
+    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
 ]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
@@ -3695,14 +3713,14 @@ test = ["pytest", "pytest-xdist", "setuptools"]
 
 [[package]]
 name = "psycopg"
-version = "3.2.7"
+version = "3.2.9"
 description = "PostgreSQL database adapter for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "psycopg-3.2.7-py3-none-any.whl", hash = "sha256:d39747d2d5b9658b69fa462ad21d31f1ba4a5722ad1d0cb952552bc0b4125451"},
-    {file = "psycopg-3.2.7.tar.gz", hash = "sha256:9afa609c7ebf139827a38c0bf61be9c024a3ed743f56443de9d38e1efc260bf3"},
+    {file = "psycopg-3.2.9-py3-none-any.whl", hash = "sha256:01a8dadccdaac2123c916208c96e06631641c0566b22005493f09663c7a8d3b6"},
+    {file = "psycopg-3.2.9.tar.gz", hash = "sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700"},
 ]
 
 [package.dependencies]
@@ -3710,8 +3728,8 @@ typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
-binary = ["psycopg-binary (==3.2.7) ; implementation_name != \"pypy\""]
-c = ["psycopg-c (==3.2.7) ; implementation_name != \"pypy\""]
+binary = ["psycopg-binary (==3.2.9) ; implementation_name != \"pypy\""]
+c = ["psycopg-c (==3.2.9) ; implementation_name != \"pypy\""]
 dev = ["ast-comments (>=1.1.2)", "black (>=24.1.0)", "codespell (>=2.2)", "dnspython (>=2.1)", "flake8 (>=4.0)", "isort-psycopg", "isort[colors] (>=6.0)", "mypy (>=1.14)", "pre-commit (>=4.0.1)", "types-setuptools (>=57.4)", "types-shapely (>=2.0)", "wheel (>=0.37)"]
 docs = ["Sphinx (>=5.0)", "furo (==2022.6.21)", "sphinx-autobuild (>=2021.3.14)", "sphinx-autodoc-typehints (>=1.12)"]
 pool = ["psycopg-pool"]
@@ -4663,14 +4681,14 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "sentry-sdk"
-version = "2.27.0"
+version = "2.28.0"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "sentry_sdk-2.27.0-py2.py3-none-any.whl", hash = "sha256:c58935bfff8af6a0856d37e8adebdbc7b3281c2b632ec823ef03cd108d216ff0"},
-    {file = "sentry_sdk-2.27.0.tar.gz", hash = "sha256:90f4f883f9eff294aff59af3d58c2d1b64e3927b28d5ada2b9b41f5aeda47daf"},
+    {file = "sentry_sdk-2.28.0-py2.py3-none-any.whl", hash = "sha256:51496e6cb3cb625b99c8e08907c67a9112360259b0ef08470e532c3ab184a232"},
+    {file = "sentry_sdk-2.28.0.tar.gz", hash = "sha256:14d2b73bc93afaf2a9412490329099e6217761cbab13b6ee8bc0e82927e1504e"},
 ]
 
 [package.dependencies]
@@ -5491,4 +5509,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "3ea9698fe1df0210eda038478602c586fb1cbe23c852e341f1862ea5d55b7924"
+content-hash = "30ed507e75df59ef6f3ffee47143ee84f689748d9162e7db0b915141e489612b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ uwsgi = "^2.0.19"
 uwsgitop = "^0.12"
 wagtail = "6.3"
 wagtail-metadata = "^5.0.0"
+djangorestframework-api-key = "^3.1.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/users/models.py
+++ b/users/models.py
@@ -18,6 +18,7 @@ from mitol.common.utils import now_in_utc
 
 from b2b.models import OrganizationPage
 from cms.constants import CMS_EDITORS_GROUP_NAME
+from openedx.constants import OPENEDX_USERNAME_MAX_LEN
 from openedx.models import OpenEdxUser
 
 MALE = "m"
@@ -171,7 +172,9 @@ def _post_create_user(user, username):
     """
     LegalAddress.objects.create(user=user)
     UserProfile.objects.create(user=user)
-    OpenEdxUser.objects.create(user=user, edx_username=username)
+    OpenEdxUser.objects.create(
+        user=user, edx_username=username[:OPENEDX_USERNAME_MAX_LEN]
+    )
 
 
 class UserManager(BaseUserManager):


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#7244

### Description (What does it do?)

Other systems will likely need to access the B2B data (orgs and contracts) stored in the system. This adds API key authentication for those endpoints, so you can be either an admin user or supply an API key to access the data.

This also updates the `b2b_list` command to add an option to list out the users that are associated with an org or contract.

### How can this be tested?

Automated tests should pass.

You should be able to create an API key in the Django Admin. Then, you should be able to access the b2b endpoints using the key: `curl -H "Authorization: Api-Key <key>" http://mitxonline.odl.local:9080/api/v0/b2b/organizations/` (and `contracts`). 

You should be able to run `b2b_list learners` and specify either `--contract` or `--org` to list users in a specific org. You may need to go in and add a relationship for a user before you'll see anything - you can do this in Django Admin; you don't have to run through the enrollment code checkout process.
