### PR TITLE
refactor: Remove syslog logging handler

### DIFF
--- a/app.json
+++ b/app.json
@@ -430,14 +430,6 @@
       "description": "E-mail to use for the from field",
       "required": false
     },
-    "MITX_ONLINE_LOG_HOST": {
-      "description": "Remote syslog server hostname",
-      "required": false
-    },
-    "MITX_ONLINE_LOG_HOST_PORT": {
-      "description": "Remote syslog server port",
-      "required": false
-    },
     "MITX_ONLINE_LOG_LEVEL": {
       "description": "The log level default",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -662,18 +662,6 @@ DJANGO_LOG_LEVEL = get_string(
     name="DJANGO_LOG_LEVEL", default="INFO", description="The log level for django"
 )
 
-# For logging to a remote syslog host
-LOG_HOST = get_string(
-    name="MITX_ONLINE_LOG_HOST",
-    default="localhost",
-    description="Remote syslog server hostname",
-)
-LOG_HOST_PORT = get_int(
-    name="MITX_ONLINE_LOG_HOST_PORT",
-    default=514,
-    description="Remote syslog server port",
-)
-
 HOSTNAME = platform.node().split(".")[0]
 
 # nplusone profiler logger configuration
@@ -700,13 +688,6 @@ LOGGING = {
             "class": "logging.StreamHandler",
             "formatter": "verbose",
         },
-        "syslog": {
-            "level": LOG_LEVEL,
-            "class": "logging.handlers.SysLogHandler",
-            "facility": "local7",
-            "formatter": "verbose",
-            "address": (LOG_HOST, LOG_HOST_PORT),
-        },
         "mail_admins": {
             "level": "ERROR",
             "filters": ["require_debug_false"],
@@ -717,7 +698,7 @@ LOGGING = {
         "django": {
             "propagate": True,
             "level": DJANGO_LOG_LEVEL,
-            "handlers": ["console", "syslog"],
+            "handlers": ["console"],
         },
         "django.request": {
             "handlers": ["mail_admins"],
@@ -726,7 +707,7 @@ LOGGING = {
         },
         "nplusone": {"handlers": ["console"], "level": "ERROR"},
     },
-    "root": {"handlers": ["console", "syslog"], "level": LOG_LEVEL},
+    "root": {"handlers": ["console"], "level": LOG_LEVEL},
 }
 
 # server-status


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removes syslog handler from Django logging and relies solely on console logging.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Verify that logs still show up in docker-compose

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
The syslog handler won't work under Docker/Kubernetes. Removing it now that this app is no longer running on Heroku.

