### PR TITLE
Deactivate audit enrollment before deferral

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -23,7 +23,11 @@ from requests.exceptions import HTTPError
 from rest_framework.status import HTTP_404_NOT_FOUND
 
 from courses import mail_api
-from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED, PROGRAM_TEXT_ID_PREFIX, ENROLL_CHANGE_STATUS_UNENROLLED
+from courses.constants import (
+    ENROLL_CHANGE_STATUS_DEFERRED,
+    ENROLL_CHANGE_STATUS_UNENROLLED,
+    PROGRAM_TEXT_ID_PREFIX,
+)
 from courses.models import (
     Course,
     CourseRun,

--- a/courses/api.py
+++ b/courses/api.py
@@ -23,7 +23,7 @@ from requests.exceptions import HTTPError
 from rest_framework.status import HTTP_404_NOT_FOUND
 
 from courses import mail_api
-from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED, PROGRAM_TEXT_ID_PREFIX
+from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED, PROGRAM_TEXT_ID_PREFIX, ENROLL_CHANGE_STATUS_UNENROLLED
 from courses.models import (
     Course,
     CourseRun,
@@ -400,6 +400,22 @@ def defer_enrollment(  # noqa: C901
         ).first()
         if to_enrollments:
             return from_enrollment, to_enrollments
+
+    # Deactivate an existing audit enrollment before enrolling in verified
+    # this way we enroll in verified even if the upgrade deadline is in the past
+    to_enrollments = CourseRunEnrollment.objects.filter(
+        user=user, run=to_run, enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
+    ).first()
+    if to_enrollments:
+        to_enrollments = deactivate_run_enrollment(
+            to_enrollments,
+            change_status=ENROLL_CHANGE_STATUS_UNENROLLED,
+            keep_failed_enrollments=keep_failed_enrollments,
+        )
+        if to_enrollments is None or to_enrollments.edx_enrolled is True:
+            raise Exception(  # noqa: TRY002
+                f"Failed to deactivate audit enrollment for course run '{to_run}'"  # noqa: EM102
+            )
 
     to_enrollments, enroll_success = create_run_enrollments(
         user=user,

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -524,14 +524,13 @@ class TestDeactivateEnrollments:
 @pytest.mark.parametrize("edx_enroll_succeeds", [True, False])
 @pytest.mark.parametrize("edx_downgrade_succeeds", [True, False])
 @pytest.mark.parametrize("has_audit_enrollment_already", [True, False])
-
-def test_defer_enrollment( # noqa: PLR0913
+def test_defer_enrollment(  # noqa: PLR0913
     mocker,
     course,
     keep_failed_enrollments,
     edx_enroll_succeeds,
     edx_downgrade_succeeds,
-    has_audit_enrollment_already
+    has_audit_enrollment_already,
 ):
     """
     defer_enrollment should downgrade current enrollment to audit and create a verified enrollment in another

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -613,6 +613,8 @@ def test_defer_enrollment( # noqa: PLR0913
 
         if has_audit_enrollment_already:
             assert patched_deactivate_run_enrollment.call_count == 1
+        else:
+            assert patched_deactivate_run_enrollment.call_count == 0
 
 
 def test_defer_enrollment_validation(mocker, user):

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -525,7 +525,7 @@ class TestDeactivateEnrollments:
 @pytest.mark.parametrize("edx_downgrade_succeeds", [True, False])
 @pytest.mark.parametrize("has_audit_enrollment_already", [True, False])
 
-def test_defer_enrollment(
+def test_defer_enrollment( # noqa: PLR0913
     mocker,
     course,
     keep_failed_enrollments,
@@ -610,6 +610,9 @@ def test_defer_enrollment(
                     course_runs[1].courseware_id,
                     keep_failed_enrollments=keep_failed_enrollments,
                 )
+
+        if has_audit_enrollment_already:
+            assert patched_deactivate_run_enrollment.call_count == 1
 
 
 def test_defer_enrollment_validation(mocker, user):

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -523,12 +523,15 @@ class TestDeactivateEnrollments:
 @pytest.mark.parametrize("keep_failed_enrollments", [True, False])
 @pytest.mark.parametrize("edx_enroll_succeeds", [True, False])
 @pytest.mark.parametrize("edx_downgrade_succeeds", [True, False])
+@pytest.mark.parametrize("has_audit_enrollment_already", [True, False])
+
 def test_defer_enrollment(
     mocker,
     course,
     keep_failed_enrollments,
     edx_enroll_succeeds,
     edx_downgrade_succeeds,
+    has_audit_enrollment_already
 ):
     """
     defer_enrollment should downgrade current enrollment to audit and create a verified enrollment in another
@@ -542,6 +545,13 @@ def test_defer_enrollment(
     )
 
     new_enrollment = CourseRunEnrollmentFactory.create(run=course_runs[1])
+    audit_enrollment = None
+    if has_audit_enrollment_already:
+        audit_enrollment = CourseRunEnrollmentFactory.create(
+            user=existing_enrollment.user,
+            run=course_runs[1],
+            enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+        )
     return_values = [
         ([new_enrollment] if edx_enroll_succeeds else [], edx_enroll_succeeds),
         (
@@ -549,7 +559,10 @@ def test_defer_enrollment(
             edx_downgrade_succeeds,
         ),
     ]
-
+    patched_deactivate_run_enrollment = mocker.patch(
+        "courses.api.deactivate_run_enrollment",
+        return_value=audit_enrollment,
+    )
     with patch(
         "courses.api.create_run_enrollments", autospec=True
     ) as patched_create_enrollments:
@@ -619,7 +632,7 @@ def test_defer_enrollment_validation(mocker, user):
     )
     mocker.patch(
         "courses.api.deactivate_run_enrollment",
-        return_value=[enrollments[1].run.courseware_id],
+        return_value=enrollments[1],
     )
 
     with pytest.raises(ValidationError):


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/mitxonline/issues/2570

### Description (What does it do?)
Deactivate audit enrollment before deferral

### How can this be tested?
Try to defer an enrollment, where the to_run is already enrolled in audit.
you can do this by running a management command.
