### PR TITLE
Adds a setting with SECURE_REDIRECT_EXEMPT to enable cms preview

### DIFF
--- a/app.json
+++ b/app.json
@@ -478,6 +478,10 @@
       "description": "Application-level SSL redirect setting.",
       "required": false
     },
+    "MITX_ONLINE_SECURE_REDIRECT_EXEMPT": {
+      "description": "Application-level SSL redirect  exemption setting.",
+      "required": false
+    },
     "MITX_ONLINE_SITE_ID": {
       "description": "The default site id for django sites framework",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -115,6 +115,12 @@ SECURE_SSL_REDIRECT = get_bool(
     description="Application-level SSL redirect setting.",
 )
 
+SECURE_REDIRECT_EXEMPT = get_bool(
+    name="MITX_ONLINE_SECURE_REDIRECT_EXEMPT",
+    default=[r"cms/pages/.*",],
+    description="Application-level SSL redirect setting.",
+)
+
 SECURE_SSL_HOST = get_string(
     name="MITX_ONLINE_SECURE_SSL_HOST",
     default=None,


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7052

### Description (What does it do?)
Adds a setting SECURE_REDIRECT_EXEMPT that If a URL path matches a regular expression in this list, the request will not be redirected to HTTPS

### How can this be tested?
nothing should break