### PR TITLE
Changes to shore up a few minor issues around login

### DIFF
--- a/frontend/public/src/containers/App.js
+++ b/frontend/public/src/containers/App.js
@@ -19,6 +19,7 @@ import Header from "../components/Header"
 import PrivateRoute from "../components/PrivateRoute"
 
 import LoginPages from "./pages/login/LoginPages"
+import LoginSso from "./pages/login/LoginSso"
 import RegisterPages from "./pages/register/RegisterPages"
 import EditProfilePage from "./pages/profile/EditProfilePage"
 import AccountSettingsPage from "./pages/settings/AccountSettingsPage"
@@ -84,6 +85,10 @@ export class App extends React.Component<Props, void> {
             <Route
               path={urljoin(match.url, String(routes.login))}
               component={LoginPages}
+            />
+            <Route
+              path={urljoin(match.url, String(routes.apiGatewayLogin))}
+              component={LoginSso}
             />
             <Route
               path={urljoin(match.url, String(routes.register))}

--- a/frontend/public/src/containers/pages/login/LoginSso.js
+++ b/frontend/public/src/containers/pages/login/LoginSso.js
@@ -1,0 +1,9 @@
+// @flow
+import React from "react"
+import { Redirect } from "react-router-dom"
+
+const LoginSso = () => {
+    return <Redirect to="/login" />
+}
+
+export default LoginSso

--- a/frontend/public/src/containers/pages/login/LoginSso.js
+++ b/frontend/public/src/containers/pages/login/LoginSso.js
@@ -3,7 +3,7 @@ import React from "react"
 import { Redirect } from "react-router-dom"
 
 const LoginSso = () => {
-    return <Redirect to="/login" />
+  return <Redirect to="/login" />
 }
 
 export default LoginSso

--- a/main/settings.py
+++ b/main/settings.py
@@ -115,6 +115,17 @@ CORS_ALLOW_CREDENTIALS = get_bool(
     description="Allow cookies to be sent in cross-site HTTP requests",
 )
 
+SESSION_COOKIE_DOMAIN = get_string(
+    name="SESSION_COOKIE_DOMAIN",
+    default=None,
+    description="Domain to set the session cookie to.",
+)
+SESSION_COOKIE_NAME = get_string(
+    name="SESSION_COOKIE_NAME",
+    default="mitxonline_sessionid",
+    description="Name of the session cookie.",
+)
+
 SECURE_SSL_REDIRECT = get_bool(
     name="MITX_ONLINE_SECURE_SSL_REDIRECT",
     default=True,

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -11,43 +11,6 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from mitol.common import envs
 
-# this is a test, but pylint thinks it ends up being unused
-# hence we import the entire module and assign it here
-# test_app_json_modified = pytest_utils.test_app_json_modified  # noqa: ERA001
-
-
-# NOTE: this is temporarily inlined here until I can stabilize the test upstream in the library
-def test_app_json_modified():
-    """
-    Pytest test that verifies app.json is up-to-date
-
-    To use this, you should import this into a test file somewhere in your project:
-
-    from mitol.common.pytest_utils import test_app_json_modified
-    """
-    import json
-    import logging
-
-    from mitol.common import envs
-
-    # this line was causing errors due to a loading error bug
-    # envs.reload()  # noqa: ERA001
-
-    with open("app.json") as app_json_file:  # noqa: PTH123
-        app_json = json.load(app_json_file)
-
-    generated_app_json = envs.generate_app_json()
-
-    if app_json != generated_app_json:
-        logging.error(
-            "Generated app.json does not match the app.json file. To fix this, run `./manage.py generate_app_json`"
-        )
-
-    # pytest will print the difference
-    assert json.dumps(app_json, sort_keys=True, indent=2) == json.dumps(
-        generated_app_json, sort_keys=True, indent=2
-    )
-
 
 @pytest.fixture(autouse=True)
 def settings_sandbox(monkeypatch):

--- a/main/views.py
+++ b/main/views.py
@@ -2,9 +2,15 @@
 mitx_online views
 """
 
+from urllib.parse import urljoin
+
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
-from django.http import HttpResponseNotFound, HttpResponseServerError
+from django.http import (
+    HttpResponseNotFound,
+    HttpResponseRedirect,
+    HttpResponseServerError,
+)
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -31,6 +37,16 @@ def index(request, **kwargs):  # noqa: ARG001
     """
     The index view. Display available programs
     """
+
+    # If we're getting sent here, and the APISIX middleware is enabled, we should
+    # punt them to its login page instead.
+
+    if (
+        request.path.startswith("/signin")
+        and not settings.MITOL_APIGATEWAY_DISABLE_MIDDLEWARE
+    ):
+        return HttpResponseRedirect(urljoin(settings.SITE_BASE_URL, "/login"))
+
     context = get_base_context(request)
     return render(request, "index.html", context=context)
 


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

- `/signin` will now redirect to `/login` if the middleware is enabled.
- Add `SESSION_COOKIE_DOMAIN` and `SESSION_COOKIE_NAME`, and default the latter to `mitxonline_sessionid`
- Update the Login button to do a full redirect when clicked - it was otherwise getting routed via React Router, which wasn't effective
- Remove the test to make sure `app.json` is up to date (but just that) since we're in k8s land now

### How can this be tested?

- Reload the page. The session cookie name should have changed. You should be able to control what the cookie's name is and domain. 
- Ensure the middleware is enabled:
   - Click Login. You should be taken to the APISIX login flow.
   - Go to /signin - you should be redirected to /login (and then prompted to log in if you're unauthed).
