### PR TITLE
Remove content_type form LineSerializer

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -325,7 +325,6 @@ class LineSerializer(serializers.ModelSerializer):
     product = serializers.SerializerMethodField()
     quantity = serializers.IntegerField()
     item_description = serializers.CharField()
-    content_type = serializers.CharField()
     unit_price = serializers.DecimalField(max_digits=9, decimal_places=2)
     total_price = serializers.DecimalField(max_digits=9, decimal_places=2)
     id = serializers.IntegerField()


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/7395


### Description (What does it do?)
Remove content_type form LineSerializer



### How can this be tested?
Make sure your user has an existing order
Go to order history 
the existing order should show up in the table.