### PR TITLE
Coupon code style for very long codes

### DIFF
--- a/frontend/public/src/components/OrderSummaryCard.js
+++ b/frontend/public/src/components/OrderSummaryCard.js
@@ -44,7 +44,7 @@ export class OrderSummaryCard extends React.Component<Props> {
 
     return (
       <div className="d-flex justify-content-between">
-        <div className="flex-grow-1">
+        <div className="flex-grow-1 w-75">
           Coupon applied (
           <em className="fw-bold text-primary">{discounts[0].discount_code}</em>{" "}
           )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
If coupon code gets too long it pushes the text outside the box.

### Screenshots (if appropriate):
<img width="503" alt="Screenshot 2025-05-28 at 10 45 35 AM" src="https://github.com/user-attachments/assets/03ee3008-8242-4cb5-a188-522934c5d5b0" />

After:
<img width="433" alt="Screenshot 2025-05-28 at 10 41 13 AM" src="https://github.com/user-attachments/assets/a74f2fc3-a827-4d3e-ac94-b9f197ec989c" />
