### PR TITLE
Some fixups for B2B course filtering

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -198,6 +198,7 @@ class CourseRunSerializer(BaseCourseRunSerializer):
         fields = BaseCourseRunSerializer.Meta.fields + [  # noqa: RUF005
             "products",
             "approved_flexible_price_exists",
+            "b2b_contract",
         ]
 
     def to_representation(self, instance):
@@ -234,7 +235,20 @@ class CourseRunSerializer(BaseCourseRunSerializer):
 class CourseWithCourseRunsSerializer(CourseSerializer):
     """Course model serializer - also serializes child course runs"""
 
-    courseruns = CourseRunSerializer(many=True, read_only=True)
+    courseruns = serializers.SerializerMethodField()
+
+    @extend_schema_field(CourseRunSerializer(many=True))
+    def get_courseruns(self, instance):
+        """Get the course runs for the given instance."""
+
+        if "org_id" in self.context:
+            courseruns = instance.courseruns.filter(
+                b2b_contract__organization_id=self.context["org_id"]
+            ).all()
+        else:
+            courseruns = instance.courseruns.filter(b2b_contract__isnull=True).all()
+
+        return CourseRunSerializer(courseruns, many=True, read_only=True).data
 
     class Meta:
         model = models.Course

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -844,9 +844,19 @@ paths:
         explode: false
         style: form
       - in: query
+        name: include_approved_financial_aid
+        schema:
+          type: boolean
+        description: Include approved financial assistance information
+      - in: query
         name: live
         schema:
           type: boolean
+      - in: query
+        name: org_id
+        schema:
+          type: number
+        description: Only show courses beloning to this B2B/UAI organization
       - name: page
         required: false
         in: query
@@ -3145,6 +3155,9 @@ components:
         approved_flexible_price_exists:
           type: boolean
           readOnly: true
+        b2b_contract:
+          type: integer
+          nullable: true
       required:
       - approved_flexible_price_exists
       - course_number

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -844,9 +844,19 @@ paths:
         explode: false
         style: form
       - in: query
+        name: include_approved_financial_aid
+        schema:
+          type: boolean
+        description: Include approved financial assistance information
+      - in: query
         name: live
         schema:
           type: boolean
+      - in: query
+        name: org_id
+        schema:
+          type: number
+        description: Only show courses beloning to this B2B/UAI organization
       - name: page
         required: false
         in: query
@@ -3145,6 +3155,9 @@ components:
         approved_flexible_price_exists:
           type: boolean
           readOnly: true
+        b2b_contract:
+          type: integer
+          nullable: true
       required:
       - approved_flexible_price_exists
       - course_number

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -844,9 +844,19 @@ paths:
         explode: false
         style: form
       - in: query
+        name: include_approved_financial_aid
+        schema:
+          type: boolean
+        description: Include approved financial assistance information
+      - in: query
         name: live
         schema:
           type: boolean
+      - in: query
+        name: org_id
+        schema:
+          type: number
+        description: Only show courses beloning to this B2B/UAI organization
       - name: page
         required: false
         in: query
@@ -3145,6 +3155,9 @@ components:
         approved_flexible_price_exists:
           type: boolean
           readOnly: true
+        b2b_contract:
+          type: integer
+          nullable: true
       required:
       - approved_flexible_price_exists
       - course_number


### PR DESCRIPTION

### What are the relevant tickets?

Related to https://github.com/mitodl/mit-learn/pull/2256

### Description (What does it do?)

In testing the above PR, I noted that we needed to specify the `org_id` when filtering for B2B courses so we'd get the applicable course runs. That argument wasn't in the generated API spec, though (and there was one other argument that wasn't either). This fixes that, and reworks how the org-based filtering works to fix some other issues.

- `org_id` and `include_approved_financial_aid` should now show up in the OpenAPI spec
- `include_approved_financial_aid` now has a filter function that is a no-op (this gets passed to the serializer, there's no actual filter)
- `org_id` filtering is now moved into the `CourseFilterSet`
   - The base `get_queryset` now adds annotations for course run count and course runs with B2B contract count
   - The base `get_queryset` filters to ensure there are more total course runs than b2b-only course runs if we're not filtering on `org_id`
   - The filter function undoes that filtering if we're allowed to filter on the specified org_id 
- Updated the CourseWithCourseRunsSerializer to either include or exclude course runs that are B2B, depending on context
   - The viewset now passes `org_id` as context to the serializer
   - If `org_id` is set, the CourseRunSerializer gets a filtered set of runs that is _just_ the organization-specific runs
   - Otherwise, it gets runs that _aren't associated_ with a contract (and only those)

### How can this be tested?

You will need a handful of courses in various states, and at least one B2B contract:
1. At least one course with course runs that are all **not** associated with a contract at all
2. At least one course with course runs, where **some** are associated with a contract
3. At least one course with **only** course runs that are associated with a contract

You will additionally need to be using an account that is in the contract.

Then, hit the `api/v2/courses/` API:
- As is: should show you the courses in sets 1 and 2 above, but only the non-B2B course runs
- With `id` filtering: should show you the courses and non-B2B course runs, but only if the specified courses fall into sets 1 and 2 above
- With `org_id` filtering: should show you the courses in sets 2 and 3 above, and should only show you B2B course runs
- With `org_id` filtering and `id` filtering: should show you the courses and B2B course runs, only for the courses that fall into sets 2 and 3 above

If you remove your user from the contract, you should be able to replicate the above test but you should get an empty set when any `org_id` filtering is applied.

Additionally, you should be able to see the `org_id` and `include_approved_financial_aid` filters in the API schema (and thus also in Swagger). 
