### PR TITLE
If getStartDateText gets a course with no runs, output empty string

### DIFF
--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -347,6 +347,10 @@ export const reverseCompareCourseRunStartDates = (
 export const getStartDateText = (
   courseware: BaseCourseRun | CourseDetailWithRuns
 ) => {
+  if (courseware.courseruns && courseware.courseruns.length === 0) {
+    return ""
+  }
+
   const courseRun = courseware.courseruns ?
     courseware.courseruns.sort(compareCourseRunStartDates)[0] :
     courseware

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -435,5 +435,11 @@ describe("utility functions", () => {
         getStartDateText(course).includes(formatPrettyDate(startDates[0]))
       )
     })
+    it("displays an empty string if it's a course and there's no course runs", () => {
+      const course = {
+        courseruns: []
+      }
+      assert.equal(getStartDateText(course), "")
+    })
   })
 })


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#7473

### Description (What does it do?)

As noted in the issue, when the frontend hit a course that had no course runs in it, it called `getStartDateText`, which then dutifully sorted nothing and moment was left to operate on an undefined. Now, if there's no course runs, this should just return an empty string.

### How can this be tested?

Create a course with a live page and everything, but no course runs. The catalog Courses tab should work as you would expect. The course should show up but it should not say anything for start date.

### Additional Context

Not sure if we want something else here besides empty string. I think generally we were expecting there to always be at least one course run in the list. (The course that tripped this up had a B2B run, and we don't want users getting into those, so we filter those out..)