### PR TITLE
Don't strip out B2B courses from the API

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -246,7 +246,7 @@ class CourseWithCourseRunsSerializer(CourseSerializer):
                 b2b_contract__organization_id=self.context["org_id"]
             ).all()
         else:
-            courseruns = instance.courseruns.filter(b2b_contract__isnull=True).all()
+            courseruns = instance.courseruns.all()
 
         return CourseRunSerializer(courseruns, many=True, read_only=True).data
 

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -33,7 +33,7 @@ from courses.views.test_utils import (
     num_queries_from_department,
     num_queries_from_programs,
 )
-from courses.views.v2 import CourseViewSet, Pagination, ProgramFilterSet
+from courses.views.v2 import Pagination, ProgramFilterSet
 from main.test_utils import assert_drf_json_equal, duplicate_queries_check
 from users.factories import UserFactory
 
@@ -326,26 +326,6 @@ def test_filter_without_org_id_authenticated_user(user_drf_client):
 
     assert course_no_contract.title in titles
     assert course_with_contract.title in titles
-
-
-def test_filter_anonymous_user_sees_no_contracted_runs():
-    course_with_contract = CourseFactory(title="Hidden Course")
-    contract = ContractPageFactory(active=True)
-    CourseRunFactory(course=course_with_contract, b2b_contract=contract)
-
-    course_no_contract = CourseFactory(title="Visible Course")
-    CourseRunFactory(course=course_no_contract)
-
-    rf = RequestFactory()
-    request = rf.get(reverse("v2:courses_api-list"))
-    request.user = AnonymousUser()
-
-    view = CourseViewSet()
-    view.request = Request(request)
-
-    queryset = view.get_queryset()
-    assert course_no_contract in queryset
-    assert course_with_contract not in queryset
 
 
 @pytest.mark.django_db


### PR DESCRIPTION

### What are the relevant tickets?

n/a

### Description (What does it do?)

https://github.com/mitodl/mitxonline/pull/2701 included a change that strips out B2B-related course runs and courses from the result set. The AI stuff needs this data, though, and for now we have a limited set of these, so this adds them back in.

The course pages for B2B courses should remain in Draft mode or they will be displayed in the MITx Online catalog.

### How can this be tested?

Make sure you have some courses that have B2B runs in them. Hit the `/api/v2/courses` endpoint - you should see them. You should not see them in the frontend unless the course has a published CMS page.

### Additional Context

We will at least need to add some filtering to the enrollment modal to ensure people can't enroll in B2B courseruns. (Or, maybe we have an API key sort of thing for the associated Learn bits that need this data? These are public APIs so it seems like we shouldn't have this more-private data in it.)
