### PR TITLE
Capture more than one exception type when testing get_float

### DIFF
--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -142,7 +142,12 @@ def test_get_float():
                 "float-positive",
                 "float-negative",
             ):
-                with pytest.raises(EnvironmentVariableParseException) as ex:
+                with pytest.raises(
+                    (
+                        EnvironmentVariableParseException,
+                        ValueError,
+                    )
+                ) as ex:
                     get_float(key, 1234)
                 assert (
                     ex.value.args[0] == f"Expected value in {key}={value} to be a float"


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

get_float raises EnvironmentVariableParseException from ValueError if it can't parse the option as a float. There's a test for this but it expected just the former. This works locally; for some reason the CI check doesn't. So, capture both.

### How can this be tested?

Tests should pass, both here and in the CI action.
