### PR TITLE
When creating user profile save edx_username

### DIFF
--- a/authentication/new_serializers.py
+++ b/authentication/new_serializers.py
@@ -33,7 +33,7 @@ class RegisterDetailsSerializer(serializers.Serializer):
         legal_address_data = validated_data.pop("legal_address")
         user_profile_data = validated_data.pop("user_profile", None)
         with transaction.atomic():
-            user.username = username
+            user.openedx_user.edx_username = username
             user.name = name
             user.save()
             if legal_address_data:

--- a/authentication/new_serializers_test.py
+++ b/authentication/new_serializers_test.py
@@ -31,7 +31,7 @@ def test_register_details_serializer_create(
     assert user.edx_username == "johndoe"
     validated_data = serializer.validated_data
     assert validated_data["user_profile"]["gender"] is None
-    assert validated_data["user_profile"]["birth_year"] == "1980"
+    assert validated_data["user_profile"]["year_of_birth"] == 1980
     assert validated_data["legal_address"]["country"] == "US"
 
 

--- a/authentication/new_serializers_test.py
+++ b/authentication/new_serializers_test.py
@@ -28,6 +28,11 @@ def test_register_details_serializer_create(
     assert serializer.is_valid()
     user = serializer.save()
     assert user.name == "John Doe"
+    assert user.edx_username == "johndoe"
+    validated_data = serializer.validated_data
+    assert validated_data["user_profile"]["gender"] is None
+    assert validated_data["user_profile"]["birth_year"] == "1980"
+    assert validated_data["legal_address"]["country"] == "US"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?
Fix missing edx_username when saving profile.
### Description (What does it do?)
When creating a user profile we need to save edx_username, instead of username field.

Nothing should break.