### PR TITLE
Added logic to send user to the gateway logout url

### DIFF
--- a/frontend/public/src/components/UserMenu.js
+++ b/frontend/public/src/components/UserMenu.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import React from "react"
 
 import MixedLink from "./MixedLink"
@@ -102,7 +103,14 @@ const UserMenu = ({ currentUser, useScreenOverlay }: Props) => {
           </MixedLink>
         </li>
         <li {...(menuChildProps.li || {})}>
-          <a href={routes.logout} aria-label="Sign Out">
+          <a
+            href={
+              SETTINGS.api_gateway_enabled ?
+                routes.apiGatewayLogout :
+                routes.logout
+            }
+            aria-label="Sign Out"
+          >
             Sign Out
           </a>
         </li>

--- a/frontend/public/src/components/UserMenu_test.js
+++ b/frontend/public/src/components/UserMenu_test.js
@@ -25,14 +25,21 @@ describe("UserMenu component", () => {
       6
     )
   })
-
-  it("has a link to logout", () => {
-    assert.equal(
-      shallow(<UserMenu currentUser={user} useScreenOverlay={false} />)
-        .find("a")
-        .at(0)
-        .prop("href"),
-      routes.logout
-    )
+  ;[
+    [true, routes.apiGatewayLogout],
+    [false, routes.logout]
+  ].forEach(([enabled, expectedUrl]) => {
+    it(`has a link to ${expectedUrl} to logout if api_gateway_enabled=${enabled.toString()}`, () => {
+      global.SETTINGS = {
+        api_gateway_enabled: enabled
+      }
+      assert.equal(
+        shallow(<UserMenu currentUser={user} useScreenOverlay={false} />)
+          .find("a")
+          .at(0)
+          .prop("href"),
+        expectedUrl
+      )
+    })
   })
 })

--- a/frontend/public/src/lib/urls.js
+++ b/frontend/public/src/lib/urls.js
@@ -17,6 +17,7 @@ export const routes = {
   catalogTab:             "/catalog/:tab",
   catalog:                "/catalog/",
   apiGatewayLogin:        "/login/",
+  apiGatewayLogout:       "/logout/oidc",
 
   // authentication related routes
   login: include("/signin/", {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of the continuing saga to ~~destroy the One Ring~~ fix https://github.com/mitodl/hq/issues/7273

### Description (What does it do?)
<!--- Describe your changes in detail -->
This updates the frontend to send the user to /logout/oidc instead of /logout when the api gateway is enabled.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to logout with `MITOL_APIGATEWAY_DISABLE_MIDDLEWARE` enabled or disabled.