### PR TITLE
fix update enrollment serializer

### DIFF
--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -89,7 +89,7 @@ from openedx.exceptions import (
 log = logging.getLogger(__name__)
 
 
-class UpdateEnrollmentSerializer(serializers.Serializer):
+class UpdateCourseRunEnrollmentSerializer(serializers.Serializer):
     receive_emails = serializers.BooleanField(
         required=False, help_text="Whether to receive course emails"
     )
@@ -434,7 +434,7 @@ class UserEnrollmentsApiViewSet(
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(
-        request=UpdateEnrollmentSerializer,
+        request=UpdateCourseRunEnrollmentSerializer,
         operation_id="enrollments_partial_update",
         description="Update enrollment email preferences",
     )

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -709,13 +709,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
       responses:
         '200':
           content:
@@ -2094,15 +2094,12 @@ components:
       properties:
         confirmed:
           type: boolean
-    PatchedUpdateEnrollmentRequest:
+    PatchedUpdateCourseRunEnrollmentRequest:
       type: object
       properties:
         receive_emails:
           type: boolean
           description: Whether to receive course emails
-        run_id:
-          type: integer
-          description: The ID of the course run for which to update email preferences
     PatchedUserRequest:
       type: object
       description: Serializer for users

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -709,13 +709,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
       responses:
         '200':
           content:
@@ -2094,15 +2094,12 @@ components:
       properties:
         confirmed:
           type: boolean
-    PatchedUpdateEnrollmentRequest:
+    PatchedUpdateCourseRunEnrollmentRequest:
       type: object
       properties:
         receive_emails:
           type: boolean
           description: Whether to receive course emails
-        run_id:
-          type: integer
-          description: The ID of the course run for which to update email preferences
     PatchedUserRequest:
       type: object
       description: Serializer for users

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -709,13 +709,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedUpdateEnrollmentRequest'
+              $ref: '#/components/schemas/PatchedUpdateCourseRunEnrollmentRequest'
       responses:
         '200':
           content:
@@ -2094,15 +2094,12 @@ components:
       properties:
         confirmed:
           type: boolean
-    PatchedUpdateEnrollmentRequest:
+    PatchedUpdateCourseRunEnrollmentRequest:
       type: object
       properties:
         receive_emails:
           type: boolean
           description: Whether to receive course emails
-        run_id:
-          type: integer
-          description: The ID of the course run for which to update email preferences
     PatchedUserRequest:
       type: object
       description: Serializer for users


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7603

### Description (What does it do?)
This PR sets up a custom serializer for the enrollments update endpoint. The `PatchedCourseRunEnrollmentRequest` is now `PatchedUpdateCourseRunEnrollmentRequest` and contains the `receive_emails` argument that it expects.

### How can this be tested?
Take a look at the OpenAPI spec and make sure it looks correct for `PATCH` requests to the enrollments API endpoint
