### PR TITLE
Update next_run_id to add B2B course run awareness

### DIFF
--- a/b2b/factories.py
+++ b/b2b/factories.py
@@ -9,7 +9,7 @@ from b2b.models import ContractPage, OrganizationIndexPage, OrganizationPage
 from cms.factories import HomePageFactory
 from cms.models import HomePage
 
-FAKE = faker.Factory.create()
+FAKE = faker.Faker()
 
 
 class OrganizationIndexPageFactory(wagtail_factories.PageFactory):
@@ -27,9 +27,9 @@ class OrganizationIndexPageFactory(wagtail_factories.PageFactory):
 class OrganizationPageFactory(wagtail_factories.PageFactory):
     """OrganizationPage factory class"""
 
-    name = FAKE.company()
-    org_key = FAKE.text(max_nb_chars=5)
-    description = FAKE.text()
+    name = FAKE.unique.company()
+    org_key = FAKE.unique.text(max_nb_chars=5)
+    description = FAKE.unique.text()
     logo = None
     parent = LazyAttribute(
         lambda _: OrganizationIndexPage.objects.first()
@@ -43,8 +43,8 @@ class OrganizationPageFactory(wagtail_factories.PageFactory):
 class ContractPageFactory(wagtail_factories.PageFactory):
     """ContractPage factory class"""
 
-    name = FAKE.bs()
-    description = FAKE.text()
+    name = FAKE.unique.bs()
+    description = FAKE.unique.text()
     organization = SubFactory(OrganizationPageFactory)
     parent = LazyAttribute(lambda o: o.organization)
     integration_type = LazyFunction(

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -98,7 +98,12 @@ class CourseSerializer(BaseCourseSerializer):
 
     def get_next_run_id(self, instance) -> int | None:
         """Get next run id"""
-        run = instance.first_unexpired_run
+        if self.context.get("org_id"):
+            run = instance.get_first_unexpired_org_run(
+                self.context.get("user_contracts")
+            )
+        else:
+            run = instance.first_unexpired_run
         return run.id if run is not None else None
 
     def get_programs(self, instance) -> list[dict] | None:

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -223,6 +223,11 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
             added_context["include_approved_financial_aid"] = True
         if qp.get("org_id"):
             added_context["org_id"] = qp.get("org_id")
+            added_context["user_contracts"] = (
+                self.request.user.b2b_contracts.values_list("id", flat=True).all()
+                if self.request.user.b2b_contracts
+                else []
+            )
         return {**super().get_serializer_context(), **added_context}
 
     @extend_schema(

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db import connection
 from django.test.client import RequestFactory
 from django.urls import reverse
+from faker import Faker
 from mitol.common.utils import now_in_utc
 from rest_framework import status
 from rest_framework.request import Request
@@ -40,9 +41,8 @@ from main.test_utils import assert_drf_json_equal, duplicate_queries_check
 from users.factories import UserFactory
 
 pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("raise_nplusone")]
-
-
 logger = logging.getLogger(__name__)
+faker = Faker()
 
 
 @pytest.mark.parametrize("course_catalog_course_count", [100], indirect=True)
@@ -425,10 +425,8 @@ def test_filter_by_org_id_unauthenticated_user(
 
 
 @pytest.mark.django_db
-def test_next_run_id_with_org_filter(
+def test_next_run_id_with_org_filter(  # noqa: PLR0915
     mock_course_run_clone,
-    user,
-    api_client,
     contract_ready_course,
 ):
     """
@@ -440,21 +438,96 @@ def test_next_run_id_with_org_filter(
     current user.
     """
 
+    api_client = APIClient()
+    orgs = []
+
+    org = OrganizationPageFactory.create()
+    org.org_key = "Org1"
+    org.name = "Test Org 1"
+    org.save()
+    orgs.append(org)
+    org = OrganizationPageFactory.create()
+    org.org_key = "Org2"
+    org.name = "Test Org 2"
+    org.save()
+    orgs.append(org)
+
+    contract = ContractPageFactory.create(organization=orgs[0])
+    second_contract = ContractPageFactory.create(organization=orgs[1])
+    test_user = UserFactory()
+    test_user.b2b_contracts.add(contract)
+    auth_api_client = APIClient()
+    auth_api_client.force_authenticate(user=test_user)
+
     one_month_prior = now_in_utc() - timedelta(days=31)
     one_month_ahead = now_in_utc() + timedelta(days=31)
-    two_months_prior = now_in_utc() - timedelta(days=62)
 
-    b2b_course, b2b_run = contract_ready_course
+    b2b_course, _ = contract_ready_course
     regular_course_run = CourseRunFactory(
         start_date=one_month_prior,
         enrollment_start=one_month_prior,
         course=b2b_course,
     )
 
+    # make the B2B run start a day further away from now than the regular run
+    # if this weren't a B2B run, then that would give it precedence
+    b2b_run, _ = create_contract_run(contract, b2b_course)
+    b2b_run.start_date = one_month_prior - timedelta(days=1)
+    b2b_run.enrollment_start = one_month_prior - timedelta(days=1)
+    b2b_run.save()
+
+    # first, test to make sure we get the regular run's ID
     resp = api_client.get(
-        reverse("v2:courses_api-detail", kwargs={"pk": regular_course_run.course.id}),
+        reverse("v2:courses_api-detail", kwargs={"pk": b2b_course.id}),
     )
 
     assert resp.status_code < 300
     resp_course = resp.json()
     assert resp_course["next_run_id"] == regular_course_run.id
+
+    # if the regular run is in the future, we shouldn't get anything
+    regular_course_run.enrollment_start = one_month_ahead
+    regular_course_run.save()
+
+    resp = api_client.get(
+        reverse("v2:courses_api-detail", kwargs={"pk": b2b_course.id}),
+    )
+
+    assert resp.status_code < 300
+    resp_course = resp.json()
+    assert not resp_course["next_run_id"]
+    assert b2b_run.enrollment_start < regular_course_run.enrollment_start
+
+    # now, test with the org filter
+    # we should get the B2B run
+    url = reverse(
+        "v2:courses_api-detail",
+        kwargs={"pk": b2b_course.id},
+    )
+
+    resp = auth_api_client.get(f"{url}?org_id={contract.organization.id}")
+
+    assert resp.status_code < 300
+    resp_course = resp.json()
+    assert resp_course["next_run_id"] == b2b_run.id
+
+    # kick the B2B run into the future and now we should get nothing again
+    b2b_run.enrollment_start = one_month_ahead
+    b2b_run.save()
+
+    resp = auth_api_client.get(f"{url}?org_id={contract.organization.id}")
+
+    assert resp.status_code < 300
+    resp_course = resp.json()
+    assert not resp_course["next_run_id"]
+
+    # finally, make a new contract and don't assign the user to it.
+    # we should get a 404, since we're filtering on an org we're not in.
+
+    second_b2b_run, _ = create_contract_run(second_contract, b2b_course)
+    second_b2b_run.enrollment_start = one_month_prior
+    second_b2b_run.save()
+
+    resp = auth_api_client.get(f"{url}?org_id={second_contract.organization.id}")
+
+    assert resp.status_code == 404

--- a/fixtures/b2b.py
+++ b/fixtures/b2b.py
@@ -20,7 +20,13 @@ def contract_ready_course():
         f"course-v1:{source_course_key.org}+{source_course_key.course}+SOURCE"
     )
     source_course_run = CourseRunFactory.create(
-        course=course, courseware_id=source_course_run_key, run_tag="SOURCE"
+        course=course,
+        courseware_id=source_course_run_key,
+        run_tag="SOURCE",
+        start_date=None,
+        end_date=None,
+        enrollment_start=None,
+        enrollment_end=None,
     )
 
     return (course, source_course_run)


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#7563

### Description (What does it do?)

If you're pulling data for a course that has runs that meet the time requirements for enrollability (start date before now, enrollment start date before now, end dates after now or not set) but are a mix of B2B course runs and regular ones, the `next_run_id` field in the course may return an invalid course run:

- If you're not filtering for a particular B2B organization, you might still get a B2B course run as the next ID if it's the next available run
- If you are filtering on organization, you might get a course run that's not the B2B run

To fix this, this PR updates `first_unexpired_run` to filter out B2B course runs entirely. It also adds a second method, `get_first_unexpired_org_run`, that filters specifically on the user's contracts (as we want to see things the user is allowed to get to - if there are runs in contracts the user isn't in, we don't want to consider those, either). The view is also updated to pull the user's contract IDs out and add them to the serializer context so it will know to use the new method if the org filter is enabled.

### How can this be tested?

Set up a course with a regular course run that can be enrolled in. Ensure you can see the course in the v2 courses API (`/api/v2/courses/`) and that the `next_run_id` points to the regular course run.

Add a contract, then add the course to the contract. Reload the courses API. You should still see the course you created, and the `next_run_id` should be the regular course run still.

Set the regular course run's enrollment start date to a future date (or, clear it), and reload the course API. You should see null for the `next_run_id`.

Add the contract to the current user. Then, hit the API with the org filter - `/api/v2/courses/?org_id=<org>`. Now, you should see the B2B course run's ID as `next_run_id`.

Set the B2B run's enrollment date to a future date and reload the course API. You should see null for `next_run_id`.

Create a new contract within the same org, and add the course to the new contract. Set the enrollment dates for the B2B runs up so that the new contract's run starts before the existing contract's run. _Do not_ add the user to the new contract. Then, reload the course API again - you should see either null or the existing contract's run ID in `next_run_id` depending on whether or not the existing run's enrollment start is in the future or not.

