### PR TITLE
save edx_username when creating profile

### DIFF
--- a/authentication/api_gateway/serializers.py
+++ b/authentication/api_gateway/serializers.py
@@ -37,7 +37,7 @@ class RegisterDetailsSerializer(serializers.Serializer):
             user.name = name
             user.save()
             if user.openedx_user is None:
-                create_user(user)
+                create_user(user, username)
             else:
                 user.openedx_user.edx_username = username
                 user.openedx_user.save()

--- a/authentication/api_gateway/serializers.py
+++ b/authentication/api_gateway/serializers.py
@@ -24,7 +24,7 @@ class RegisterDetailsSerializer(serializers.Serializer):
     legal_address = LegalAddressSerializer(write_only=True)
     user_profile = UserProfileSerializer(write_only=True)
 
-    def create(self, validated_data):
+    def save(self, validated_data):
         """Save user legal address and user profile"""
         request = self.context["request"]
         user = request.user

--- a/authentication/api_gateway/serializers.py
+++ b/authentication/api_gateway/serializers.py
@@ -36,11 +36,7 @@ class RegisterDetailsSerializer(serializers.Serializer):
         with transaction.atomic():
             user.name = name
             user.save()
-            if user.openedx_user is None:
-                create_user(user, username)
-            else:
-                user.openedx_user.edx_username = username
-                user.openedx_user.save()
+            create_user(user, username)
 
             if legal_address_data:
                 legal_address = LegalAddressSerializer(

--- a/authentication/api_gateway/serializers_test.py
+++ b/authentication/api_gateway/serializers_test.py
@@ -1,9 +1,15 @@
 import pytest
+import responses
+from rest_framework import status
+
 
 from authentication.api_gateway.serializers import (
     RegisterDetailsSerializer,
     RegisterExtraDetailsSerializer,
 )
+from openedx.constants import PLATFORM_EDX
+from openedx.models import OpenEdxUser
+from users.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -29,6 +35,60 @@ def test_register_details_serializer_create(
     user = serializer.save()
     assert user.name == "John Doe"
     assert user.edx_username == "johndoe"
+    validated_data = serializer.validated_data
+    assert validated_data["user_profile"]["gender"] is None
+    assert validated_data["user_profile"]["year_of_birth"] == 1980
+    assert validated_data["legal_address"]["country"] == "US"
+
+
+
+@pytest.mark.django_db
+@responses.activate
+def test_register_no_edx_user(  # noqa: PLR0913
+    mocker, settings, user, valid_address_dict, user_profile_dict, rf
+):
+    """Test the create method of RegisterDetailsSerializer"""
+
+    request = rf.post("/api/profile/details/")
+
+    user = UserFactory.create(
+        no_openedx_user=True, no_openedx_api_auth=True
+    )
+    request.user = user
+
+    responses.add(
+        responses.POST,
+        f"{settings.OPENEDX_API_BASE_URL}/user_api/v1/account/registration/",
+        json=dict(success=True),  # noqa: C408
+        status=status.HTTP_200_OK,
+    )
+
+    patched_create_edx_auth_token = mocker.patch("openedx.api.create_edx_auth_token")
+
+    data = {
+        "name": "John Doe",
+        "username": "johndoe",
+        "legal_address": valid_address_dict,
+        "user_profile": user_profile_dict,
+    }
+    assert user.openedx_user is None
+
+    serializer = RegisterDetailsSerializer(data=data, context={"request": request})
+    assert serializer.is_valid(), serializer.errors
+
+    assert serializer.is_valid()
+    user = serializer.save()
+
+    assert (
+        OpenEdxUser.objects.filter(
+            user=user, has_been_synced=True
+        ).exists()
+        is True
+    )
+    assert patched_create_edx_auth_token.call_count == 1
+    assert user.name == "John Doe"
+    assert user.openedx_users.exists() is True
+    assert user.openedx_users.first().has_been_synced is True
     validated_data = serializer.validated_data
     assert validated_data["user_profile"]["gender"] is None
     assert validated_data["user_profile"]["year_of_birth"] == 1980

--- a/authentication/api_gateway/serializers_test.py
+++ b/authentication/api_gateway/serializers_test.py
@@ -12,7 +12,7 @@ from users.factories import UserFactory
 
 @pytest.mark.django_db
 def test_register_details_serializer_create(
-    user, valid_address_dict, user_profile_dict, rf
+    mocker, user, valid_address_dict, user_profile_dict, rf
 ):
     """Test the create method of RegisterDetailsSerializer"""
 
@@ -25,6 +25,8 @@ def test_register_details_serializer_create(
         "legal_address": valid_address_dict,
         "user_profile": user_profile_dict,
     }
+    mock_create_edx_user = mocker.patch("openedx.api.create_edx_user")
+    mock_create_edx_auth_token = mocker.patch("openedx.api.create_edx_auth_token")
 
     serializer = RegisterDetailsSerializer(data=data, context={"request": request})
     assert serializer.is_valid(), serializer.errors
@@ -32,7 +34,6 @@ def test_register_details_serializer_create(
     assert serializer.is_valid()
     user = serializer.save()
     assert user.name == "John Doe"
-    assert user.edx_username == "johndoe"
     validated_data = serializer.validated_data
     assert validated_data["user_profile"]["gender"] is None
     assert validated_data["user_profile"]["year_of_birth"] == 1980

--- a/authentication/api_gateway/serializers_test.py
+++ b/authentication/api_gateway/serializers_test.py
@@ -38,6 +38,8 @@ def test_register_details_serializer_create(
     assert validated_data["user_profile"]["gender"] is None
     assert validated_data["user_profile"]["year_of_birth"] == 1980
     assert validated_data["legal_address"]["country"] == "US"
+    assert mock_create_edx_user.call_count == 1
+    assert mock_create_edx_auth_token.call_count == 1
 
 
 @pytest.mark.django_db

--- a/authentication/api_gateway/serializers_test.py
+++ b/authentication/api_gateway/serializers_test.py
@@ -2,12 +2,10 @@ import pytest
 import responses
 from rest_framework import status
 
-
 from authentication.api_gateway.serializers import (
     RegisterDetailsSerializer,
     RegisterExtraDetailsSerializer,
 )
-from openedx.constants import PLATFORM_EDX
 from openedx.models import OpenEdxUser
 from users.factories import UserFactory
 
@@ -41,7 +39,6 @@ def test_register_details_serializer_create(
     assert validated_data["legal_address"]["country"] == "US"
 
 
-
 @pytest.mark.django_db
 @responses.activate
 def test_register_no_edx_user(  # noqa: PLR0913
@@ -51,9 +48,7 @@ def test_register_no_edx_user(  # noqa: PLR0913
 
     request = rf.post("/api/profile/details/")
 
-    user = UserFactory.create(
-        no_openedx_user=True, no_openedx_api_auth=True
-    )
+    user = UserFactory.create(no_openedx_user=True, no_openedx_api_auth=True)
     request.user = user
 
     responses.add(
@@ -79,12 +74,7 @@ def test_register_no_edx_user(  # noqa: PLR0913
     assert serializer.is_valid()
     user = serializer.save()
 
-    assert (
-        OpenEdxUser.objects.filter(
-            user=user, has_been_synced=True
-        ).exists()
-        is True
-    )
+    assert OpenEdxUser.objects.filter(user=user, has_been_synced=True).exists() is True
     assert patched_create_edx_auth_token.call_count == 1
     assert user.name == "John Doe"
     assert user.openedx_users.exists() is True

--- a/authentication/api_gateway/views_test.py
+++ b/authentication/api_gateway/views_test.py
@@ -31,6 +31,7 @@ def test_post_user_profile_detail(valid_address_dict, client, user):
     assert resp.status_code == status.HTTP_200_OK
     # Checks that user's name in database is also updated
     assert User.objects.get(pk=user.pk).name == data["name"]
+    assert User.objects.get(pk=user.pk).edx_username == data["username"]
 
     data = {
         "name": "John Doe",

--- a/authentication/api_gateway/views_test.py
+++ b/authentication/api_gateway/views_test.py
@@ -15,7 +15,7 @@ pytestmark = [
 ]
 
 
-def test_post_user_profile_detail(valid_address_dict, client, user):
+def test_post_user_profile_detail(mocker, valid_address_dict, client, user):
     """Test that user can save profile details"""
     client.force_login(user)
     data = {
@@ -24,6 +24,8 @@ def test_post_user_profile_detail(valid_address_dict, client, user):
         "legal_address": valid_address_dict,
         "user_profile": {},
     }
+    mock_create_edx_user = mocker.patch("openedx.api.create_edx_user")
+    mock_create_edx_auth_token = mocker.patch("openedx.api.create_edx_auth_token")
     resp = client.post(
         reverse("profile-details-api"), data, content_type="application/json"
     )
@@ -31,7 +33,8 @@ def test_post_user_profile_detail(valid_address_dict, client, user):
     assert resp.status_code == status.HTTP_200_OK
     # Checks that user's name in database is also updated
     assert User.objects.get(pk=user.pk).name == data["name"]
-    assert User.objects.get(pk=user.pk).edx_username == data["username"]
+    assert mock_create_edx_user.called is True
+    assert mock_create_edx_auth_token.called is True
 
     data = {
         "name": "John Doe",

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -100,9 +100,6 @@ def create_edx_user(user, edx_username=None):
         )
 
         if open_edx_user.edx_username is None:
-            if edx_username is None:
-                # If we don't have an edx username provided, generate one from the user's email
-                edx_username = user.email
             open_edx_user.edx_username = edx_username
             open_edx_user.save()
 
@@ -129,7 +126,7 @@ def create_edx_user(user, edx_username=None):
         resp = req_session.post(
             edx_url(OPENEDX_REGISTER_USER_PATH),
             data=dict(
-                username=user.edx_username,
+                username=open_edx_user.edx_username,
                 email=user.email,
                 name=user.name,
                 country=user.legal_address.country if user.legal_address else None,

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -123,7 +123,7 @@ def edx_username_validation_response_mock(username_exists, settings):
     "provided_username", ["test_username", None]  # noqa: PT006
 )
 @pytest.mark.parametrize("missing_username", [True, False])
-def test_create_edx_user(
+def test_create_edx_user(  # noqa: PLR0913
     settings,
     application,
     has_been_synced,

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -119,8 +119,18 @@ def edx_username_validation_response_mock(username_exists, settings):
 @responses.activate
 @pytest.mark.parametrize("has_been_synced", [True, False])
 @pytest.mark.parametrize("access_token_count", [0, 1, 3])
-@pytest.mark.parametrize("provided_username, missing_username", [["test_username", True], ["test_username", False], [None, False]])
-def test_create_edx_user(settings, application, has_been_synced, access_token_count, provided_username, missing_username):
+@pytest.mark.parametrize(
+    "provided_username,missing_username",
+    [["test_username", True], ["test_username", False], [None, False]],
+)
+def test_create_edx_user(
+    settings,
+    application,
+    has_been_synced,
+    access_token_count,
+    provided_username,
+    missing_username
+):
     """Test that create_edx_user makes a request to create an edX user"""
     user = UserFactory.create(openedx_user__has_been_synced=has_been_synced)
     openedx_user = user.openedx_users.first()

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -88,7 +88,7 @@ def test_create_user(user, mocker):
     mock_create_edx_user = mocker.patch("openedx.api.create_edx_user")
     mock_create_edx_auth_token = mocker.patch("openedx.api.create_edx_auth_token")
     create_user(user)
-    mock_create_edx_user.assert_called_with(user)
+    mock_create_edx_user.assert_called_with(user, None)
     mock_create_edx_auth_token.assert_called_with(user)
 
 

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -120,7 +120,8 @@ def edx_username_validation_response_mock(username_exists, settings):
 @pytest.mark.parametrize("has_been_synced", [True, False])
 @pytest.mark.parametrize("access_token_count", [0, 1, 3])
 @pytest.mark.parametrize(
-    "provided_username", ["test_username", None]  # noqa: PT006
+    "provided_username",
+    ["test_username", None],
 )
 @pytest.mark.parametrize("missing_username", [True, False])
 def test_create_edx_user(  # noqa: PLR0913
@@ -129,7 +130,7 @@ def test_create_edx_user(  # noqa: PLR0913
     has_been_synced,
     access_token_count,
     provided_username,
-    missing_username
+    missing_username,
 ):
     """Test that create_edx_user makes a request to create an edX user"""
     user = UserFactory.create(openedx_user__has_been_synced=has_been_synced)


### PR DESCRIPTION
### What are the relevant tickets?
edx username not saved properly
and Fix https://github.com/mitodl/hq/issues/7609

### Description (What does it do?)

Add create_edx_user to profile creation
Onboarding API should call create_edx_user when the user submits the profile information.

Now it passes the provided username to create_user .

### How can this be tested?
create a new account , fillout  the profile 
You edx user should have a edx_username saved correctly.
The edx api call to create user should succeed.