### PR TITLE
Add create_edx_user to profile creation

### DIFF
--- a/authentication/api_gateway/serializers.py
+++ b/authentication/api_gateway/serializers.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from rest_framework import serializers
 
+from openedx.api import create_user
 from hubspot_sync.task_helpers import sync_hubspot_user
 from users.serializers import (
     LegalAddressSerializer,
@@ -49,7 +50,7 @@ class RegisterDetailsSerializer(serializers.Serializer):
                 )
                 if user_profile.is_valid():
                     user_profile.save()
-
+        create_user(user)
         sync_hubspot_user(user)
         return user
 

--- a/authentication/api_gateway/serializers.py
+++ b/authentication/api_gateway/serializers.py
@@ -6,8 +6,8 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from rest_framework import serializers
 
-from openedx.api import create_user
 from hubspot_sync.task_helpers import sync_hubspot_user
+from openedx.api import create_user
 from users.serializers import (
     LegalAddressSerializer,
     UserProfileSerializer,

--- a/authentication/api_gateway/serializers_test.py
+++ b/authentication/api_gateway/serializers_test.py
@@ -7,15 +7,17 @@ from authentication.api_gateway.serializers import (
 
 
 @pytest.mark.django_db
-def test_register_details_serializer_create(mocker,
-    user, valid_address_dict, user_profile_dict, rf
+def test_register_details_serializer_create(
+    mocker, user, valid_address_dict, user_profile_dict, rf
 ):
     """Test the create method of RegisterDetailsSerializer"""
 
     request = rf.post("/api/profile/details/")
     request.user = user
     mock_client = mocker.MagicMock()
-    edx_api_mock = mocker.patch("openedx.api.get_edx_api_client", return_value=mock_client)
+    edx_api_mock = mocker.patch(
+        "openedx.api.get_edx_api_client", return_value=mock_client
+    )
 
     data = {
         "name": "John Doe",

--- a/authentication/api_gateway/serializers_test.py
+++ b/authentication/api_gateway/serializers_test.py
@@ -7,13 +7,15 @@ from authentication.api_gateway.serializers import (
 
 
 @pytest.mark.django_db
-def test_register_details_serializer_create(
+def test_register_details_serializer_create(mocker,
     user, valid_address_dict, user_profile_dict, rf
 ):
     """Test the create method of RegisterDetailsSerializer"""
 
     request = rf.post("/api/profile/details/")
     request.user = user
+    mock_client = mocker.MagicMock()
+    edx_api_mock = mocker.patch("openedx.api.get_edx_api_client", return_value=mock_client)
 
     data = {
         "name": "John Doe",
@@ -26,6 +28,7 @@ def test_register_details_serializer_create(
     assert serializer.is_valid(), serializer.errors
 
     assert serializer.is_valid()
+    assert edx_api_mock.called is True
     user = serializer.save()
     assert user.name == "John Doe"
     assert user.edx_username == "johndoe"

--- a/authentication/api_gateway/views_test.py
+++ b/authentication/api_gateway/views_test.py
@@ -15,7 +15,9 @@ def test_post_user_profile_detail(mocker, valid_address_dict, client, user):
     """Test that user can save profile details"""
     client.force_login(user)
     mock_client = mocker.MagicMock()
-    edx_api_mock = mocker.patch("openedx.api.get_edx_api_client", return_value=mock_client)
+    edx_api_mock = mocker.patch(
+        "openedx.api.get_edx_api_client", return_value=mock_client
+    )
     data = {
         "name": "John Doe",
         "username": "johndoe",


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/7609

### Description (What does it do?)
Add create_edx_user to profile creation
Onboarding API should call create_edx_user when the user submits the profile information

### How can this be tested?
tests should pass.