### PR TITLE
Make CSRF_COOKIE_DOMAIN configurable by env variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -110,6 +110,10 @@
       "description": "minute value for scheduled task to process refund requests",
       "required": false
     },
+    "CSRF_COOKIE_DOMAIN": {
+      "description": "Domain to set the CSRF cookie to.",
+      "required": false
+    },
     "CSRF_TRUSTED_ORIGINS": {
       "description": "Comma separated string of trusted domains that should be CSRF exempt",
       "required": false
@@ -549,6 +553,18 @@
       "description": "The base redirect URL for an OAuth Application for the Open edX API",
       "required": false
     },
+    "OPENEDX_COURSES_SERVICE_WORKER_CLIENT_ID": {
+      "description": "OAuth2 client id for retirement service worker",
+      "required": false
+    },
+    "OPENEDX_COURSES_SERVICE_WORKER_CLIENT_SECRET": {
+      "description": "OAuth2 client secret for retirement service worker",
+      "required": false
+    },
+    "OPENEDX_COURSE_BASE_URL": {
+      "description": "The base URL to use to construct URLs to a course",
+      "required": false
+    },
     "OPENEDX_OAUTH_APP_NAME": {
       "description": "The 'name' value for the Open edX OAuth Application",
       "required": true
@@ -576,6 +592,10 @@
     "OPENEDX_SOCIAL_LOGIN_PATH": {
       "description": "Open edX social auth login url",
       "required": false
+    },
+    "OPENEDX_STUDIO_API_BASE_URL": {
+      "description": "The base URL for the Open edX Studio CMS API",
+      "required": true
     },
     "OPENEDX_TOKEN_EXPIRES_HOURS": {
       "description": "The number of hours until an access token for the Open edX API expires",
@@ -682,6 +702,14 @@
     },
     "SENTRY_LOG_LEVEL": {
       "description": "The log level for Sentry",
+      "required": false
+    },
+    "SESSION_COOKIE_DOMAIN": {
+      "description": "Domain to set the session cookie to.",
+      "required": false
+    },
+    "SESSION_COOKIE_NAME": {
+      "description": "Name of the session cookie.",
       "required": false
     },
     "SITE_NAME": {

--- a/app.json
+++ b/app.json
@@ -210,6 +210,10 @@
       "description": "The root directory for locally stored media. Typically not used.",
       "required": false
     },
+    "MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS": {
+      "description": "The list of hosts the app is allowed to redirect to",
+      "required": false
+    },
     "MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST": {
       "description": "The URL to redirect to after logging out",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -104,6 +104,12 @@ ALLOWED_REDIRECT_HOSTS = get_list_literal(
     description="List of hosts allowed to redirect to after login",
 )
 
+CSRF_COOKIE_DOMAIN = get_string(
+    name="CSRF_COOKIE_DOMAIN",
+    default=None,
+    description="Domain to set the CSRF cookie to.",
+)
+
 CSRF_TRUSTED_ORIGINS = get_delimited_list(
     name="CSRF_TRUSTED_ORIGINS",
     default=[],
@@ -1452,6 +1458,8 @@ MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST = get_string(
 MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS = [
     "localhost",
     "mitxonline.odl.local",
+    "mitxonline.learn.c4103.com",
+    "courses.c4103.com",
 ]
 
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -1455,13 +1455,11 @@ MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST = get_string(
 )
 
 # Set to the list of hosts the app is allowed to redirect to.
-MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS = [
-    "localhost",
-    "mitxonline.odl.local",
-    "mitxonline.learn.c4103.com",
-    "courses.c4103.com",
-]
-
+MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS = get_delimited_list(
+    name="MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS",
+    default="localhost,mitxonline.odl.local",
+    description="The list of hosts the app is allowed to redirect to",
+)
 
 OPENTELEMETRY_ENABLED = get_bool(
     name="OPENTELEMETRY_ENABLED",

--- a/main/settings.py
+++ b/main/settings.py
@@ -1457,7 +1457,7 @@ MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST = get_string(
 # Set to the list of hosts the app is allowed to redirect to.
 MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS = get_delimited_list(
     name="MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS",
-    default="localhost,mitxonline.odl.local",
+    default=["localhost", "mitxonline.odl.local"],
     description="The list of hosts the app is allowed to redirect to",
 )
 

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -129,7 +129,10 @@ def test_mitol_apigateway_allowed_redirect_hosts(settings_sandbox):
     """Verify that we can configure MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS with a var"""
     # Test the default
     settings_vars = settings_sandbox.get()
-    assert settings_vars.get("MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS") == []
+    assert settings_vars.get("MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS") == [
+        "localhost",
+        "mitxonline.odl.local",
+    ]
 
     # Verify the env var works
     settings_vars = settings_sandbox.patch(

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -125,6 +125,24 @@ def test_csrf_trusted_origins(settings_sandbox):
     ]
 
 
+def test_mitol_apigateway_allowed_redirect_hosts(settings_sandbox):
+    """Verify that we can configure MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS with a var"""
+    # Test the default
+    settings_vars = settings_sandbox.get()
+    assert settings_vars.get("MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS") == []
+
+    # Verify the env var works
+    settings_vars = settings_sandbox.patch(
+        {
+            "MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS": "some.domain.com, some.other.domain.org",
+        }
+    )
+    assert settings_vars.get("MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS") == [
+        "some.domain.com",
+        "some.other.domain.org",
+    ]
+
+
 def test_db_ssl_enable(monkeypatch, settings_sandbox):
     """Verify that we can enable/disable database SSL with a var"""
     # Check default state is SSL on

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -17,6 +17,7 @@ def settings_sandbox(monkeypatch):
     """Cleanup settings after a test"""
 
     monkeypatch.delenv("MITX_ONLINE_DB_DISABLE_SSL", raising=False)
+    monkeypatch.delenv("CSRF_COOKIE_DOMAIN", raising=False)
     monkeypatch.delenv("CSRF_TRUSTED_ORIGINS", raising=False)
     monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "main.settings")
     monkeypatch.setenv("MAILGUN_SENDER_DOMAIN", "mailgun.fake.domain")
@@ -93,6 +94,17 @@ def test_admin_settings(settings_sandbox, settings):
     settings.ADMINS = (("Admins", test_admin_email),)
     mail.mail_admins("Test", "message")
     assert test_admin_email in mail.outbox[0].to
+
+
+def test_csrf_cookie_domain(settings_sandbox):
+    """Verify that we can configure CSRF_COOKIE_DOMAIN with a var"""
+    # Test the default
+    settings_vars = settings_sandbox.get()
+    assert settings_vars.get("CSRF_COOKIE_DOMAIN") is None
+
+    # Verify the env var works
+    settings_vars = settings_sandbox.patch({"CSRF_COOKIE_DOMAIN": "some.domain.com"})
+    assert settings_vars.get("CSRF_COOKIE_DOMAIN") == "some.domain.com"
 
 
 def test_csrf_trusted_origins(settings_sandbox):


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7625

### Description (What does it do?)
This PR adds `CSRF_COOKIE_DOMAIN` as a configurable setting in `settings.py`. It is not required and defaults to `None`. This is being done to make CSRF to MITx Online possible from our other websites, namely MIT Learn.

### How can this be tested?
- In your `.env` file, set `CSRF_COOKIE_DOMAIN=.odl.local`
- Spin up `mitxonline` on this branch
- Open a Django shell and run the following, after which you should see the cookie domain set to `.odl.local`:
```
from django.conf import settings
settings.CSRF_COOKIE_DOMAIN
```
