### PR TITLE
Fix divide-by-zero error if there is a full-value discount

### DIFF
--- a/hubspot_sync/conftest.py
+++ b/hubspot_sync/conftest.py
@@ -87,6 +87,33 @@ def hubspot_order():
 
 
 @pytest.fixture
+def hubspot_b2b_order():
+    """Return an order for testing with hubspot - this is a B2B order, so zero-value"""
+    order = factories.OrderFactory()
+    with reversion.create_revision():
+        product = factories.ProductFactory.create(price=Decimal("0"))
+
+    factories.LineFactory.create(
+        order=order,
+        product_version=Version.objects.get_for_object(product).first(),
+        purchased_object=product.purchasable_object,
+    )
+
+    HubspotObjectFactory.create(
+        content_object=order.purchaser,
+        content_type=ContentType.objects.get_for_model(User),
+        object_id=order.purchaser.id,
+    )
+    HubspotObjectFactory.create(
+        content_object=product,
+        content_type=ContentType.objects.get_for_model(Product),
+        object_id=product.id,
+    )
+
+    return order
+
+
+@pytest.fixture
 def hubspot_order_id(hubspot_order):
     """Create a HubspotObject for hubspot_order"""
     return HubspotObjectFactory.create(

--- a/hubspot_sync/serializers.py
+++ b/hubspot_sync/serializers.py
@@ -219,6 +219,8 @@ class OrderToDealSerializer(serializers.ModelSerializer):
             discount_percent = discount.amount
         elif discount.discount_type == DISCOUNT_TYPE_DOLLARS_OFF:
             discount_percent = Decimal(discount.amount / product_price) * 100
+        elif discount.amount == 0 or product_price == 0:
+            discount_percent = Decimal(100)
         else:
             discount_percent = Decimal(
                 ((product_price - discount.amount) / product_price) * 100


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#7510

### Description (What does it do?)

For B2B courses, we create discount codes that set the effective price to $0. These are linked to products that are also $0. The serializer didn't check for this, so it kept trying to divide by zero, which caused errors. Now we check for either a discount that's fixed-price $0 or a product that is $0, and return 100% discount in that case.

### How can this be tested?

Automated tests should pass.

I don't think you need a properly working HubSpot setup to test this but you'll need it set up enough that the sync tasks run. You _do not_ need to do the specific B2B setup for this - the issue is entirely due to the discount and product setup, which you can just do with a normal discount and product.

1. Set up a course/etc. and a product. (Ideally, set up one that is zero-value but if you do that it _will_ need to be attached to a B2B contract.)
2. Set up a discount that is specifically fixed-price, and sets the price to $0. _A percent-off discount set to 100% won't work._ 
3. Buy the product with the discount.
4. Check your Celery logs. You should not see the error reported in the issue linked to above.

### Additional Context

Maybe we want orders that have a discount and a product worth $0 to be something besides 100% off in HubSpot? We can change that if we want but this seems like a very very edgy edge case. 