### PR TITLE
Couple small fixes for the one-click enroll API

### DIFF
--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -1,6 +1,7 @@
 """Views for the B2B API (v0)."""
 
 from django.contrib.contenttypes.models import ContentType
+from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
@@ -52,15 +53,16 @@ class Enroll(APIView):
         request=None,
         responses=CreateB2BEnrollmentSerializer,
     )
+    @csrf_exempt
     def post(self, request, readable_id: str, format=None):  # noqa: A002, ARG002
         """Create an enrollment for the given course run."""
 
         course_run_content_type = ContentType.objects.get_for_model(CourseRun)
         courserun = CourseRun.objects.filter(
-            readable_id=readable_id, b2b_contract__isnull=False
+            courseware_id=readable_id, b2b_contract__isnull=False
         ).get()
         product = Product.objects.filter(
-            content_type=course_run_content_type, purchasable_object_id=courserun.id
+            content_type=course_run_content_type, object_id=courserun.id
         ).get()
 
         return Response(

--- a/b2b/views/v0/urls.py
+++ b/b2b/views/v0/urls.py
@@ -1,6 +1,6 @@
 """URL routing for v0 of the B2B API."""
 
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 from rest_framework.routers import SimpleRouter
 
 from b2b.views.v0 import ContractPageViewSet, Enroll, OrganizationPageViewSet
@@ -21,5 +21,5 @@ v0_router.register(
 
 urlpatterns = [
     re_path(r"^", include(v0_router.urls)),
-    re_path(r"^enroll/<str:readable_id>/", Enroll.as_view()),
+    path(r"enroll/<str:readable_id>/", Enroll.as_view()),
 ]


### PR DESCRIPTION

### What are the relevant tickets?

n/a

### Description (What does it do?)

There were a handful of issues that prevented the one-click enroll API from working:

- Routing needed to be fixed - seemed correct at the time, appeared correct in the route list in the error, actually wasn't
- Added a CSRF exemption for the route (since we'll basically always be posting to it from a different app)
- Fixed some errors in model field names

### How can this be tested?

Hit the API with a course run ID that is both in a B2B contract _that your user is also in_ and is one you're not actively enrolled in. (So, you can use one that you _have_ been enrolled in, but only if you unenroll yourself.) This should work, and you should get an order ID back.

If you do it again, you should get an error, because we don't allow you to re-buy if you're enrolled in the course run. If you're not in the contract, you should also get an error. If your contract isn't free-to-enroll, you should get a response as such - you'll have to check out like you would with a regular purchased course.
