### PR TITLE
Repair faulty users when OpenEdxUser exists already

### DIFF
--- a/users/models_test.py
+++ b/users/models_test.py
@@ -104,6 +104,10 @@ def test_faulty_user_qset():
     UserFactory.create(is_active=False, no_openedx_user=True, no_openedx_api_auth=True)
     good_users = users[0:2]
     expected_faulty_users = users[2:]
+    # Create OpenEdxUser for one of the faulty users
+    OpenEdxUserFactory.create(user=expected_faulty_users[0], has_been_synced=False)
+    # Create OpenEdxApiAuth for the same faulty user
+    OpenEdxApiAuthFactory.create(user=expected_faulty_users[0])
     OpenEdxApiAuthFactory.create_batch(
         3,
         user=factory.Iterator(good_users + [users[3]]),  # noqa: RUF005


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/7610

### Description (What does it do?)

Update the FaultyOpenEdxUserManager manager to also include users who have edx_username set but have not been synced.
### How can this be tested?

Tests should pass

You can test this by updating your OpenEdxUser `has_been_synced` to false and then making sure that the task has picked it up and tried to sync with edx.
