### PR TITLE
Add a command to fix missing edx_username values

### DIFF
--- a/openedx/management/commands/repair_openedx_usernames.py
+++ b/openedx/management/commands/repair_openedx_usernames.py
@@ -1,0 +1,60 @@
+"""
+Repairs the openedx username
+"""
+
+import sys
+
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+from django.db.models import F, Q
+from tabulate import tabulate
+
+from openedx import api
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Repairs the openedx username
+    """
+
+    help = "Repairs the openedx username"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user-id",
+            action="append",
+            help="The ID of the user to repair",
+        )
+
+    def handle(self, *args, **kwargs):  # noqa: ARG002
+        users = User.objects.filter(
+            Q(openedx_users=None) | Q(openedx_users__edx_username=None)
+        ).exclude(Q(username=F("email")) | Q(username__icontains="@"))
+
+        if kwargs["user_id"]:
+            users = users.filter(id__in=kwargs["user_id"])
+
+        if users.count() == 0:
+            self.stdout.write("No users found")
+            sys.exit(1)
+
+        self.stdout.write("Found the following users:")
+        self.stdout.write("")
+
+        self.stdout.write(
+            tabulate(
+                [(user.email, user.username) for user in users],
+                headers=["email", "username"],
+            )
+        )
+        self.stdout.write("")
+
+        answer = input("Continue to repair these users? (y/n): ").lower()
+
+        if answer == "y":
+            for user in users:
+                api.create_user(user, user.username)
+        else:
+            self.stdout.write("No actions taken, exiting")

--- a/poetry.lock
+++ b/poetry.lock
@@ -4970,6 +4970,21 @@ release = ["twine"]
 test = ["pylint", "pytest", "pytest-black", "pytest-cov", "pytest-pylint"]
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+description = "Pretty-print tabular data"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
+    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 name = "telepath"
 version = "0.3.1"
 description = "A library for exchanging data between Python and JavaScript"
@@ -5567,4 +5582,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "c3fac029e77113f3677c04bcc4b69aeb6ae4e01cf22443aeb1563b18e0eac54e"
+content-hash = "6b7f62d1d85daad5a5364fd7a17607976a431d8709702ce019fa4ab2015df63d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ mitol-django-google-sheets = "^2025.6.13"
 mitol-django-google-sheets-deferrals = "^2025.3.17"
 mitol-django-google-sheets-refunds = "^2025.6.13"
 pytest-lazy-fixtures = "^1.1.4"
+tabulate = "^0.9.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/7652

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a management command that updates a user's `OpenEdxUser.edx_username` from their `User.username`. By default it does this for all users that have either not `OpenEdxUser` record or a null `OpenEdxUser.edx_username`. A specific user can be specified as well.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Ensure you have at least two users with a null `edx_username`. If you create one, be sure they have a `LegalAddress` and `UserProfile` and that `User.name` is populated.
- Run `./manage.py repair_openedx_username`, you should see you users in the list. Choose no (n).
- Run `./manage.py repair_openedx_username --user-id ID`, you should see only that user. Choose yes (y), the user should have `edx_username` set and be created in openedx. 
- Run `./manage.py repair_openedx_username`, you should see the remaining users. Choose yes (y) and the remaining users should be repaired.