### PR TITLE
Expose CSRF_COOKIE_DOMAIN as a setting that can be changed via environment

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -109,7 +109,6 @@ CSRF_COOKIE_DOMAIN = get_string(
     default=None,
     description="Domain to set the CSRF cookie to.",
 )
-
 CSRF_TRUSTED_ORIGINS = get_delimited_list(
     name="CSRF_TRUSTED_ORIGINS",
     default=[],


### PR DESCRIPTION

### What are the relevant tickets?

Related to https://github.com/mitodl/mit-learn/pull/2312

### Description (What does it do?)

MITx Online doesn't have a setting for `CSRF_COOKIE_DOMAIN`, which means it defaults to the hostname that it's running under, which then means that any other app can't retrieve the CSRF token. This exposes the setting so that you can set it in the `.env` file to fix this issue.

### How can this be tested?

The above PR is a good test bed for this. You'll need to get Learn set up appropriately - see the PR for details. This assumes you have a "typical" setup for OL apps - each one is at a domain under `.odl.local`.

With MITx Online on the main branch, test changing the email settings from within Learn. It should fail with a CSRF token missing error.

Switch to this branch, and set the `.env` file up so that `CSRF_COOKIE_DOMAIN=".odl.local"` (the leading . is important). Restart the app. Try changing email settings from Learn again. It should work. If it doesn't, you may need to close out your session or remove cookies - if you have a stale csrftoken cookie, it won't have the domain change.

### Additional Context

I thought about exposing the cookie name too but there's not a good way to get settings into the frontend app at build time (that I know of - this app's build system is very different from other apps). Usually we pass these sorts of things in via a JSON blob that gets injected into the Django template at runtime but using that for the CSRF token seems less than great, so I didn't do that.