### PR TITLE
Auto-generate edX username on enroll

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -767,7 +767,7 @@ def enroll_in_edx_course_runs(
     edx_client = get_edx_api_service_client()
 
     if reconcile_edx_username(user):
-        user.reload_from_db()
+        user.refresh_from_db()
 
     username = user.edx_username
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2691,14 +2691,14 @@ touchstone = ["python3-saml (>=1.10.1) ; python_version < \"3.13\""]
 
 [[package]]
 name = "mitol-django-common"
-version = "2025.5.23"
+version = "2025.6.20"
 description = "MIT Open Learning django app extensions for common utilities"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mitol_django_common-2025.5.23-py3-none-any.whl", hash = "sha256:3ec46487146473293e3918c29ef92412ffd9f3ca1ce442ddc06c4a80ae0afe09"},
-    {file = "mitol_django_common-2025.5.23.tar.gz", hash = "sha256:5b56dfc1b5ad6d843bf19c2a3b529a1e8f69f466a8c548f796f0ab193882b2e9"},
+    {file = "mitol_django_common-2025.6.20-py3-none-any.whl", hash = "sha256:a3a1d2ed1570cf905132651ab1338cf30924904c6f4d98af62e80cf9a25d4f54"},
+    {file = "mitol_django_common-2025.6.20.tar.gz", hash = "sha256:5060a99537a571ec8e5b94a3972161a318ae60dc7df4154ebcc8cb5f29cfbdbb"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#7679

### Description (What does it do?)

This makes sure the user has a valid `OpenEdxUser` record before we try to enroll them in the course. They likely _should_ have one, but there are some instances where they won't, and in those cases this will generate the username.

This uses the generation code that was moved from xPRO into ol-django in this PR: https://github.com/mitodl/ol-django/pull/266 and it will use the user's name to generate the username, with the email as the fallback if they don't have a name for whatever reason. If the user has a username in their profile _and_ it's not an email address, then this will just use the user's username (truncated to the max length for edX usernames, which is usually 30). 

### How can this be tested?

Automated tests should pass.

Test with a working edX integration. Create a user that does not have an OpenEdxUser record (e.g. via SSO) and then try to enroll them in a course. It should create an OpenEdxUser record for the user and then try to enroll the user in the course.
