### PR TITLE
Only repair users who are active

### DIFF
--- a/openedx/management/commands/repair_openedx_usernames.py
+++ b/openedx/management/commands/repair_openedx_usernames.py
@@ -29,9 +29,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):  # noqa: ARG002
-        users = User.objects.filter(
-            Q(openedx_users=None) | Q(openedx_users__edx_username=None)
-        ).exclude(Q(username=F("email")) | Q(username__icontains="@"))
+        users = (
+            User.objects.filter(is_active=True)
+            .filter(Q(openedx_users=None) | Q(openedx_users__edx_username=None))
+            .exclude(Q(username=F("email")) | Q(username__icontains="@"))
+        )
 
         if kwargs["user_id"]:
             users = users.filter(id__in=kwargs["user_id"])


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds an additional filter to only repair active users.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to run `./manage.py repair_openedx_usernames` and it will not list users that have a null `edx_username` but are inactive.