### PR TITLE
fix: Set custom CSRF cookie name

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -110,6 +110,12 @@ CSRF_COOKIE_DOMAIN = get_string(
     description="Domain to set the CSRF cookie to.",
 )
 
+CSRF_COOKIE_NAME = get_string(
+    name="CSRF_COOKIE_NAME",
+    default="csrf_mitxonline",
+    description="Cookie name to use for the CSRF token.",
+)
+
 CSRF_TRUSTED_ORIGINS = get_delimited_list(
     name="CSRF_TRUSTED_ORIGINS",
     default=[],


### PR DESCRIPTION
### What are the relevant tickets?
https://github.mit.edu/mitxonline/mitxonline-issues/issues/942

### Description (What does it do?)
<!--- Describe your changes in detail -->
The csrftoken cookie is now conflicting with CSRF in the edx-platform application. This sets a different cookie name to avoid those conflicts since the cookie is being set on a shared domain namespace.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Verify that the CSRF cookie name is set to the custom value

