### PR TITLE
Switch usages of 'csrftoken' to 'csrf_mitxonline'

### DIFF
--- a/frontend/public/src/components/CourseProductDetailEnroll.js
+++ b/frontend/public/src/components/CourseProductDetailEnroll.js
@@ -27,7 +27,7 @@ import {
 import { formatPrettyDate, emptyOrNil } from "../lib/util"
 import moment from "moment-timezone"
 import { getFirstRelevantRun } from "../lib/courseApi"
-import { getCookie } from "../lib/api"
+import { getCSRFCookie } from "../lib/api"
 import users, { currentUserSelector } from "../lib/queries/users"
 import {
   enrollmentMutation,
@@ -236,7 +236,7 @@ export class CourseProductDetailEnroll extends React.Component<
   }
 
   getEnrollmentForm(run: EnrollmentFlaggedCourseRun) {
-    const csrfToken = getCookie("csrftoken")
+    const csrfToken = getCSRFCookie()
 
     return (
       <form action="/enrollments/" method="post">
@@ -566,7 +566,7 @@ export class CourseProductDetailEnroll extends React.Component<
     hasMultipleEnrollableRuns: boolean,
     product: Product | null
   ) {
-    const csrfToken = getCookie("csrftoken")
+    const csrfToken = getCSRFCookie()
     return run ? (
       <h2>
         {(product && run.is_upgradable) || hasMultipleEnrollableRuns ? (

--- a/frontend/public/src/components/ProgramProductDetailEnroll.js
+++ b/frontend/public/src/components/ProgramProductDetailEnroll.js
@@ -31,7 +31,7 @@ import queries from "../lib/queries"
 import { formatPrettyDate, emptyOrNil } from "../lib/util"
 import moment from "moment-timezone"
 import { isFinancialAssistanceAvailable } from "../lib/courseApi"
-import { getCookie } from "../lib/api"
+import { getCSRFCookie } from "../lib/api"
 import type { User, Country } from "../flow/authTypes"
 import users, { currentUserSelector } from "../lib/queries/users"
 import AddlProfileFieldsForm from "./forms/AddlProfileFieldsForm"
@@ -317,7 +317,7 @@ export class ProgramProductDetailEnroll extends React.Component<
   }
 
   getEnrollmentForm(run: EnrollmentFlaggedCourseRun) {
-    const csrfToken = getCookie("csrftoken")
+    const csrfToken = getCSRFCookie()
 
     return (
       <form action="/enrollments/" method="post">

--- a/frontend/public/src/lib/api.js
+++ b/frontend/public/src/lib/api.js
@@ -35,6 +35,10 @@ export function removeCookie(name: string) {
   document.cookie = `${name}=;path=/;`
 }
 
+export function getCSRFCookie(): string | null {
+  return getCookie("csrf_mitxonline")
+}
+
 export function csrfSafeMethod(method: string): boolean {
   // these HTTP methods do not require CSRF protection
   return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method)
@@ -50,7 +54,7 @@ const setWith = R.curry((path, valFunc, obj) => R.set(path, valFunc(), obj))
 
 const csrfToken = R.unless(
   R.compose(csrfSafeMethod, R.prop("method")),
-  setWith(R.lensPath(["headers", "X-CSRFToken"]), () => getCookie("csrftoken"))
+  setWith(R.lensPath(["headers", "X-CSRFToken"]), () => getCSRFCookie())
 )
 
 const jsonHeaders = R.merge({

--- a/frontend/public/src/lib/api_test.js
+++ b/frontend/public/src/lib/api_test.js
@@ -5,6 +5,7 @@ import sinon from "sinon"
 import {
   getCookie,
   removeCookie,
+  getCSRFCookie,
   fetchJSONWithCSRF,
   fetchWithCSRF,
   csrfSafeMethod,
@@ -74,7 +75,7 @@ describe("api", function() {
 
     describe("fetchWithCSRF", () => {
       beforeEach(() => {
-        document.cookie = `csrftoken=${CSRF_TOKEN}`
+        document.cookie = `csrf_mitxonline=${CSRF_TOKEN}`
       })
 
       it("fetches and populates appropriate headers for GET", () => {
@@ -140,7 +141,7 @@ describe("api", function() {
 
     describe("fetchJSONWithCSRF", () => {
       it("fetches and populates appropriate headers for JSON", () => {
-        document.cookie = `csrftoken=${CSRF_TOKEN}`
+        document.cookie = `csrf_mitxonline=${CSRF_TOKEN}`
         const expectedJSON = { data: true }
 
         fetchMock.mock("/url", (url, opts) => {
@@ -171,7 +172,7 @@ describe("api", function() {
       })
 
       it("handles responses with no data", () => {
-        document.cookie = `csrftoken=${CSRF_TOKEN}`
+        document.cookie = `csrf_mitxonline=${CSRF_TOKEN}`
         const expectedJSON = { data: true }
 
         fetchMock.mock("/url", (url, opts) => {
@@ -276,6 +277,13 @@ describe("api", function() {
       document.cookie = "key=cookie"
       removeCookie("unknown")
       assert.equal(getCookie("key"), "cookie")
+    })
+  })
+
+  describe("getCSRFCookie", () => {
+    it("gets a cookie", () => {
+      document.cookie = "csrf_mitxonline=cookie"
+      assert.equal("cookie", getCSRFCookie())
     })
   })
 

--- a/frontend/public/src/lib/queries/util.js
+++ b/frontend/public/src/lib/queries/util.js
@@ -1,7 +1,7 @@
 // @flow
 import { nthArg } from "ramda"
 
-import { getCookie } from "../api"
+import { getCSRFCookie } from "../api"
 
 import type { QueryState } from "redux-query-react/src/types.js"
 
@@ -15,7 +15,7 @@ export const hasUnauthorizedResponse = (queryState: ?QueryState) =>
 
 export const getCsrfOptions = () => ({
   headers: {
-    "X-CSRFTOKEN": getCookie("csrftoken")
+    "X-CSRFTOKEN": getCSRFCookie()
   }
 })
 

--- a/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
+++ b/frontend/staff-dashboard/src/hooks/useDrfDataProvider.ts
@@ -10,7 +10,7 @@ import dataProvider from "@pankod/refine-simple-rest";
 import { stringify } from "query-string";
 
 axios.defaults.withCredentials = true;
-axios.defaults.xsrfCookieName = 'csrftoken';
+axios.defaults.xsrfCookieName = 'csrf_mitxonline';
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 
 const axiosInterface = axios.create();

--- a/locustfile.py.example
+++ b/locustfile.py.example
@@ -16,7 +16,7 @@ class DjangoAdminUser(HttpUser):
         self.login()
 
     def login(self):
-        csrf_token = self.client.cookies['csrftoken']
+        csrf_token = self.client.cookies['csrf_mitxonline']
         self.client.post(
             "/admin/login/",
             {

--- a/main/settings.py
+++ b/main/settings.py
@@ -110,11 +110,8 @@ CSRF_COOKIE_DOMAIN = get_string(
     description="Domain to set the CSRF cookie to.",
 )
 
-CSRF_COOKIE_NAME = get_string(
-    name="CSRF_COOKIE_NAME",
-    default="csrf_mitxonline",
-    description="Cookie name to use for the CSRF token.",
-)
+# NOTE: this is hardcoded in many places so we do not allow it to be dynamic
+CSRF_COOKIE_NAME = "csrf_mitxonline"
 
 CSRF_TRUSTED_ORIGINS = get_delimited_list(
     name="CSRF_TRUSTED_ORIGINS",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Switches usages of the csrf cookie name to `csrf_mitxonline` to match `settings.py`. It also changes `CSRF_COOKIE_NAME` to be a hardcoded value to ensure this is never set without understanding that support needs to be added for it.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
The site should still be functional.