### PR TITLE
Added the private auth complete route for no apisix

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -65,6 +65,8 @@ OPENEDX_OAUTH2_ACCESS_TOKEN_EXPIRY_MARGIN_SECONDS = 10
 OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS = 60
 OPENEDX_AUTH_MAX_TTL_IN_SECONDS = 60 * 60
 
+OPENEDX_AUTH_COMPLETE_URL = "openedx-private-oauth-complete-no-apisix"
+
 ACCESS_TOKEN_HEADER_NAME = "X-Access-Token"  # noqa: S105
 
 
@@ -200,7 +202,7 @@ def create_edx_auth_token(user):
 
         # Step 4
         redirect_uri = urljoin(
-            settings.SITE_BASE_URL, reverse("openedx-private-oauth-complete")
+            settings.SITE_BASE_URL, reverse(OPENEDX_AUTH_COMPLETE_URL)
         )
         url = edx_url(OPENEDX_OAUTH2_AUTHORIZE_PATH)
         params = dict(  # noqa: C408
@@ -296,7 +298,7 @@ def update_edx_user_email(user):
         resp.raise_for_status()
 
         redirect_uri = urljoin(
-            settings.SITE_BASE_URL, reverse("openedx-private-oauth-complete")
+            settings.SITE_BASE_URL, reverse(OPENEDX_AUTH_COMPLETE_URL)
         )
         url = edx_url(OPENEDX_OAUTH2_AUTHORIZE_PATH)
         params = dict(  # noqa: C408

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -308,14 +308,12 @@ def test_create_edx_auth_token(settings):
     responses.add(
         responses.GET,
         f"{settings.OPENEDX_API_BASE_URL}/oauth2/authorize",
-        headers={
-            "Location": f"{settings.SITE_BASE_URL}/login/_private/complete?code={code}"
-        },
+        headers={"Location": f"{settings.SITE_BASE_URL}/_/auth/complete?code={code}"},
         status=status.HTTP_302_FOUND,
     )
     responses.add(
         responses.GET,
-        f"{settings.SITE_BASE_URL}/login/_private/complete",
+        f"{settings.SITE_BASE_URL}/_/auth/complete",
         status=status.HTTP_200_OK,
     )
     responses.add(
@@ -335,7 +333,7 @@ def test_create_edx_auth_token(settings):
         grant_type="authorization_code",
         client_id=settings.OPENEDX_API_CLIENT_ID,
         client_secret=settings.OPENEDX_API_CLIENT_SECRET,
-        redirect_uri=f"{settings.SITE_BASE_URL}/login/_private/complete",
+        redirect_uri=f"{settings.SITE_BASE_URL}/_/auth/complete",
     )
 
     assert OpenEdxApiAuth.objects.filter(user=user).exists()
@@ -385,14 +383,12 @@ def test_update_edx_user_email(settings):
     responses.add(
         responses.GET,
         f"{settings.OPENEDX_API_BASE_URL}/oauth2/authorize",
-        headers={
-            "Location": f"{settings.SITE_BASE_URL}/login/_private/complete?code={code}"
-        },
+        headers={"Location": f"{settings.SITE_BASE_URL}/_/auth/complete?code={code}"},
         status=status.HTTP_302_FOUND,
     )
     responses.add(
         responses.GET,
-        f"{settings.SITE_BASE_URL}/login/_private/complete",
+        f"{settings.SITE_BASE_URL}/_/auth/complete",
         status=status.HTTP_200_OK,
     )
 

--- a/openedx/urls.py
+++ b/openedx/urls.py
@@ -10,4 +10,9 @@ urlpatterns = (
         views.openedx_private_auth_complete,
         name="openedx-private-oauth-complete",
     ),
+    path(
+        "_/auth/complete",
+        views.openedx_private_auth_complete,
+        name="openedx-private-oauth-complete-no-apisix",
+    ),
 )

--- a/openedx/views_test.py
+++ b/openedx/views_test.py
@@ -7,7 +7,14 @@ from rest_framework import status
 pytestmark = [pytest.mark.django_db]
 
 
-def test_openedx_private_auth_complete_view(client):
+@pytest.mark.parametrize(
+    "route",
+    [
+        "openedx-private-oauth-complete",
+        "openedx-private-oauth-complete-no-apisix",
+    ],
+)
+def test_openedx_private_auth_complete_view(client, route):
     """Verify the openedx_private_auth_complete view returns a 200"""
-    response = client.get(reverse("openedx-private-oauth-complete"))
+    response = client.get(reverse(route))
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds the private auth complete view to a url that apisix won't intercept for auth.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the app, the url `/_/auth/complete` should resolve to a HTTP 200 response (there will be no content)