### PR TITLE
Get start date for a program based on the next avaialble course run

### DIFF
--- a/courses/serializers/v2/programs.py
+++ b/courses/serializers/v2/programs.py
@@ -73,6 +73,7 @@ class ProgramSerializer(serializers.ModelSerializer):
     time_commitment = serializers.SerializerMethodField()
     min_weekly_hours = serializers.SerializerMethodField()
     max_weekly_hours = serializers.SerializerMethodField()
+    start_date = serializers.SerializerMethodField()
 
     def get_courses(self, instance) -> list[int]:
         return [course[0].id for course in instance.courses if course[0].live]
@@ -216,6 +217,15 @@ class ProgramSerializer(serializers.ModelSerializer):
             return instance.page.max_weeks
 
         return None
+
+    def get_start_date(self, instance) -> str | None:
+        """
+        Get the start date of the program by finding the first available run.
+        """
+        first_unexpired_run = instance.first_unexpired_run
+        if first_unexpired_run and first_unexpired_run.start_date:
+            return first_unexpired_run.start_date
+        return instance.start_date
 
     class Meta:
         model = Program

--- a/courses/serializers/v2/programs_test.py
+++ b/courses/serializers/v2/programs_test.py
@@ -76,6 +76,13 @@ def test_serialize_program(
     program_department = Department.objects.create(name="Math")
     program_with_empty_requirements.departments.add(program_department)
 
+    first_unexpired_run = program_with_empty_requirements.first_unexpired_run
+
+    if not remove_tree:
+        expected_start_date = first_unexpired_run.start_date
+    else:
+        expected_start_date = program_with_empty_requirements.start_date
+
     data = ProgramSerializer(
         instance=program_with_empty_requirements, context=mock_context
     ).data
@@ -100,7 +107,7 @@ def test_serialize_program(
             "live": True,
             "topics": [{"name": topic.name} for topic in topics],
             "availability": "anytime",
-            "start_date": program_with_empty_requirements.start_date,
+            "start_date": expected_start_date,
             "end_date": program_with_empty_requirements.end_date,
             "enrollment_start": program_with_empty_requirements.enrollment_start,
             "enrollment_end": program_with_empty_requirements.enrollment_end,

--- a/courses/views/test_utils.py
+++ b/courses/views/test_utils.py
@@ -54,7 +54,7 @@ def num_queries_from_programs(programs, version="v1"):
                 num_queries += num_queries_from_course(course)
             num_queries += 4 + (6 * num_courses) + 1
         if version == "v2":
-            num_queries += 6 + (17 * num_courses) + 1
+            num_queries += 6 + (17 * num_courses) + 2
     return num_queries
 
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3229,8 +3229,10 @@ components:
           $ref: '#/components/schemas/AvailabilityEnum'
         start_date:
           type: string
-          format: date-time
           nullable: true
+          description: Get the start date of the program by finding the first available
+            run.
+          readOnly: true
         end_date:
           type: string
           format: date-time
@@ -3296,6 +3298,7 @@ components:
       - req_tree
       - required_prerequisites
       - requirements
+      - start_date
       - time_commitment
       - title
       - topics

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3229,8 +3229,10 @@ components:
           $ref: '#/components/schemas/AvailabilityEnum'
         start_date:
           type: string
-          format: date-time
           nullable: true
+          description: Get the start date of the program by finding the first available
+            run.
+          readOnly: true
         end_date:
           type: string
           format: date-time
@@ -3296,6 +3298,7 @@ components:
       - req_tree
       - required_prerequisites
       - requirements
+      - start_date
       - time_commitment
       - title
       - topics

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -3229,8 +3229,10 @@ components:
           $ref: '#/components/schemas/AvailabilityEnum'
         start_date:
           type: string
-          format: date-time
           nullable: true
+          description: Get the start date of the program by finding the first available
+            run.
+          readOnly: true
         end_date:
           type: string
           format: date-time
@@ -3296,6 +3298,7 @@ components:
       - req_tree
       - required_prerequisites
       - requirements
+      - start_date
       - time_commitment
       - title
       - topics


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/7698

### Description (What does it do?)
Get start date for a program based on the next avaialble course run


### How can this be tested?
tests should pass