### PR TITLE
Fix prefetches on courses API

### DIFF
--- a/courses/views/test_utils.py
+++ b/courses/views/test_utils.py
@@ -26,8 +26,8 @@ def num_queries_from_course(course, version="v1"):
     num_programs = len(course.programs)
     num_course_runs = course.courseruns.count()
     if version == "v1":
-        return (9 * num_programs) + (num_course_runs * 6) + 22
-    return num_programs + (num_course_runs * 6) + 22
+        return (9 * num_programs) + (num_course_runs * 6) + 20
+    return num_programs + (num_course_runs * 6) + 20
 
 
 def num_queries_from_programs(programs, version="v1"):

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -833,7 +833,7 @@ paths:
         name: org_id
         schema:
           type: number
-        description: Only show courses beloning to this B2B/UAI organization
+        description: Only show courses belonging to this B2B/UAI organization
       - name: page
         required: false
         in: query

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -833,7 +833,7 @@ paths:
         name: org_id
         schema:
           type: number
-        description: Only show courses beloning to this B2B/UAI organization
+        description: Only show courses belonging to this B2B/UAI organization
       - name: page
         required: false
         in: query

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -833,7 +833,7 @@ paths:
         name: org_id
         schema:
           type: number
-        description: Only show courses beloning to this B2B/UAI organization
+        description: Only show courses belonging to this B2B/UAI organization
       - name: page
         required: false
         in: query


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/mitxonline/issues/2774

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes a regression introduced in my [previous PR]() that fixed the tests being flaky. At the time the API filtering wasn't being tested in `views_test.py` so this didn't get caught until RC. It's caused by the fact that the filter specifies its own prefetch for `courseruns` when `?courserun_is_enrollable=` is passed. I opted for putting the logic in the `Filterset` itself. It feels like there should be a better way to do this, but it's good enough for now.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Tests should pass