### PR TITLE
shuffle around middleware so CSRF works in Wagtail

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -321,6 +321,8 @@ MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "mitol.apigateway.middleware.ApisixUserMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -330,7 +332,6 @@ MIDDLEWARE = (
     "hijack.middleware.HijackUserMiddleware",
     "main.middleware.CachelessAPIMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
-    "mitol.apigateway.middleware.ApisixUserMiddleware",
     "oauth2_provider.middleware.OAuth2TokenMiddleware",
     "django_scim.middleware.SCIMAuthCheckMiddleware",
 )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7739

### Description (What does it do?)
This PR fixes an issue with the ordering of the middleware that was causing CSRF validation to fail while using the Wagtail CMS mounted at `/cms`. 

### How can this be tested?
- Spin up `mitxonline` with Keycloak / APISIX enabled
- Browse to MITx Online and log in as an admin
- Navigate to `/cms` to load Wagtail
- Attempt to either make an edit to an existing page, create a new one or delete a page
- You should not get a CSRF error
