### PR TITLE
Fix typo in the b2b_list command; some minor changes for local deployments

### DIFF
--- a/b2b/management/commands/b2b_list.py
+++ b/b2b/management/commands/b2b_list.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         if code.order_redemptions.count() == 0:
             return "No"
         elif code.order_redemptions.count() == 1:
-            return code.order_redemptions.first().redemeed_by.email
+            return code.order_redemptions.first().redeemed_by.email
 
         return code.order_redemptions.count()
 

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -59,6 +59,9 @@ routes:
           set:
             Content-Security-Policy: frame-ancestors 'self' ${{OPENEDX_API_BASE_URL}}
     uris:
-      - "/login*"
+      - "/login"
+      - "/login/"
+      - "/admin/login*"
+
 
 #END

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,10 @@ x-extra-hosts:
   &default-extra-hosts # pragma: allowlist secret
   - "edx.odl.local:${OPENEDX_IP:-172.22.0.1}"
   - "host.docker.internal:host-gateway"
-  - "local.openedx.io:host-gateway"
-  - "studio.local.openedx.io:host-gateway"
+  - "openedx.odl.local:host-gateway"
+  - "studio.openedx.odl.local:host-gateway"
+  - "apps.openedx.odl.local:host-gateway"
+  - "mitxonline.odl.local:host-gateway"
 
 services:
   db:
@@ -216,7 +218,7 @@ services:
     profiles:
       - apisix
     environment:
-      - OPENEDX_API_BASE_URL=${OPENEDX_API_BASE_URL:-http://local.openedx.io:8000}
+      - OPENEDX_API_BASE_URL={OPENEDX_API_BASE_URL:-http://openedx.odl.local:8000}
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-ol-local}
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-apisix}
       - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET}


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

Listing out enrollment codes includes whether or not they've been redeemed, and there was a typo in redeemed, so this fixes it.

This also updates a couple of small things:
- Added a couple more edX hostnames to the extra hosts list: `apps.openedx.odl.local` and `studio.openedx.odl.local`
- Updated the login-required routes for APISIX - instead of wildcarding `/login`, it now uses specific routes so that the OAuth routes continue to work

### How can this be tested?

This only is a problem if you try to list out enrollment codes (`b2b_list contracts --codes <id>`) that have been redeemed, so you'll need to generate a contract that uses enrollment codes - just create one with a price and a learner cap - and then redeem one. You should be able to list out the codes, and it should show you which have been redeemed.

The other changes should not break anything; if you're running with a working Tutor install, it should "just work" if you've configured your Tutor instance to use `openedx.odl.local`. 
