### PR TITLE
Handle edx_username outside transaction

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -108,7 +108,7 @@ def create_edx_user(user, edx_username=None):
             user=user, platform=PLATFORM_EDX
         )
 
-        if open_edx_user.edx_username:
+        if not open_edx_user.edx_username:
             # no username has been set so skip this
             return False
 

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -222,7 +222,7 @@ def create_edx_auth_token(user):
     # 6. Redeem access token for a refresh/access token pair
 
     # if the user hasn't been created on openedx, we can't do any of this
-    if user.openedxusers.filter(
+    if not user.openedxusers.filter(
         edx_username__isnull=False, has_been_synced=True
     ).exists():
         return None

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -105,7 +105,9 @@ def create_edx_user(user, edx_username=None):
 
     with transaction.atomic():
         open_edx_user, _ = OpenEdxUser.objects.select_for_update().get_or_create(
-            user=user, platform=PLATFORM_EDX
+            user=user,
+            platform=PLATFORM_EDX,
+            defaults={"edx_username": edx_username or None},
         )
 
         if not open_edx_user.edx_username:

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -222,7 +222,7 @@ def create_edx_auth_token(user):
     # 6. Redeem access token for a refresh/access token pair
 
     # if the user hasn't been created on openedx, we can't do any of this
-    if not user.openedxusers.filter(
+    if not user.openedx_users.filter(
         edx_username__isnull=False, has_been_synced=True
     ).exists():
         return None

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -136,6 +136,9 @@ def test_create_edx_user(  # noqa: PLR0913
     missing_username,
 ):
     """Test that create_edx_user makes a request to create an edX user"""
+    if has_been_synced and missing_username:
+        pytest.skip("Invalidation combination")
+
     user = UserFactory.create(openedx_user__has_been_synced=has_been_synced)
     openedx_user = user.openedx_users.first()
     if missing_username:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This solves a deadlock situation where we were updating the `edx_username` inside of the transaction but that causes openedx's registration API to not be able to see that value when it makes a call to `/user/me` because we haven't committed it to the DB. This moves that code into an equivalent `update()` query outside of the transaction. It also adds a check inside that transaction to bail if `edx_username` is `None` and a similar check to `create_edx_auth_token` that we now need too because it's not guaranteed that method gets called and the user exists in openedx anymore because the username isn't set nor has the user been synced.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to register for a user locally, the user should be created in openedx, and their social auth uid should match their `edx_username` and NOT be `"None"`.