### PR TITLE
remove wildcarding functionality in middleware

### DIFF
--- a/main/middleware.py
+++ b/main/middleware.py
@@ -6,8 +6,6 @@ from django.conf import settings
 from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.deprecation import MiddlewareMixin
 
-SUBDOMAIN_THRESHOLD = 3
-
 
 class CachelessAPIMiddleware(MiddlewareMixin):
     """Add Cache-Control header to API responses"""
@@ -41,14 +39,7 @@ class HostBasedCSRFMiddleware(CsrfViewMiddleware):
                 if parsed_origin.netloc:
                     csrf_trusted_hosts.append(parsed_origin.netloc)
             if host in csrf_trusted_hosts:
-                host_parts = host.split(".")
-                # Only wildcard on second tier subdomains (3 parts or more)
-                # e.g. "api.learn.mit.edu" -> ".learn.mit.edu"
-                if len(host_parts) > SUBDOMAIN_THRESHOLD:
-                    parent_domain = "." + ".".join(host_parts[1:])
-                else:
-                    parent_domain = host
-                response.cookies[settings.CSRF_COOKIE_NAME]["domain"] = (
-                    parent_domain.split(":")[0]
-                )
+                response.cookies[settings.CSRF_COOKIE_NAME]["domain"] = host.split(":")[
+                    0
+                ]
         return response

--- a/main/middleware_test.py
+++ b/main/middleware_test.py
@@ -8,7 +8,7 @@ from main.middleware import HostBasedCSRFMiddleware
     ("host", "expected_domain"),
     [
         ("http://mitxonline.mit.edu", "mitxonline.mit.edu"),
-        ("http://api.learn.mit.edu", ".learn.mit.edu"),
+        ("http://api.learn.mit.edu", "api.learn.mit.edu"),
         ("http://learn.mit.edu", "learn.mit.edu"),
         ("http://mitxonline.odl.local:8013", "mitxonline.odl.local"),
         ("http://example.com", ""),
@@ -16,7 +16,7 @@ from main.middleware import HostBasedCSRFMiddleware
         ("not-a-url", ""),
         ("http://", ""),
         ("http://mitxonline.mit.edu:8080", ""),
-        ("http://sub.sub.sub.learn.mit.edu", ".sub.sub.learn.mit.edu"),
+        ("http://sub.sub.sub.learn.mit.edu", "sub.sub.sub.learn.mit.edu"),
         ("http://localhost", ""),
     ],
 )


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mitxonline/pull/2786

### Description (What does it do?)
This PR follows up the above PR based on some testing in RC. The functionality that sets a wildcard domain on the response CSRF cookie is not necessary, since the domain being used is from `HTTP_REFERER` (validated against `CSRF_TRUSTED_ORIGINS`.

### How can this be tested?
You should be able to follow the same steps as in https://github.com/mitodl/mitxonline/pull/2786 and everything should still work. This fix is mostly for RC / Production.
