### PR TITLE
Add price range from the cms page to api

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -45,6 +45,8 @@ class CourseSerializer(BaseCourseSerializer):
     time_commitment = serializers.SerializerMethodField()
     min_weekly_hours = serializers.SerializerMethodField()
     max_weekly_hours = serializers.SerializerMethodField()
+    min_price = serializers.SerializerMethodField()
+    max_price = serializers.SerializerMethodField()
 
     @extend_schema_field(bool)
     def get_required_prerequisites(self, instance):
@@ -166,6 +168,25 @@ class CourseSerializer(BaseCourseSerializer):
 
         return None
 
+    min_price = serializers.SerializerMethodField()
+    max_price = serializers.SerializerMethodField()
+
+    def get_min_price(self, instance) -> int | None:
+        """
+        Get the min price of the product from the CMS page.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "min_price"):
+            return instance.page.min_price
+        return None
+
+    def get_max_price(self, instance) -> int | None:
+        """
+        Get the max price of the product from the CMS page.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "max_price"):
+            return instance.page.max_price
+        return None
+
     class Meta:
         model = models.Course
         fields = [
@@ -182,6 +203,8 @@ class CourseSerializer(BaseCourseSerializer):
             "duration",
             "min_weeks",
             "max_weeks",
+            "min_price",
+            "max_price",
             "time_commitment",
             "availability",
             "min_weekly_hours",

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -168,9 +168,6 @@ class CourseSerializer(BaseCourseSerializer):
 
         return None
 
-    min_price = serializers.SerializerMethodField()
-    max_price = serializers.SerializerMethodField()
-
     def get_min_price(self, instance) -> int | None:
         """
         Get the min price of the product from the CMS page.

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -74,6 +74,8 @@ def test_serialize_course(
             "duration": course.page.length,
             "max_weeks": course.page.max_weeks,
             "min_weeks": course.page.min_weeks,
+            "min_price": course.page.min_price,
+            "max_price": course.page.max_price,
             "time_commitment": course.page.effort,
             "programs": (
                 BaseProgramSerializer(course.programs, many=True).data
@@ -119,6 +121,8 @@ def test_serialize_course_required_prerequisites(
             "duration": course.page.length,
             "max_weeks": course.page.max_weeks,
             "min_weeks": course.page.min_weeks,
+            "min_price": course.page.min_price,
+            "max_price": course.page.max_price,
             "time_commitment": course.page.effort,
             "programs": None,
         },

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -129,31 +129,10 @@ class ProductPurchasableObjectField(serializers.RelatedField):
 class BaseProductSerializer(serializers.ModelSerializer):
     """Simple serializer for Product without related purchasable objects"""
 
-    min_price = serializers.SerializerMethodField()
-    max_price = serializers.SerializerMethodField()
-
-    def get_min_price(self, instance) -> int | None:
-        """
-        Get the min price of the product from the CMS page.
-        """
-        if hasattr(instance, "page") and hasattr(instance.page, "min_price"):
-            return instance.page.min_price
-        return None
-
-    def get_max_price(self, instance) -> int | None:
-        """
-        Get the max price of the product from the CMS page.
-        """
-        if hasattr(instance, "page") and hasattr(instance.page, "max_price"):
-            return instance.page.max_price
-        return None
-
     class Meta:
         fields = [
             "id",
             "price",
-            "min_price",
-            "max_price",
             "description",
             "is_active",
         ]

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -129,10 +129,31 @@ class ProductPurchasableObjectField(serializers.RelatedField):
 class BaseProductSerializer(serializers.ModelSerializer):
     """Simple serializer for Product without related purchasable objects"""
 
+    min_price = serializers.SerializerMethodField()
+    max_price = serializers.SerializerMethodField()
+
+    def get_min_price(self, instance) -> int | None:
+        """
+        Get the min price of the product from the CMS page.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "min_price"):
+            return instance.page.min_price
+        return None
+
+    def get_max_price(self, instance) -> int | None:
+        """
+        Get the max price of the product from the CMS page.
+        """
+        if hasattr(instance, "page") and hasattr(instance.page, "max_price"):
+            return instance.page.max_price
+        return None
+
     class Meta:
         fields = [
             "id",
             "price",
+            "min_price",
+            "max_price",
             "description",
             "is_active",
         ]

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1425,6 +1425,16 @@ components:
           nullable: true
           description: Get the max weeks of the course from the CMS page.
           readOnly: true
+        min_price:
+          type: integer
+          nullable: true
+          description: Get the min price of the product from the CMS page.
+          readOnly: true
+        max_price:
+          type: integer
+          nullable: true
+          description: Get the max price of the product from the CMS page.
+          readOnly: true
         time_commitment:
           type: string
           nullable: true
@@ -1459,8 +1469,10 @@ components:
       - departments
       - duration
       - id
+      - max_price
       - max_weekly_hours
       - max_weeks
+      - min_price
       - min_weekly_hours
       - min_weeks
       - next_run_id

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -1425,6 +1425,16 @@ components:
           nullable: true
           description: Get the max weeks of the course from the CMS page.
           readOnly: true
+        min_price:
+          type: integer
+          nullable: true
+          description: Get the min price of the product from the CMS page.
+          readOnly: true
+        max_price:
+          type: integer
+          nullable: true
+          description: Get the max price of the product from the CMS page.
+          readOnly: true
         time_commitment:
           type: string
           nullable: true
@@ -1459,8 +1469,10 @@ components:
       - departments
       - duration
       - id
+      - max_price
       - max_weekly_hours
       - max_weeks
+      - min_price
       - min_weekly_hours
       - min_weeks
       - next_run_id

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -1425,6 +1425,16 @@ components:
           nullable: true
           description: Get the max weeks of the course from the CMS page.
           readOnly: true
+        min_price:
+          type: integer
+          nullable: true
+          description: Get the min price of the product from the CMS page.
+          readOnly: true
+        max_price:
+          type: integer
+          nullable: true
+          description: Get the max price of the product from the CMS page.
+          readOnly: true
         time_commitment:
           type: string
           nullable: true
@@ -1459,8 +1469,10 @@ components:
       - departments
       - duration
       - id
+      - max_price
       - max_weekly_hours
       - max_weeks
+      - min_price
       - min_weekly_hours
       - min_weeks
       - next_run_id


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7698
### Description (What does it do?)
Adding min_price and max_price to the Course and Product Serializer

### Screenshots (if appropriate):
<img width="228" height="131" alt="Screenshot 2025-07-16 at 11 58 17 AM" src="https://github.com/user-attachments/assets/2fae3298-dbd5-4d1c-b1f0-e0d9d6ada5d2" />


Go to http://mitxonline.odl.local:8013/api/v2/courses/
and http://mitxonline.odl.local:8013/api/v2/programs/