### PR TITLE
 Disable create-account page when keycloak login is enabled

### DIFF
--- a/frontend/public/src/containers/pages/register/RegisterEmailPage.js
+++ b/frontend/public/src/containers/pages/register/RegisterEmailPage.js
@@ -17,7 +17,8 @@ import {
   STATE_REGISTER_CONFIRM_SENT,
   STATE_LOGIN_PASSWORD,
   STATE_REGISTER_EMAIL,
-  handleAuthResponse
+  handleAuthResponse,
+  generateLoginRedirectUrl
 } from "../../../lib/auth"
 import { qsNextSelector } from "../../../lib/selectors"
 import { ALERT_TYPE_TEXT } from "../../../constants"
@@ -46,6 +47,14 @@ type Props = {
 const accountExistsNotificationText = (email: string): string =>
   `You already have an account with ${email}. Enter password to sign in.`
 export class RegisterEmailPage extends React.Component<Props> {
+  componentDidMount() {
+    // If OIDC login is disabled but API gateway is enabled, redirect to login
+    if (!SETTINGS.oidc_login_url && SETTINGS.api_gateway_enabled) {
+      generateLoginRedirectUrl()
+      return
+    }
+  }
+
   async onSubmit(
     { email, recaptcha }: RegisterEmailFormValues,
     { setSubmitting, setErrors }: any


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7841

### Description (What does it do?)
Redirects the user to the Keycloak login page from the create account page when the following are set:
```
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False
EXPOSE_OIDC_LOGIN=False
```

### How can this be tested?
Visit http://mitxonline.odl.local:9080/create-account/.
Ensure that you are redirected to the keycloak login page.
