### PR TITLE
Fix the URL generation for B2B course runs

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Iterable
 from decimal import Decimal
 from typing import Union
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 from uuid import uuid4
 
 import reversion
@@ -147,7 +147,9 @@ def create_contract_run(
         is_self_paced=True,
         live=True,
         b2b_contract=contract,
-        courseware_url_path=urljoin(settings.OPENEDX_COURSE_BASE_URL, new_readable_id),
+        courseware_url_path=urljoin(
+            settings.OPENEDX_COURSE_BASE_URL, quote(new_readable_id)
+        ),
     )
     course_run.save()
     clone_courserun.delay(course_run.id, base_id=clone_course_run.courseware_id)

--- a/b2b/api_test.py
+++ b/b2b/api_test.py
@@ -498,5 +498,6 @@ def test_create_contract_run(mocker, source_run_exists, run_exists):
     assert course.courseruns.filter(courseware_id=target_course_id).exists()
     assert created_run.courseware_id == target_course_id
     assert created_product.object_id == created_run.id
+    assert settings.OPENEDX_COURSE_BASE_URL in created_run.courseware_url
 
     mocked_clone_run.assert_called()


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#7860

### Description (What does it do?)

Updates the courseware_url property generation as noted in the original issue.

### How can this be tested?

Automated tests should pass. There's a test to make sure the base URL is in the generated URL now.

Otherwise, create a B2B course run by using the `b2b_contract courseware` command. This will trigger `create_contract_run` and thus will hit the changed code. Once done, the created run should have the proper URL in it. (The readable ID will be urlencoded.)

### Additional Context

The original issue notes removing the `OPENEDX_COURSE_BASE_URL` setting and using the API base URL instead - these are completely different, at least on local deployments, so I haven't done this. (Ex: `http://apps.openedx.odl.local:2000/learning/course/course-v1:xPRO+Test1+5T2025/home` is the URL for a course in Tutor locally; if we used the base API URL for this, it'd be starting at `http://openedx.odl.local:8000` so that's a non-starter.) This does need to be set in RC and production but that's a separate issue for a separate repo. We've just been setting them by hand for now.
