### PR TITLE
Adding default extra hosts to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ x-extra-hosts:
   - "studio.openedx.odl.local:host-gateway"
   - "apps.openedx.odl.local:host-gateway"
   - "mitxonline.odl.local:host-gateway"
+  - "local.openedx.io:host-gateway"
+  - "studio.local.openedx.io:host-gateway"
 
 services:
   db:


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adding default extra hosts to docker compose:
  - "local.openedx.io:host-gateway"
  - "studio.local.openedx.io:host-gateway"


### How can this be tested?
nothing should break.

