### PR TITLE
Fix overwriting of name field with blank values

### DIFF
--- a/users/adapters.py
+++ b/users/adapters.py
@@ -63,7 +63,7 @@ class LearnUserAdapter(UserAdapter):
         """
         super().from_dict(d)
 
-        self.obj.name = d.get("fullName", "")
+        self.obj.name = d.get("fullName", self.obj.name)  # name's default is ""
 
         first_name = d.get("name", {}).get("given_name", "")
         if first_name:

--- a/users/adapters_test.py
+++ b/users/adapters_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from users.adapters import UserAdapter
+from users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_user_adapter_blank_fields():
+    """Test that an incoming request with no name data doesn't blank out fields"""
+    user = UserFactory.create(
+        name="Joe Smith",
+        legal_address__first_name="Joe",
+        legal_address__last_name="Smith",
+    )
+
+    adapter = UserAdapter(user)
+    adapter.from_dict(
+        {
+            "active": True,
+            "userName": "jsmith",
+            "externalId": "1",
+        }
+    )
+    adapter.save()
+
+    user.refresh_from_db()
+
+    assert user.name == "Joe Smith"
+    assert user.legal_address.first_name == "Joe"
+    assert user.legal_address.last_name == "Smith"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes an issue where we were overwriting a non-empty `User.name` values with a blank string when the field was missing from the SCIM payload. It prevents data corruption by misconfiguration of the SCIM remote.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You can test this by removing the `fullName` attribute from the scim remote in keycloak and performing a sync. In this branch is should not result in the name being set as blank.
