### PR TITLE
Fix sentry + uwsgi warning for localdev

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -46,3 +46,4 @@ if-not-env = UWSGI_POST_BUFFERING
 post-buffering = 65535
 endif =
 stats = /tmp/uwsgi-stats.sock
+py-call-uwsgi-fork-hooks = true


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

Gets rid of this warning:

```
web-1      | *** Operational MODE: preforking+threaded ***
web-1      | /opt/venv/lib/python3.10/site-packages/sentry_sdk/_compat.py:86: Warning: IMPORTANT: We detected the use of uWSGI in preforking mode without thread support. This might lead to crashing workers. Please run uWSGI with both "--enable-threads" and "--py-call-uwsgi-fork-hooks" for full support.
web-1      |   warn(
```

We already have it configured this way in deployed environments.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run `docker compose up` and you should not see the warning in the output