### PR TITLE
Dont sync test course runs for product page enrollment scenarios

### DIFF
--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -27,9 +27,11 @@ def sync_courseruns_data():
     from courses.api import sync_course_mode, sync_course_runs
 
     now = now_in_utc()
-    runs = CourseRun.objects.live().filter(
-        Q(expiration_date__isnull=True) | Q(expiration_date__gt=now)
-    ).exclude(run_tag__startswith="fake-")
+    runs = (
+        CourseRun.objects.live()
+        .filter(Q(expiration_date__isnull=True) | Q(expiration_date__gt=now))
+        .exclude(run_tag__startswith="fake-")
+    )
 
     # `sync_course_runs` logs internally so no need to capture/output the returned values
     sync_course_mode(runs)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Dont sync course runs that have run_tag starting with "fake-"
Related to https://mit-office-of-digital-learning.sentry.io/issues/2660949245/events/179f7bfe94544ea9a0c1cd289e805d83/?environment=rc&groupId=2660949245&pageEnd=2025-07-25T00%3A00%3A14.888&pageStart=2025-07-24T00%3A00%3A14.888&project=5864687&query=is%3Aunresolved&referrer=previous-event&source=issue_details



### How can this be tested?
nothing should break.
This will reduce the Sentry errors on RC.