### PR TITLE
Catch the 406 Exception when user does not exist and create user

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -38,7 +38,6 @@ from openedx.exceptions import (
     EdxApiEmailSettingsErrorException,
     EdxApiEnrollErrorException,
     EdxApiRegistrationValidationException,
-    EdxApiUserDoesNotExistError,
     EdxApiUserUpdateError,
     NoEdxApiAuthError,
     OpenEdXOAuth2Error,


### PR DESCRIPTION
### What are the relevant tickets?
Should fix this 
https://mit-office-of-digital-learning.sentry.io/issues/3990651903/events/0abec4a79b514e5fae2bfa27978b38fd/?environment=rc&environment=production&project=5864687
### Description (What does it do?)
Reorders exception handling to catch 406 Not Acceptable exception.



### How can this be tested?
create a user on MITx Online without a corresponding edx user. Try enrolling in a course.
