### PR TITLE
add collections to program, show program type requirements

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -7,6 +7,7 @@ import factory
 import faker
 import pytest
 import pytz
+import wagtail_factories
 from factory import SubFactory, fuzzy
 from factory.django import DjangoModelFactory
 
@@ -342,3 +343,21 @@ def program_with_requirements():
         mut_exclusive_courses=mut_exclusive_courses,
         mut_exclusive_courses_node=mut_exclusive_courses_node,
     )
+
+
+class ProgramCollectionFactory(wagtail_factories.PageFactory):
+    """Factory for ProgramCollection"""
+
+    description = fuzzy.FuzzyText(prefix="Description of Collection ")
+    live = True
+
+    class Meta:
+        model = "courses.ProgramCollection"
+
+    @factory.post_generation
+    def programs(self, create, extracted):
+        if not create or not extracted:
+            return
+        for program in extracted:
+            self.programs.add(program)
+        self.save()

--- a/courses/views/test_utils.py
+++ b/courses/views/test_utils.py
@@ -36,9 +36,9 @@ def num_queries_from_programs(programs, version="v1"):
     fixture always generates the same (3 course runs per course, no more than 3 courses per program.
 
     The added on num_queries value is:
-    - 4 query to get the program, related courses, related runs, department
-    - 3 times num_courses for wagtail to get the generic data for the program and courses
-    - 3 times num_courses for program requirements plus one for the initial call
+    - 4 (v1) / 9 (v2) query to get the program, program collections, related courses, related runs, department
+    - 3 (v1) / 6 (v2) times num_courses for wagtail to get the generic data for the program and courses
+    - 3 (v1) / 6 (v2) times num_courses for program requirements plus one for the initial call
 
 
     Args:
@@ -54,7 +54,7 @@ def num_queries_from_programs(programs, version="v1"):
                 num_queries += num_queries_from_course(course)
             num_queries += 4 + (6 * num_courses) + 1
         if version == "v2":
-            num_queries += 6 + (17 * num_courses) + 2
+            num_queries += 9 + (17 * num_courses) + 2
     return num_queries
 
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3282,21 +3282,44 @@ components:
           items:
             type: integer
           readOnly: true
+        collections:
+          type: array
+          items:
+            type: integer
+          readOnly: true
         requirements:
           type: object
           properties:
-            required:
-              type: array
-              items:
-                oneOf:
-                - type: integer
-              description: List of required course IDs
-            electives:
-              type: array
-              items:
-                oneOf:
-                - type: integer
-              description: List of elective course IDs
+            courses:
+              type: object
+              properties:
+                required:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of required course IDs
+                electives:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of elective course IDs
+            programs:
+              type: object
+              properties:
+                required:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of required program IDs
+                electives:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of elective program IDs
           readOnly: true
         req_tree:
           type: array
@@ -3389,6 +3412,7 @@ components:
           readOnly: true
       required:
       - certificate_type
+      - collections
       - courses
       - departments
       - duration

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3282,21 +3282,44 @@ components:
           items:
             type: integer
           readOnly: true
+        collections:
+          type: array
+          items:
+            type: integer
+          readOnly: true
         requirements:
           type: object
           properties:
-            required:
-              type: array
-              items:
-                oneOf:
-                - type: integer
-              description: List of required course IDs
-            electives:
-              type: array
-              items:
-                oneOf:
-                - type: integer
-              description: List of elective course IDs
+            courses:
+              type: object
+              properties:
+                required:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of required course IDs
+                electives:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of elective course IDs
+            programs:
+              type: object
+              properties:
+                required:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of required program IDs
+                electives:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of elective program IDs
           readOnly: true
         req_tree:
           type: array
@@ -3389,6 +3412,7 @@ components:
           readOnly: true
       required:
       - certificate_type
+      - collections
       - courses
       - departments
       - duration

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -3282,21 +3282,44 @@ components:
           items:
             type: integer
           readOnly: true
+        collections:
+          type: array
+          items:
+            type: integer
+          readOnly: true
         requirements:
           type: object
           properties:
-            required:
-              type: array
-              items:
-                oneOf:
-                - type: integer
-              description: List of required course IDs
-            electives:
-              type: array
-              items:
-                oneOf:
-                - type: integer
-              description: List of elective course IDs
+            courses:
+              type: object
+              properties:
+                required:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of required course IDs
+                electives:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of elective course IDs
+            programs:
+              type: object
+              properties:
+                required:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of required program IDs
+                electives:
+                  type: array
+                  items:
+                    oneOf:
+                    - type: integer
+                  description: List of elective program IDs
           readOnly: true
         req_tree:
           type: array
@@ -3389,6 +3412,7 @@ components:
           readOnly: true
       required:
       - certificate_type
+      - collections
       - courses
       - departments
       - duration


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7916
Closes https://github.com/mitodl/hq/issues/7915

### Description (What does it do?)
This PR:
- Adds `collections` to the API response for `Program` objects, which contains an array of integer ids matching `ProgramCollection` objects that list the `Program` in its `programs` field
- Restructures the `requirements` field in the API response to include keys for both `courses` and `programs`, including `required` and `elective` under that for each type

### How can this be tested?
- Make sure you have some test `Program` objects in your database, at least one of which has another `Program` listed as a requirement
- Create a program collection in Wagtail at Root -> Home Page -> Program Collections
- Add some programs to the collection and click Publish
- Make sure your user is enrolled in the programs
- Visit the `Program` API endpoint at `/api/v2/programs/`
- Verify that on the programs that are part of collections, you see a `collections` array with the integer ID's of the associated collections
- Verify that the `requirements` node has the `Program` requirements you added on the appropriate `Program`