### PR TITLE
Add certificate retrieval APIs

### DIFF
--- a/courses/serializers/v2/certificates.py
+++ b/courses/serializers/v2/certificates.py
@@ -1,0 +1,86 @@
+"""Serializers for certificate data."""
+
+from rest_framework import serializers
+from wagtail.api.v2.serializers import PageSerializer
+
+from courses.models import BaseCertificate, CourseRunCertificate, ProgramCertificate
+from users.serializers import UserSerializer
+
+
+class BaseCertificateSerializer(serializers.ModelSerializer):
+    """Serializer for the shared BaseCertificate model"""
+
+    user = UserSerializer()
+    certificate_page = serializers.SerializerMethodField()
+
+    def get_certificate_page(self, instance):
+        """
+        Retrieve the certificate page. For certificates, we want to return the
+        page data for the specific revision of the page we're working with, or
+        we may display incorrect data to the end user. (The implementation of
+        this is the same across both certificate types, even though the field
+        definition itself is slightly different.)
+        """
+
+        if hasattr(instance, "certificate_page_revision"):
+            cert = instance.certificate_page_revision.as_object()
+
+            # This should change once the Wagtail API stuff gets merged.
+            return PageSerializer(cert).data
+
+        return None
+
+    class Meta:
+        """Meta options for the serializer."""
+
+        model = BaseCertificate
+        fields = [
+            "user",
+            "uuid",
+            "is_revoked",
+            "certificate_page",
+        ]
+        readonly_fields = [
+            "user",
+            "uuid",
+            "is_revoked",
+            "certificate_page",
+        ]
+
+
+class CourseRunCertificateSerializer(BaseCertificateSerializer):
+    """Serializer for course certificates."""
+
+    class Meta:
+        """Meta options for the serializer."""
+
+        model = CourseRunCertificate
+        fields = [
+            *BaseCertificateSerializer.Meta.fields,
+            "course_run",
+            "certificate_page_revision",
+        ]
+        readonly_fields = [
+            *BaseCertificateSerializer.Meta.readonly_fields,
+            "course_run",
+            "certificate_page_revision",
+        ]
+
+
+class ProgramCertificateSerializer(BaseCertificateSerializer):
+    """Serializer for course certificates."""
+
+    class Meta:
+        """Meta options for the serializer."""
+
+        model = ProgramCertificate
+        fields = [
+            *BaseCertificateSerializer.Meta.fields,
+            "program",
+            "certificate_page_revision",
+        ]
+        readonly_fields = [
+            *BaseCertificateSerializer.Meta.readonly_fields,
+            "program",
+            "certificate_page_revision",
+        ]

--- a/courses/serializers/v2/certificates.py
+++ b/courses/serializers/v2/certificates.py
@@ -15,7 +15,7 @@ from cms.wagtail_api.schema.serializers import (
     PageMetaSerializer,
 )
 from courses.models import BaseCertificate, CourseRunCertificate, ProgramCertificate
-from users.serializers import UserSerializer
+from users.serializers import PublicUserSerializer
 
 
 class PageMetaModelSerializer(PageMetaSerializer, serializers.ModelSerializer):
@@ -140,7 +140,7 @@ class CertificatePageModelSerializer(
 class BaseCertificateSerializer(serializers.ModelSerializer):
     """Serializer for the shared BaseCertificate model"""
 
-    user = UserSerializer()
+    user = PublicUserSerializer()
     certificate_page = serializers.SerializerMethodField()
 
     @extend_schema_field(CertificatePageModelSerializer)

--- a/courses/serializers/v2/certificates.py
+++ b/courses/serializers/v2/certificates.py
@@ -30,13 +30,13 @@ class PageMetaModelSerializer(PageMetaSerializer, serializers.ModelSerializer):
     def get_html_url(self, instance):
         """Return PageHtmlUrlField. This is wrapped for OpenAPI schema generation."""
 
-        return PageHtmlUrlField(instance.html_url)
+        return PageHtmlUrlField().to_representation(instance)
 
     @extend_schema_field(str)
     def get_locale(self, instance):
         """Return PageLocaleField. This is wrapped for OpenAPI schema generation."""
 
-        return PageLocaleField(instance.locale)
+        return PageLocaleField().to_representation(instance)
 
     @extend_schema_field(str)
     def get_type(self, instance):
@@ -111,9 +111,7 @@ class CertificatePageModelSerializer(
     def get_meta(self, instance):
         """Get page metadata."""
 
-        return PageMetaModelSerializer(
-            instance.page_ptr, context={"request": self.context["request"]}
-        ).data
+        return PageMetaModelSerializer(instance.page_ptr).data
 
     class Meta:
         """Meta opts for the serializer."""
@@ -158,9 +156,7 @@ class BaseCertificateSerializer(serializers.ModelSerializer):
         if hasattr(instance, "certificate_page_revision"):
             cert = instance.certificate_page_revision.as_object()
 
-            return CertificatePageModelSerializer(
-                cert, context={"request": self.context["request"]}
-            ).data
+            return CertificatePageModelSerializer(cert).data
 
         return None
 
@@ -202,6 +198,7 @@ class CourseRunCertificateSerializer(BaseCertificateSerializer):
         ]
 
 
+@extend_schema_serializer(component_name="V2ProgramCertificateSerializer")
 class ProgramCertificateSerializer(BaseCertificateSerializer):
     """Serializer for course certificates."""
 

--- a/courses/serializers/v2/certificates_test.py
+++ b/courses/serializers/v2/certificates_test.py
@@ -1,0 +1,91 @@
+"""Tests for the certificates serializers."""
+
+import pytest
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from cms.factories import CoursePageFactory, ProgramPageFactory
+from courses.factories import CourseRunCertificateFactory, ProgramCertificateFactory
+from courses.serializers.v2.certificates import (
+    CourseRunCertificateSerializer,
+    ProgramCertificateSerializer,
+)
+from main.test_utils import assert_drf_json_equal
+from users.serializers import UserSerializer
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def anon_drf_client():
+    """Just return an API client without a session."""
+
+    return APIClient()
+
+
+@pytest.mark.parametrize(
+    "is_program",
+    [
+        True,
+        False,
+    ],
+)
+def test_serialize_certificate(is_program):
+    """Test that the certificate serializes properly."""
+
+    if is_program:
+        courseware_page = ProgramPageFactory.create()
+    else:
+        courseware_page = CoursePageFactory.create()
+
+    cert_page = courseware_page.certificate_page
+    cert_page.save_revision()  # we need at least one
+
+    if is_program:
+        certificate = ProgramCertificateFactory.create(
+            certificate_page_revision=cert_page.revisions.last()
+        )
+        serialized_data = ProgramCertificateSerializer(certificate).data
+    else:
+        certificate = CourseRunCertificateFactory.create(
+            certificate_page_revision=cert_page.revisions.last()
+        )
+        serialized_data = CourseRunCertificateSerializer(certificate).data
+
+    expected_data = {
+        "user": UserSerializer(certificate.user).data,
+        "uuid": certificate.uuid,
+        "is_revoked": certificate.is_revoked,
+        "certificate_page_revision": cert_page.revisions.last().id,
+        "certificate_page": {
+            "id": cert_page.id,
+            "meta": {
+                "type": "cms.CertificatePage",
+                "detail_url": reverse(
+                    "wagtailapi:pages:detail", kwargs={"pk": cert_page.id}
+                ),
+                "html_url": cert_page.full_url,
+                "slug": cert_page.page_ptr.slug,
+                "show_in_menus": cert_page.page_ptr.show_in_menus,
+                "seo_title": cert_page.page_ptr.seo_title,
+                "search_description": cert_page.page_ptr.search_description,
+                "first_published_at": cert_page.page_ptr.first_published_at,
+                "alias_of": cert_page.page_ptr.alias_of,
+                "locale": cert_page.page_ptr.locale.language_code,
+                "live": cert_page.page_ptr.live,
+                "last_published_at": cert_page.page_ptr.last_published_at,
+            },
+            "title": cert_page.title,
+            "product_name": cert_page.product_name,
+            "CEUs": cert_page.CEUs,
+            "overrides": [],
+            "signatory_items": cert_page.signatory_items,
+        },
+    }
+
+    if is_program:
+        expected_data["program"] = certificate.program.id
+    else:
+        expected_data["course_run"] = certificate.course_run.id
+
+    assert_drf_json_equal(expected_data, serialized_data, ignore_order=True)

--- a/courses/serializers/v2/certificates_test.py
+++ b/courses/serializers/v2/certificates_test.py
@@ -11,7 +11,7 @@ from courses.serializers.v2.certificates import (
     ProgramCertificateSerializer,
 )
 from main.test_utils import assert_drf_json_equal
-from users.serializers import UserSerializer
+from users.serializers import PublicUserSerializer
 
 pytestmark = [pytest.mark.django_db]
 
@@ -53,7 +53,7 @@ def test_serialize_certificate(is_program):
         serialized_data = CourseRunCertificateSerializer(certificate).data
 
     expected_data = {
-        "user": UserSerializer(certificate.user).data,
+        "user": PublicUserSerializer(certificate.user).data,
         "uuid": certificate.uuid,
         "is_revoked": certificate.is_revoked,
         "certificate_page_revision": cert_page.revisions.last().id,

--- a/courses/urls/v2/urls.py
+++ b/courses/urls/v2/urls.py
@@ -1,3 +1,4 @@
+from django.urls import path
 from rest_framework import routers
 
 from courses.views import v2
@@ -13,4 +14,7 @@ router.register(
 router.register(r"courses", v2.CourseViewSet, basename="courses_api")
 router.register(r"departments", v2.DepartmentViewSet, basename="departments_api")
 
-urlpatterns = router.urls
+urlpatterns = [
+    *router.urls,
+    path(r"course_certificates/<str:cert_uuid>/", v2.get_course_certificate),
+]

--- a/courses/urls/v2/urls.py
+++ b/courses/urls/v2/urls.py
@@ -17,4 +17,5 @@ router.register(r"departments", v2.DepartmentViewSet, basename="departments_api"
 urlpatterns = [
     *router.urls,
     path(r"course_certificates/<str:cert_uuid>/", v2.get_course_certificate),
+    path(r"program_certificates/<str:cert_uuid>/", v2.get_program_certificate),
 ]

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -8,9 +8,9 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import viewsets
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.pagination import PageNumberPagination
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import AllowAny, IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
 from courses.models import (
@@ -336,6 +336,7 @@ class ProgramCollectionViewSet(viewsets.ReadOnlyModelViewSet):
     responses=CourseRunCertificateSerializer,
 )
 @api_view(["GET"])
+@permission_classes([AllowAny])
 def get_course_certificate(request, cert_uuid):
     """Get a course certificate by UUID."""
 
@@ -353,6 +354,7 @@ def get_course_certificate(request, cert_uuid):
     responses=ProgramCertificateSerializer,
 )
 @api_view(["GET"])
+@permission_classes([AllowAny])
 def get_program_certificate(request, cert_uuid):
     """Get a program certificate by UUID."""
 

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -7,12 +7,15 @@ from django.db.models import Count, Exists, OuterRef, Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
+from rest_framework.decorators import api_view
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.response import Response
 
 from courses.models import (
     Course,
     CourseRun,
+    CourseRunCertificate,
     CoursesTopic,
     Department,
     Program,
@@ -20,6 +23,7 @@ from courses.models import (
     ProgramRequirement,
     ProgramRequirementNodeType,
 )
+from courses.serializers.v2.certificates import CourseRunCertificateSerializer
 from courses.serializers.v2.courses import (
     CourseTopicSerializer,
     CourseWithCourseRunsSerializer,
@@ -318,3 +322,14 @@ class ProgramCollectionViewSet(viewsets.ReadOnlyModelViewSet):
             .prefetch_related("programs")
             .order_by("title")
         )
+
+
+@api_view(["GET"])
+def get_course_certificate(request, cert_uuid):
+    """Get a course certificate by UUID."""
+
+    cert = CourseRunCertificate.objects.filter(is_revoked=False, uuid=cert_uuid).get()
+
+    return Response(
+        CourseRunCertificateSerializer(cert, context={"request": request}).data
+    )

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -20,11 +20,15 @@ from courses.models import (
     CoursesTopic,
     Department,
     Program,
+    ProgramCertificate,
     ProgramCollection,
     ProgramRequirement,
     ProgramRequirementNodeType,
 )
-from courses.serializers.v2.certificates import CourseRunCertificateSerializer
+from courses.serializers.v2.certificates import (
+    CourseRunCertificateSerializer,
+    ProgramCertificateSerializer,
+)
 from courses.serializers.v2.courses import (
     CourseTopicSerializer,
     CourseWithCourseRunsSerializer,
@@ -339,4 +343,21 @@ def get_course_certificate(request, cert_uuid):
 
     return Response(
         CourseRunCertificateSerializer(cert, context={"request": request}).data
+    )
+
+
+@extend_schema(
+    parameters=[
+        OpenApiParameter("cert_uuid", OpenApiTypes.UUID, OpenApiParameter.PATH),
+    ],
+    responses=ProgramCertificateSerializer,
+)
+@api_view(["GET"])
+def get_program_certificate(request, cert_uuid):
+    """Get a program certificate by UUID."""
+
+    cert = ProgramCertificate.objects.filter(is_revoked=False, uuid=cert_uuid).get()
+
+    return Response(
+        ProgramCertificateSerializer(cert, context={"request": request}).data
     )

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -5,7 +5,8 @@ Course API Views version 2
 import django_filters
 from django.db.models import Count, Exists, OuterRef, Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import viewsets
 from rest_framework.decorators import api_view
 from rest_framework.pagination import PageNumberPagination
@@ -324,6 +325,12 @@ class ProgramCollectionViewSet(viewsets.ReadOnlyModelViewSet):
         )
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter("cert_uuid", OpenApiTypes.UUID, OpenApiParameter.PATH),
+    ],
+    responses=CourseRunCertificateSerializer,
+)
 @api_view(["GET"])
 def get_course_certificate(request, cert_uuid):
     """Get a course certificate by UUID."""

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -814,6 +814,8 @@ paths:
         required: true
       tags:
       - course_certificates
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -1099,6 +1101,8 @@ paths:
         required: true
       tags:
       - program_certificates
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -3942,7 +3946,7 @@ components:
       description: Serializer for course certificates.
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/PublicUser'
         uuid:
           type: string
           format: uuid
@@ -4274,7 +4278,7 @@ components:
       description: Serializer for course certificates.
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/PublicUser'
         uuid:
           type: string
           format: uuid

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1086,6 +1086,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/V2ProgramCollection'
           description: ''
+  /api/v2/program_certificates/{cert_uuid}/:
+    get:
+      operationId: program_certificates_retrieve
+      description: Get a program certificate by UUID.
+      parameters:
+      - in: path
+        name: cert_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - program_certificates
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2ProgramCertificate'
+          description: ''
   /api/v2/programs/:
     get:
       operationId: programs_list_v2
@@ -4249,6 +4269,39 @@ components:
       - time_commitment
       - title
       - topics
+    V2ProgramCertificate:
+      type: object
+      description: Serializer for course certificates.
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        is_revoked:
+          type: boolean
+          readOnly: true
+          title: Revoked
+          description: Indicates whether or not the certificate is revoked
+        certificate_page:
+          allOf:
+          - $ref: '#/components/schemas/CertificatePageModel'
+          readOnly: true
+        program:
+          type: integer
+          readOnly: true
+        certificate_page_revision:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - certificate_page
+      - certificate_page_revision
+      - is_revoked
+      - program
+      - user
+      - uuid
     V2ProgramCollection:
       type: object
       description: Serializer for ProgramCollection

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -801,6 +801,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/V1Program'
           description: ''
+  /api/v2/course_certificates/{cert_uuid}/:
+    get:
+      operationId: course_certificates_retrieve
+      description: Get a course certificate by UUID.
+      parameters:
+      - in: path
+        name: cert_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - course_certificates
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2CourseRunCertificate'
+          description: ''
   /api/v2/courses/:
     get:
       operationId: api_v2_courses_list
@@ -1207,6 +1227,38 @@ components:
       required:
       - items
       - meta
+    CertificatePageModel:
+      type: object
+      description: Extends the CertificatePageSerializer to work with a model object.
+      properties:
+        id:
+          type: integer
+        meta:
+          allOf:
+          - $ref: '#/components/schemas/PageMetaModel'
+          readOnly: true
+        title:
+          type: string
+        product_name:
+          type: string
+        CEUs:
+          type: string
+        overrides:
+          type: array
+          items:
+            $ref: '#/components/schemas/Override'
+        signatory_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SignatoryItem'
+      required:
+      - CEUs
+      - id
+      - meta
+      - overrides
+      - product_name
+      - signatory_items
+      - title
     ChangeEmailRequestCreate:
       type: object
       description: Serializer for starting a user email change
@@ -2200,6 +2252,70 @@ components:
           nullable: true
         locale:
           type: string
+        live:
+          type: boolean
+        last_published_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - alias_of
+      - detail_url
+      - first_published_at
+      - html_url
+      - last_published_at
+      - live
+      - locale
+      - search_description
+      - seo_title
+      - show_in_menus
+      - slug
+      - type
+    PageMetaModel:
+      type: object
+      description: Extends the PageMetaSerializer to work with a Page object
+      properties:
+        type:
+          type: string
+          description: |-
+            Get the page type, in a more simple manner than Wagtail.
+
+            The Wagtail version of this is PageTypeField, and it tries to modify the
+            context, which we neither need nor is in the correct format for it.
+          readOnly: true
+        detail_url:
+          type: string
+          description: |-
+            Get the detail URL, which should be the API call for this page.
+
+            The Wagtail version of this is DetailUrlField and it also tries to make
+            changes to the context that we don't need.
+          readOnly: true
+        html_url:
+          type: string
+          description: Return PageHtmlUrlField. This is wrapped for OpenAPI schema
+            generation.
+          readOnly: true
+        slug:
+          type: string
+        show_in_menus:
+          type: boolean
+        seo_title:
+          type: string
+        search_description:
+          type: string
+        first_published_at:
+          type: string
+          format: date-time
+          nullable: true
+        alias_of:
+          type: string
+          nullable: true
+        locale:
+          type: string
+          description: Return PageLocaleField. This is wrapped for OpenAPI schema
+            generation.
+          readOnly: true
         live:
           type: boolean
         last_published_at:
@@ -3801,6 +3917,39 @@ components:
       - products
       - run_tag
       - title
+    V2CourseRunCertificate:
+      type: object
+      description: Serializer for course certificates.
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        is_revoked:
+          type: boolean
+          readOnly: true
+          title: Revoked
+          description: Indicates whether or not the certificate is revoked
+        certificate_page:
+          allOf:
+          - $ref: '#/components/schemas/CertificatePageModel'
+          readOnly: true
+        course_run:
+          type: integer
+          readOnly: true
+        certificate_page_revision:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - certificate_page
+      - certificate_page_revision
+      - course_run
+      - is_revoked
+      - user
+      - uuid
     V2CourseWithCourseRuns:
       type: object
       description: Course model serializer - also serializes child course runs

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -814,6 +814,8 @@ paths:
         required: true
       tags:
       - course_certificates
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -1099,6 +1101,8 @@ paths:
         required: true
       tags:
       - program_certificates
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -3942,7 +3946,7 @@ components:
       description: Serializer for course certificates.
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/PublicUser'
         uuid:
           type: string
           format: uuid
@@ -4274,7 +4278,7 @@ components:
       description: Serializer for course certificates.
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/PublicUser'
         uuid:
           type: string
           format: uuid

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -1086,6 +1086,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/V2ProgramCollection'
           description: ''
+  /api/v2/program_certificates/{cert_uuid}/:
+    get:
+      operationId: program_certificates_retrieve
+      description: Get a program certificate by UUID.
+      parameters:
+      - in: path
+        name: cert_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - program_certificates
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2ProgramCertificate'
+          description: ''
   /api/v2/programs/:
     get:
       operationId: programs_list_v2
@@ -4249,6 +4269,39 @@ components:
       - time_commitment
       - title
       - topics
+    V2ProgramCertificate:
+      type: object
+      description: Serializer for course certificates.
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        is_revoked:
+          type: boolean
+          readOnly: true
+          title: Revoked
+          description: Indicates whether or not the certificate is revoked
+        certificate_page:
+          allOf:
+          - $ref: '#/components/schemas/CertificatePageModel'
+          readOnly: true
+        program:
+          type: integer
+          readOnly: true
+        certificate_page_revision:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - certificate_page
+      - certificate_page_revision
+      - is_revoked
+      - program
+      - user
+      - uuid
     V2ProgramCollection:
       type: object
       description: Serializer for ProgramCollection

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -801,6 +801,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/V1Program'
           description: ''
+  /api/v2/course_certificates/{cert_uuid}/:
+    get:
+      operationId: course_certificates_retrieve
+      description: Get a course certificate by UUID.
+      parameters:
+      - in: path
+        name: cert_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - course_certificates
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2CourseRunCertificate'
+          description: ''
   /api/v2/courses/:
     get:
       operationId: api_v2_courses_list
@@ -1207,6 +1227,38 @@ components:
       required:
       - items
       - meta
+    CertificatePageModel:
+      type: object
+      description: Extends the CertificatePageSerializer to work with a model object.
+      properties:
+        id:
+          type: integer
+        meta:
+          allOf:
+          - $ref: '#/components/schemas/PageMetaModel'
+          readOnly: true
+        title:
+          type: string
+        product_name:
+          type: string
+        CEUs:
+          type: string
+        overrides:
+          type: array
+          items:
+            $ref: '#/components/schemas/Override'
+        signatory_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SignatoryItem'
+      required:
+      - CEUs
+      - id
+      - meta
+      - overrides
+      - product_name
+      - signatory_items
+      - title
     ChangeEmailRequestCreate:
       type: object
       description: Serializer for starting a user email change
@@ -2200,6 +2252,70 @@ components:
           nullable: true
         locale:
           type: string
+        live:
+          type: boolean
+        last_published_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - alias_of
+      - detail_url
+      - first_published_at
+      - html_url
+      - last_published_at
+      - live
+      - locale
+      - search_description
+      - seo_title
+      - show_in_menus
+      - slug
+      - type
+    PageMetaModel:
+      type: object
+      description: Extends the PageMetaSerializer to work with a Page object
+      properties:
+        type:
+          type: string
+          description: |-
+            Get the page type, in a more simple manner than Wagtail.
+
+            The Wagtail version of this is PageTypeField, and it tries to modify the
+            context, which we neither need nor is in the correct format for it.
+          readOnly: true
+        detail_url:
+          type: string
+          description: |-
+            Get the detail URL, which should be the API call for this page.
+
+            The Wagtail version of this is DetailUrlField and it also tries to make
+            changes to the context that we don't need.
+          readOnly: true
+        html_url:
+          type: string
+          description: Return PageHtmlUrlField. This is wrapped for OpenAPI schema
+            generation.
+          readOnly: true
+        slug:
+          type: string
+        show_in_menus:
+          type: boolean
+        seo_title:
+          type: string
+        search_description:
+          type: string
+        first_published_at:
+          type: string
+          format: date-time
+          nullable: true
+        alias_of:
+          type: string
+          nullable: true
+        locale:
+          type: string
+          description: Return PageLocaleField. This is wrapped for OpenAPI schema
+            generation.
+          readOnly: true
         live:
           type: boolean
         last_published_at:
@@ -3801,6 +3917,39 @@ components:
       - products
       - run_tag
       - title
+    V2CourseRunCertificate:
+      type: object
+      description: Serializer for course certificates.
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        is_revoked:
+          type: boolean
+          readOnly: true
+          title: Revoked
+          description: Indicates whether or not the certificate is revoked
+        certificate_page:
+          allOf:
+          - $ref: '#/components/schemas/CertificatePageModel'
+          readOnly: true
+        course_run:
+          type: integer
+          readOnly: true
+        certificate_page_revision:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - certificate_page
+      - certificate_page_revision
+      - course_run
+      - is_revoked
+      - user
+      - uuid
     V2CourseWithCourseRuns:
       type: object
       description: Course model serializer - also serializes child course runs

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -814,6 +814,8 @@ paths:
         required: true
       tags:
       - course_certificates
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -1099,6 +1101,8 @@ paths:
         required: true
       tags:
       - program_certificates
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -3942,7 +3946,7 @@ components:
       description: Serializer for course certificates.
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/PublicUser'
         uuid:
           type: string
           format: uuid
@@ -4274,7 +4278,7 @@ components:
       description: Serializer for course certificates.
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/PublicUser'
         uuid:
           type: string
           format: uuid

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -1086,6 +1086,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/V2ProgramCollection'
           description: ''
+  /api/v2/program_certificates/{cert_uuid}/:
+    get:
+      operationId: program_certificates_retrieve
+      description: Get a program certificate by UUID.
+      parameters:
+      - in: path
+        name: cert_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - program_certificates
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2ProgramCertificate'
+          description: ''
   /api/v2/programs/:
     get:
       operationId: programs_list_v2
@@ -4249,6 +4269,39 @@ components:
       - time_commitment
       - title
       - topics
+    V2ProgramCertificate:
+      type: object
+      description: Serializer for course certificates.
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        is_revoked:
+          type: boolean
+          readOnly: true
+          title: Revoked
+          description: Indicates whether or not the certificate is revoked
+        certificate_page:
+          allOf:
+          - $ref: '#/components/schemas/CertificatePageModel'
+          readOnly: true
+        program:
+          type: integer
+          readOnly: true
+        certificate_page_revision:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - certificate_page
+      - certificate_page_revision
+      - is_revoked
+      - program
+      - user
+      - uuid
     V2ProgramCollection:
       type: object
       description: Serializer for ProgramCollection

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -801,6 +801,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/V1Program'
           description: ''
+  /api/v2/course_certificates/{cert_uuid}/:
+    get:
+      operationId: course_certificates_retrieve
+      description: Get a course certificate by UUID.
+      parameters:
+      - in: path
+        name: cert_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - course_certificates
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2CourseRunCertificate'
+          description: ''
   /api/v2/courses/:
     get:
       operationId: api_v2_courses_list
@@ -1207,6 +1227,38 @@ components:
       required:
       - items
       - meta
+    CertificatePageModel:
+      type: object
+      description: Extends the CertificatePageSerializer to work with a model object.
+      properties:
+        id:
+          type: integer
+        meta:
+          allOf:
+          - $ref: '#/components/schemas/PageMetaModel'
+          readOnly: true
+        title:
+          type: string
+        product_name:
+          type: string
+        CEUs:
+          type: string
+        overrides:
+          type: array
+          items:
+            $ref: '#/components/schemas/Override'
+        signatory_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SignatoryItem'
+      required:
+      - CEUs
+      - id
+      - meta
+      - overrides
+      - product_name
+      - signatory_items
+      - title
     ChangeEmailRequestCreate:
       type: object
       description: Serializer for starting a user email change
@@ -2200,6 +2252,70 @@ components:
           nullable: true
         locale:
           type: string
+        live:
+          type: boolean
+        last_published_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - alias_of
+      - detail_url
+      - first_published_at
+      - html_url
+      - last_published_at
+      - live
+      - locale
+      - search_description
+      - seo_title
+      - show_in_menus
+      - slug
+      - type
+    PageMetaModel:
+      type: object
+      description: Extends the PageMetaSerializer to work with a Page object
+      properties:
+        type:
+          type: string
+          description: |-
+            Get the page type, in a more simple manner than Wagtail.
+
+            The Wagtail version of this is PageTypeField, and it tries to modify the
+            context, which we neither need nor is in the correct format for it.
+          readOnly: true
+        detail_url:
+          type: string
+          description: |-
+            Get the detail URL, which should be the API call for this page.
+
+            The Wagtail version of this is DetailUrlField and it also tries to make
+            changes to the context that we don't need.
+          readOnly: true
+        html_url:
+          type: string
+          description: Return PageHtmlUrlField. This is wrapped for OpenAPI schema
+            generation.
+          readOnly: true
+        slug:
+          type: string
+        show_in_menus:
+          type: boolean
+        seo_title:
+          type: string
+        search_description:
+          type: string
+        first_published_at:
+          type: string
+          format: date-time
+          nullable: true
+        alias_of:
+          type: string
+          nullable: true
+        locale:
+          type: string
+          description: Return PageLocaleField. This is wrapped for OpenAPI schema
+            generation.
+          readOnly: true
         live:
           type: boolean
         last_published_at:
@@ -3801,6 +3917,39 @@ components:
       - products
       - run_tag
       - title
+    V2CourseRunCertificate:
+      type: object
+      description: Serializer for course certificates.
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        is_revoked:
+          type: boolean
+          readOnly: true
+          title: Revoked
+          description: Indicates whether or not the certificate is revoked
+        certificate_page:
+          allOf:
+          - $ref: '#/components/schemas/CertificatePageModel'
+          readOnly: true
+        course_run:
+          type: integer
+          readOnly: true
+        certificate_page_revision:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - certificate_page
+      - certificate_page_revision
+      - course_run
+      - is_revoked
+      - user
+      - uuid
     V2CourseWithCourseRuns:
       type: object
       description: Course model serializer - also serializes child course runs

--- a/scripts/test/openapi_spec_check.sh
+++ b/scripts/test/openapi_spec_check.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 TMPDIR="$(mktemp -d)"
 SPECS_DIR=./openapi/specs/
 
+./manage.py migrate --noinput
 ./manage.py generate_openapi_spec \
 	--directory=$TMPDIR --fail-on-warn
 


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#7867

### Description (What does it do?)

Add certificate retrieval APIs to MITx Online.

There are two, because there are two kinds of certificate:
- `/api/v2/course_certificate/` retrieves a course certificate
- `/api/v2/program_certificate/` retrieves a program certificate

These take the UUID that is returned from the enrollment API and return the certificate data. They should not require authentication. Both the user's specific certificate information is returned and the Wagtail page information for the page.

### How can this be tested?

Automated tests should pass.

Manual tests will require you to have a certificate page created, and a certificate issued for a user (for both a course and a program). Once you have that, you should be able to hit the API in the Swagger UI and get the certificate data back as expected. You should not need a user session to get data back - certificates should be viewable by anonymous users.

This won't return a rendered page; it's intended to be used by the front end to assemble the rendered certificate in the browser.