### PR TITLE
Add a management command to extend dates on unused courpons

### DIFF
--- a/ecommerce/management/commands/extend_coupons.py
+++ b/ecommerce/management/commands/extend_coupons.py
@@ -1,14 +1,13 @@
 
 from django.core.management import BaseCommand
 
-from docs.source.conf import extensions
 from ecommerce.models import Discount
 from main.utils import parse_supplied_date
 
 
 class Command(BaseCommand):
     """
-    Generates discount (sometimes called enrollment) codes with some parameters.
+    Extends existing unused discount codes with some parameters.
 
     Make sure that the prefix you are providing has a term associated with the discount or that
     it is unique across all discounts.

--- a/ecommerce/management/commands/extend_coupons.py
+++ b/ecommerce/management/commands/extend_coupons.py
@@ -1,0 +1,51 @@
+
+from django.core.management import BaseCommand
+
+from docs.source.conf import extensions
+from ecommerce.models import Discount
+from main.utils import parse_supplied_date
+
+
+class Command(BaseCommand):
+    """
+    Generates discount (sometimes called enrollment) codes with some parameters.
+
+    Make sure that the prefix you are providing has a term associated with the discount or that
+    it is unique across all discounts.
+
+    ./manage.py extend_coupons --discount-code-prefix B2B_NNN_2T2025_ --expires 2026-12-12
+    """
+
+    help = "Extend expiration date for unused coupons discount/enrollment codes."
+
+    def add_arguments(self, parser) -> None:
+
+        parser.add_argument(
+            "--expires",
+            type=str,
+            help="Expiration date for the code, in ISO-8601 (YYYY-MM-DD) format.",
+            required=True,
+        )
+
+        parser.add_argument(
+            "--discount-code-prefix",
+            type=str,
+            help="The prefix to filter the codes for extension.",
+            required=True,
+        )
+
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument  # noqa: ARG002
+        """
+        Extends the expiration date of discount codes that match a given prefix.
+        """
+
+        code_prefix = kwargs.get("discount_code_prefix")
+        discounts = Discount.objects.filter(discount_code__contains=code_prefix)
+        extension_date = parse_supplied_date(kwargs.get("expires"))
+
+        for discount_code in discounts:
+            if not discount_code.is_redeemed:
+                discount_code.expiration_date = extension_date
+                discount_code.save()
+
+        self.stdout.write(self.style.SUCCESS(f"Coupons expiration date extended."))

--- a/ecommerce/management/commands/extend_coupons.py
+++ b/ecommerce/management/commands/extend_coupons.py
@@ -1,4 +1,3 @@
-
 from django.core.management import BaseCommand
 
 from ecommerce.models import Discount
@@ -18,7 +17,6 @@ class Command(BaseCommand):
     help = "Extend expiration date for unused coupons discount/enrollment codes."
 
     def add_arguments(self, parser) -> None:
-
         parser.add_argument(
             "--expires",
             type=str,
@@ -47,4 +45,4 @@ class Command(BaseCommand):
                 discount_code.expiration_date = extension_date
                 discount_code.save()
 
-        self.stdout.write(self.style.SUCCESS(f"Coupons expiration date extended."))
+        self.stdout.write(self.style.SUCCESS("Coupons expiration date extended."))


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
We have seen several requests to extend the expiration date for B2B coupons.
Related example issue https://github.mit.edu/mitxonline/mitxonline-issues/issues/970

### How can this be tested?
Try to run the command for previously created coupons and check that the expiration date got updated.