### PR TITLE
Update scim package to pick up sync search fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2880,14 +2880,14 @@ setuptools = "*"
 
 [[package]]
 name = "mitol-django-scim"
-version = "2025.7.28"
+version = "2025.7.29"
 description = "Django application for SCIM integrations"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mitol_django_scim-2025.7.28-py3-none-any.whl", hash = "sha256:39fb60621a80ef9884abb3ca21bf5833a5cd6e016749457756cbb5fa89e30057"},
-    {file = "mitol_django_scim-2025.7.28.tar.gz", hash = "sha256:2a25414f19843519d4327c5e9c471d9d6e9ed13bb7823e330dfe6baa4a3cadbf"},
+    {file = "mitol_django_scim-2025.7.29-py3-none-any.whl", hash = "sha256:aa10c93756d15a2fd8e8f747095e53d0c9aa7510d6fad8ce559db5ad67acfb87"},
+    {file = "mitol_django_scim-2025.7.29.tar.gz", hash = "sha256:d9470c0b6293f3030229a2e495b249cad5b96f1cdc4b932a8dc67f9c433bd739"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/mitxonline/issues/2840

### Description (What does it do?)
<!--- Describe your changes in detail -->
This updates the scim package to pick up a fix for the scim sync.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Set `MITOL_SCIM_KEYCLOAK_SEARCH_BATCH_SIZE=5` and run `./manage.py scim_sync` and you should see it make a request to search for every 5 users rather than every 100 (the default) and rather than the default of the task size (1000)