### PR TITLE
Fix configure_instance management command - department creation

### DIFF
--- a/main/management/commands/configure_instance.py
+++ b/main/management/commands/configure_instance.py
@@ -210,7 +210,7 @@ class Command(BaseCommand):
             "program-v1:MITx+DEDP",
             "Data, Economics and Development Policy",
             live=True,
-            depts="Economics",
+            depts=["Economics"],
             create_depts=True,
         )
 
@@ -240,7 +240,7 @@ class Command(BaseCommand):
             create_run="Demo_Course",
             run_url=f"http://{edx_host}/courses/course-v1:edX+DemoX+Demo_Course/",
             program="program-v1:MITx+DEDP",
-            depts="Science",
+            depts=["Science"],
             create_depts=True,
         )
 
@@ -252,7 +252,7 @@ class Command(BaseCommand):
             live=True,
             create_run="course",
             run_url=f"http://{edx_host}/courses/course-v1:edX+E2E-101+course/",
-            depts="Math",
+            depts=["Math"],
             create_depts=True,
         )
 


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
Fixes the Department creation in the configure_instance command.  Previously this was failing as departments were being created for each letter in the department name rather than "Economics".

### How can this be tested?
Ensure the configure_instance command can run successfully and created the departments.
