### PR TITLE
fix course creation in configure_instance

### DIFF
--- a/main/management/commands/configure_instance.py
+++ b/main/management/commands/configure_instance.py
@@ -210,7 +210,7 @@ class Command(BaseCommand):
             "program-v1:MITx+DEDP",
             "Data, Economics and Development Policy",
             live=True,
-            depts="Economics",
+            depts=["Economics"],
             create_depts=True,
         )
 
@@ -240,7 +240,7 @@ class Command(BaseCommand):
             create_run="Demo_Course",
             run_url=f"http://{edx_host}/courses/course-v1:edX+DemoX+Demo_Course/",
             program="program-v1:MITx+DEDP",
-            depts="Science",
+            depts=["Science"],
             create_depts=True,
         )
 
@@ -252,7 +252,7 @@ class Command(BaseCommand):
             live=True,
             create_run="course",
             run_url=f"http://{edx_host}/courses/course-v1:edX+E2E-101+course/",
-            depts="Math",
+            depts=["Math"],
             create_depts=True,
         )
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7985

### Description (What does it do?)
This PR fixes a bug in the `configure_instance` script in the part that creates the Edx Demonstration Course and E2E Test Course. Currently, these commands pass a single string to the `depts` argument on `create_courseware`. On the other end, in `create_courseware`, this is treated as an array. This causes the string to be split into its individual characters, and a `Department` object is created for each letter. Once it gets to the second course, it hits a letter that has already been used and a collision occurs. This PR simply passes arrays instead.

### Screenshots (if appropriate):
This is what Django admin for `Department` looks like currently after running `configure_instance`:
<img width="921" height="521" alt="image" src="https://github.com/user-attachments/assets/9a1b637d-2a91-46aa-9ac4-88b2811e0906" />
After this fix:
<img width="1296" height="332" alt="image" src="https://github.com/user-attachments/assets/31d18a70-c83c-4736-b4b9-bd3b193ea7b3" />

### How can this be tested?
- Spin up a fresh instance of `mitxonline`
- Set up OpenEdx and run `configure_instance` in the way described in the guide: https://github.com/mitodl/handbook/blob/master/openedx/MITx-edx-integration-tutor.md#mit-application-setup
- The command should not create errant one letter departments as shown in the above screenshot
