### PR TITLE
remove id requirement from program enrollment listing view

### DIFF
--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -475,21 +475,21 @@ class UserEnrollmentsApiViewSet(
             raise NotImplementedError
 
 
-@extend_schema(
-    responses={200: UserProgramEnrollmentDetailSerializer},
-    parameters=[
-        OpenApiParameter(
-            name="id",
-            type=OpenApiTypes.INT,
-            location=OpenApiParameter.PATH,
-            description="Program enrollment ID",
-            required=True,
-        )
-    ],
-)
 class UserProgramEnrollmentsViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
 
+    id_parameter = OpenApiParameter(
+        name="id",
+        type=OpenApiTypes.INT,
+        location=OpenApiParameter.PATH,
+        description="Program enrollment ID",
+        required=True,
+    )
+
+    @extend_schema(
+        responses={200: UserProgramEnrollmentDetailSerializer},
+        parameters=[],
+    )
     def list(self, request):
         """
         Returns a unified set of program and course enrollments for the current
@@ -528,6 +528,25 @@ class UserProgramEnrollmentsViewSet(viewsets.ViewSet):
             UserProgramEnrollmentDetailSerializer(program_list, many=True).data
         )
 
+    @extend_schema(
+        responses={200: UserProgramEnrollmentDetailSerializer},
+        parameters=[id_parameter],
+    )
+    def retrieve(self, request, pk=None):
+        """
+        Retrieve a specific program enrollment.
+        """
+        program = Program.objects.get(pk=pk)
+        enrollment = ProgramEnrollment.objects.get(user=request.user, program=program)
+        serializer = UserProgramEnrollmentDetailSerializer(
+            enrollment, context={"request": request}
+        )
+        return Response(serializer.data)
+
+    @extend_schema(
+        responses={200: UserProgramEnrollmentDetailSerializer},
+        parameters=[id_parameter],
+    )
     def destroy(self, request, pk=None):
         """
         Unenroll the user from this program. This is simpler than the corresponding

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -702,6 +702,21 @@ paths:
       description: |-
         Returns a unified set of program and course enrollments for the current
         user.
+      tags:
+      - program_enrollments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserProgramEnrollmentDetail'
+          description: ''
+  /api/v1/program_enrollments/{id}/:
+    get:
+      operationId: program_enrollments_retrieve
+      description: Retrieve a specific program enrollment.
       parameters:
       - in: path
         name: id
@@ -716,11 +731,8 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/UserProgramEnrollmentDetail'
+                $ref: '#/components/schemas/UserProgramEnrollmentDetail'
           description: ''
-  /api/v1/program_enrollments/{id}/:
     delete:
       operationId: program_enrollments_destroy
       description: |-

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -702,6 +702,21 @@ paths:
       description: |-
         Returns a unified set of program and course enrollments for the current
         user.
+      tags:
+      - program_enrollments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserProgramEnrollmentDetail'
+          description: ''
+  /api/v1/program_enrollments/{id}/:
+    get:
+      operationId: program_enrollments_retrieve
+      description: Retrieve a specific program enrollment.
       parameters:
       - in: path
         name: id
@@ -716,11 +731,8 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/UserProgramEnrollmentDetail'
+                $ref: '#/components/schemas/UserProgramEnrollmentDetail'
           description: ''
-  /api/v1/program_enrollments/{id}/:
     delete:
       operationId: program_enrollments_destroy
       description: |-

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -702,6 +702,21 @@ paths:
       description: |-
         Returns a unified set of program and course enrollments for the current
         user.
+      tags:
+      - program_enrollments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserProgramEnrollmentDetail'
+          description: ''
+  /api/v1/program_enrollments/{id}/:
+    get:
+      operationId: program_enrollments_retrieve
+      description: Retrieve a specific program enrollment.
       parameters:
       - in: path
         name: id
@@ -716,11 +731,8 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/UserProgramEnrollmentDetail'
+                $ref: '#/components/schemas/UserProgramEnrollmentDetail'
           description: ''
-  /api/v1/program_enrollments/{id}/:
     delete:
       operationId: program_enrollments_destroy
       description: |-


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8012

### Description (What does it do?)
This PR adds an explicit `retrieve` view to `UserProgramEnrollmentsViewSet`, setting the required `id` parameter on that and the `destroy` view. The `list` endpoint had the parameter removed, so you can query it without arguments and get all of the program enrollments for the current user.

### How can this be tested?
- Spin up `mitxonline` on this branch
- Create some program enrollments for your user
- Visit `/api/schema/swagger-ui/#/program_enrollments/program_enrollments_list`
- Verify that the listing view requires no parameters and returns all your program enrollments
- Verify that the retrieval and destroy endpoints still require ID and function
