### PR TITLE
Remove display of edx_username to rid N+1 queries

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -121,7 +121,6 @@ class UserAdmin(ContribUserAdmin, HijackUserAdminMixin, TimestampedModelAdmin):
         "global_id",
         "email",
         "name",
-        "edx_username",
         "is_staff",
         "last_login",
     )
@@ -141,10 +140,6 @@ class UserAdmin(ContribUserAdmin, HijackUserAdminMixin, TimestampedModelAdmin):
         UserProfileInline,
         UserContractPageInline,
     ]
-
-    @admin.display(description="OpenedX Username")
-    def edx_username(self, obj):
-        return obj.edx_username
 
 
 @admin.register(BlockList)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This solves a performance issue of the user django admin that could be causing knock-on effects to other users of the application by locking up the server for many seconds. I'm just removing the display of `edx_username` instead of trying to optimize it because it's not the most useful you can filter or search for them.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Go to `/admin/users/user` and verify you no longer see the `edx_username` field.