### PR TITLE
add extra data to certificate endpoint

### DIFF
--- a/courses/serializers/v2/certificates.py
+++ b/courses/serializers/v2/certificates.py
@@ -15,6 +15,7 @@ from cms.wagtail_api.schema.serializers import (
     PageMetaSerializer,
 )
 from courses.models import BaseCertificate, CourseRunCertificate, ProgramCertificate
+from courses.serializers.v2.courses import CourseRunWithCourseSerializer
 from users.serializers import PublicUserSerializer
 
 
@@ -181,6 +182,8 @@ class BaseCertificateSerializer(serializers.ModelSerializer):
 @extend_schema_serializer(component_name="V2CourseRunCertificateSerializer")
 class CourseRunCertificateSerializer(BaseCertificateSerializer):
     """Serializer for course certificates."""
+
+    course_run = CourseRunWithCourseSerializer()
 
     class Meta:
         """Meta options for the serializer."""

--- a/courses/serializers/v2/certificates.py
+++ b/courses/serializers/v2/certificates.py
@@ -16,6 +16,7 @@ from cms.wagtail_api.schema.serializers import (
 )
 from courses.models import BaseCertificate, CourseRunCertificate, ProgramCertificate
 from courses.serializers.v2.courses import CourseRunWithCourseSerializer
+from courses.serializers.v2.programs import ProgramSerializer
 from users.serializers import PublicUserSerializer
 
 
@@ -204,6 +205,8 @@ class CourseRunCertificateSerializer(BaseCertificateSerializer):
 @extend_schema_serializer(component_name="V2ProgramCertificateSerializer")
 class ProgramCertificateSerializer(BaseCertificateSerializer):
     """Serializer for course certificates."""
+
+    program = ProgramSerializer()
 
     class Meta:
         """Meta options for the serializer."""

--- a/courses/serializers/v2/certificates_test.py
+++ b/courses/serializers/v2/certificates_test.py
@@ -10,6 +10,7 @@ from courses.serializers.v2.certificates import (
     CourseRunCertificateSerializer,
     ProgramCertificateSerializer,
 )
+from courses.serializers.v2.courses import CourseRunWithCourseSerializer
 from main.test_utils import assert_drf_json_equal
 from users.serializers import PublicUserSerializer
 
@@ -86,6 +87,8 @@ def test_serialize_certificate(is_program):
     if is_program:
         expected_data["program"] = certificate.program.id
     else:
-        expected_data["course_run"] = certificate.course_run.id
+        expected_data["course_run"] = CourseRunWithCourseSerializer(
+            certificate.course_run
+        ).data
 
     assert_drf_json_equal(expected_data, serialized_data, ignore_order=True)

--- a/courses/serializers/v2/certificates_test.py
+++ b/courses/serializers/v2/certificates_test.py
@@ -11,6 +11,7 @@ from courses.serializers.v2.certificates import (
     ProgramCertificateSerializer,
 )
 from courses.serializers.v2.courses import CourseRunWithCourseSerializer
+from courses.serializers.v2.programs import ProgramSerializer
 from main.test_utils import assert_drf_json_equal
 from users.serializers import PublicUserSerializer
 
@@ -85,7 +86,7 @@ def test_serialize_certificate(is_program):
     }
 
     if is_program:
-        expected_data["program"] = certificate.program.id
+        expected_data["program"] = ProgramSerializer(certificate.program).data
     else:
         expected_data["course_run"] = CourseRunWithCourseSerializer(
             certificate.course_run

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -4285,8 +4285,7 @@ components:
           - $ref: '#/components/schemas/CertificatePageModel'
           readOnly: true
         course_run:
-          type: integer
-          readOnly: true
+          $ref: '#/components/schemas/V2CourseRunWithCourse'
         certificate_page_revision:
           type: integer
           readOnly: true

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -4673,8 +4673,7 @@ components:
           - $ref: '#/components/schemas/CertificatePageModel'
           readOnly: true
         program:
-          type: integer
-          readOnly: true
+          $ref: '#/components/schemas/V2Program'
         certificate_page_revision:
           type: integer
           readOnly: true

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -4285,8 +4285,7 @@ components:
           - $ref: '#/components/schemas/CertificatePageModel'
           readOnly: true
         course_run:
-          type: integer
-          readOnly: true
+          $ref: '#/components/schemas/V2CourseRunWithCourse'
         certificate_page_revision:
           type: integer
           readOnly: true

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -4673,8 +4673,7 @@ components:
           - $ref: '#/components/schemas/CertificatePageModel'
           readOnly: true
         program:
-          type: integer
-          readOnly: true
+          $ref: '#/components/schemas/V2Program'
         certificate_page_revision:
           type: integer
           readOnly: true

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -4285,8 +4285,7 @@ components:
           - $ref: '#/components/schemas/CertificatePageModel'
           readOnly: true
         course_run:
-          type: integer
-          readOnly: true
+          $ref: '#/components/schemas/V2CourseRunWithCourse'
         certificate_page_revision:
           type: integer
           readOnly: true

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -4673,8 +4673,7 @@ components:
           - $ref: '#/components/schemas/CertificatePageModel'
           readOnly: true
         program:
-          type: integer
-          readOnly: true
+          $ref: '#/components/schemas/V2Program'
         certificate_page_revision:
           type: integer
           readOnly: true


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/8009

### Description (What does it do?)
This PR replaces the integer ID's on the `course_certificates` and `program_certificates` endpoints for `course_run` and `program` respectively with the serialized representation of the object they represent. For `course_run`, `CourseRunWithCourseSerializer` was used and for `program` I used `ProgramSerializer`.

### How can this be tested?
- Spin up MITx Online on this branch
- Make sure you have sufficient data to test certificates:
  - Some test courses (Django admin)
  - Some test programs (Django admin)
  - A B2B organization with associated programs (Using B2B management commands, see docs for more detail)
  - Your user should be enrolled in at least one of these courses and have a grade (Enrollments done in the dashboard UI, grades in Django admin)
  - Course run and program certificates created for your user (Django admin and Wagtail)
- Once you have created the course run and program certificates, use their UUID (from Django admin) to hit the certificates URL and ensure that the serialized course run / program are included in the response:
  - `/api/v2/course_certificates/uuid-goes-here`
  - `/api/v2/program_certificates/uuid-goes-here`