### PR TITLE
Add flag to disable user repair task

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -1503,3 +1503,9 @@ OPENTELEMETRY_EXPORT_TIMEOUT_MS = get_int(
     default=5000,
     description="Timeout for opentelemetry export",
 )
+
+DISABLE_USER_REPAIR_TASK = get_bool(
+    name="DISABLE_USER_REPAIR_TASK",
+    default=False,
+    description="Disable the task so it no-ops",
+)

--- a/openedx/tasks.py
+++ b/openedx/tasks.py
@@ -1,9 +1,15 @@
 """Courseware tasks"""
 
+import logging
+
+from django.conf import settings
+
 from main.celery import app
 from openedx import api
 from users.api import get_user_by_id
 from users.models import User
+
+log = logging.getLogger()
 
 
 @app.task(acks_late=True)
@@ -33,6 +39,9 @@ def retry_failed_edx_enrollments():
 @app.task(acks_late=True)
 def repair_faulty_openedx_users():
     """Calls the API method to repair faulty openedx users"""
+    if settings.DISABLE_USER_REPAIR_TASK:
+        log.info("Skipping repair_faulty_openedx_users task as it is disabled")
+        return None
     repaired_users = api.repair_faulty_openedx_users()
     return [user.email for user in repaired_users]
 

--- a/openedx/tasks_test.py
+++ b/openedx/tasks_test.py
@@ -5,8 +5,9 @@ import pytest
 from openedx import tasks
 from users.factories import UserFactory
 
+pytestmark = pytest.mark.django_db
 
-@pytest.mark.django_db
+
 def test_create_edx_user_from_id(mocker):
     """Test that create_edx_user_from_id loads a user and calls the API method to create an edX user"""
     patch_create_user = mocker.patch("openedx.tasks.api.create_user")
@@ -15,7 +16,6 @@ def test_create_edx_user_from_id(mocker):
     patch_create_user.assert_called_once_with(user)
 
 
-@pytest.mark.django_db
 def test_update_edx_user_email_async(mocker):
     """Test that create_edx_user_from_id loads a user and calls the API method to create an edX user"""
     patch_update_user = mocker.patch("openedx.tasks.api.update_edx_user_email")
@@ -24,10 +24,21 @@ def test_update_edx_user_email_async(mocker):
     patch_update_user.assert_called_once_with(user)
 
 
-@pytest.mark.django_db
 def test_update_edx_user_name_async(mocker):
     """Test that change_edx_user_name_async loads a user and calls the API method to update an edX user name"""
     patch_update_user = mocker.patch("openedx.tasks.api.update_edx_user_name")
     user = UserFactory.create()
     tasks.change_edx_user_name_async.delay(user.id)
     patch_update_user.assert_called_once_with(user)
+
+
+@pytest.mark.parametrize("disabled", [True, False])
+def test_repair_faulty_openedx_users(mocker, settings, disabled):
+    """Test that repair_faulty_openedx_users only runs if enabled"""
+    patch_repair_users = mocker.patch("openedx.tasks.api.repair_faulty_openedx_users")
+
+    settings.DISABLE_USER_REPAIR_TASK = disabled
+
+    tasks.repair_faulty_openedx_users.delay()
+
+    assert patch_repair_users.call_count == (0 if disabled else 1)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8207

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds an environment variable that disables the repair task because it's being problematic right now and unable to complete the bulk of its work until https://github.com/mitodl/mitxonline/pull/2881 lands and we can catch up.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Set `REPAIR_OPENEDX_USERS_FREQUENCY` to something low like `60` (seconds) and when `DISABLE_USER_REPAIR_TASK` is set to true you should see the message "Skipping repair_faulty_openedx_users task as it is disabled" in the logs, if it's false then you should see the task run successfully