### PR TITLE
Only reconcile B2B organizations if we need to

### DIFF
--- a/authentication/backends/apisix_remote_user_org.py
+++ b/authentication/backends/apisix_remote_user_org.py
@@ -39,7 +39,7 @@ class ApisixRemoteUserOrgBackend(ApisixRemoteUserBackend):
                 for org in apisix_header["organization"]
             ]
 
-        if org_uuids.sort() != user.b2b_organization_sso_ids.sort():
+        if sorted(org_uuids) != sorted(user.b2b_organization_sso_ids):
             # Only bother with this if we need to (and pass it off to Celery if we do)
             queue_reconcile_user_orgs.delay(user.id, org_uuids)
 

--- a/authentication/backends/apisix_remote_user_org.py
+++ b/authentication/backends/apisix_remote_user_org.py
@@ -9,7 +9,7 @@ import logging
 from mitol.apigateway.api import decode_x_header
 from mitol.apigateway.backends import ApisixRemoteUserBackend
 
-from b2b.tasks import queue_reconcile_user_orgs
+from b2b.api import reconcile_user_orgs
 
 log = logging.getLogger(__name__)
 
@@ -40,6 +40,6 @@ class ApisixRemoteUserOrgBackend(ApisixRemoteUserBackend):
             ]
 
         # Task should check to see if it needs to run or not
-        queue_reconcile_user_orgs.delay(user.id, org_uuids)
+        reconcile_user_orgs(user, org_uuids)
 
         return user

--- a/authentication/backends/apisix_remote_user_org.py
+++ b/authentication/backends/apisix_remote_user_org.py
@@ -39,8 +39,7 @@ class ApisixRemoteUserOrgBackend(ApisixRemoteUserBackend):
                 for org in apisix_header["organization"]
             ]
 
-        if sorted(org_uuids) != sorted(user.b2b_organization_sso_ids):
-            # Only bother with this if we need to (and pass it off to Celery if we do)
-            queue_reconcile_user_orgs.delay(user.id, org_uuids)
+        # Task should check to see if it needs to run or not
+        queue_reconcile_user_orgs.delay(user.id, org_uuids)
 
         return user

--- a/b2b/api.py
+++ b/b2b/api.py
@@ -729,7 +729,7 @@ def reconcile_user_orgs(user, organizations):
     - tuple(int, int); contracts added and contracts removed
     """
 
-    if organizations.sort() == user.b2b_organization_sso_ids.sort():
+    if sorted(organizations) == sorted(user.b2b_organization_sso_ids):
         return (
             0,
             0,

--- a/b2b/api.py
+++ b/b2b/api.py
@@ -729,6 +729,12 @@ def reconcile_user_orgs(user, organizations):
     - tuple(int, int); contracts added and contracts removed
     """
 
+    if organizations.sort() == user.b2b_organization_sso_ids.sort():
+        return (
+            0,
+            0,
+        )
+
     user_contracts_qs = user.b2b_contracts.filter(
         integration_type=CONTRACT_INTEGRATION_SSO
     )

--- a/b2b/api.py
+++ b/b2b/api.py
@@ -730,6 +730,18 @@ def reconcile_user_orgs(user, organizations):
     - tuple(int, int); contracts added and contracts removed
     """
 
+    user_org_cache_key = f"org-membership-cache-{user.id}"
+    cached_org_membership = caches["redis"].get(user_org_cache_key, False)
+
+    if cached_org_membership and sorted(cached_org_membership) == sorted(organizations):
+        log.info("reconcile_user_orgs: skipping reconcilation for %s", user.id)
+        return (
+            0,
+            0,
+        )
+
+    log.info("reconcile_user_orgs: running reconcilation for %s", user.id)
+
     user_contracts_qs = user.b2b_contracts.filter(
         integration_type=CONTRACT_INTEGRATION_SSO
     )

--- a/b2b/tasks.py
+++ b/b2b/tasks.py
@@ -1,3 +1,4 @@
+# ruff: noqa: PLC0415
 """Tasks for the B2B app."""
 
 from main.celery import app
@@ -11,3 +12,15 @@ def queue_enrollment_code_check(contract_id: int):
 
     contract = ContractPage.objects.get(id=contract_id)
     ensure_enrollment_codes_exist(contract)
+
+
+@app.task()
+def queue_reconcile_user_orgs(user_id, orgs):
+    """Queue the reconcile_user_orgs call (which is potentially expensive.)"""
+
+    from django.contrib.auth import get_user_model
+
+    from b2b.api import reconcile_user_orgs
+
+    reconcile_user = get_user_model().objects.get(pk=user_id)
+    reconcile_user_orgs(reconcile_user, orgs)

--- a/b2b/tasks.py
+++ b/b2b/tasks.py
@@ -1,14 +1,7 @@
 # ruff: noqa: PLC0415
 """Tasks for the B2B app."""
 
-import logging
-
-from django.contrib.auth import get_user_model
-from django.core.cache import caches
-
 from main.celery import app
-
-log = logging.getLogger(__name__)
 
 
 @app.task()
@@ -19,22 +12,3 @@ def queue_enrollment_code_check(contract_id: int):
 
     contract = ContractPage.objects.get(id=contract_id)
     ensure_enrollment_codes_exist(contract)
-
-
-@app.task()
-def queue_reconcile_user_orgs(user_id, orgs):
-    """Queue the reconcile_user_orgs call (which is potentially expensive.)"""
-
-    from b2b.api import reconcile_user_orgs
-
-    user_org_cache_key = f"org-membership-cache-{user_id}"
-    cached_org_membership = caches["redis"].get(user_org_cache_key, False)
-
-    if cached_org_membership and sorted(cached_org_membership) == sorted(orgs):
-        log.info("queue_reconcile_user_orgs: skipping reconcilation for %s", user_id)
-        return
-
-    log.info("queue_reconcile_user_orgs: performing reconciliation for %s", user_id)
-
-    reconcile_user = get_user_model().objects.get(pk=user_id)
-    reconcile_user_orgs(reconcile_user, orgs)

--- a/b2b/tasks.py
+++ b/b2b/tasks.py
@@ -1,7 +1,14 @@
 # ruff: noqa: PLC0415
 """Tasks for the B2B app."""
 
+import logging
+
+from django.contrib.auth import get_user_model
+from django.core.cache import caches
+
 from main.celery import app
+
+log = logging.getLogger(__name__)
 
 
 @app.task()
@@ -18,9 +25,16 @@ def queue_enrollment_code_check(contract_id: int):
 def queue_reconcile_user_orgs(user_id, orgs):
     """Queue the reconcile_user_orgs call (which is potentially expensive.)"""
 
-    from django.contrib.auth import get_user_model
-
     from b2b.api import reconcile_user_orgs
+
+    user_org_cache_key = f"org-membership-cache-{user_id}"
+    cached_org_membership = caches["redis"].get(user_org_cache_key, False)
+
+    if cached_org_membership and sorted(cached_org_membership) == sorted(orgs):
+        log.info("queue_reconcile_user_orgs: skipping reconcilation for %s", user_id)
+        return
+
+    log.info("queue_reconcile_user_orgs: performing reconciliation for %s", user_id)
 
     reconcile_user = get_user_model().objects.get(pk=user_id)
     reconcile_user_orgs(reconcile_user, orgs)

--- a/users/models.py
+++ b/users/models.py
@@ -346,6 +346,15 @@ class User(
             pk__in=self.b2b_contracts.values_list("organization", flat=True).distinct()
         ).all()
 
+    @cached_property
+    def b2b_organization_sso_ids(self):
+        """Similar to b2b_organizations, but returns just the UUIDs."""
+        return list(
+            self.b2b_organizations.filter(
+                sso_organization_id__isnull=False
+            ).values_list("sso_organization_id", flat=True)
+        )
+
     class Meta:
         constraints = [
             models.UniqueConstraint(Lower("email"), name="user_email_unique"),


### PR DESCRIPTION
### What are the relevant tickets?

Partially closes mitodl/hq#8222

### Description (What does it do?)

The `ApisixRemoteOrgUserBackend` calls the API to reconcile the user's organization memberships every time it runs, which is a lot (every request that involves the backend). So, this updates the backend and the API to only perform the reconciliation if it's actually necessary. It caches the org membership for the user in Redis so we can check there rather than hitting the database.

To facilitate this, there is a new cached property in the User model that returns just the user's organization SSO IDs.

### How can this be tested?

The default timeout for cached data is 5 minutes, so ideally try to perform the steps within MITx Online within those 5 minutes. (Or, [adjust your settings](https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-CACHES-TIMEOUT) so that the timeout is higher.)

Create two orgs in Keycloak. Then, create corresponding organizations and SSO contracts in Keycloak.

Add your test user to _one_ of the orgs in Keycloak. Do not add the user to the org in MITx Online.

Log in to MITx Online with your test user - ideally using an incognito window - and watch the web container logs. You should see messages from `reconcile_user_orgs`. The user should be attached to the org accordingly. You should only see a flurry of DB activity once; subsequent page loads or API hits should call the API but it should notice that the membership hasn't changed and should then not do anything.

In Keycloak, add your test user to the _second_ org. (Again, do not adjust org membership for the user in MITx Online.)

Start a new session as your test user. The reconciliation should happen, and your user should be attached to the new org; you should see some DB activity but only once. 

### Additional Context

APISIX doesn't re-retrieve the user's information once they have an established session. So, if you adjust the org membership for the user and you don't start a new session, you won't see the membership change.

The reconciliation process can potentially be expensive, especially once we start getting more contracts in, so having it run on each request seems like a thing that needed fixing. (If your org membership changes, we could potentially have to throw you in a bunch of contracts, or remove you from a bunch of contracts.) This now explicitly short-circuits if the orgs we get back from APISIX are the same one the user's already in.

This is sort of the first step to having an explicit link between users and orgs - since the idea is to have orgs live mostly in Keycloak, we'll need an actual FK there rather than relying on contract enrollment. 