### PR TITLE
Actually make the contract attach API not require CSRF

### DIFF
--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -24,6 +24,7 @@ from b2b.serializers.v0 import (
 )
 from courses.models import CourseRun
 from ecommerce.models import Discount, Product
+from main.authentication import CsrfExemptSessionAuthentication
 from main.constants import USER_MSG_TYPE_B2B_ENROLL_SUCCESS
 
 
@@ -86,12 +87,14 @@ class AttachContractApi(APIView):
     """View for attaching a user to a B2B contract."""
 
     permission_classes = [IsAuthenticated]
+    authentication_classes = [
+        CsrfExemptSessionAuthentication,
+    ]
 
     @extend_schema(
         request=None,
         responses=ContractPageSerializer(many=True),
     )
-    @csrf_exempt
     def post(self, request, enrollment_code: str, format=None):  # noqa: A002, ARG002
         """
         Use the provided enrollment code to attach the user to a B2B contract.

--- a/main/authentication.py
+++ b/main/authentication.py
@@ -1,0 +1,17 @@
+"""Custom authentication handlers for DRF."""
+
+from rest_framework.authentication import SessionAuthentication
+
+
+class CsrfExemptSessionAuthentication(SessionAuthentication):
+    """
+    Authentication handler that ignores CSRF.
+
+    Otherwise, SessionAuthentication will enforce CSRF check, even if you tell
+    it not to.
+    """
+
+    def enforce_csrf(self, request):  # noqa: ARG002
+        """No-op CSRF enforcement"""
+
+        return


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#8256

### Description (What does it do?)

The `b2b/attach` API allows a user to submit an enrollment code for a given contract so that they can be added to the contract without enrolling in a course. This allows users to skip the usual flow for doing this, which requires that the learner decide about which course they want to take, and then take a round-trip through the MITx Online cart to finish up.

This was failing sometimes because the endpoint required CSRF, and the user won't necessarily have that yet. (This may be their first interaction with the MITx Online after logging into Learn.) So, this PR fixes that by no-oping the CSRF check. (This was marked `csrf_exempt` with a decorator, but that doesn't work for `APIView`-based views it seems.)

### How can this be tested?

You will need a contract set up in MITx Online that has enrollment codes. This doesn't need to be a new contract, or a contract your test user isn't already in. You'll need at least one of the enrollment codes for that contract.

1. Open Learn in a new incognito/private window.
2. Open the developer tools and open the Network tab so you can see the request as it happens.
3. Go to the attach URL for the code you're going to use - `http://learn.odl.local:9080/attach/<code>` 
4. Watch the network tab. You should see it attempt to hit the attach API with the specified code, and it should work.
5. You should be redirected to the dashboard in Learn, and you should see the organization (if you weren't in it already).