### PR TITLE
Add an IsAdminOrReadOnly permission set for contracts/orgs

### DIFF
--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -26,6 +26,7 @@ from courses.models import CourseRun
 from ecommerce.models import Discount, Product
 from main.authentication import CsrfExemptSessionAuthentication
 from main.constants import USER_MSG_TYPE_B2B_ENROLL_SUCCESS
+from main.permissions import IsAdminOrReadOnly
 
 
 class OrganizationPageViewSet(viewsets.ReadOnlyModelViewSet):
@@ -35,7 +36,7 @@ class OrganizationPageViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = OrganizationPage.objects.all()
     serializer_class = OrganizationPageSerializer
-    permission_classes = [IsAdminUser | HasAPIKey]
+    permission_classes = [IsAdminOrReadOnly | HasAPIKey]
     lookup_field = "slug"
     lookup_url_kwarg = "organization_slug"
 
@@ -47,7 +48,7 @@ class ContractPageViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = ContractPage.objects.all()
     serializer_class = ContractPageSerializer
-    permission_classes = [IsAdminUser | HasAPIKey]
+    permission_classes = [IsAdminOrReadOnly | HasAPIKey]
     lookup_field = "slug"
     lookup_url_kwarg = "contract_slug"
 

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -6,7 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.utils import extend_schema
 from mitol.common.utils.datetime import now_in_utc
 from rest_framework import status, viewsets
-from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_api_key.permissions import HasAPIKey

--- a/main/permissions.py
+++ b/main/permissions.py
@@ -28,7 +28,7 @@ class IsAdminOrReadOnly(permissions.IsAdminUser):
     Allows full access to admins, but read-only access to authenticated users.
     """
 
-    def has_permission(self, request, view):
+    def has_permission(self, request, view):  # noqa: ARG002
         """Return True if the user is an admin, or if the user is authenticated and making a safe request."""
         if request.user and request.user.is_staff:
             return True

--- a/main/permissions.py
+++ b/main/permissions.py
@@ -32,4 +32,8 @@ class IsAdminOrReadOnly(permissions.IsAdminUser):
         """Return True if the user is an admin, or if the user is authenticated and making a safe request."""
         if request.user and request.user.is_staff:
             return True
-        return request.method in permissions.SAFE_METHODS and request.user and request.user.is_authenticated
+        return (
+            request.method in permissions.SAFE_METHODS
+            and request.user
+            and request.user.is_authenticated
+        )

--- a/main/permissions.py
+++ b/main/permissions.py
@@ -21,3 +21,15 @@ class UserIsOwnerPermission(permissions.BasePermission):
             owner = getattr(obj, owner_field)
 
         return owner == request.user
+
+
+class IsAdminOrReadOnly(permissions.IsAdminUser):
+    """
+    Allows full access to admins, but read-only access to authenticated users.
+    """
+
+    def has_permission(self, request, view):
+        """Return True if the user is an admin, or if the user is authenticated and making a safe request."""
+        if request.user and request.user.is_staff:
+            return True
+        return request.method in permissions.SAFE_METHODS and request.user and request.user.is_authenticated


### PR DESCRIPTION

### What are the relevant tickets?
N/A

### Description (What does it do?)

https://github.com/mitodl/mit-learn/pull/2453 in Learn updates the org dashboard to hit the contracts page API, which requires an admin user; didn't catch this in testing but it breaks the org dashboard if you're not an admin. So, adding a permissions class to allow read-only if authed, read/write if staff permissions.

### How can this be tested?

Should be able to hit `/api/b2b/v0/contracts` and `organizations` as a non-admin, but won't be able to write to them.
Should be able to write to the above if an admin.
