### PR TITLE
Save generated username in desired field too since locking uses this

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -368,9 +368,11 @@ def reconcile_edx_username(user, *, desired_username=None):
                     )
 
                 if not OpenEdxUser.objects.filter(
-                    edx_username=username_to_try
+                    edx_username=username_to_try,
+                    desired_edx_username=username_to_try,
                 ).exists():
                     edx_user.edx_username = username_to_try
+                    edx_user.desired_edx_username = username_to_try
                     edx_user.save()
                     break
 


### PR DESCRIPTION
### What are the relevant tickets?

#2893 

### Description (What does it do?)

`create_edx_user_request` uses the `desired_edx_username` field but the changes I made to `reconcile_edx_username` doesn't update that field, just the actual edx_username field, so it seems to get confused a bit.


### How can this be tested?

Test should pass, creating a user in edX that had to be generated should also work.