### PR TITLE
Skip onboarding if the user has any enrollments

### DIFF
--- a/authentication/api_gateway/views.py
+++ b/authentication/api_gateway/views.py
@@ -129,16 +129,18 @@ class GatewayLoginView(View):
         GET endpoint for logging a user in.
         """
         redirect_url = get_redirect_url(request)
-        if not request.user.is_anonymous:
-            profile = request.user.user_profile
-            if (
-                not profile.completed_onboarding
-                and request.GET.get("skip_onboarding", "0") == "0"
-            ):
-                params = urlencode({"next": redirect_url})
-                redirect_url = f"{settings.MITXONLINE_NEW_USER_LOGIN_URL}?{params}"
-                profile.completed_onboarding = True
-                profile.save()
+        user = request.user
+        if (
+            not user.is_anonymous
+            and not user.should_skip_onboarding
+            and request.GET.get("skip_onboarding", "0") == "0"
+        ):
+            params = urlencode({"next": redirect_url})
+            redirect_url = f"{settings.MITXONLINE_NEW_USER_LOGIN_URL}?{params}"
+
+            profile = user.user_profile
+            profile.completed_onboarding = True
+            profile.save()
         return redirect(redirect_url)
 
 

--- a/users/models.py
+++ b/users/models.py
@@ -355,6 +355,13 @@ class User(
             ).values_list("sso_organization_id", flat=True)
         )
 
+    @property
+    def should_skip_onboarding(self):
+        return (
+            self.user_profile.completed_onboarding
+            or self.courserunenrollment_set(manager="all_objects").exists()
+        )
+
     class Meta:
         constraints = [
             models.UniqueConstraint(Lower("email"), name="user_email_unique"),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8311

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds code that skips onboarding if the user has any enrollments.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
For an existing user that has at least 1 enrollment, set `completed_onboarding` to `False` on their profile and login. They should not be redirected to onboarding. Optionally, you can test this behavior with the same scenario but by clicking the "Continue to Course" button on the learn dashboard. Both are logically identical they just differ in the user's destination.