### PR TITLE
Fixes for contract/org page displays in Django Admin

### DIFF
--- a/b2b/admin.py
+++ b/b2b/admin.py
@@ -9,14 +9,17 @@ from b2b.models import (
 )
 
 
-@admin.register(DiscountContractAttachmentRedemption)
-class DiscountContractAttachmentRedemptionAdmin(admin.ModelAdmin):
-    """Admin for discount attachments."""
+class ReadOnlyModelAdmin(admin.ModelAdmin):
+    """Read-only admin for models."""
 
-    list_display = ["user", "contract", "discount", "created_on"]
-    date_hierarchy = "created_on"
-    fields = ["user", "contract", "discount", "created_on"]
-    readonly_fields = ["user", "contract", "discount", "created_on"]
+    def __init__(self, *args, **kwargs):
+        """Set the readonly_fields to the fields if we can."""
+
+        self.readonly_fields = self.fields or [
+            field.name
+            for field in self.model._meta.fields  # noqa: SLF001
+        ]
+        super().__init__(*args, **kwargs)
 
     def has_add_permission(self, request):  # noqa: ARG002
         """Disable create."""
@@ -29,5 +32,57 @@ class DiscountContractAttachmentRedemptionAdmin(admin.ModelAdmin):
         return False
 
 
-admin.site.register(OrganizationPage)
-admin.site.register(ContractPage)
+@admin.register(DiscountContractAttachmentRedemption)
+class DiscountContractAttachmentRedemptionAdmin(ReadOnlyModelAdmin):
+    """Admin for discount attachments."""
+
+    list_display = ["user", "contract", "discount", "created_on"]
+    date_hierarchy = "created_on"
+    fields = ["user", "contract", "discount", "created_on"]
+    readonly_fields = ["user", "contract", "discount", "created_on"]
+
+
+@admin.register(ContractPage)
+class ContractPageAdmin(ReadOnlyModelAdmin):
+    """Admin for contract pages."""
+
+    list_display = [
+        "id",
+        "slug",
+        "title",
+        "organization",
+        "integration_type",
+        "contract_start",
+        "contract_end",
+    ]
+    list_filter = ["integration_type", "organization", "contract_start", "contract_end"]
+    date_hierarchy = "contract_start"
+    fields = [
+        "id",
+        "active",
+        "slug",
+        "organization",
+        "title",
+        "description",
+        "integration_type",
+        "contract_start",
+        "contract_end",
+        "max_learners",
+        "enrollment_fixed_price",
+    ]
+
+
+@admin.register(OrganizationPage)
+class OrganizationPageAdmin(ReadOnlyModelAdmin):
+    """Admin for organization pages."""
+
+    list_display = ["id", "slug", "name", "org_key"]
+    fields = [
+        "id",
+        "slug",
+        "name",
+        "org_key",
+        "description",
+        "logo",
+        "sso_organization_id",
+    ]

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -108,6 +108,11 @@ class OrganizationPage(Page):
             .distinct()
         )
 
+    def __str__(self):
+        """Return a reasonable representation of the org as a string."""
+
+        return f"{self.name} <{self.org_key}>"
+
 
 class ContractPage(Page):
     """Stores information about a contract with an organization."""


### PR DESCRIPTION

### What are the relevant tickets?

Closes mitodl/hq#8309

### Description (What does it do?)

The `ModelAdmin`s for the B2B contract and org models were added in for convenience but were done in a pretty quick, bare-bones fashion. So, these aren't the most usable things in general, and the Contracts page display here throws a 503 in an environment that has a bunch of data in it. 

So, this PR fixes a few issues:
- Limit the display for organization page and course page models so that it's not pulling in a ton of extra data that we don't need, and to limit to the actually relevant fields for these models (stripping out all the Wagtail internal model fields that we don't care about so much)
- Update the list and filtering for these pages so they have some reasonable options
- Makes the contract and org page displays read-only - if you want to edit things, you should be doing that via management command or via Wagtail. (Again, these things are only in here for convenience. We don't want to support anything beyond viewing these objects in the Django Admin.)

### How can this be tested?

Set up your MITx Online instance with at least a single contract and org. It doesn't need to have anything in it.

Then, from Django Admin, you should be able to see the contracts and organizations pages under B2B, and they should be pretty usable. You should get reasonable fields for the list views, and reasonable/useful list options. When viewing an object, you should not be able to make changes. You should not be able to add or delete objects.
