### PR TITLE
fix: append slash to userinfo endpoint

### DIFF
--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -12,5 +12,5 @@ def test_well_known_openid_configuration(client, settings):
         "issuer": "http://mitx-online.local",
         "authorization_endpoint": "http://mitx-online.local/oauth2/authorize/",
         "token_endpoint": "http://mitx-online.local/oauth2/token/",
-        "userinfo_endpoint": "http://mitx-online.local/api/v0/userinfo",
+        "userinfo_endpoint": "http://mitx-online.local/api/v0/userinfo/",
     }

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -379,7 +379,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/StaffDashboardUser'
           description: ''
-  /api/v0/userinfo:
+  /api/v0/userinfo/:
     get:
       operationId: userinfo_retrieve
       description: |-

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -379,7 +379,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/StaffDashboardUser'
           description: ''
-  /api/v0/userinfo:
+  /api/v0/userinfo/:
     get:
       operationId: userinfo_retrieve
       description: |-

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -379,7 +379,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/StaffDashboardUser'
           description: ''
-  /api/v0/userinfo:
+  /api/v0/userinfo/:
     get:
       operationId: userinfo_retrieve
       description: |-

--- a/users/urls.py
+++ b/users/urls.py
@@ -54,7 +54,7 @@ urlpatterns = [
         name="users_api-current_user",
     ),
     path(
-        "api/v0/userinfo",
+        "api/v0/userinfo/",
         UserInfoViewSet.as_view({"get": "retrieve"}),
         name="userinfo_api",
     ),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
A followup for https://github.com/mitodl/mitxonline/pull/2897, It adds the slash at the end of the URL for the userinfo endpoint. Open edX is calling it with slash and MITx Online throws 404.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout this branch
- Visit `/.well-known/openid-configuration`
- It should return userinfo_endpoint ending with a slash

