### PR TITLE
Add repair tasks that can be run in parallel

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -585,12 +585,21 @@ def repair_faulty_edx_user(user):
     return created_user, created_auth_token
 
 
-def repair_faulty_openedx_users():
+def repair_all_faulty_openedx_users():
     """
     Loops through all Users that are incorrectly configured with the openedx and attempts to get
     them in the correct state.
     """
-    for user in User.faulty_users_iterator():
+    users = User.faulty_users_iterator()
+    repair_faulty_openedx_users(users)
+
+
+def repair_faulty_openedx_users(users):
+    """
+    Loops through all Users that are incorrectly configured with the openedx and attempts to get
+    them in the correct state.
+    """
+    for user in users:
         try:
             # edX is our only openedx for the time being. If a different openedx is added, this
             # function will need to be updated.


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/8417

### Description (What does it do?)
<!--- Describe your changes in detail -->
This updates the `repair_missing_courseware_records` command so that it will run all the repairs in parallel instead of synchronously because we have 300k to get through.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Create some users in a broken state and run the `./manage.py repair_missing_courseware_records --parallel`  command. It should run in celery in parallel
