### PR TITLE
Fix 500 errors viewing financial assistance requests in Django Admin

### DIFF
--- a/flexiblepricing/models.py
+++ b/flexiblepricing/models.py
@@ -1,5 +1,3 @@
-import json
-
 import reversion
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -49,9 +47,8 @@ class FlexiblePricingRequestSubmission(AbstractFormSubmission):
     user = models.ForeignKey(AUTH_USER_MODEL, on_delete=models.CASCADE)
 
     def __str__(self):
-        formdata = json.loads(self.form_data)
         return "Flexible Pricing request from {user}: annual income {income}".format(
-            user=self.user.edx_username, income=formdata["your_income"]
+            user=self.user.edx_username, income=self.form_data["your_income"]
         )
 
 


### PR DESCRIPTION
### What are the relevant tickets?

Relevant Sentry error: https://mit-office-of-digital-learning.sentry.io/issues/6794957726/?environment=production&project=5864687&query=is%3Aunresolved&referrer=issue-stream

### Description (What does it do?)

I hit a 500 error trying to modify a financial assistance request in Django Admin, and got the linked Sentry error. As it turns out, the `__str__` function for the form submission model (which stores what the user entered into the form in Wagtail) was trying to parse a JSON string containing the form data; at some point, the field that it was trying to parse became a `JSONField` (or maybe it was before and the handling of this changed, I don't know) so trying to parse it again resulted in the error. So, this just updates the `__str__` function to not do that anymore. 

### How can this be tested?

Submit a financial assistance request through the app in the normal way. You should be able to view it in the Django Admin. 

### Additional Context

These are usually managed through the Staff Dashboard but sometimes there's a need to edit the record via Django Admin. (For example, today I was trying to fix the country data on the submitted form, which is not editable in the staff dashboard.)