### PR TITLE
Fix django admin

### DIFF
--- a/openedx/admin.py
+++ b/openedx/admin.py
@@ -20,6 +20,7 @@ class OpenEdxUserAdmin(ModelAdminRunActionsForAllMixin, admin.ModelAdmin):
     raw_id_fields = ["user"]
     actions = ["repair_all_faulty_openedx_users"]
     run_for_all_actions = ["repair_all_faulty_openedx_users"]
+    readonly_fields = ["has_sync_error", "sync_error_data"]
 
     def get_queryset(self, request):
         """Overrides base queryset"""

--- a/users/admin.py
+++ b/users/admin.py
@@ -48,11 +48,16 @@ class UserProfileInline(admin.StackedInline):
 
 
 _username_warning = """
-<div style="background-color: #dc3545; color: #fff; padding: 10px; font-size: 16px; border-radius: 5px;">
-   <strong>WARNING:</strong>
+<div style="background-color: #dc3545; color: #fff; padding: 10px; font-size: 16px; border-radius: 5px; margin-bottom: 10px;">
+   <strong>WARNING:</strong><br/>
    Changing this username will require you to apply the same change in edX immediately after.<br /><br>
    Do not make this change unless you can perform the same change to the edX username, or you have someone
    else lined up to do it.
+</div>
+<div style="background-color: #0088e2; color: #fff; padding: 10px; font-size: 16px; border-radius: 5px;">
+   <strong>NOTE:</strong><br/>
+   If the user has not been synced to openedx yet, you will need to set Desired Edx Username as well. <br/><br/>
+   This is ultimately the source of truth on what value to start with when attempting to create the user.
 </div>
 """
 
@@ -86,6 +91,7 @@ class OpenEdxUserInline(admin.StackedInline):
             {
                 "fields": (
                     "edx_username",
+                    "desired_edx_username",
                     "has_been_synced",
                     "has_sync_error",
                     "pretty_sync_error_data",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes an issue with trying to set the username for users who haven't had their openedx user created yet. It always overrides `desired_edx_username` to be the value of `edx_username`.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Create a user but don't input an edx username, check their record in django-admin and enter an edx_username.
- Check the database directly and confirm that the `desired_edx_username` field also updated to the same value.