### PR TITLE
for cert retrieval, return 400, 404 appropriately

### DIFF
--- a/courses/urls/v2/urls.py
+++ b/courses/urls/v2/urls.py
@@ -21,6 +21,14 @@ router.register(
 
 urlpatterns = [
     *router.urls,
-    path(r"course_certificates/<str:cert_uuid>/", v2.get_course_certificate),
-    path(r"program_certificates/<str:cert_uuid>/", v2.get_program_certificate),
+    path(
+        r"course_certificates/<str:cert_uuid>/",
+        v2.get_course_certificate,
+        name="get_course_certificate",
+    ),
+    path(
+        r"program_certificates/<str:cert_uuid>/",
+        v2.get_program_certificate,
+        name="get_program_certificate",
+    ),
 ]

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -6,11 +6,12 @@ import contextlib
 
 import django_filters
 from django.db.models import Count, Prefetch
+from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from mitol.olposthog.features import is_enabled
-from rest_framework import mixins, status, viewsets
+from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import (
@@ -463,7 +464,9 @@ class UserEnrollmentsApiViewSet(
 def get_course_certificate(request, cert_uuid):
     """Get a course certificate by UUID."""
 
-    cert = CourseRunCertificate.objects.filter(is_revoked=False, uuid=cert_uuid).get()
+    cert_uuid = serializers.UUIDField().to_internal_value(cert_uuid)
+
+    cert = get_object_or_404(CourseRunCertificate, is_revoked=False, uuid=cert_uuid)
 
     return Response(
         CourseRunCertificateSerializer(cert, context={"request": request}).data
@@ -481,7 +484,9 @@ def get_course_certificate(request, cert_uuid):
 def get_program_certificate(request, cert_uuid):
     """Get a program certificate by UUID."""
 
-    cert = ProgramCertificate.objects.filter(is_revoked=False, uuid=cert_uuid).get()
+    cert_uuid = serializers.UUIDField().to_internal_value(cert_uuid)
+
+    cert = get_object_or_404(ProgramCertificate, is_revoked=False, uuid=cert_uuid)
 
     return Response(
         ProgramCertificateSerializer(cert, context={"request": request}).data


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/8521

### Description (What does it do?)
This changes `v2/course_certificates/<str:cert_uuid>/` and `v2/program_certificates/<str:cert_uuid>/` endpoints to return better status codes.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Try retrieving from `mitxonline.odl.local:8065/api/v2/course_certificates/{uuid}/` with a an invalid uuid or a valid uuid for which no certificate exists. Should get 400 or 404 appropriately. 
