### PR TITLE
Check to see what type the CMS submission data is before generating string representation

### DIFF
--- a/flexiblepricing/models.py
+++ b/flexiblepricing/models.py
@@ -1,3 +1,5 @@
+import json
+
 import reversion
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -47,8 +49,14 @@ class FlexiblePricingRequestSubmission(AbstractFormSubmission):
     user = models.ForeignKey(AUTH_USER_MODEL, on_delete=models.CASCADE)
 
     def __str__(self):
+        if not self.form_data:
+            formdata = {"your_income": "Invalid"}
+        elif type(self.form_data) is dict:
+            formdata = self.form_data
+        else:
+            formdata = json.loads(self.form_data)
         return "Flexible Pricing request from {user}: annual income {income}".format(
-            user=self.user.edx_username, income=self.form_data["your_income"]
+            user=self.user.edx_username, income=formdata["your_income"]
         )
 
 


### PR DESCRIPTION
### What are the relevant tickets?

Relevant Sentry error: https://mit-office-of-digital-learning.sentry.io/issues/6794957726/?environment=production&project=5864687&query=is%3Aunresolved&referrer=issue-stream

The new Sentry error: https://mit-office-of-digital-learning.sentry.io/issues/6872452919/events/latest/events/?environment=rc&project=5864687&query=is%3Aunresolved&referrer=latest-event

https://github.com/mitodl/hq/issues/7992#issuecomment-3219959568


### Description (What does it do?)

https://github.com/mitodl/mitxonline/pull/2925 pulled the `json.loads` call to parse the financial assistance form submission data from the Wagtail model. (This is actually JSON, stored in a JSONField, so this _seemed_ unnecessary.) This resulted in new errors because it seems on RC and production we get back a bare string now, and not a `dict`.

So, now, we check the type of the field before trying to use it in `__str__`. If it's null, we return back an "Invalid" message; if it's a dict, we just return that; if it's a string, we try to parse it as JSON. This should cover the cases that we have.

### How can this be tested?

Set up a course with financial assistance, and submit a form. Then, try to load the submission in the Django Admin. It should work.

In the Django Shell, you should also be able to load the relevant `FlexiblePrice` object and be able to do (ex.) `fp.cms_submission` and get back a reasonable string representation of the submission.

### Additional Context

The `cms_submission` is the Wagtail form data - we don't really use this, but it does get stored in case we need to see what the user submitted. Most of this gets loaded into the actual `FlexiblePrice` model.