### PR TITLE
Improve Wagtail OpenApi Schema

### DIFF
--- a/cms/wagtail_api/schema/views.py
+++ b/cms/wagtail_api/schema/views.py
@@ -60,6 +60,14 @@ class WagtailCertificatePagesSchemaView(APIView):
         summary="List all Certificate Pages",
         description="Returns pages of type cms.CertificatePage",
         responses=CertificatePageListSerializer,
+        parameters=[
+            OpenApiParameter(
+                name="readable_id",
+                required=False,
+                type=str,
+                description="filter by course readable_id",
+            ),
+        ],
     )
     def get(self, request, *args, **kwargs):  # noqa: ARG002
         # You can return a dummy response or redirect to actual Wagtail logic
@@ -82,6 +90,14 @@ class WagtailCoursePagesSchemaView(APIView):
         summary="List all Course Pages",
         description="Returns pages of type cms.CoursePage",
         responses=CoursePageListSerializer,
+        parameters=[
+            OpenApiParameter(
+                name="readable_id",
+                required=False,
+                type=str,
+                description="filter by course readable_id",
+            ),
+        ],
     )
     def get(self, request, *args, **kwargs):  # noqa: ARG002
         # You can return a dummy response or redirect to actual Wagtail logic
@@ -104,6 +120,14 @@ class WagtailProgramPagesSchemaView(APIView):
         summary="List all Program Pages",
         description="Returns pages of type cms.ProgramPage",
         responses=ProgramPageListSerializer,
+        parameters=[
+            OpenApiParameter(
+                name="readable_id",
+                required=False,
+                type=str,
+                description="filter by course readable_id",
+            ),
+        ],
     )
     def get(self, request, *args, **kwargs):  # noqa: ARG002
         # You can return a dummy response or redirect to actual Wagtail logic

--- a/cms/wagtail_api/schema/views.py
+++ b/cms/wagtail_api/schema/views.py
@@ -60,14 +60,6 @@ class WagtailCertificatePagesSchemaView(APIView):
         summary="List all Certificate Pages",
         description="Returns pages of type cms.CertificatePage",
         responses=CertificatePageListSerializer,
-        parameters=[
-            OpenApiParameter(
-                name="readable_id",
-                required=False,
-                type=str,
-                description="filter by course readable_id",
-            ),
-        ],
     )
     def get(self, request, *args, **kwargs):  # noqa: ARG002
         # You can return a dummy response or redirect to actual Wagtail logic
@@ -125,7 +117,7 @@ class WagtailProgramPagesSchemaView(APIView):
                 name="readable_id",
                 required=False,
                 type=str,
-                description="filter by course readable_id",
+                description="filter by program readable_id",
             ),
         ],
     )

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1135,6 +1135,12 @@ paths:
       operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1149,6 +1155,12 @@ paths:
       operationId: pages_?fields=*&type=cms.CoursePage_retrieve
       description: Returns pages of type cms.CoursePage
       summary: List all Course Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1163,6 +1175,12 @@ paths:
       operationId: pages_?fields=*&type=cms.ProgramPage_retrieve
       description: Returns pages of type cms.ProgramPage
       summary: List all Program Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1135,12 +1135,6 @@ paths:
       operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
-      parameters:
-      - in: query
-        name: readable_id
-        schema:
-          type: string
-        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1180,7 +1174,7 @@ paths:
         name: readable_id
         schema:
           type: string
-        description: filter by course readable_id
+        description: filter by program readable_id
       tags:
       - pages
       responses:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -1135,6 +1135,12 @@ paths:
       operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1149,6 +1155,12 @@ paths:
       operationId: pages_?fields=*&type=cms.CoursePage_retrieve
       description: Returns pages of type cms.CoursePage
       summary: List all Course Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1163,6 +1175,12 @@ paths:
       operationId: pages_?fields=*&type=cms.ProgramPage_retrieve
       description: Returns pages of type cms.ProgramPage
       summary: List all Program Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -1135,12 +1135,6 @@ paths:
       operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
-      parameters:
-      - in: query
-        name: readable_id
-        schema:
-          type: string
-        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1180,7 +1174,7 @@ paths:
         name: readable_id
         schema:
           type: string
-        description: filter by course readable_id
+        description: filter by program readable_id
       tags:
       - pages
       responses:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -1135,6 +1135,12 @@ paths:
       operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1149,6 +1155,12 @@ paths:
       operationId: pages_?fields=*&type=cms.CoursePage_retrieve
       description: Returns pages of type cms.CoursePage
       summary: List all Course Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1163,6 +1175,12 @@ paths:
       operationId: pages_?fields=*&type=cms.ProgramPage_retrieve
       description: Returns pages of type cms.ProgramPage
       summary: List all Program Pages
+      parameters:
+      - in: query
+        name: readable_id
+        schema:
+          type: string
+        description: filter by course readable_id
       tags:
       - pages
       responses:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -1135,12 +1135,6 @@ paths:
       operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
-      parameters:
-      - in: query
-        name: readable_id
-        schema:
-          type: string
-        description: filter by course readable_id
       tags:
       - pages
       responses:
@@ -1180,7 +1174,7 @@ paths:
         name: readable_id
         schema:
           type: string
-        description: filter by course readable_id
+        description: filter by program readable_id
       tags:
       - pages
       responses:


### PR DESCRIPTION
### What are the relevant tickets?
For. https://github.com/mitodl/hq/issues/8414

### Description (What does it do?)
Adds readable ID to the params for API requests like https://api.learn.mit.edu/mitxonline/api/v2/pages/?fields=*&type=cms.CoursePage&readable_id=course-v1%3AMITxT%2B7.28.1x

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Try hitting `api/v2/pages/?fields=*&type=cms.CoursePage&readable_id={some-readable-id}` Locally; it should work I guess. 

I have also tested it by double checking that the param is included in code generated by https://github.com/mitodl/mitxonline-api-clients

### Additional Context
Weird that v0.yaml, v1.yaml, and v2.yaml include all the APIs. We should look into that sometime.
