### PR TITLE
fix: do not update open edx profile if user is not synced

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -445,6 +445,12 @@ def update_edx_user_profile(user):
     Args:
         user(user.models.User): the user to update
     """
+    if not user.openedx_user_exists:
+        log.info(
+            "Skipping user profile update for %s, user has no Open edX account", user
+        )
+        return
+
     auth = get_valid_edx_api_auth(user)
     req_session = requests.Session()
     resp = req_session.patch(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/mitxonline/issues/2857

### Description (What does it do?)
<!--- Describe your changes in detail -->
Do not make profile updates if openedx user is not synced.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master branch and create a user. Do not start Tutor/Open edx so that user is not synced.
- Make changes to the user profile at `/profile/`
- Notice that you get `OpenEdxApiAuth.DoesNotExist` in logs
- Checkout this branch and repeat above. Notice that now you get an info log like `"Skipping user profile update for %s, user has no Open edX account"`