### PR TITLE
fix: handle non-ascii username collisions

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -160,7 +160,9 @@ def _generate_unique_username(base_username, max_length=OPENEDX_USERNAME_MAX_LEN
     return None
 
 
-def _handle_username_collision(resp, data, open_edx_user, user, suggested_usernames, suggestions_extracted):  # noqa: PLR0913
+def _handle_username_collision(  # noqa: PLR0913
+    resp, data, open_edx_user, user, suggested_usernames, suggestions_extracted
+):
     """
     Handle username collision by trying OpenEdX suggestions or falling back to local generation.
     

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -160,7 +160,7 @@ def _generate_unique_username(base_username, max_length=OPENEDX_USERNAME_MAX_LEN
     return None
 
 
-def _handle_username_collision(resp, data, open_edx_user, user, suggested_usernames, suggestions_extracted):
+def _handle_username_collision(resp, data, open_edx_user, user, suggested_usernames, suggestions_extracted):  # noqa: PLR0913
     """
     Handle username collision by trying OpenEdX suggestions or falling back to local generation.
     

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -24,7 +24,6 @@ from openedx.api import (
     ACCESS_TOKEN_HEADER_NAME,
     OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS,
     OPENEDX_REGISTRATION_VALIDATION_PATH,
-    generate_unique_username,
     bulk_retire_edx_users,
     create_edx_auth_token,
     create_edx_user,
@@ -47,7 +46,7 @@ from openedx.api import (
     update_edx_user_name,
     update_edx_user_profile,
     validate_username_email_with_edx,
-    _generate_unique_username,
+    generate_unique_username,
 )
 from openedx.constants import (
     EDX_DEFAULT_ENROLLMENT_MODE,
@@ -306,9 +305,9 @@ def test_create_edx_user_conflict(settings, username_suggestions, base_username,
     ],
 )
 def test_generate_unique_username(base_username, expected_prefix):
-    """Test that _generate_unique_username generates unique usernames"""
+    """Test that generate_unique_username generates unique usernames"""
     
-    username = _generate_unique_username(base_username)
+    username = generate_unique_username(base_username)
     assert username.startswith(expected_prefix)
     assert len(username) > len(base_username)
 

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -235,7 +235,7 @@ def test_create_edx_user(  # noqa: PLR0913
 @responses.activate
 @pytest.mark.usefixtures("application")
 @pytest.mark.parametrize(
-    "username_suggestions,base_username,expected_username_pattern,test_description",
+    ("username_suggestions", "base_username", "expected_username_pattern", "test_description"),
     [
         (
             ["openedx-generated-username"],
@@ -297,7 +297,7 @@ def test_create_edx_user_conflict(settings, username_suggestions, base_username,
 
 
 @pytest.mark.parametrize(
-    "base_username,expected_prefix",
+    ("base_username", "expected_prefix"),
     [
         ("testuser", "testuser_"),
         ("José", "José_"),

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -24,6 +24,7 @@ from openedx.api import (
     ACCESS_TOKEN_HEADER_NAME,
     OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS,
     OPENEDX_REGISTRATION_VALIDATION_PATH,
+    generate_unique_username,
     bulk_retire_edx_users,
     create_edx_auth_token,
     create_edx_user,


### PR DESCRIPTION
### What are the relevant tickets?
[#8527](https://github.com/mitodl/hq/issues/8527)

### Description (What does it do?)
When OpenEdX returns empty username suggestions for usernames containing non-ASCII characters (like "Nguyễn"), the system was raising an `OpenEdxUserCreateError` instead of falling back to local username generation. This fix implements a fallback mechanism that generates unique usernames locally using random number suffixes when OpenEdX suggestions are unavailable.

#### Changes

- Added `_generate_unique_username()` helper function to modularize username generation logic
- Updated `_create_edx_user_request()` to fall back to local username generation when OpenEdX returns empty suggestions
- Refactored `reconcile_edx_username()` to use the same modular username generation function

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Create a user with non-ASCII username: `Nguyễn`. Verify the user gets created both in MITxOnline and edX.
2. Try to create another user with the same username
3. Verify the behavior:
    - The second user should be created successfully (not fail with an error)
    - The second user should get a unique username with a random suffix
    - No OpenEdxUserCreateError should be raised
    - Both users should exist in the system with different usernames

