### PR TITLE
Use absolute URLs for feature_image_source

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -267,9 +267,11 @@ def ensure_instructors_index() -> cms_models.InstructorIndexPage:
 
 def get_wagtail_img_src(image_obj) -> str:
     """Returns the image source URL for a Wagtail Image object"""
+    root_rel = urljoin(settings.MEDIA_URL, image_obj.file.name)
+    abs_url = urljoin(settings.SITE_BASE_URL, root_rel)
     return (
         "{url}?{qs}".format(
-            url=urljoin(settings.MEDIA_URL, image_obj.file.name),
+            url=abs_url,
             qs=urlencode({"v": image_obj.file_hash}),
         )
         if image_obj

--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -92,13 +92,14 @@ def test_ensure_home_page_and_site():
 def test_get_wagtail_img_src(settings):
     """get_wagtail_img_src should return the correct image URL"""
     settings.MEDIA_URL = "/mediatest/"
-    img_path = "/path/to/my-image.jpg"
+    settings.SITE_BASE_URL = "http://mitxonline.test"
+    img_filename = "path/to/my-image.jpg"
     img_hash = "abc123"
     home_page = HomePageFactory.build(
-        hero__file__filename=img_path, hero__file_hash=img_hash
+        hero__file__filename=img_filename, hero__file_hash=img_hash
     )
     img_src = get_wagtail_img_src(home_page.hero)
-    assert img_src == f"{img_path}?v={img_hash}"
+    assert img_src == f"http://mitxonline.test/mediatest/{img_filename}?v={img_hash}"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?
- For https://github.com/mitodl/hq/issues/8414

### Description (What does it do?)
Makes `feature_image_src` a fully qualified URL so we can use it on other sites (like Learn)

### How can this be tested?
Check that:
- images still work as expected within MITxOnline
- images in the wagtail API responses, e.g., http://api.learn.odl.local:8065/mitxonline/api/v2/pages/?fields=*&type=cms.CoursePage&readable_id=course-v1%3AMITxT%2B7.28.1x-fake, include fully qualified URLs.

