### PR TITLE
Check that image_obj is there and has a file before generating a URL.

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -267,6 +267,9 @@ def ensure_instructors_index() -> cms_models.InstructorIndexPage:
 
 def get_wagtail_img_src(image_obj) -> str:
     """Returns the image source URL for a Wagtail Image object"""
+    if not image_obj or not image_obj.file:
+        return ""
+
     root_rel = urljoin(settings.MEDIA_URL, image_obj.file.name)
     abs_url = urljoin(settings.SITE_BASE_URL, root_rel)
     return (


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/8414
Previous PR: https://github.com/mitodl/mitxonline/pull/2946

### Description (What does it do?)

The above PR added some code to rework how the image URLs are generated for Wagtail images. This failed for me for a page that had a blank image in it because the `image_obj` was null. So, this just adds a quick check to make sure the `image_obj` is set and has a file before proceeding.

### How can this be tested?

Automated tests should work.

If you try to view a course page that doesn't have a featured image, it should work. 
