### PR TITLE
respect the order of ID's passed as query string args to the courses API

### DIFF
--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -5,7 +5,7 @@ Course API Views version 2
 import contextlib
 
 import django_filters
-from django.db.models import Case, Count, Prefetch, When
+from django.db.models import Count, F, Func, Prefetch
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
@@ -268,7 +268,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
             try:
                 ids = [int(id_str.strip()) for id_str in id_filter.split(",")]
                 queryset = queryset.filter(id__in=ids).order_by(
-                    Case(*[When(id=pk, then=pos) for pos, pk in enumerate(ids)])
+                    Func(ids, F("id"), function="array_position")
                 )
             except (ValueError, TypeError):
                 queryset = queryset.order_by("title")


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8626

### Description (What does it do?)
This PR adds functionality to the `get_queryset` function of `CoursesViewSet`. To request multiple course details from this API, you need to pass an array of integer ID's to the `id` query string param. The `get_queryset` function was blanket ordering all results with `order_by("title")`, which would give alphabetical ordering. This PR ensures that if ID's are passed that the returned courses follow the order in which they were passed in.

### How can this be tested?
- Make sure you have 10+ courses labeled with numbers 1-10+ in their title. You can use the test courses created by `populate_course_data` for this.
- Get the integer `id` properties of these courses by looking in Django admin
- Visit the API at `/api/v2/courses/?id=` and after the equals sign add in the id's of your courses separated by commas
- Ensure that the courses are returned in the order you specified
- Swap around the ID's and ensure this remains the case