### PR TITLE
Only repair users who have logged in at least once

### DIFF
--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -703,6 +703,11 @@ def _create_faulty_users():
         openedx_user__has_sync_error=True,
     )
 
+    # same as the ones that get returned, but no last_login excludes them
+    UserFactory.create(last_login=None, no_openedx_user=True)
+    UserFactory.create(last_login=None, no_openedx_api_auth=True)
+    UserFactory.create(last_login=None, openedx_user__has_been_synced=False)
+
     return [
         UserFactory.create(no_openedx_user=True),
         UserFactory.create(no_openedx_api_auth=True),

--- a/users/factories.py
+++ b/users/factories.py
@@ -1,11 +1,11 @@
 """Factory for Users"""
 
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 from factory import Faker, RelatedFactory, SelfAttribute, SubFactory, Trait
 from factory.django import DjangoModelFactory
-from factory.fuzzy import FuzzyText
+from factory.fuzzy import FuzzyDateTime, FuzzyText
 from social_django.models import UserSocialAuth
 
 from users.models import GENDER_CHOICES, LegalAddress, User, UserProfile
@@ -37,6 +37,7 @@ class UserFactory(DjangoModelFactory):
         "openedx.factories.OpenEdxApiAuthFactory",
         "user",
     )
+    last_login = FuzzyDateTime(datetime(2008, 1, 1, tzinfo=timezone.utc))
 
     class Meta:
         model = User

--- a/users/models.py
+++ b/users/models.py
@@ -236,7 +236,7 @@ class FaultyOpenEdxUserManager(BaseUserManager):
                 openedx_user_count=Count("openedx_users"),
                 openedx_api_auth_count=Count("openedx_api_auth"),
             )
-            .filter(is_active=True)
+            .filter(is_active=True, last_login__isnull=False)
             .filter(
                 Q(openedx_user_count=0)
                 | Q(openedx_api_auth_count=0)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/8417

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds an additional filter to the existing query to filter our users that have never logged in.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Create a user that has a null `last_login` and has no OpenEdxUser
- Create anotherthat has a non-null `last_login` and has no OpenEdxUser
- When the repair celery task runs, it should only repair the second user