### PR TITLE
fix: disable restframework browseable API

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -1133,9 +1133,9 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSIONING": "rest_framework.versioning.NamespaceVersioning",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "ALLOWED_VERSIONS": ["v0", "v1", "v2"],
-    "DEFAULT_RENDERER_CLASSES": (
-        "rest_framework.renderers.JSONRenderer",
-    ) if not DEBUG else (
+    "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",)
+    if not DEBUG
+    else (
         "rest_framework.renderers.JSONRenderer",
         "rest_framework.renderers.BrowsableAPIRenderer",
     ),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/8600

### Description (What does it do?)
<!--- Describe your changes in detail -->
Restframework browseable API is enabled on Prod. Users can access that interface and make API requests. It can be risky to enable it.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Go to https://mitxonline.mit.edu/enrollments/ and see that the browseable API is enabled.
- Checkout this branch and set DEBUG to True, it should be enabled. Set DEBUG = False and it should be disabled.
