### PR TITLE
Update the B2B course run creation code to explicitly look for a source course

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -113,7 +113,7 @@ def create_contract_run(
 
     if not clone_course_run:
         try:
-            clone_course_run = course.courseruns.order_by("-id").get()
+            clone_course_run = course.courseruns.order_by("-id").first()
             log.warning(
                 "create_contract_run: No SOURCE run for %s, using %s",
                 course,
@@ -122,6 +122,10 @@ def create_contract_run(
         except CourseRun.DoesNotExist as exc:
             msg = f"No course runs available for {course}."
             raise SourceCourseIncompleteError(msg) from exc
+
+    if not clone_course_run:
+        msg = f"No course runs available for {course}."
+        raise SourceCourseIncompleteError(msg)
 
     new_run_tag = B2B_RUN_TAG_FORMAT.format(
         year=now_in_utc().year,

--- a/b2b/api.py
+++ b/b2b/api.py
@@ -81,7 +81,8 @@ def create_contract_run(
     for the given course. This code expects you to pass in an MITx Online course
     that has a readable ID like 'course-v1:UAI_SOURCE+number` and that it has a
     run of some sort. This should just be a single run. If there's multiple runs,
-    this code will grab the last one in the database.
+    this will look for a run tag of "SOURCE". Failing that, it will try to use
+    the _first_ run in the list.
 
     The MITx Online course run will belong to the source course. They will get a
     course key that is modified to represent the organization they belong to,
@@ -108,11 +109,19 @@ def create_contract_run(
         Product: The created Product object.
     """
 
-    clone_course_run = course.courseruns.last()
+    clone_course_run = course.courseruns.filter(run_tag="SOURCE").first()
 
     if not clone_course_run:
-        msg = f"No course runs available for {course}."
-        raise SourceCourseIncompleteError(msg)
+        try:
+            clone_course_run = course.courseruns.order_by("-id").get()
+            log.warning(
+                "create_contract_run: No SOURCE run for %s, using %s",
+                course,
+                clone_course_run,
+            )
+        except CourseRun.DoesNotExist as exc:
+            msg = f"No course runs available for {course}."
+            raise SourceCourseIncompleteError(msg) from exc
 
     new_run_tag = B2B_RUN_TAG_FORMAT.format(
         year=now_in_utc().year,


### PR DESCRIPTION

### What are the relevant tickets?

https://github.com/mitodl/hq/issues/8631

### Description (What does it do?)

While working through 8631, I noticed that the re-run code was grabbing the wrong course runs for creating a contract run. We have specific runs that are marked with a run tag of `SOURCE` that should be used for new contract runs, but the API was grabbing the most recent course run. (When this was written, the naming for these wasn't set up yet.) This fixes the lookup to look specifically for a course with a run tag of `SOURCE`, and then fall back to the _first_ course run.

This PR also updates the B2B contract management documentation to include info about the automated course run creation process.

### How can this be tested?

You will need MITx Online and edX running and configured properly to talk to each other. MITx Online also needs to be set up with a service account to create course re-runs. The details for this are in the documentation - run `pants docs ::` to build the docs.

In edX, create a source course. The run tag should be `SOURCE` and the organization should be (by convention) `UAI_SOURCE`. Create a corresponding course and course run in MITx Online for this (you can use `import_courserun` to make this easier). 

In MITx Online, create another run or two for the source course, with different run tags. You can create corresponding re-runs in edX manually if you want - these shouldn't be used, though, so it's not strictly required.

In MITx Online, create a new contract, then assign the source course (_not_ course run) to the course. The system should create you a new course run for the contract, and it should try to re-run the `SOURCE` course run in edX for the contract.

Repeat these steps, but don't put in a `SOURCE` run. Instead, give the first course run a different run tag. The system should grab this course run to create contract runs.
