### PR TITLE
Fix openedx user sync issues

### DIFF
--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -234,12 +234,52 @@ def test_create_edx_user(  # noqa: PLR0913
 
 @responses.activate
 @pytest.mark.usefixtures("application")
+def test_create_edx_user_dupe_email_username(settings):
+    """Test that create_edx_user handles a 409 response from the edX API"""
+    user = UserFactory.create(
+        openedx_user__has_been_synced=False,
+    )
+    error_data = {
+        "error_code": "duplicate-email-username",
+        "username_suggestions": [],
+    }
+
+    resp1 = responses.add(
+        responses.GET,
+        f"{settings.OPENEDX_API_BASE_URL}/api/mobile/v0.5/my_user_info",
+        json={},
+        status=status.HTTP_200_OK,
+    )
+    resp2 = responses.add(
+        responses.POST,
+        f"{settings.OPENEDX_API_BASE_URL}/user_api/v1/account/registration/",
+        json=error_data,
+        status=status.HTTP_409_CONFLICT,
+    )
+
+    create_edx_user(user)
+
+    assert resp1.call_count == 0
+    assert resp2.call_count == 1
+
+    user.refresh_from_db()
+
+    edx_user = user.openedx_users.first()
+
+    assert edx_user.has_been_synced is False
+    assert edx_user.has_sync_error is True
+    assert edx_user.sync_error_data == error_data
+
+
+@responses.activate
+@pytest.mark.usefixtures("application")
 @pytest.mark.parametrize(
     (
         "username_suggestions",
         "base_username",
         "expected_username_pattern",
         "test_description",
+        "edx_username_conflicts",
     ),
     [
         (
@@ -247,6 +287,7 @@ def test_create_edx_user(  # noqa: PLR0913
             "testuser",
             lambda username: username == "openedx-generated-username",
             "with OpenEdX suggestions",
+            False,
         ),
         (
             [],
@@ -254,21 +295,35 @@ def test_create_edx_user(  # noqa: PLR0913
             lambda username: username.startswith("José_")
             and len(username) > len("José"),
             "with empty suggestions (non-ASCII fallback)",
+            False,
+        ),
+        (
+            [],
+            "José",
+            lambda username: username.startswith("José_")
+            and len(username) > len("José"),
+            "with empty suggestions (non-ASCII fallback)",
+            True,
         ),
     ],
 )
-def test_create_edx_user_conflict(
+def test_create_edx_user_conflict(  # noqa: PLR0913
     settings,
     username_suggestions,
     base_username,
     expected_username_pattern,
     test_description,
+    edx_username_conflicts,
 ):
     """Test that create_edx_user handles a 409 response from the edX API"""
     user = UserFactory.create(
         openedx_user__has_been_synced=False,
         openedx_user__desired_edx_username=base_username,
     )
+    if edx_username_conflicts:
+        UserFactory.create(
+            openedx_user__edx_username=base_username,
+        )
 
     resp1 = responses.add(
         responses.GET,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8707
Fixes https://github.com/mitodl/hq/issues/8708

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes two issues that came up in RC:
- If a user has a `desired_edx_username` that conflicts with an existing `edx_username` value the whole operation fails due to the unique constraint
- If a user has both an email and an edx_username that conflicts, a different error is returned. The code correctly doesn't try any futher, but an error is logged to sentry instead of being recorded to the `OpenEdxUser` error data.
- Refactored a bit because the `create_edx_user_request` function was getting so big it was failing lint errors

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Test https://github.com/mitodl/hq/issues/8708
- Create a new user, skip the onboarding form. 
- Go to django admin and set a `desired_edx_username` value that conflicts with an existing `edx_username` value.
- Run the `repair_missing_courseware_records` command on that user, they should get a different numerically suffixed username.

Test  https://github.com/mitodl/hq/issues/8707
- Create a new user, skip the onboarding form.
- Change the email address to conflict with another user in openedx and do the same with `desired_edx_username`
- Run the `repair_missing_courseware_records` command on that user, they should get `has_sync_error` set to true and `sync_error_data` populated with the error message from openedx. This state will then exclude the user from any further attempts to repair them until their state is fixed (no need to test that, just an fyi).