### PR TITLE
Capture all 400/409 errors from openedx

### DIFF
--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -234,15 +234,21 @@ def test_create_edx_user(  # noqa: PLR0913
 
 @responses.activate
 @pytest.mark.usefixtures("application")
-def test_create_edx_user_dupe_email_username(settings):
+@pytest.mark.parametrize(
+    "error_data",
+    [
+        {"error_code": "duplicate-email"},
+        {
+            "error_code": "duplicate-email-username",
+            "username_suggestions": [],
+        },
+    ],
+)
+def test_create_edx_user_409_errors(settings, error_data):
     """Test that create_edx_user handles a 409 response from the edX API"""
     user = UserFactory.create(
         openedx_user__has_been_synced=False,
     )
-    error_data = {
-        "error_code": "duplicate-email-username",
-        "username_suggestions": [],
-    }
 
     resp1 = responses.add(
         responses.GET,

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -3,10 +3,6 @@
 from mitol.common.utils import get_error_response_summary
 
 
-class OpenEdxUserCreateError(Exception):
-    """Exception creating the OpenEdxUser"""
-
-
 class OpenEdXOAuth2Error(Exception):
     """We were unable to obtain a refresh token from openedx"""
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8707

### Description (What does it do?)
<!--- Describe your changes in detail -->
This does two main things:
- Gets rid of `OpenEdxUserCreateError` because it makes it more difficult to tell the nature of the actually underlying error
- Use `raise_for_status()` on the last request so we get an more reasonable error type related to what actually caused this to fail
- Move the recording of 400/409 errors outside the loop so that we capture it no matter what, and regardless of whatever `error_code` is.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This is for more extreme cases that are difficult to get setup without probably hacking the app significantly. The changes here are simple enough so a good review and testing the known use cases of creating users w/ conflicting usernames should be adequate.