### PR TITLE
Wagtail permissions and url fix

### DIFF
--- a/cms/wagtail_api/views.py
+++ b/cms/wagtail_api/views.py
@@ -54,7 +54,7 @@ class WagtailPagesAPIViewSet(PagesAPIViewSet):
         """
         Returns the appropriate permissions based on the 'type' query parameter.
         """
-        page_type = self.request.query_params.get("type")
+        page_type = self.request.query_params.get("type", "").lower()
         if page_type in PageType.anonymous_access_allowed_types():
             return [AllowAny()]
         return [IsAuthenticated()]

--- a/openapi/hooks.py
+++ b/openapi/hooks.py
@@ -169,24 +169,24 @@ def insert_wagtail_pages_schema(endpoints):
     )
     endpoints.append(
         (
-            "/api/v2/pages/?fields=*&type=cms.CertificatePage",
-            "^api/v2/pages/?fields=*&type=cms.CertificatePage$",
+            "/api/v2/pages/?fields=*&type=cms.certificatepage",
+            "^api/v2/pages/?fields=*&type=cms.certificatepage$",
             "GET",
             certificate_view,
         )
     )
     endpoints.append(
         (
-            "/api/v2/pages/?fields=*&type=cms.CoursePage",
-            "^api/v2/pages/?fields=*&type=cms.CoursePage$",
+            "/api/v2/pages/?fields=*&type=cms.coursepage",
+            "^api/v2/pages/?fields=*&type=cms.coursepage$",
             "GET",
             course_view,
         )
     )
     endpoints.append(
         (
-            "/api/v2/pages/?fields=*&type=cms.ProgramPage",
-            "^api/v2/pages/?fields=*&type=cms.ProgramPage$",
+            "/api/v2/pages/?fields=*&type=cms.programpage",
+            "^api/v2/pages/?fields=*&type=cms.programpage$",
             "GET",
             program_view,
         )

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1130,9 +1130,9 @@ paths:
                 - $ref: '#/components/schemas/CertificatePage'
                 - $ref: '#/components/schemas/Page'
           description: Returns a page of any known Wagtail page type
-  /api/v2/pages/?fields=*&type=cms.CertificatePage:
+  /api/v2/pages/?fields=*&type=cms.certificatepage:
     get:
-      operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
+      operationId: pages_?fields=*&type=cms.certificatepage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
       tags:
@@ -1144,9 +1144,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CertificatePageList'
           description: ''
-  /api/v2/pages/?fields=*&type=cms.CoursePage:
+  /api/v2/pages/?fields=*&type=cms.coursepage:
     get:
-      operationId: pages_?fields=*&type=cms.CoursePage_retrieve
+      operationId: pages_?fields=*&type=cms.coursepage_retrieve
       description: Returns pages of type cms.CoursePage
       summary: List all Course Pages
       parameters:
@@ -1164,9 +1164,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CoursePageList'
           description: ''
-  /api/v2/pages/?fields=*&type=cms.ProgramPage:
+  /api/v2/pages/?fields=*&type=cms.programpage:
     get:
-      operationId: pages_?fields=*&type=cms.ProgramPage_retrieve
+      operationId: pages_?fields=*&type=cms.programpage_retrieve
       description: Returns pages of type cms.ProgramPage
       summary: List all Program Pages
       parameters:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -1130,9 +1130,9 @@ paths:
                 - $ref: '#/components/schemas/CertificatePage'
                 - $ref: '#/components/schemas/Page'
           description: Returns a page of any known Wagtail page type
-  /api/v2/pages/?fields=*&type=cms.CertificatePage:
+  /api/v2/pages/?fields=*&type=cms.certificatepage:
     get:
-      operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
+      operationId: pages_?fields=*&type=cms.certificatepage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
       tags:
@@ -1144,9 +1144,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CertificatePageList'
           description: ''
-  /api/v2/pages/?fields=*&type=cms.CoursePage:
+  /api/v2/pages/?fields=*&type=cms.coursepage:
     get:
-      operationId: pages_?fields=*&type=cms.CoursePage_retrieve
+      operationId: pages_?fields=*&type=cms.coursepage_retrieve
       description: Returns pages of type cms.CoursePage
       summary: List all Course Pages
       parameters:
@@ -1164,9 +1164,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CoursePageList'
           description: ''
-  /api/v2/pages/?fields=*&type=cms.ProgramPage:
+  /api/v2/pages/?fields=*&type=cms.programpage:
     get:
-      operationId: pages_?fields=*&type=cms.ProgramPage_retrieve
+      operationId: pages_?fields=*&type=cms.programpage_retrieve
       description: Returns pages of type cms.ProgramPage
       summary: List all Program Pages
       parameters:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -1130,9 +1130,9 @@ paths:
                 - $ref: '#/components/schemas/CertificatePage'
                 - $ref: '#/components/schemas/Page'
           description: Returns a page of any known Wagtail page type
-  /api/v2/pages/?fields=*&type=cms.CertificatePage:
+  /api/v2/pages/?fields=*&type=cms.certificatepage:
     get:
-      operationId: pages_?fields=*&type=cms.CertificatePage_retrieve
+      operationId: pages_?fields=*&type=cms.certificatepage_retrieve
       description: Returns pages of type cms.CertificatePage
       summary: List all Certificate Pages
       tags:
@@ -1144,9 +1144,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CertificatePageList'
           description: ''
-  /api/v2/pages/?fields=*&type=cms.CoursePage:
+  /api/v2/pages/?fields=*&type=cms.coursepage:
     get:
-      operationId: pages_?fields=*&type=cms.CoursePage_retrieve
+      operationId: pages_?fields=*&type=cms.coursepage_retrieve
       description: Returns pages of type cms.CoursePage
       summary: List all Course Pages
       parameters:
@@ -1164,9 +1164,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CoursePageList'
           description: ''
-  /api/v2/pages/?fields=*&type=cms.ProgramPage:
+  /api/v2/pages/?fields=*&type=cms.programpage:
     get:
-      operationId: pages_?fields=*&type=cms.ProgramPage_retrieve
+      operationId: pages_?fields=*&type=cms.programpage_retrieve
       description: Returns pages of type cms.ProgramPage
       summary: List all Program Pages
       parameters:


### PR DESCRIPTION
### What are the relevant tickets?
Small followup to https://github.com/mitodl/mitxonline/pull/2952

### Description (What does it do?)
Makes url casing more consistent. See code comment.


### How can this be tested?
1. Check that `/api/v2/pages/?type=cms.courspage&fields=*` and `/api/v2/pages/?type=cms.CoursPage&fields=*` are both accessible to anonymous users, and that `/api/v2/pages/?type=cms.courspage&fields=*` shows up int he OpenAPI spec.
2. Similar for programs/certifies.
