### PR TITLE
Courses API w/ org= handle anonymous

### DIFF
--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -271,10 +271,11 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
         if qp.get("include_approved_financial_aid"):
             added_context["include_approved_financial_aid"] = True
         if qp.get("org_id"):
+            user = self.request.user
             added_context["org_id"] = qp.get("org_id")
             added_context["user_contracts"] = (
-                self.request.user.b2b_contracts.values_list("id", flat=True).all()
-                if self.request.user.b2b_contracts
+                user.b2b_contracts.values_list("id", flat=True).all()
+                if user.is_authenticated and user.b2b_contracts
                 else []
             )
         return {**super().get_serializer_context(), **added_context}

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -287,6 +287,21 @@ def test_get_course(
 
 
 @pytest.mark.django_db
+def test_filter_with_org_id_anonymous():
+    org = OrganizationPageFactory(name="Test Org")
+
+    client = APIClient()
+
+    unrelated_course = Course.objects.create(title="Other Course")
+    CourseRunFactory(course=unrelated_course)
+
+    url = reverse("v2:courses_api-list")
+    response = client.get(url, {"org_id": org.id})
+
+    assert response.data["results"] == []
+
+
+@pytest.mark.django_db
 def test_filter_with_org_id_returns_contracted_course(
     mocker, contract_ready_course, mock_course_run_clone
 ):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8750

### Description (What does it do?)
<!--- Describe your changes in detail -->
While it's not expected, sometimes the courses API is called with `?org_id=` for an anonymous user, probably due to a session timeout coinciding with a dashboard load. This prevents a 500 error. Will address how to handle the anonymous use case more resiliently in a separate PR since it'll require a new API.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This is a bit complicated to test, so I think I'd say the test I wrote is enough to cover it.