### PR TITLE
Fix Provide More Info dialog to save to profile

### DIFF
--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -149,6 +149,43 @@ const findStates = (country: string, countries: Array<Country>) => {
     null
 }
 
+const renderFirstNameField = errors => {
+  const hasError =
+    errors && errors.legal_address && errors.legal_address.first_name
+  return (
+    <div>
+      <CardLabel
+        htmlFor="legal_address.first_name"
+        isRequired={true}
+        label="First Name"
+        subLabel="Name that will appear on emails"
+      />
+      <Field
+        type="text"
+        name="legal_address.first_name"
+        id="legal_address.first_name"
+        className="form-control"
+        autoComplete="given-name"
+        aria-invalid={
+          hasError ? "true" : null
+        }
+        aria-describedby={
+          hasError ?
+            "first-name-error" :
+            null
+        }
+        aria-description="Name cannot start with, or contain, a special character"
+        title="Name cannot start with, or contain, a special character."
+        required
+      />
+      <ErrorMessage
+        id="first-name-error"
+        name="legal_address.first_name"
+        component={FormError}
+      />
+    </div>)
+}
+
 const renderYearOfBirthField = errors => {
   const hasError =
     errors && errors.user_profile && errors.user_profile.year_of_birth
@@ -202,8 +239,14 @@ export const LegalAddressCountryFields = ({
         values.legal_address.country === "CA") &&
         !values.legal_address.state)
   )
+  const [showFirstNameField, setshowFirstNameField] = React.useState(
+    values.legal_address.first_name === ""
+  )
 
   React.useEffect(() => {
+    if (values.legal_address.first_name === "") {
+      setshowFirstNameField(true)
+    }
     if (values.user_profile.year_of_birth === "") {
       setShowYearOfBirthField(true)
     }
@@ -219,6 +262,9 @@ export const LegalAddressCountryFields = ({
 
   return (
     <React.Fragment>
+      {showFirstNameField ? (
+        <div className="form-group">{renderFirstNameField(errors)}</div>
+      ) : null}
       {showYearOfBirthField ? (
         <div className="form-group">{renderYearOfBirthField(errors)}</div>
       ) : null}

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -166,14 +166,8 @@ const renderFirstNameField = errors => {
         id="legal_address.first_name"
         className="form-control"
         autoComplete="given-name"
-        aria-invalid={
-          hasError ? "true" : null
-        }
-        aria-describedby={
-          hasError ?
-            "first-name-error" :
-            null
-        }
+        aria-invalid={hasError ? "true" : null}
+        aria-describedby={hasError ? "first-name-error" : null}
         aria-description="Name cannot start with, or contain, a special character"
         title="Name cannot start with, or contain, a special character."
         required
@@ -183,7 +177,8 @@ const renderFirstNameField = errors => {
         name="legal_address.first_name"
         component={FormError}
       />
-    </div>)
+    </div>
+  )
 }
 
 const renderLastNameField = errors => {
@@ -203,14 +198,8 @@ const renderLastNameField = errors => {
         id="legal_address.last_name"
         className="form-control"
         autoComplete="family-name"
-        aria-invalid={
-          hasError ? "true" : null
-        }
-        aria-describedby={
-          hasError ?
-            "last-name-error" :
-            null
-        }
+        aria-invalid={hasError ? "true" : null}
+        aria-describedby={hasError ? "last-name-error" : null}
         aria-description="Name cannot start with, or contain, a special character"
         title="Name cannot start with, or contain, a special character."
         required
@@ -220,7 +209,8 @@ const renderLastNameField = errors => {
         name="legal_address.last_name"
         component={FormError}
       />
-    </div>)
+    </div>
+  )
 }
 
 const renderYearOfBirthField = errors => {
@@ -280,7 +270,7 @@ export const LegalAddressCountryFields = ({
     values.legal_address.first_name === ""
   )
   const [showLastNameField, setShowLastNameField] = React.useState(
-    values.legal_address.first_name === ""
+    values.legal_address.last_name === ""
   )
 
   React.useEffect(() => {
@@ -408,12 +398,8 @@ export const LegalAddressFields = ({
   const addressErrors = errors && errors.legal_address
   return (
     <React.Fragment>
-      <div className="form-group">
-        {renderFirstNameField(errors)}
-      </div>
-      <div className="form-group">
-        {renderLastNameField(errors)}
-      </div>
+      <div className="form-group">{renderFirstNameField(errors)}</div>
+      <div className="form-group">{renderLastNameField(errors)}</div>
       <div className="form-group">
         <CardLabel
           htmlFor="name"

--- a/frontend/public/src/components/forms/ProfileFormFields.js
+++ b/frontend/public/src/components/forms/ProfileFormFields.js
@@ -186,6 +186,43 @@ const renderFirstNameField = errors => {
     </div>)
 }
 
+const renderLastNameField = errors => {
+  const hasError =
+    errors && errors.legal_address && errors.legal_address.last_name
+  return (
+    <div>
+      <CardLabel
+        htmlFor="legal_address.last_name"
+        isRequired={true}
+        label="Last Name"
+        subLabel="Name that will appear on emails"
+      />
+      <Field
+        type="text"
+        name="legal_address.last_name"
+        id="legal_address.last_name"
+        className="form-control"
+        autoComplete="family-name"
+        aria-invalid={
+          hasError ? "true" : null
+        }
+        aria-describedby={
+          hasError ?
+            "last-name-error" :
+            null
+        }
+        aria-description="Name cannot start with, or contain, a special character"
+        title="Name cannot start with, or contain, a special character."
+        required
+      />
+      <ErrorMessage
+        id="last-name-error"
+        name="legal_address.last_name"
+        component={FormError}
+      />
+    </div>)
+}
+
 const renderYearOfBirthField = errors => {
   const hasError =
     errors && errors.user_profile && errors.user_profile.year_of_birth
@@ -239,13 +276,19 @@ export const LegalAddressCountryFields = ({
         values.legal_address.country === "CA") &&
         !values.legal_address.state)
   )
-  const [showFirstNameField, setshowFirstNameField] = React.useState(
+  const [showFirstNameField, setShowFirstNameField] = React.useState(
+    values.legal_address.first_name === ""
+  )
+  const [showLastNameField, setShowLastNameField] = React.useState(
     values.legal_address.first_name === ""
   )
 
   React.useEffect(() => {
     if (values.legal_address.first_name === "") {
-      setshowFirstNameField(true)
+      setShowFirstNameField(true)
+    }
+    if (values.legal_address.last_name === "") {
+      setShowLastNameField(true)
     }
     if (values.user_profile.year_of_birth === "") {
       setShowYearOfBirthField(true)
@@ -264,6 +307,9 @@ export const LegalAddressCountryFields = ({
     <React.Fragment>
       {showFirstNameField ? (
         <div className="form-group">{renderFirstNameField(errors)}</div>
+      ) : null}
+      {showLastNameField ? (
+        <div className="form-group">{renderLastNameField(errors)}</div>
       ) : null}
       {showYearOfBirthField ? (
         <div className="form-group">{renderYearOfBirthField(errors)}</div>
@@ -363,58 +409,10 @@ export const LegalAddressFields = ({
   return (
     <React.Fragment>
       <div className="form-group">
-        <CardLabel
-          htmlFor="legal_address.first_name"
-          isRequired={true}
-          label="First Name"
-          subLabel="Name that will appear on emails"
-        />
-        <Field
-          type="text"
-          name="legal_address.first_name"
-          id="legal_address.first_name"
-          className="form-control"
-          autoComplete="given-name"
-          aria-invalid={
-            addressErrors && addressErrors.first_name ? "true" : null
-          }
-          aria-describedby={
-            addressErrors && addressErrors.first_name ?
-              "first-name-error" :
-              null
-          }
-          aria-description="Name cannot start with, or contain, a special character"
-          title="Name cannot start with, or contain, a special character."
-          required
-        />
-        <ErrorMessage
-          id="first-name-error"
-          name="legal_address.first_name"
-          component={FormError}
-        />
+        {renderFirstNameField(errors)}
       </div>
       <div className="form-group">
-        <CardLabel
-          htmlFor="legal_address.last_name"
-          isRequired={true}
-          label="Last Name"
-        />
-        <Field
-          type="text"
-          name="legal_address.last_name"
-          id="legal_address.last_name"
-          className="form-control"
-          autoComplete="family-name"
-          aria-invalid={
-            addressErrors && addressErrors.last_name ? "true" : null
-          }
-          aria-describedby={
-            addressErrors && addressErrors.last_name ? "last-name-error" : null
-          }
-          aria-description="Name cannot start with, or contain, a special character"
-          required
-        />
-        <ErrorMessage name="legal_address.last_name" component={FormError} />
+        {renderLastNameField(errors)}
       </div>
       <div className="form-group">
         <CardLabel


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/8492
### Description (What does it do?)
adds all required fields (that are currently blank) to the dialog requesting to fill out missing fields.

### Screenshots (if appropriate):
<img width="565" height="555" alt="Screenshot 2025-09-30 at 9 39 25 AM" src="https://github.com/user-attachments/assets/e3436361-c6e1-4d03-85b4-b0e244538884" />


### How can this be tested?
Create a user account
make sure not to fillout the "create-profile" form
enroll yourself in a current course
click go to Course
fillout the missing fields
NOTE: it should only ask for missing required fields
Go to profile and verify that the fields got saved into the profile.
