### PR TITLE
fix: use global id for user sync filtering

### DIFF
--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -387,15 +387,12 @@ def batch_upsert_hubspot_objects(  # pylint:disable=too-many-arguments  # noqa: 
             id__in=[id[0] for id in synced_object_ids]  # noqa: A001
         )
         if model_name == "user":
-            unsynced_objects = (
-                unsynced_objects.filter(
-                    is_active=True,
-                    email__contains="@",
-                    global_id__isnull=False,
-                    last_login__isnull=False,
-                )
-                .order_by(F("hubspot_sync_datetime").asc(nulls_first=True))
-            )
+            unsynced_objects = unsynced_objects.filter(
+                is_active=True,
+                email__contains="@",
+                global_id__isnull=False,
+                last_login__isnull=False,
+            ).order_by(F("hubspot_sync_datetime").asc(nulls_first=True))
         unsynced_object_ids = unsynced_objects.values_list("id", flat=True)
         object_ids = unsynced_object_ids if create else synced_object_ids
     elif not create:


### PR DESCRIPTION
### What are the relevant tickets?
[#8421](https://github.com/mitodl/hq/issues/8421)

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR updates our bulk HubSpot contact sync to reflect our SCIM-based provisioning. Historically we filtered bulk “create --users” by requiring a social_auth record, which made sense when most real users logged in interactively. Since SCIM now provisions many legitimate users without social_auth, those users were excluded from bulk syncs and not synced to hubspot. 

We now select users with `is_active=True`, a valid email, and [global_id](https://github.com/mitodl/mitxonline/blob/main/users/models.py#L292) present, replacing the social_auth check. This aligns bulk backfills with registration and --ids flows and ensures SCIM-provisioned users are included.

### How can this be tested?

1. Run `python manage.py sync_db_to_hubspot create --users` and verify:
    - New contacts are created for active users with valid emails and global_id (no social auth object needed).
    - hubspot_sync_datetime is set on success.

