### PR TITLE
Don't raise zeal exceptions normally

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -359,6 +359,7 @@ if DEBUG or ENVIRONMENT == "pytest":
     # this should be the first middleware so we catch any issues in our own middleware
     MIDDLEWARE += ("zeal.middleware.zeal_middleware",)
 
+ZEAL_RAISE = False
 ZEAL_ALLOWLIST = []
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This sets zeal not to raise exceptions normally as we only want that during tests.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to run the app and hit the home page and no exceptions be raised but warnings should be logged.