### PR TITLE
login button redirect not working with apisix

### DIFF
--- a/frontend/public/src/containers/pages/login/LoginSso.js
+++ b/frontend/public/src/containers/pages/login/LoginSso.js
@@ -4,7 +4,9 @@ import qs from "query-string"
 
 const LoginSso = () => {
   useEffect(() => {
-    const nextUrl = new URLSearchParams(window.location.search).get('next') || window.location.pathname
+    const nextUrl =
+      new URLSearchParams(window.location.search).get("next") ||
+      window.location.pathname
     const params = qs.stringify({ next: nextUrl })
 
     window.location.href = `/login/?${params}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -6750,9 +6750,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001716
-  resolution: "caniuse-lite@npm:1.0.30001716"
-  checksum: ff087ff38c339d0b697ef7862f575cdd0aeb5986a9c3660be97071c3b3c5ccf52380da73bb8397fdb8a528e4f05de009f6885219f7f6d908b1bff2d89334bfce
+  version: 1.0.30001748
+  resolution: "caniuse-lite@npm:1.0.30001748"
+  checksum: b3c19786e384d7a54796138f2b1d4e675ca4f9f1fd5e0402ffe1442025e799e5c27e64b0c3fcebef542aa5fa3410c5af8b965f890fff3c0e10cc2b3127a043fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8746

### Description (What does it do?)
Forces a redirect to the login page when apisix is being used for authentication.

### How can this be tested?
Ensure that the two following environment variables are set:
```
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False
EXPOSE_OIDC_LOGIN=False
```
1. `docker compose up`
2. Visit http://mitxonline.odl.local:9080/catalog/courses
3. Click the "Login" button
4. Verify that you are redirected to Keycloak.
