### PR TITLE
Removing first and last name requirement for a PATCH request

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -102,16 +102,12 @@ class LegalAddressSerializer(serializers.ModelSerializer):
 
     def validate_first_name(self, value):
         """Validates the first name of the user"""
-        if value == "":
-            raise serializers.ValidationError("First name cannot be blank")  # noqa: EM101
         if value and not USER_GIVEN_NAME_RE.match(value):
             raise serializers.ValidationError("First name is not valid")  # noqa: EM101
         return value
 
     def validate_last_name(self, value):
         """Validates the last name of the user"""
-        if value == "":
-            raise serializers.ValidationError("Last name cannot be blank")  # noqa: EM101
         if value and not USER_GIVEN_NAME_RE.match(value):
             raise serializers.ValidationError("Last name is not valid")  # noqa: EM101
         return value

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -37,8 +37,6 @@ def test_validate_legal_address(valid_address_dict):
 @pytest.mark.parametrize(
     "field,value,error",  # noqa: PT006
     [
-        ["first_name", "", "First name cannot be blank"],  # noqa: PT007
-        ["last_name", "", "Last name cannot be blank"],  # noqa: PT007
         ["country", "", "This field may not be blank."],  # noqa: PT007
         ["country", None, "This field may not be null."],  # noqa: PT007
     ],


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/8492

### Description (What does it do?)
Allows for a PATCH request to succeed when last name and first name are missing.
### Screenshots (if appropriate):
<img width="535" height="326" alt="Screenshot 2025-10-07 at 1 15 40 PM" src="https://github.com/user-attachments/assets/b817d826-3752-49ac-8168-ffc4fa6bf9b2" />


### How can this be tested?
Set up your user to have blank first and last name in the LegalAddress part of the profile.

Enroll your user in some course.
Go to dashboard and try to "go to course", you should be able to submit the missing year or country successfully.
Check in the admin or the profile page that the field was successfully updated.