### PR TITLE
Prefer enrollable course runs for start date

### DIFF
--- a/frontend/public/src/lib/util.js
+++ b/frontend/public/src/lib/util.js
@@ -351,9 +351,24 @@ export const getStartDateText = (
     return ""
   }
 
-  const courseRun = courseware.courseruns ?
-    courseware.courseruns.sort(compareCourseRunStartDates)[0] :
-    courseware
+  // When a course with multiple runs is provided, compute the label
+  // from runs that are still open for enrollment
+  // (`is_enrollable` true). This keeps the catalog card from showing
+  // start dates for long‑past, closed runs when a newer enrollable run
+  // exists.
+  let courseRun
+  if (courseware.courseruns) {
+    const enrollableRuns = courseware.courseruns.filter(
+      run => run.is_enrollable
+    )
+
+    const runsToConsider =
+      enrollableRuns.length > 0 ? enrollableRuns : courseware.courseruns
+
+    courseRun = runsToConsider.sort(compareCourseRunStartDates)[0]
+  } else {
+    courseRun = courseware
+  }
 
   if (!courseRun.start_date) {
     return ""

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -435,6 +435,34 @@ describe("utility functions", () => {
         getStartDateText(course).includes(formatPrettyDate(startDates[0]))
       )
     })
+
+    it("prefers enrollable runs when choosing the start date for a course", () => {
+      const pastDate = moment().subtract(30, "days")
+      const futureDate = moment().add(10, "days")
+
+      const course = {
+        courseruns: [
+          {
+            start_date:     pastDate,
+            is_enrollable:  false,
+            is_self_paced:  false,
+            is_archived:    false
+          },
+          {
+            start_date:     futureDate,
+            is_enrollable:  true,
+            is_self_paced:  false,
+            is_archived:    false
+          }
+        ]
+      }
+
+      const text = getStartDateText(course)
+
+      assert.isTrue(text.includes("Starts"))
+      assert.isTrue(text.includes(formatPrettyDate(futureDate)))
+      assert.isFalse(text.includes(formatPrettyDate(pastDate)))
+    })
     it("displays an empty string if it's a course and there's no course runs", () => {
       const course = {
         courseruns: []

--- a/frontend/public/src/lib/util_test.js
+++ b/frontend/public/src/lib/util_test.js
@@ -443,16 +443,16 @@ describe("utility functions", () => {
       const course = {
         courseruns: [
           {
-            start_date:     pastDate,
-            is_enrollable:  false,
-            is_self_paced:  false,
-            is_archived:    false
+            start_date:    pastDate,
+            is_enrollable: false,
+            is_self_paced: false,
+            is_archived:   false
           },
           {
-            start_date:     futureDate,
-            is_enrollable:  true,
-            is_self_paced:  false,
-            is_archived:    false
+            start_date:    futureDate,
+            is_enrollable: true,
+            is_self_paced: false,
+            is_archived:   false
           }
         ]
       }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10496

### Description (What does it do?)
When computing the start date label for multi-run courses, prefer runs that are still open for enrollment (is_enrollable). If no enrollable runs exist, fall back to all runs. This avoids showing start dates from long-past, closed runs while preserving existing behavior for single-run courseware and still using compareCourseRunStartDates for sorting.


### How can this be tested?
Create a course with two course runs, one in the past and one currently open for enrollment.  Visit the catalog page and verify that the start date is for the course run that's currently open for enrollment.
