### PR TITLE
Only return enrollable course runs

### DIFF
--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -277,8 +277,9 @@ class CourseWithCourseRunsSerializer(CourseSerializer):
 
     @extend_schema_field(CourseRunSerializer(many=True))
     def get_courseruns(self, instance):
-        # Use prefetched course runs to preserve prefetched products
-        courseruns = instance.courseruns.all()
+        # Use prefetched course runs to preserve prefetched products, but
+        # restrict to runs that are currently enrollable.
+        courseruns = instance.courseruns.enrollable().all()
         if "org_id" in self.context:
             courseruns = [
                 run

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -148,7 +148,9 @@ def test_course_with_course_runs_only_includes_enrollable_runs(mock_context, set
     course = enrollable_run.course
 
     # Make a non-enrollable run for the same course by setting enrollment_end in the past
-    non_enrollable_run = CourseRunFactory.create(course=course, past_enrollment_end=True)  # noqa: F841
+    non_enrollable_run = CourseRunFactory.create(
+        course=course, past_enrollment_end=True
+    )
 
     data = CourseWithCourseRunsSerializer(instance=course, context=mock_context).data
 

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -148,7 +148,9 @@ def test_course_with_course_runs_only_includes_enrollable_runs(mock_context, set
     course = enrollable_run.course
 
     # Make a non-enrollable run for the same course by setting enrollment_end in the past
-    non_enrollable_run = CourseRunFactory.create(course=course, past_enrollment_end=True)
+    non_enrollable_run = CourseRunFactory.create(
+        course=course, past_enrollment_end=True
+    )
 
     data = CourseWithCourseRunsSerializer(instance=course, context=mock_context).data
 

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -148,7 +148,7 @@ def test_course_with_course_runs_only_includes_enrollable_runs(mock_context, set
     course = enrollable_run.course
 
     # Make a non-enrollable run for the same course by setting enrollment_end in the past
-    non_enrollable_run = CourseRunFactory.create(course=course, past_enrollment_end=True)
+    non_enrollable_run = CourseRunFactory.create(course=course, past_enrollment_end=True)  # noqa: F841
 
     data = CourseWithCourseRunsSerializer(instance=course, context=mock_context).data
 

--- a/courses/serializers/v2/courses_test.py
+++ b/courses/serializers/v2/courses_test.py
@@ -141,6 +141,22 @@ def test_serialize_course_required_prerequisites(
     )
 
 
+def test_course_with_course_runs_only_includes_enrollable_runs(mock_context, settings):
+    """CourseWithCourseRunsSerializer should only return enrollable course runs."""
+    # Create a course with two runs: one enrollable (default factory), one not enrollable
+    enrollable_run = CourseRunFactory.create()
+    course = enrollable_run.course
+
+    # Make a non-enrollable run for the same course by setting enrollment_end in the past
+    non_enrollable_run = CourseRunFactory.create(course=course, past_enrollment_end=True)
+
+    data = CourseWithCourseRunsSerializer(instance=course, context=mock_context).data
+
+    # Only the enrollable run should be present
+    returned_run_ids = {run["id"] for run in data["courseruns"]}
+    assert returned_run_ids == {enrollable_run.id}
+
+
 class TestCourseRunEnrollmentSerializerV2:
     """Test the v2 CourseRunEnrollmentSerializer."""
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10496

### Description (What does it do?)
Adds a filter to only return enrollable course runs as part of the response from CourseWithCourseRunsSerializer

### How can this be tested?
Create a course with two course runs, one in the past and one currently open for enrollment. Visit the catalog page and verify that the start date is for the course run that's currently open for enrollment.
