### PR TITLE
feat: add edx certificate webhook

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -933,33 +933,32 @@ def get_certificate_grade_eligible_runs(now):
 def generate_course_run_certificates(  # noqa: C901
     user=None,
     course_run=None,
-    is_webhook=False,  # noqa: FBT002
+    force=False,  # noqa: FBT002
 ):
     """
     Hits the edX grades API and generates the certificates and grades for users for course runs.
 
+    Each parameter works independently:
+    - If course_run is provided, only that course run is processed (skipping eligibility filtering).
+    - If user is provided, only that user's grade/certificate is processed.
+    - If force is True, certificate date/eligibility checks are bypassed.
+
     When called without arguments (periodic task path), it fetches all eligible course runs and
     processes grades/certificates for all users in each run.
-
-    When called with user, course_run, and is_webhook=True (webhook path), it processes a single
-    user's grade and certificate for a specific course run, bypassing certificate_available_date
-    and course run eligibility checks since edX has already determined the certificate is ready.
 
     Args:
         user (User or None): If provided, process only this user's grade/certificate.
         course_run (CourseRun or None): If provided, process only this course run.
-        is_webhook (bool): If True, bypass eligibility checks.
+        force (bool): If True, bypass certificate_available_date and eligibility checks.
 
     Returns:
         None
     """
     now = now_in_utc()
 
-    # Webhook path: use the provided course run directly, no eligibility filtering
-    if is_webhook and user and course_run:
+    if course_run:
         course_runs = [course_run]
     else:
-        # Periodic task path: fetch all eligible runs
         course_runs = get_certificate_grade_eligible_runs(now)
 
         if course_runs is None or course_runs.count() == 0:
@@ -986,7 +985,7 @@ def generate_course_run_certificates(  # noqa: C901
             except ValidationError:
                 msg = f"Can't save grade {edx_grade} for {run_user} in {run}, skipping certificate generation"
                 log.exception(msg)
-                if is_webhook:
+                if len(course_runs) == 1:
                     return
                 continue
 
@@ -996,14 +995,15 @@ def generate_course_run_certificates(  # noqa: C901
                 updated_grades_count += 1
 
             # Check certificate generation eligibility
-            # For webhooks: bypass checks since edX has already determined the certificate is ready
-            # For periodic task:
+            # When force is True: bypass checks (e.g. webhook path where edX already
+            #   determined the certificate is ready)
+            # Otherwise:
             #   1. For self_paced course runs we generate certificates right away irrespective
             #      of certificate_available_date
             #   2. For other course runs we generate certificates if the certificate_available_date
             #      has passed
             if (
-                is_webhook
+                force
                 or run.is_self_paced
                 or (
                     run.certificate_available_date

--- a/courses/api.py
+++ b/courses/api.py
@@ -930,34 +930,70 @@ def get_certificate_grade_eligible_runs(now):
     return course_runs  # noqa: RET504
 
 
-def generate_course_run_certificates():
+def generate_course_run_certificates(  # noqa: C901
+    user=None,
+    course_run=None,
+    is_webhook=False,  # noqa: FBT002
+):
     """
-    Hits the edX grades API for eligible course runs and generates the certificates and grades for users for course runs
+    Hits the edX grades API and generates the certificates and grades for users for course runs.
+
+    When called without arguments (periodic task path), it fetches all eligible course runs and
+    processes grades/certificates for all users in each run.
+
+    When called with user, course_run, and is_webhook=True (webhook path), it processes a single
+    user's grade and certificate for a specific course run, bypassing certificate_available_date
+    and course run eligibility checks since edX has already determined the certificate is ready.
+
+    Args:
+        user (User or None): If provided, process only this user's grade/certificate.
+        course_run (CourseRun or None): If provided, process only this course run.
+        is_webhook (bool): If True, bypass eligibility checks.
+
+    Returns:
+        str or None: The certificate status - "created", "exists", or None.
     """
     now = now_in_utc()
-    course_runs = get_certificate_grade_eligible_runs(now)
 
-    if course_runs is None or course_runs.count() == 0:
-        log.info("No course runs matched the certificates generation criteria")
-        return
+    certificate_status = None
+
+    # Webhook path: use the provided course run directly, no eligibility filtering
+    if is_webhook and user and course_run:
+        course_runs = [course_run]
+    else:
+        # Periodic task path: fetch all eligible runs
+        course_runs = get_certificate_grade_eligible_runs(now)
+
+        if course_runs is None or course_runs.count() == 0:
+            log.info("No course runs matched the certificates generation criteria")
+            return certificate_status
 
     for run in course_runs:
-        edx_grade_user_iter = exception_logging_generator(
-            get_edx_grades_with_users(run)
-        )
+        if is_webhook:
+            # Webhook: fetch grade for the specific user only
+            edx_grade_user_iter = get_edx_grades_with_users(run, user=user)
+        else:
+            edx_grade_user_iter = exception_logging_generator(
+                get_edx_grades_with_users(run)
+            )
         created_grades_count, updated_grades_count, generated_certificates_count = (
             0,
             0,
             0,
         )
-        for edx_grade, user in edx_grade_user_iter:
+        for edx_grade, run_user in edx_grade_user_iter:
             try:
                 course_run_grade, created, updated = ensure_course_run_grade(
-                    user=user, course_run=run, edx_grade=edx_grade, should_update=True
+                    user=run_user,
+                    course_run=run,
+                    edx_grade=edx_grade,
+                    should_update=True,
                 )
             except ValidationError:
-                msg = f"Can't save grade {edx_grade} for {user} in {run}, skipping certificate generation"
+                msg = f"Can't save grade {edx_grade} for {run_user} in {run}, skipping certificate generation"
                 log.exception(msg)
+                if is_webhook:
+                    return certificate_status
                 continue
 
             if created:
@@ -966,29 +1002,57 @@ def generate_course_run_certificates():
                 updated_grades_count += 1
 
             # Check certificate generation eligibility
+            # For webhooks: bypass checks since edX has already determined the certificate is ready
+            # For periodic task:
             #   1. For self_paced course runs we generate certificates right away irrespective
-            #   of certificate_available_date
-            #   2. For others course runs we generate the certificates if the certificate_available_date of course run
-            #   has passed
-            if run.is_self_paced or (
-                run.certificate_available_date and run.certificate_available_date <= now
+            #      of certificate_available_date
+            #   2. For other course runs we generate certificates if the certificate_available_date
+            #      has passed
+            if (
+                is_webhook
+                or run.is_self_paced
+                or (
+                    run.certificate_available_date
+                    and run.certificate_available_date <= now
+                )
             ):
-                _, created, deleted = process_course_run_grade_certificate(
+                certificate, created, deleted = process_course_run_grade_certificate(
                     course_run_grade=course_run_grade
                 )
 
                 if deleted:
                     log.warning(
-                        "Certificate deleted for user %s and course_run %s", user, run
+                        "Certificate deleted for user %s and course_run %s",
+                        run_user,
+                        run,
                     )
                 elif created:
                     log.warning(
-                        "Certificate created for user %s and course_run %s", user, run
+                        "Certificate created for user %s and course_run %s",
+                        run_user,
+                        run,
                     )
                     generated_certificates_count += 1
+
+                if created:
+                    certificate_status = "created"
+                elif certificate:
+                    certificate_status = "exists"
+                elif is_webhook:
+                    log.info(
+                        "Certificate not created for user %s and course_run %s: "
+                        "user is not certificate eligible (passed=%s, has_paid_enrollment=%s)",
+                        run_user,
+                        run,
+                        course_run_grade.passed,
+                        course_run_grade.is_certificate_eligible,
+                    )
+
         log.info(
             f"Finished processing course run {run}: created grades for {created_grades_count} users, updated grades for {updated_grades_count} users, generated certificates for {generated_certificates_count} users"  # noqa: G004
         )
+
+    return certificate_status
 
 
 def manage_course_run_certificate_access(user, courseware_id, revoke_state):

--- a/courses/api.py
+++ b/courses/api.py
@@ -1010,7 +1010,7 @@ def generate_course_run_certificates(  # noqa: C901
                     and run.certificate_available_date <= now
                 )
             ):
-                certificate, created, deleted = process_course_run_grade_certificate(
+                _, created, deleted = process_course_run_grade_certificate(
                     course_run_grade=course_run_grade
                 )
 
@@ -1027,16 +1027,6 @@ def generate_course_run_certificates(  # noqa: C901
                         run,
                     )
                     generated_certificates_count += 1
-
-                if is_webhook and not created and not certificate:
-                    log.info(
-                        "Certificate not created for user %s and course_run %s: "
-                        "user is not certificate eligible (passed=%s, has_paid_enrollment=%s)",
-                        run_user,
-                        run,
-                        course_run_grade.passed,
-                        course_run_grade.is_certificate_eligible,
-                    )
 
         log.info(
             f"Finished processing course run {run}: created grades for {created_grades_count} users, updated grades for {updated_grades_count} users, generated certificates for {generated_certificates_count} users"  # noqa: G004

--- a/courses/api.py
+++ b/courses/api.py
@@ -939,7 +939,7 @@ def generate_course_run_certificates(  # noqa: C901
     Hits the edX grades API and generates the certificates and grades for users for course runs.
 
     Each parameter works independently:
-    - If course_run is provided, only that course run is processed (skipping eligibility filtering).
+    - If course_run is provided, only that course run is processed (skipping course runs eligibility filtering).
     - If user is provided, only that user's grade/certificate is processed.
     - If force is True, certificate date/eligibility checks are bypassed.
 
@@ -985,8 +985,6 @@ def generate_course_run_certificates(  # noqa: C901
             except ValidationError:
                 msg = f"Can't save grade {edx_grade} for {run_user} in {run}, skipping certificate generation"
                 log.exception(msg)
-                if len(course_runs) == 1:
-                    return
                 continue
 
             if created:

--- a/courses/api.py
+++ b/courses/api.py
@@ -951,11 +951,9 @@ def generate_course_run_certificates(  # noqa: C901
         is_webhook (bool): If True, bypass eligibility checks.
 
     Returns:
-        str or None: The certificate status - "created", "exists", or None.
+        None
     """
     now = now_in_utc()
-
-    certificate_status = None
 
     # Webhook path: use the provided course run directly, no eligibility filtering
     if is_webhook and user and course_run:
@@ -966,16 +964,12 @@ def generate_course_run_certificates(  # noqa: C901
 
         if course_runs is None or course_runs.count() == 0:
             log.info("No course runs matched the certificates generation criteria")
-            return certificate_status
+            return
 
     for run in course_runs:
-        if is_webhook:
-            # Webhook: fetch grade for the specific user only
-            edx_grade_user_iter = get_edx_grades_with_users(run, user=user)
-        else:
-            edx_grade_user_iter = exception_logging_generator(
-                get_edx_grades_with_users(run)
-            )
+        edx_grade_user_iter = exception_logging_generator(
+            get_edx_grades_with_users(run, user=user)
+        )
         created_grades_count, updated_grades_count, generated_certificates_count = (
             0,
             0,
@@ -993,7 +987,7 @@ def generate_course_run_certificates(  # noqa: C901
                 msg = f"Can't save grade {edx_grade} for {run_user} in {run}, skipping certificate generation"
                 log.exception(msg)
                 if is_webhook:
-                    return certificate_status
+                    return
                 continue
 
             if created:
@@ -1034,11 +1028,7 @@ def generate_course_run_certificates(  # noqa: C901
                     )
                     generated_certificates_count += 1
 
-                if created:
-                    certificate_status = "created"
-                elif certificate:
-                    certificate_status = "exists"
-                elif is_webhook:
+                if is_webhook and not created and not certificate:
                     log.info(
                         "Certificate not created for user %s and course_run %s: "
                         "user is not certificate eligible (passed=%s, has_paid_enrollment=%s)",
@@ -1051,8 +1041,6 @@ def generate_course_run_certificates(  # noqa: C901
         log.info(
             f"Finished processing course run {run}: created grades for {created_grades_count} users, updated grades for {updated_grades_count} users, generated certificates for {generated_certificates_count} users"  # noqa: G004
         )
-
-    return certificate_status
 
 
 def manage_course_run_certificate_access(user, courseware_id, revoke_state):

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -80,6 +80,7 @@ from courses.factories import (
 
 # pylint: disable=redefined-outer-name
 from courses.models import (
+    CourseRunCertificate,
     CourseRunEnrollment,
     EnrollmentMode,
     PaidCourseRun,
@@ -1261,11 +1262,11 @@ def test_generate_course_certificates_with_course_end_date(
 
 
 @pytest.mark.parametrize(
-    "enrollment_mode, grade, passed, expected_result",  # noqa: PT006
+    ("enrollment_mode", "grade", "passed", "should_create_cert"),
     [
-        (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, "created"),
-        (EDX_ENROLLMENT_VERIFIED_MODE, 0.30, False, None),
-        (EDX_ENROLLMENT_AUDIT_MODE, 0.80, True, None),
+        (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, True),
+        (EDX_ENROLLMENT_VERIFIED_MODE, 0.30, False, False),
+        (EDX_ENROLLMENT_AUDIT_MODE, 0.80, True, False),
     ],
 )
 @patch("courses.signals.upsert_custom_properties")
@@ -1276,9 +1277,9 @@ def test_webhook_certificate_status(  # noqa: PLR0913
     enrollment_mode,
     grade,
     passed,
-    expected_result,
+    should_create_cert,
 ):
-    """Test that the webhook path returns the correct certificate status based on enrollment and grade"""
+    """Test that the webhook path creates a certificate based on enrollment mode and grade"""
     enrollment = CourseRunEnrollmentFactory.create(
         user=user, enrollment_mode=enrollment_mode
     )
@@ -1297,11 +1298,12 @@ def test_webhook_certificate_status(  # noqa: PLR0913
         return_value=(grade_obj, True, False),
     )
 
-    result = generate_course_run_certificates(
-        user=user, course_run=course_run, is_webhook=True
-    )
+    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
 
-    assert result == expected_result
+    assert (
+        CourseRunCertificate.objects.filter(user=user, course_run=course_run).exists()
+        == should_create_cert
+    )
 
 
 @patch("courses.signals.upsert_custom_properties")
@@ -1327,10 +1329,10 @@ def test_webhook_certificate_already_exists(
     )
 
     # First call creates the certificate
-    result1 = generate_course_run_certificates(
-        user=user, course_run=course_run, is_webhook=True
-    )
-    assert result1 == "created"
+    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
+    assert CourseRunCertificate.objects.filter(
+        user=user, course_run=course_run
+    ).exists()
 
     # Mock the grade fetch again for second call
     mocker.patch(
@@ -1338,11 +1340,12 @@ def test_webhook_certificate_already_exists(
         return_value=iter([(passed_grade_with_enrollment, user)]),
     )
 
-    # Second call should find it already exists
-    result2 = generate_course_run_certificates(
-        user=user, course_run=course_run, is_webhook=True
+    # Second call should not create a duplicate certificate
+    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
+    assert (
+        CourseRunCertificate.objects.filter(user=user, course_run=course_run).count()
+        == 1
     )
-    assert result2 == "exists"
 
 
 @patch("courses.signals.upsert_custom_properties")
@@ -1372,11 +1375,11 @@ def test_webhook_certificate_bypasses_certificate_available_date(
         return_value=(passed_grade_with_enrollment, True, False),
     )
 
-    result = generate_course_run_certificates(
-        user=user, course_run=course_run, is_webhook=True
-    )
+    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
 
-    assert result == "created"
+    assert CourseRunCertificate.objects.filter(
+        user=user, course_run=course_run
+    ).exists()
 
 
 def test_webhook_no_grade_from_edx(
@@ -1391,11 +1394,11 @@ def test_webhook_no_grade_from_edx(
         return_value=iter([]),
     )
 
-    result = generate_course_run_certificates(
-        user=user, course_run=course_run, is_webhook=True
-    )
+    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
 
-    assert result is None
+    assert not CourseRunCertificate.objects.filter(
+        user=user, course_run=course_run
+    ).exists()
 
 
 @patch("courses.signals.upsert_custom_properties")

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1298,7 +1298,7 @@ def test_webhook_certificate_status(  # noqa: PLR0913
         return_value=(grade_obj, True, False),
     )
 
-    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
+    generate_course_run_certificates(user=user, course_run=course_run, force=True)
 
     assert (
         CourseRunCertificate.objects.filter(user=user, course_run=course_run).exists()
@@ -1329,7 +1329,7 @@ def test_webhook_certificate_already_exists(
     )
 
     # First call creates the certificate
-    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
+    generate_course_run_certificates(user=user, course_run=course_run, force=True)
     assert CourseRunCertificate.objects.filter(
         user=user, course_run=course_run
     ).exists()
@@ -1341,7 +1341,7 @@ def test_webhook_certificate_already_exists(
     )
 
     # Second call should not create a duplicate certificate
-    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
+    generate_course_run_certificates(user=user, course_run=course_run, force=True)
     assert (
         CourseRunCertificate.objects.filter(user=user, course_run=course_run).count()
         == 1
@@ -1375,7 +1375,7 @@ def test_webhook_certificate_bypasses_certificate_available_date(
         return_value=(passed_grade_with_enrollment, True, False),
     )
 
-    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
+    generate_course_run_certificates(user=user, course_run=course_run, force=True)
 
     assert CourseRunCertificate.objects.filter(
         user=user, course_run=course_run
@@ -1394,7 +1394,7 @@ def test_webhook_no_grade_from_edx(
         return_value=iter([]),
     )
 
-    generate_course_run_certificates(user=user, course_run=course_run, is_webhook=True)
+    generate_course_run_certificates(user=user, course_run=course_run, force=True)
 
     assert not CourseRunCertificate.objects.filter(
         user=user, course_run=course_run

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1260,6 +1260,144 @@ def test_generate_course_certificates_with_course_end_date(
     )
 
 
+@pytest.mark.parametrize(
+    "enrollment_mode, grade, passed, expected_result",  # noqa: PT006
+    [
+        (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, "created"),
+        (EDX_ENROLLMENT_VERIFIED_MODE, 0.30, False, None),
+        (EDX_ENROLLMENT_AUDIT_MODE, 0.80, True, None),
+    ],
+)
+@patch("courses.signals.upsert_custom_properties")
+def test_webhook_certificate_status(  # noqa: PLR0913
+    mock_upsert_custom_properties,
+    mocker,
+    user,
+    enrollment_mode,
+    grade,
+    passed,
+    expected_result,
+):
+    """Test that the webhook path returns the correct certificate status based on enrollment and grade"""
+    enrollment = CourseRunEnrollmentFactory.create(
+        user=user, enrollment_mode=enrollment_mode
+    )
+    course_run = enrollment.run
+    grade_obj = CourseRunGradeFactory.create(
+        course_run=course_run, user=user, grade=grade, passed=passed
+    )
+
+    mocker.patch("hubspot_sync.api.upsert_custom_properties")
+    mocker.patch(
+        "courses.api.get_edx_grades_with_users",
+        return_value=iter([(grade_obj, user)]),
+    )
+    mocker.patch(
+        "courses.api.ensure_course_run_grade",
+        return_value=(grade_obj, True, False),
+    )
+
+    result = generate_course_run_certificates(
+        user=user, course_run=course_run, is_webhook=True
+    )
+
+    assert result == expected_result
+
+
+@patch("courses.signals.upsert_custom_properties")
+def test_webhook_certificate_already_exists(
+    mock_upsert_custom_properties,
+    mocker,
+    passed_grade_with_enrollment,
+):
+    """Test that the webhook path returns certificate_exists when certificate already created"""
+    course_run = passed_grade_with_enrollment.course_run
+    user = passed_grade_with_enrollment.user
+
+    mocker.patch(
+        "hubspot_sync.api.upsert_custom_properties",
+    )
+    mocker.patch(
+        "courses.api.get_edx_grades_with_users",
+        return_value=iter([(passed_grade_with_enrollment, user)]),
+    )
+    mocker.patch(
+        "courses.api.ensure_course_run_grade",
+        return_value=(passed_grade_with_enrollment, False, False),
+    )
+
+    # First call creates the certificate
+    result1 = generate_course_run_certificates(
+        user=user, course_run=course_run, is_webhook=True
+    )
+    assert result1 == "created"
+
+    # Mock the grade fetch again for second call
+    mocker.patch(
+        "courses.api.get_edx_grades_with_users",
+        return_value=iter([(passed_grade_with_enrollment, user)]),
+    )
+
+    # Second call should find it already exists
+    result2 = generate_course_run_certificates(
+        user=user, course_run=course_run, is_webhook=True
+    )
+    assert result2 == "exists"
+
+
+@patch("courses.signals.upsert_custom_properties")
+def test_webhook_certificate_bypasses_certificate_available_date(
+    mock_upsert_custom_properties,
+    mocker,
+    passed_grade_with_enrollment,
+):
+    """Test that the webhook path creates a certificate even when certificate_available_date is in the future"""
+    course_run = passed_grade_with_enrollment.course_run
+    user = passed_grade_with_enrollment.user
+
+    # Set certificate_available_date to far in the future
+    course_run.is_self_paced = False
+    course_run.certificate_available_date = now_in_utc() + timedelta(days=365)
+    course_run.save()
+
+    mocker.patch(
+        "hubspot_sync.api.upsert_custom_properties",
+    )
+    mocker.patch(
+        "courses.api.get_edx_grades_with_users",
+        return_value=iter([(passed_grade_with_enrollment, user)]),
+    )
+    mocker.patch(
+        "courses.api.ensure_course_run_grade",
+        return_value=(passed_grade_with_enrollment, True, False),
+    )
+
+    result = generate_course_run_certificates(
+        user=user, course_run=course_run, is_webhook=True
+    )
+
+    assert result == "created"
+
+
+def test_webhook_no_grade_from_edx(
+    mocker,
+    user,
+):
+    """Test that the webhook path handles the case when no grade is found in edX"""
+    course_run = CourseRunFactory.create()
+
+    mocker.patch(
+        "courses.api.get_edx_grades_with_users",
+        return_value=iter([]),
+    )
+
+    result = generate_course_run_certificates(
+        user=user, course_run=course_run, is_webhook=True
+    )
+
+    assert result is None
+
+
 @patch("courses.signals.upsert_custom_properties")
 def test_course_run_certificates_access(mock_upsert_custom_properties, mocker):
     """Tests that the revoke and unrevoke for a course run certificates sets the states properly"""

--- a/openedx/urls.py
+++ b/openedx/urls.py
@@ -21,8 +21,8 @@ urlpatterns = (
         name="openedx-enrollment-webhook",
     ),
     path(
-        "api/process_certificate_webhook/",
-        views.ProcessCertificateWebhookView.as_view(),
-        name="process-certificate-webhook",
+        "api/openedx_webhook/certificate/",
+        views.edx_certificate_webhook,
+        name="openedx-certificate-webhook",
     ),
 )

--- a/openedx/urls.py
+++ b/openedx/urls.py
@@ -21,8 +21,8 @@ urlpatterns = (
         name="openedx-enrollment-webhook",
     ),
     path(
-        "api/certificate_webhook/",
-        views.CertificateWebhookView.as_view(),
-        name="certificate-webhook",
-    )
+        "api/process_certificate_webhook/",
+        views.ProcessCertificateWebhookView.as_view(),
+        name="process-certificate-webhook",
+    ),
 )

--- a/openedx/urls.py
+++ b/openedx/urls.py
@@ -20,4 +20,9 @@ urlpatterns = (
         views.edx_enrollment_webhook,
         name="openedx-enrollment-webhook",
     ),
+    path(
+        "api/certificate_webhook/",
+        views.CertificateWebhookView.as_view(),
+        name="certificate-webhook",
+    )
 )

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -11,7 +11,7 @@ from rest_framework.decorators import (
     authentication_classes,
     permission_classes,
 )
-from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -11,10 +11,11 @@ from rest_framework.decorators import (
     authentication_classes,
     permission_classes,
 )
-from rest_framework.permissions import IsAdminUser
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.views import APIView
 from rest_framework.response import Response
 
-from courses.api import create_local_enrollment
+from courses.api import create_local_enrollment, generate_course_run_certificates
 from courses.models import CourseRun
 from users.models import User
 
@@ -119,3 +120,63 @@ def edx_enrollment_webhook(request):
         },
         status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
     )
+class CertificateWebhookView(APIView):
+    """
+    API view for receiving certificate creation events from Open edX.
+
+    When Open edX creates a certificate for a user, it sends a POST request
+    to this endpoint with the user's email and the course ID. This view then
+    fetches the grade from edX, syncs it locally, and creates the corresponding
+    certificate in MITx Online.
+    """
+
+    authentication_classes = [OAuth2Authentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):  # noqa: D102
+        user_email = request.data.get("user_id")
+        course_run_id = request.data.get("course_id")
+
+        if not user_email or not course_run_id:
+            return Response(
+                {"error": "Both 'user_id' and 'course_id' are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            user = User.objects.get(email__iexact=user_email)
+        except User.DoesNotExist:
+            return Response(
+                {"error": f"User with email '{user_email}' not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            course_run = CourseRun.objects.get(courseware_id=course_run_id)
+        except CourseRun.DoesNotExist:
+            return Response(
+                {"error": f"Course run with id '{course_run_id}' not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        log.info(
+            "Certificate webhook received for user %s, course run %s",
+            user_email,
+            course_run_id,
+        )
+
+        certificate_status = generate_course_run_certificates(
+            user=user,
+            course_run=course_run,
+            is_webhook=True,
+        )
+
+        response_status = (
+            status.HTTP_201_CREATED
+            if certificate_status == "created"
+            else status.HTTP_200_OK
+        )
+
+        return Response(
+            {"certificate_status": certificate_status}, status=response_status
+        )

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -12,11 +12,11 @@ from rest_framework.decorators import (
     permission_classes,
 )
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
-from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from courses.api import create_local_enrollment, generate_course_run_certificates
-from courses.models import CourseRun
+from courses.models import CourseRun, CourseRunCertificate
 from users.models import User
 
 log = logging.getLogger(__name__)
@@ -120,7 +120,9 @@ def edx_enrollment_webhook(request):
         },
         status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
     )
-class CertificateWebhookView(APIView):
+
+
+class ProcessCertificateWebhookView(APIView):
     """
     API view for receiving certificate creation events from Open edX.
 
@@ -165,18 +167,20 @@ class CertificateWebhookView(APIView):
             course_run_id,
         )
 
-        certificate_status = generate_course_run_certificates(
+        if CourseRunCertificate.objects.filter(
+            user=user, course_run=course_run
+        ).exists():
+            log.info(
+                "Certificate already exists for user %s and course run %s, skipping",
+                user_email,
+                course_run_id,
+            )
+            return Response(status=status.HTTP_200_OK)
+
+        generate_course_run_certificates(
             user=user,
             course_run=course_run,
             is_webhook=True,
         )
 
-        response_status = (
-            status.HTTP_201_CREATED
-            if certificate_status == "created"
-            else status.HTTP_200_OK
-        )
-
-        return Response(
-            {"certificate_status": certificate_status}, status=response_status
-        )
+        return Response(status=status.HTTP_200_OK)

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -13,7 +13,6 @@ from rest_framework.decorators import (
 )
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from courses.api import create_local_enrollment, generate_course_run_certificates
 from courses.models import CourseRun, CourseRunCertificate
@@ -123,65 +122,98 @@ def edx_enrollment_webhook(request):
 
 
 @extend_schema(exclude=True)
-class ProcessCertificateWebhookView(APIView):
+@api_view(["POST"])
+@authentication_classes([OAuth2Authentication])
+@permission_classes([IsAdminUser])
+def edx_certificate_webhook(request):
     """
-    API view for receiving certificate creation events from Open edX.
+    Webhook endpoint for receiving certificate creation events from Open edX.
 
     When Open edX creates a certificate for a user, it sends a POST request
     to this endpoint with the user's email and the course ID. This view then
     fetches the grade from edX, syncs it locally, and creates the corresponding
     certificate in MITx Online.
+
+    Authentication: OAuth2 Bearer token (Django OAuth Toolkit access token).
+
+    Expected payload:
+        {
+            "email": "learner@example.com",
+            "course_id": "course-v1:MITx+1.001x+2025_T1"
+        }
     """
+    user_email = request.data.get("email")
+    course_run_id = request.data.get("course_id")
 
-    authentication_classes = [OAuth2Authentication]
-    permission_classes = [IsAdminUser]
+    log.info(
+        "Certificate webhook: Received (email=%s, course_id=%s)",
+        user_email,
+        course_run_id,
+    )
 
-    def post(self, request):
-        user_email = request.data.get("user_id")
-        course_run_id = request.data.get("course_id")
-
-        if not user_email or not course_run_id:
-            return Response(
-                {"error": "Both 'user_id' and 'course_id' are required."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        try:
-            user = User.objects.get(email__iexact=user_email)
-        except User.DoesNotExist:
-            return Response(
-                {"error": f"User with email '{user_email}' not found."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
-        try:
-            course_run = CourseRun.objects.get(courseware_id=course_run_id)
-        except CourseRun.DoesNotExist:
-            return Response(
-                {"error": f"Course run with id '{course_run_id}' not found."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
-        log.info(
-            "Certificate webhook received for user %s, course run %s",
+    if not user_email or not course_run_id:
+        log.warning(
+            "Certificate webhook: missing required fields (email=%s, course_id=%s)",
             user_email,
             course_run_id,
         )
-
-        if CourseRunCertificate.objects.filter(
-            user=user, course_run=course_run
-        ).exists():
-            log.info(
-                "Certificate already exists for user %s and course run %s, skipping",
-                user_email,
-                course_run_id,
-            )
-            return Response(status=status.HTTP_200_OK)
-
-        generate_course_run_certificates(
-            user=user,
-            course_run=course_run,
-            force=True,
+        return Response(
+            {"error": "Both 'email' and 'course_id' are required."},
+            status=status.HTTP_400_BAD_REQUEST,
         )
 
+    try:
+        user = User.objects.get(email__iexact=user_email)
+    except User.DoesNotExist:
+        log.warning(
+            "Certificate webhook: user not found (email=%s, course_id=%s)",
+            user_email,
+            course_run_id,
+        )
+        return Response(
+            {"error": f"User with email '{user_email}' not found."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    try:
+        course_run = CourseRun.objects.get(courseware_id=course_run_id)
+    except CourseRun.DoesNotExist:
+        log.warning(
+            "Certificate webhook: course run not found (email=%s, course_id=%s)",
+            user_email,
+            course_run_id,
+        )
+        return Response(
+            {"error": f"Course run with id '{course_run_id}' not found."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    log.info(
+        "Certificate webhook: validation passed, processing certificate for user %s, course run %s",
+        user_email,
+        course_run_id,
+    )
+
+    if CourseRunCertificate.objects.filter(
+        user=user, course_run=course_run
+    ).exists():
+        log.info(
+            "Certificate webhook: certificate already exists for user %s and course run %s, skipping",
+            user_email,
+            course_run_id,
+        )
         return Response(status=status.HTTP_200_OK)
+
+    generate_course_run_certificates(
+        user=user,
+        course_run=course_run,
+        force=True,
+    )
+
+    log.info(
+        "Certificate webhook: finished processing for user %s, course run %s",
+        user_email,
+        course_run_id,
+    )
+
+    return Response(status=status.HTTP_200_OK)

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -122,6 +122,7 @@ def edx_enrollment_webhook(request):
     )
 
 
+@extend_schema(exclude=True)
 class ProcessCertificateWebhookView(APIView):
     """
     API view for receiving certificate creation events from Open edX.
@@ -133,7 +134,7 @@ class ProcessCertificateWebhookView(APIView):
     """
 
     authentication_classes = [OAuth2Authentication]
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser]
 
     def post(self, request):
         user_email = request.data.get("user_id")

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -181,7 +181,7 @@ class ProcessCertificateWebhookView(APIView):
         generate_course_run_certificates(
             user=user,
             course_run=course_run,
-            is_webhook=True,
+            force=True,
         )
 
         return Response(status=status.HTTP_200_OK)

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -133,7 +133,7 @@ class CertificateWebhookView(APIView):
     authentication_classes = [OAuth2Authentication]
     permission_classes = [IsAuthenticated]
 
-    def post(self, request):  # noqa: D102
+    def post(self, request):
         user_email = request.data.get("user_id")
         course_run_id = request.data.get("course_id")
 

--- a/openedx/views.py
+++ b/openedx/views.py
@@ -194,9 +194,7 @@ def edx_certificate_webhook(request):
         course_run_id,
     )
 
-    if CourseRunCertificate.objects.filter(
-        user=user, course_run=course_run
-    ).exists():
+    if CourseRunCertificate.objects.filter(user=user, course_run=course_run).exists():
         log.info(
             "Certificate webhook: certificate already exists for user %s and course run %s, skipping",
             user_email,

--- a/openedx/views_test.py
+++ b/openedx/views_test.py
@@ -283,6 +283,15 @@ class TestProcessCertificateWebhookView:
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    def test_non_admin_returns_403(self, user_drf_client):
+        """Test that non-admin authenticated users are rejected"""
+        response = user_drf_client.post(
+            self.WEBHOOK_URL,
+            {"user_id": "test@example.com", "course_id": "course-v1:MITx+1+2024"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     @pytest.mark.parametrize(
         "payload, expected_error_field",  # noqa: PT006
         [
@@ -292,10 +301,10 @@ class TestProcessCertificateWebhookView:
         ],
     )
     def test_missing_fields_returns_400(
-        self, user_drf_client, payload, expected_error_field
+        self, admin_drf_client, payload, expected_error_field
     ):
         """Test that missing required fields return 400"""
-        response = user_drf_client.post(
+        response = admin_drf_client.post(
             self.WEBHOOK_URL,
             payload,
             format="json",
@@ -313,7 +322,7 @@ class TestProcessCertificateWebhookView:
         ids=["user_not_found", "course_run_not_found"],
     )
     def test_not_found_returns_404(
-        self, user_drf_client, user, user_email, courseware_id
+        self, admin_drf_client, user, user_email, courseware_id
     ):
         """Test that a non-existent user or course run returns 404"""
         if courseware_id is None:
@@ -321,7 +330,7 @@ class TestProcessCertificateWebhookView:
         if user_email is None:
             user_email = user.email
 
-        response = user_drf_client.post(
+        response = admin_drf_client.post(
             self.WEBHOOK_URL,
             {"user_id": user_email, "course_id": courseware_id},
             format="json",
@@ -353,7 +362,7 @@ class TestProcessCertificateWebhookView:
     def test_certificate_status(  # noqa: PLR0913
         self,
         mocker,
-        user_drf_client,
+        admin_drf_client,
         user,
         enrollment_mode,
         grade,
@@ -381,7 +390,7 @@ class TestProcessCertificateWebhookView:
             return_value=(grade_obj, True, False),
         )
 
-        response = user_drf_client.post(
+        response = admin_drf_client.post(
             self.WEBHOOK_URL,
             {"user_id": user.email, "course_id": course_run.courseware_id},
             format="json",
@@ -398,7 +407,7 @@ class TestProcessCertificateWebhookView:
     def test_idempotent_certificate_already_exists(
         self,
         mocker,
-        user_drf_client,
+        admin_drf_client,
         user,
     ):
         """Test that when a certificate already exists the webhook returns 200 without reprocessing"""
@@ -421,7 +430,7 @@ class TestProcessCertificateWebhookView:
             return_value=(passed_grade, True, False),
         )
 
-        response1 = user_drf_client.post(
+        response1 = admin_drf_client.post(
             self.WEBHOOK_URL,
             {"user_id": user.email, "course_id": course_run.courseware_id},
             format="json",
@@ -433,7 +442,7 @@ class TestProcessCertificateWebhookView:
 
         mock_generate = mocker.patch("openedx.views.generate_course_run_certificates")
 
-        response2 = user_drf_client.post(
+        response2 = admin_drf_client.post(
             self.WEBHOOK_URL,
             {"user_id": user.email, "course_id": course_run.courseware_id},
             format="json",

--- a/openedx/views_test.py
+++ b/openedx/views_test.py
@@ -301,14 +301,16 @@ class TestCertificateWebhookView:
             assert expected_error_field in response.data["error"]
 
     @pytest.mark.parametrize(
-        "user_email, courseware_id",
+        ("user_email", "courseware_id"),
         [
             ("nonexistent@example.com", None),
             (None, "course-v1:NonExistent+0+2099"),
         ],
         ids=["user_not_found", "course_run_not_found"],
     )
-    def test_not_found_returns_404(self, user_drf_client, user, user_email, courseware_id):
+    def test_not_found_returns_404(
+        self, user_drf_client, user, user_email, courseware_id
+    ):
         """Test that a non-existent user or course run returns 404"""
         if courseware_id is None:
             courseware_id = CourseRunFactory.create().courseware_id
@@ -324,14 +326,59 @@ class TestCertificateWebhookView:
         assert "not found" in response.data["error"]
 
     @pytest.mark.parametrize(
-        "enrollment_mode, grade, passed, is_self_paced, expected_status_code, expected_cert_status, cert_should_exist",  # noqa: E501
+        (
+            "enrollment_mode",
+            "grade",
+            "passed",
+            "is_self_paced",
+            "expected_status_code",
+            "expected_cert_status",
+            "cert_should_exist",
+        ),
         [
-            (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, True, status.HTTP_201_CREATED, "created", True),
-            (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, False, status.HTTP_201_CREATED, "created", True),
-            (EDX_ENROLLMENT_VERIFIED_MODE, 0.30, False, True, status.HTTP_200_OK, None, False),
-            (EDX_ENROLLMENT_AUDIT_MODE, 0.80, True, True, status.HTTP_200_OK, None, False),
+            (
+                EDX_ENROLLMENT_VERIFIED_MODE,
+                0.80,
+                True,
+                True,
+                status.HTTP_201_CREATED,
+                "created",
+                True,
+            ),
+            (
+                EDX_ENROLLMENT_VERIFIED_MODE,
+                0.80,
+                True,
+                False,
+                status.HTTP_201_CREATED,
+                "created",
+                True,
+            ),
+            (
+                EDX_ENROLLMENT_VERIFIED_MODE,
+                0.30,
+                False,
+                True,
+                status.HTTP_200_OK,
+                None,
+                False,
+            ),
+            (
+                EDX_ENROLLMENT_AUDIT_MODE,
+                0.80,
+                True,
+                True,
+                status.HTTP_200_OK,
+                None,
+                False,
+            ),
         ],
-        ids=["verified_passed_self_paced", "verified_passed_instructor_paced", "verified_not_passed", "audit_passed"],
+        ids=[
+            "verified_passed_self_paced",
+            "verified_passed_instructor_paced",
+            "verified_not_passed",
+            "audit_passed",
+        ],
     )
     def test_certificate_status(  # noqa: PLR0913
         self,
@@ -375,7 +422,9 @@ class TestCertificateWebhookView:
         assert response.status_code == expected_status_code
         assert response.data["certificate_status"] == expected_cert_status
         assert (
-            CourseRunCertificate.objects.filter(user=user, course_run=course_run).exists()
+            CourseRunCertificate.objects.filter(
+                user=user, course_run=course_run
+            ).exists()
             == cert_should_exist
         )
 

--- a/openedx/views_test.py
+++ b/openedx/views_test.py
@@ -268,17 +268,17 @@ class TestEdxEnrollmentWebhook:
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-class TestProcessCertificateWebhookView:
-    """Tests for the ProcessCertificateWebhookView"""
+class TestEdxCertificateWebhook:
+    """Tests for the edx_certificate_webhook view"""
 
-    WEBHOOK_URL = reverse("process-certificate-webhook")
+    WEBHOOK_URL = reverse("openedx-certificate-webhook")
 
     def test_unauthenticated_returns_401(self):
         """Test that unauthenticated requests are rejected"""
         client = APIClient()
         response = client.post(
             self.WEBHOOK_URL,
-            {"user_id": "test@example.com", "course_id": "course-v1:MITx+1+2024"},
+            {"email": "test@example.com", "course_id": "course-v1:MITx+1+2024"},
             format="json",
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -287,7 +287,7 @@ class TestProcessCertificateWebhookView:
         """Test that non-admin authenticated users are rejected"""
         response = user_drf_client.post(
             self.WEBHOOK_URL,
-            {"user_id": "test@example.com", "course_id": "course-v1:MITx+1+2024"},
+            {"email": "test@example.com", "course_id": "course-v1:MITx+1+2024"},
             format="json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -295,8 +295,8 @@ class TestProcessCertificateWebhookView:
     @pytest.mark.parametrize(
         "payload, expected_error_field",  # noqa: PT006
         [
-            ({"course_id": "course-v1:MITx+1+2024"}, "user_id"),
-            ({"user_id": "test@example.com"}, "course_id"),
+            ({"course_id": "course-v1:MITx+1+2024"}, "email"),
+            ({"email": "test@example.com"}, "course_id"),
             ({}, None),
         ],
     )
@@ -332,7 +332,7 @@ class TestProcessCertificateWebhookView:
 
         response = admin_drf_client.post(
             self.WEBHOOK_URL,
-            {"user_id": user_email, "course_id": courseware_id},
+            {"email": user_email, "course_id": courseware_id},
             format="json",
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -392,7 +392,7 @@ class TestProcessCertificateWebhookView:
 
         response = admin_drf_client.post(
             self.WEBHOOK_URL,
-            {"user_id": user.email, "course_id": course_run.courseware_id},
+            {"email": user.email, "course_id": course_run.courseware_id},
             format="json",
         )
 
@@ -432,7 +432,7 @@ class TestProcessCertificateWebhookView:
 
         response1 = admin_drf_client.post(
             self.WEBHOOK_URL,
-            {"user_id": user.email, "course_id": course_run.courseware_id},
+            {"email": user.email, "course_id": course_run.courseware_id},
             format="json",
         )
         assert response1.status_code == status.HTTP_200_OK
@@ -444,7 +444,7 @@ class TestProcessCertificateWebhookView:
 
         response2 = admin_drf_client.post(
             self.WEBHOOK_URL,
-            {"user_id": user.email, "course_id": course_run.courseware_id},
+            {"email": user.email, "course_id": course_run.courseware_id},
             format="json",
         )
         assert response2.status_code == status.HTTP_200_OK

--- a/openedx/views_test.py
+++ b/openedx/views_test.py
@@ -18,8 +18,10 @@ from courses.factories import (
 )
 from courses.models import (
     CourseRunCertificate,
+    CourseRunEnrollment,
 )
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
+from users.factories import UserFactory
 
 pytestmark = [pytest.mark.django_db]
 
@@ -264,10 +266,12 @@ class TestEdxEnrollmentWebhook:
             HTTP_AUTHORIZATION=f"Bearer {oauth_token.token}",
         )
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-class TestCertificateWebhookView:
-    """Tests for the CertificateWebhookView"""
 
-    WEBHOOK_URL = reverse("certificate-webhook")
+
+class TestProcessCertificateWebhookView:
+    """Tests for the ProcessCertificateWebhookView"""
+
+    WEBHOOK_URL = reverse("process-certificate-webhook")
 
     def test_unauthenticated_returns_401(self):
         """Test that unauthenticated requests are rejected"""
@@ -331,47 +335,13 @@ class TestCertificateWebhookView:
             "grade",
             "passed",
             "is_self_paced",
-            "expected_status_code",
-            "expected_cert_status",
             "cert_should_exist",
         ),
         [
-            (
-                EDX_ENROLLMENT_VERIFIED_MODE,
-                0.80,
-                True,
-                True,
-                status.HTTP_201_CREATED,
-                "created",
-                True,
-            ),
-            (
-                EDX_ENROLLMENT_VERIFIED_MODE,
-                0.80,
-                True,
-                False,
-                status.HTTP_201_CREATED,
-                "created",
-                True,
-            ),
-            (
-                EDX_ENROLLMENT_VERIFIED_MODE,
-                0.30,
-                False,
-                True,
-                status.HTTP_200_OK,
-                None,
-                False,
-            ),
-            (
-                EDX_ENROLLMENT_AUDIT_MODE,
-                0.80,
-                True,
-                True,
-                status.HTTP_200_OK,
-                None,
-                False,
-            ),
+            (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, True, True),
+            (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, False, True),
+            (EDX_ENROLLMENT_VERIFIED_MODE, 0.30, False, True, False),
+            (EDX_ENROLLMENT_AUDIT_MODE, 0.80, True, True, False),
         ],
         ids=[
             "verified_passed_self_paced",
@@ -389,8 +359,6 @@ class TestCertificateWebhookView:
         grade,
         passed,
         is_self_paced,
-        expected_status_code,
-        expected_cert_status,
         cert_should_exist,
     ):
         """Test certificate creation based on enrollment mode and grade"""
@@ -419,8 +387,7 @@ class TestCertificateWebhookView:
             format="json",
         )
 
-        assert response.status_code == expected_status_code
-        assert response.data["certificate_status"] == expected_cert_status
+        assert response.status_code == status.HTTP_200_OK
         assert (
             CourseRunCertificate.objects.filter(
                 user=user, course_run=course_run
@@ -434,7 +401,7 @@ class TestCertificateWebhookView:
         user_drf_client,
         user,
     ):
-        """Test that duplicate webhook calls return 200 without creating duplicate certs"""
+        """Test that when a certificate already exists the webhook returns 200 without reprocessing"""
         mocker.patch("courses.signals.upsert_custom_properties")
         enrollment = CourseRunEnrollmentFactory.create(
             user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
@@ -454,33 +421,25 @@ class TestCertificateWebhookView:
             return_value=(passed_grade, True, False),
         )
 
-        # First call
         response1 = user_drf_client.post(
             self.WEBHOOK_URL,
             {"user_id": user.email, "course_id": course_run.courseware_id},
             format="json",
         )
-        assert response1.status_code == status.HTTP_201_CREATED
-        assert response1.data["certificate_status"] == "created"
+        assert response1.status_code == status.HTTP_200_OK
+        assert CourseRunCertificate.objects.filter(
+            user=user, course_run=course_run
+        ).exists()
 
-        # Reset mocks for second call
-        mocker.patch(
-            "courses.api.get_edx_grades_with_users",
-            return_value=iter([(passed_grade, user)]),
-        )
-        mocker.patch(
-            "courses.api.ensure_course_run_grade",
-            return_value=(passed_grade, False, False),
-        )
+        mock_generate = mocker.patch("openedx.views.generate_course_run_certificates")
 
-        # Second call
         response2 = user_drf_client.post(
             self.WEBHOOK_URL,
             {"user_id": user.email, "course_id": course_run.courseware_id},
             format="json",
         )
         assert response2.status_code == status.HTTP_200_OK
-        assert response2.data["certificate_status"] == "exists"
+        mock_generate.assert_not_called()
         assert (
             CourseRunCertificate.objects.filter(
                 user=user, course_run=course_run

--- a/openedx/views_test.py
+++ b/openedx/views_test.py
@@ -11,9 +11,15 @@ from oauthlib.common import generate_token
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from courses.factories import CourseRunFactory
-from courses.models import CourseRunEnrollment
-from users.factories import UserFactory
+from courses.factories import (
+    CourseRunEnrollmentFactory,
+    CourseRunFactory,
+    CourseRunGradeFactory,
+)
+from courses.models import (
+    CourseRunCertificate,
+)
+from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
 pytestmark = [pytest.mark.django_db]
 
@@ -258,3 +264,177 @@ class TestEdxEnrollmentWebhook:
             HTTP_AUTHORIZATION=f"Bearer {oauth_token.token}",
         )
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+class TestCertificateWebhookView:
+    """Tests for the CertificateWebhookView"""
+
+    WEBHOOK_URL = reverse("certificate-webhook")
+
+    def test_unauthenticated_returns_401(self):
+        """Test that unauthenticated requests are rejected"""
+        client = APIClient()
+        response = client.post(
+            self.WEBHOOK_URL,
+            {"user_id": "test@example.com", "course_id": "course-v1:MITx+1+2024"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        "payload, expected_error_field",  # noqa: PT006
+        [
+            ({"course_id": "course-v1:MITx+1+2024"}, "user_id"),
+            ({"user_id": "test@example.com"}, "course_id"),
+            ({}, None),
+        ],
+    )
+    def test_missing_fields_returns_400(
+        self, user_drf_client, payload, expected_error_field
+    ):
+        """Test that missing required fields return 400"""
+        response = user_drf_client.post(
+            self.WEBHOOK_URL,
+            payload,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        if expected_error_field:
+            assert expected_error_field in response.data["error"]
+
+    @pytest.mark.parametrize(
+        "user_email, courseware_id",
+        [
+            ("nonexistent@example.com", None),
+            (None, "course-v1:NonExistent+0+2099"),
+        ],
+        ids=["user_not_found", "course_run_not_found"],
+    )
+    def test_not_found_returns_404(self, user_drf_client, user, user_email, courseware_id):
+        """Test that a non-existent user or course run returns 404"""
+        if courseware_id is None:
+            courseware_id = CourseRunFactory.create().courseware_id
+        if user_email is None:
+            user_email = user.email
+
+        response = user_drf_client.post(
+            self.WEBHOOK_URL,
+            {"user_id": user_email, "course_id": courseware_id},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "not found" in response.data["error"]
+
+    @pytest.mark.parametrize(
+        "enrollment_mode, grade, passed, is_self_paced, expected_status_code, expected_cert_status, cert_should_exist",  # noqa: E501
+        [
+            (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, True, status.HTTP_201_CREATED, "created", True),
+            (EDX_ENROLLMENT_VERIFIED_MODE, 0.80, True, False, status.HTTP_201_CREATED, "created", True),
+            (EDX_ENROLLMENT_VERIFIED_MODE, 0.30, False, True, status.HTTP_200_OK, None, False),
+            (EDX_ENROLLMENT_AUDIT_MODE, 0.80, True, True, status.HTTP_200_OK, None, False),
+        ],
+        ids=["verified_passed_self_paced", "verified_passed_instructor_paced", "verified_not_passed", "audit_passed"],
+    )
+    def test_certificate_status(  # noqa: PLR0913
+        self,
+        mocker,
+        user_drf_client,
+        user,
+        enrollment_mode,
+        grade,
+        passed,
+        is_self_paced,
+        expected_status_code,
+        expected_cert_status,
+        cert_should_exist,
+    ):
+        """Test certificate creation based on enrollment mode and grade"""
+        course_run = CourseRunFactory.create(is_self_paced=is_self_paced)
+        CourseRunEnrollmentFactory.create(
+            user=user, run=course_run, enrollment_mode=enrollment_mode
+        )
+        grade_obj = CourseRunGradeFactory.create(
+            course_run=course_run, user=user, grade=grade, passed=passed
+        )
+
+        mocker.patch("courses.signals.upsert_custom_properties")
+        mocker.patch("hubspot_sync.api.upsert_custom_properties")
+        mocker.patch(
+            "courses.api.get_edx_grades_with_users",
+            return_value=iter([(grade_obj, user)]),
+        )
+        mocker.patch(
+            "courses.api.ensure_course_run_grade",
+            return_value=(grade_obj, True, False),
+        )
+
+        response = user_drf_client.post(
+            self.WEBHOOK_URL,
+            {"user_id": user.email, "course_id": course_run.courseware_id},
+            format="json",
+        )
+
+        assert response.status_code == expected_status_code
+        assert response.data["certificate_status"] == expected_cert_status
+        assert (
+            CourseRunCertificate.objects.filter(user=user, course_run=course_run).exists()
+            == cert_should_exist
+        )
+
+    def test_idempotent_certificate_already_exists(
+        self,
+        mocker,
+        user_drf_client,
+        user,
+    ):
+        """Test that duplicate webhook calls return 200 without creating duplicate certs"""
+        mocker.patch("courses.signals.upsert_custom_properties")
+        enrollment = CourseRunEnrollmentFactory.create(
+            user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+        )
+        course_run = enrollment.run
+        passed_grade = CourseRunGradeFactory.create(
+            course_run=course_run, user=user, grade=0.80, passed=True
+        )
+
+        mocker.patch("hubspot_sync.api.upsert_custom_properties")
+        mocker.patch(
+            "courses.api.get_edx_grades_with_users",
+            return_value=iter([(passed_grade, user)]),
+        )
+        mocker.patch(
+            "courses.api.ensure_course_run_grade",
+            return_value=(passed_grade, True, False),
+        )
+
+        # First call
+        response1 = user_drf_client.post(
+            self.WEBHOOK_URL,
+            {"user_id": user.email, "course_id": course_run.courseware_id},
+            format="json",
+        )
+        assert response1.status_code == status.HTTP_201_CREATED
+        assert response1.data["certificate_status"] == "created"
+
+        # Reset mocks for second call
+        mocker.patch(
+            "courses.api.get_edx_grades_with_users",
+            return_value=iter([(passed_grade, user)]),
+        )
+        mocker.patch(
+            "courses.api.ensure_course_run_grade",
+            return_value=(passed_grade, False, False),
+        )
+
+        # Second call
+        response2 = user_drf_client.post(
+            self.WEBHOOK_URL,
+            {"user_id": user.email, "course_id": course_run.courseware_id},
+            format="json",
+        )
+        assert response2.status_code == status.HTTP_200_OK
+        assert response2.data["certificate_status"] == "exists"
+        assert (
+            CourseRunCertificate.objects.filter(
+                user=user, course_run=course_run
+            ).count()
+            == 1
+        )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10777

### Description (What does it do?)
This PR adds a webhook API endpoint (POST /api/certificate_webhook/) that receives certificate creation events from an Open edX plugin. When edX creates a certificate, the plugin (WIP, see: https://github.com/mitodl/open-edx-plugins/pull/684) sends the user's email and course run ID; this endpoint fetches the grade from edX, syncs it locally, and creates the corresponding certificate in MITx Online.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

**1. Set up OAuth2 credentials**

Create an OAuth2 access token in Django admin (`/admin/oauth2_provider/accesstoken/`) or use an existing access token.

**2. Prerequisites**

Ensure the user has a verified enrollment in the course run, and the course run exists in edX with a passing grade for the user.

**3. Test certificate creation (201)**

```bash
curl -s -w "\nHTTP_STATUS: %{http_code}\n" -X POST \
  http://localhost:9080/api/process_certificate_webhook/ \
  -H "Authorization: Bearer <your_access_token>" \
  -H "Content-Type: application/json" \
  -d '{"user_id": "<user_email>", "course_id": "<course_run_courseware_id>"}'
```

Expected response:
```json
{"certificate_status": "created"}
HTTP_STATUS: 200
```

**4. Test idempotency — duplicate call (200)**

Run the same curl command again. Expected response:
```json
{"certificate_status": "exists"}
HTTP_STATUS: 200
```

**5. Test unauthenticated request (401)**

```bash
curl -s -w "\nHTTP_STATUS: %{http_code}\n" -X POST \
  http://localhost:9080/api/process_certificate_webhook/ \
  -H "Content-Type: application/json" \
  -d '{"user_id": "test@example.com", "course_id": "course-v1:MITx+1+2024"}'
```

Expected: `HTTP_STATUS: 401`

**6. Test missing fields (400)**

```bash
curl -s -w "\nHTTP_STATUS: %{http_code}\n" -X POST \
  http://localhost:9080/api/process_certificate_webhook/ \
  -H "Authorization: Bearer <your_access_token>" \
  -H "Content-Type: application/json" \
  -d '{"user_id": "test@example.com"}'
```

Expected: `HTTP_STATUS: 400` with error about missing `course_id`.




### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
