### PR TITLE
Adds action to populate empty verifiable creds by courserun or program

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -41,6 +41,26 @@ from main.utils import get_field_names
 from openedx.tasks import retry_failed_edx_enrollments
 
 
+class VerifiableCredentialBackfillAdminMixin:
+    def populate_verifiable_credentials_for_certificate(self, request, certificates):
+        """Helper method to create and associate a verifiable credential for a given certificate"""
+        failed_certificates = []
+        for certificate in certificates:
+            try:
+                create_verifiable_credential(certificate, raise_on_error=True)
+            except Exception:  # noqa: PERF203, BLE001
+                failed_certificates.append(certificate)
+
+        message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates."
+        level = messages.INFO
+        if failed_certificates:
+            # We indicate IDs, but errors should also be logged to sentry from within create_verifiable_credential
+            level = messages.WARNING
+            message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates, but encountered errors for certificates with IDs: {[cert.id for cert in failed_certificates]}"
+
+        self.message_user(request, message, level=level)
+
+
 class ProgramContractPageInline(admin.TabularInline):
     """Inline for contract pages"""
 
@@ -52,7 +72,7 @@ class ProgramContractPageInline(admin.TabularInline):
 
 
 @admin.register(Program)
-class ProgramAdmin(admin.ModelAdmin):
+class ProgramAdmin(VerifiableCredentialBackfillAdminMixin, admin.ModelAdmin):
     """Admin for Program"""
 
     model = Program
@@ -83,7 +103,7 @@ class ProgramAdmin(admin.ModelAdmin):
                 program_id__in=program_ids, verifiable_credential__isnull=True
             )
         )
-        populate_verifiable_credentials_for_certificate(self, request, certificates)
+        self.populate_verifiable_credentials_for_certificate(request, certificates)
 
 
 @admin.register(ProgramRun)
@@ -142,7 +162,7 @@ class CourseAdmin(admin.ModelAdmin):
 
 
 @admin.register(CourseRun)
-class CourseRunAdmin(TimestampedModelAdmin):
+class CourseRunAdmin(VerifiableCredentialBackfillAdminMixin, TimestampedModelAdmin):
     """Admin for CourseRun"""
 
     model = CourseRun
@@ -184,7 +204,7 @@ class CourseRunAdmin(TimestampedModelAdmin):
                 course_run_id__in=course_run_ids, verifiable_credential__isnull=True
             )
         )
-        populate_verifiable_credentials_for_certificate(self, request, certificates)
+        self.populate_verifiable_credentials_for_certificate(request, certificates)
 
 
 @admin.register(ProgramEnrollment)
@@ -730,22 +750,3 @@ class EnrollmentModeAdmin(admin.ModelAdmin):
     list_filter = [
         "requires_payment",
     ]
-
-
-def populate_verifiable_credentials_for_certificate(admin, request, certificates):
-    """Helper method to create and associate a verifiable credential for a given certificate"""
-    failed_certificates = []
-    for certificate in certificates:
-        try:
-            create_verifiable_credential(certificate, raise_on_error=True)
-        except Exception:  # noqa: PERF203, BLE001
-            failed_certificates.append(certificate)
-
-    message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates."
-    level = messages.INFO
-    if failed_certificates:
-        # We indicate IDs, but errors should also be logged to sentry from within create_verifiable_credential
-        level = messages.WARNING
-        message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates, but encountered errors for certificates with IDs: {[cert.id for cert in failed_certificates]}"
-
-    admin.message_user(request, message, level=level)

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -2,7 +2,7 @@
 Admin site bindings for profiles
 """
 
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.admin.decorators import display
 from django.db import models
 from django.forms import TextInput
@@ -10,7 +10,7 @@ from django.urls import reverse
 from mitol.common.admin import TimestampedModelAdmin
 
 import cms.admin  # noqa: F401
-from courses.api import downgrade_learner
+from courses.api import create_verifiable_credential, downgrade_learner
 from courses.forms import ProgramAdminForm
 from courses.models import (
     BlockedCountry,
@@ -68,6 +68,21 @@ class ProgramAdmin(admin.ModelAdmin):
     )
     list_filter = ["live", "b2b_only", "program_type", "display_mode", "departments"]
     inlines = [ProgramContractPageInline]
+    actions = ["populate_verifiable_credentials_for_program"]
+
+    @admin.action(
+        description="Backfill verifiable credentials for program certificates"
+    )
+    def populate_verifiable_credentials_for_courserun(self, request, queryset):
+        """Admin action to regenerate verifiable credentials for a program"""
+        program_ids = queryset.values_list("id", flat=True)
+        # If a cert already has a cred, leave it alone for now.
+        certificates = list(
+            ProgramCertificate.objects.filter(
+                id__in=program_ids, verifiable_credential__isnull=True
+            )
+        )
+        populate_verifiable_credentials_for_certificate(self, request, certificates)
 
 
 @admin.register(ProgramRun)
@@ -153,6 +168,22 @@ class CourseRunAdmin(TimestampedModelAdmin):
         models.CharField: {"widget": TextInput(attrs={"size": "80"})},
         models.TextField: {"widget": TextInput(attrs={"size": "100"})},
     }
+
+    actions = ["populate_verifiable_credentials_for_courserun"]
+
+    @admin.action(
+        description="Backfill verifiable credentials for course run certificates"
+    )
+    def populate_verifiable_credentials_for_courserun(self, request, queryset):
+        """Admin action to regenerate verifiable credentials for a course run"""
+        course_run_ids = queryset.values_list("id", flat=True)
+        # If a cert already has a cred, leave it alone for now.
+        certificates = list(
+            CourseRunCertificate.objects.filter(
+                course_run_id__in=course_run_ids, verifiable_credential__isnull=True
+            )
+        )
+        populate_verifiable_credentials_for_certificate(self, request, certificates)
 
 
 @admin.register(ProgramEnrollment)
@@ -686,3 +717,21 @@ class EnrollmentModeAdmin(admin.ModelAdmin):
     list_filter = [
         "requires_payment",
     ]
+
+
+def populate_verifiable_credentials_for_certificate(admin, request, certificates):
+    """Helper method to create and associate a verifiable credential for a given certificate"""
+    failed_certificates = []
+    for certificate in certificates:
+        try:
+            create_verifiable_credential(certificate, raise_on_error=True)
+        except Exception:  # noqa: PERF203, BLE001
+            failed_certificates.append(certificate)
+
+    message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates."
+    level = messages.INFO
+    if failed_certificates:
+        level = messages.WARNING
+        message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates, but failed to create credentials for {len(failed_certificates)} certificates with IDs: {[cert.id for cert in failed_certificates]}"
+
+    admin.message_user(request, message, level=level)

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -34,6 +34,7 @@ from courses.models import (
     ProgramEnrollmentAudit,
     ProgramRun,
     RelatedProgram,
+    VerifiableCredential,
 )
 from main.admin import AuditableModelAdmin, ModelAdminRunActionsForAllMixin
 from main.utils import get_field_names
@@ -73,7 +74,7 @@ class ProgramAdmin(admin.ModelAdmin):
     @admin.action(
         description="Backfill verifiable credentials for program certificates"
     )
-    def populate_verifiable_credentials_for_courserun(self, request, queryset):
+    def populate_verifiable_credentials_for_program(self, request, queryset):
         """Admin action to regenerate verifiable credentials for a program"""
         program_ids = queryset.values_list("id", flat=True)
         # If a cert already has a cred, leave it alone for now.
@@ -666,6 +667,18 @@ class ProgramCertificateAdmin(TimestampedModelAdmin):
         return self.model.all_objects.get_queryset().select_related("user", "program")
 
 
+@admin.register(VerifiableCredential)
+class VerifiableCredentialAdmin(TimestampedModelAdmin):
+    """Admin for VerifiableCredential"""
+
+    model = VerifiableCredential
+    include_timestamps_in_list = True
+    list_display = ["uuid", "programcertificate", "courseruncertificate"]
+
+    def has_add_permission(self, request, obj=None):  # noqa: ARG002
+        return False
+
+
 @admin.register(PartnerSchool)
 class PartnerSchoolAdmin(TimestampedModelAdmin):
     """Admin for PartnerSchool"""
@@ -731,6 +744,7 @@ def populate_verifiable_credentials_for_certificate(admin, request, certificates
     message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates."
     level = messages.INFO
     if failed_certificates:
+        # We indicate IDs, but errors should also be logged to sentry from within create_verifiable_credential
         level = messages.WARNING
         message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates, but failed to create credentials for {len(failed_certificates)} certificates with IDs: {[cert.id for cert in failed_certificates]}"
 

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -80,7 +80,7 @@ class ProgramAdmin(admin.ModelAdmin):
         # If a cert already has a cred, leave it alone for now.
         certificates = list(
             ProgramCertificate.objects.filter(
-                id__in=program_ids, verifiable_credential__isnull=True
+                program_id__in=program_ids, verifiable_credential__isnull=True
             )
         )
         populate_verifiable_credentials_for_certificate(self, request, certificates)
@@ -746,6 +746,6 @@ def populate_verifiable_credentials_for_certificate(admin, request, certificates
     if failed_certificates:
         # We indicate IDs, but errors should also be logged to sentry from within create_verifiable_credential
         level = messages.WARNING
-        message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates, but failed to create credentials for {len(failed_certificates)} certificates with IDs: {[cert.id for cert in failed_certificates]}"
+        message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates, but encountered errors for certificates with IDs: {[cert.id for cert in failed_certificates]}"
 
     admin.message_user(request, message, level=level)

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -698,6 +698,10 @@ class VerifiableCredentialAdmin(TimestampedModelAdmin):
     def has_add_permission(self, request, obj=None):  # noqa: ARG002
         return False
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("programcertificate", "courseruncertificate")
+
 
 @admin.register(PartnerSchool)
 class PartnerSchoolAdmin(TimestampedModelAdmin):

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -51,12 +51,12 @@ class VerifiableCredentialBackfillAdminMixin:
             except Exception:  # noqa: PERF203, BLE001
                 failed_certificates.append(certificate)
 
-        message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates."
+        message = f"Successfully requested verifiable credential backfill for {len(certificates)} {self.model._meta.model_name} certificates."  # noqa: SLF001
         level = messages.INFO
         if failed_certificates:
             # We indicate IDs, but errors should also be logged to sentry from within create_verifiable_credential
             level = messages.WARNING
-            message = f"Successfully requested verifiable credential backfill for {len(certificates)} course run certificates, but encountered errors for certificates with IDs: {[cert.id for cert in failed_certificates]}"
+            message = f"Successfully requested verifiable credential backfill for {len(certificates)} {self.model._meta.model_name} certificates, but encountered errors for certificates with IDs: {[cert.id for cert in failed_certificates]}"  # noqa: SLF001
 
         self.message_user(request, message, level=level)
 

--- a/courses/management/commands/backfill_verifiable_credentials.py
+++ b/courses/management/commands/backfill_verifiable_credentials.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
             program_ids = Program.objects.filter(readable_id__in=ids).values_list(
                 "id", flat=True
             )
-            certificates = ProgramCertificate.objects.filter(id__in=program_ids)
+            certificates = ProgramCertificate.objects.filter(program_id__in=program_ids)
         elif courseware_type == "course":
             course_run_ids = CourseRun.objects.filter(
                 courseware_id__in=ids


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10692

### Description (What does it do?)
- Adds an action on the Program and CourseRun pages to generate verifiable credentials for certificates issued for those programs or courseruns which don't already have a verifiable credential record.
  - Indicates how many certificate backfills were attempted. In the event of a failure, outputs the UUID for the certificates which resulted in errors..
    - N.B. Certificates for which backfills were attempted but didn't complete due to not having `should_provision_verifiable_credential` set DO NOT count as failures.
- Adds a super thin admin panel for verifiable creds. This is because previously deleting those records required shell access. Now that individual records can be deleted, couple with the above change, admins can delete and regenerate verifiable credentials if needed.
- Fixes a small issue with program backfills

### Screenshots (if appropriate):
<img width="1656" height="946" alt="Screenshot 2026-04-08 at 12 11 09 PM" src="https://github.com/user-attachments/assets/7a39be42-1341-43fd-a33a-30234d5c1a7f" />
<img width="1613" height="807" alt="Screenshot 2026-04-08 at 12 12 35 PM" src="https://github.com/user-attachments/assets/40cfdb20-19c7-472f-9b51-5d121173da04" />

Verifiable creds admin view
<img width="1618" height="540" alt="Screenshot 2026-04-08 at 2 01 25 PM" src="https://github.com/user-attachments/assets/9c6984b5-978e-48f7-9305-5086dc9d5511" />



### How can this be tested?
This is most easily tested if you already have a certificate provisioned. If you do, the only steps required are:
- Set the following env vars
```
VERIFIABLE_CREDENTIAL_SIGNER_URL=http://dcc.odl.local:4005/instance/test/credentials/issue
VERIFIABLE_CREDENTIAL_BEARER_TOKEN='test'
```
- Ensure that `COMPOSE_PROFILES` has `verifiable-creds` in addition to whatever else you normally have set up.
- Go to the CMS page for the certificate, add any value in the new `Verifiable credential criteria` field and check `Should provision verifiable credential`. Publish your changes
- If you have already provisioned a verifiable credential for it, delete it. This can be done by visiting the new admin page for Verifiable Credentials and deleting the object with the same UUID, or by deleting it via django or DB shell.
- Go to the courserun or program admin page (depending on which type of certificate you've got) and select the corresponding row.
- Select the backfill action from the drop down and select `Go`.
- Observe that a verifiable credential has been provisioned for the corresponding certificate.

If you don't have a certificate provisioned, you'll need a fair amount of boilerplate set up, principally correctly set up courses, course runs and/or programs, along with their corresponding CMS pages. The `test_datagen` script sets up a lot of that if you are able to use it - once that's done you should only need to:
- Create a Program or CourseRunEnrollment for the user you'll create the cert for (I did this using the admin page)
- Create the certificate of the corresponding type (Also performed via admin)

