### PR TITLE
Use prefetch in enrollment upgrade task

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -52,6 +52,7 @@ from courses.models import (
     ProgramCertificate,
     ProgramEnrollment,
     ProgramRequirement,
+    ProgramRequirementNodeType,
     VerifiableCredential,
 )
 from courses.serializers.base import get_thumbnail_url
@@ -1724,6 +1725,40 @@ def rerun_course_run(  # noqa: PLR0913
     return new_run
 
 
+def _get_program_requirements_data(program: Program) -> dict:
+    """Return requirement data for a program, using prefetched requirements when available."""
+    prefetched_requirements = getattr(program, "_prefetched_objects_cache", {}).get(
+        "all_requirements"
+    )
+    if prefetched_requirements is None:
+        return program._courses_with_requirements_data
+
+    main_ops = [req for req in prefetched_requirements if req.depth == 2]
+    if not main_ops:
+        return {
+            "courses": [],
+            "required_courses": [],
+            "elective_courses": [],
+            "required_title": "Required Courses",
+            "elective_title": "Elective Courses",
+            "minimum_elective_requirement": None,
+        }
+
+    path_to_operator = {op.path: op for op in main_ops}
+    course_requirements = [
+        req
+        for req in prefetched_requirements
+        if req.node_type == ProgramRequirementNodeType.COURSE
+        and any(req.path.startswith(op.path) for op in main_ops)
+    ]
+
+    requirements_data = program._process_course_requirements(
+        course_requirements, path_to_operator
+    )
+    program._courses_with_requirements_data = requirements_data
+    return requirements_data
+
+
 def upgrade_program_enrollment_if_eligible(program_enrollment):
     """
     For a given program enrollment checks if learner is qualified for an upgrade
@@ -1736,29 +1771,28 @@ def upgrade_program_enrollment_if_eligible(program_enrollment):
     program = program_enrollment.program
     user = program_enrollment.user
 
-    if ProgramCertificate.objects.filter(
-        user=program_enrollment.user, program=program
-    ).exists():
+    if program_enrollment.certificate is not None:
         return program_enrollment, False
 
-    program_course_ids = [course[0].id for course in program.courses]
-
+    requirements_data = _get_program_requirements_data(program)
+    program_course_ids = [course.id for course, _ in requirements_data["courses"]]
     verified_courses = Course.objects.filter(
         id__in=program_course_ids,
         courseruns__enrollments__user=user,
         courseruns__enrollments__enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
         courseruns__enrollments__active=True,
     ).distinct()
-
     verified_course_ids = set(verified_courses.values_list("id", flat=True))
 
     # make sure all core courses are verified
-    required_courses = program.required_courses
+    required_courses = requirements_data["required_courses"]
     if not all(course.id in verified_course_ids for course in required_courses):
         return program_enrollment, False
 
-    nim_elective_num = program.minimum_elective_courses_requirement
-    elective_course_ids = [course.id for course in program.elective_courses]
+    nim_elective_num = requirements_data["minimum_elective_requirement"]
+    elective_course_ids = [
+        course.id for course in requirements_data["elective_courses"]
+    ]
     verified_elective_count = verified_courses.filter(
         id__in=elective_course_ids
     ).count()

--- a/courses/api.py
+++ b/courses/api.py
@@ -52,7 +52,6 @@ from courses.models import (
     ProgramCertificate,
     ProgramEnrollment,
     ProgramRequirement,
-    ProgramRequirementNodeType,
     VerifiableCredential,
 )
 from courses.serializers.base import get_thumbnail_url
@@ -1723,42 +1722,6 @@ def rerun_course_run(  # noqa: PLR0913
         process_course_run_clone(new_run, base_run.courseware_id)
 
     return new_run
-
-
-def _get_program_requirements_data(program: Program) -> dict:
-    """Return requirement data for a program, using prefetched requirements when available."""
-    prefetched_requirements = getattr(program, "_prefetched_objects_cache", {}).get(
-        "all_requirements"
-    )
-    if prefetched_requirements is None:
-        return program._courses_with_requirements_data
-
-    main_ops = [req for req in prefetched_requirements if req.depth == 2]
-    if not main_ops:
-        return {
-            "courses": [],
-            "required_courses": [],
-            "elective_courses": [],
-            "required_title": "Required Courses",
-            "elective_title": "Elective Courses",
-            "minimum_elective_requirement": None,
-        }
-
-    path_to_operator = {op.path: op for op in main_ops}
-    course_requirements = [
-        req
-        for req in prefetched_requirements
-        if req.node_type == ProgramRequirementNodeType.COURSE
-        and any(req.path.startswith(op.path) for op in main_ops)
-    ]
-
-    requirements_data = program._process_course_requirements(
-        course_requirements, path_to_operator
-    )
-    program._courses_with_requirements_data = requirements_data
-    return requirements_data
-
-
 def upgrade_program_enrollment_if_eligible(program_enrollment):
     """
     For a given program enrollment checks if learner is qualified for an upgrade
@@ -1774,7 +1737,7 @@ def upgrade_program_enrollment_if_eligible(program_enrollment):
     if program_enrollment.certificate is not None:
         return program_enrollment, False
 
-    requirements_data = _get_program_requirements_data(program)
+    requirements_data = program.get_courses_with_requirements_data()
     program_course_ids = [course.id for course, _ in requirements_data["courses"]]
     verified_courses = Course.objects.filter(
         id__in=program_course_ids,
@@ -1793,9 +1756,7 @@ def upgrade_program_enrollment_if_eligible(program_enrollment):
     elective_course_ids = [
         course.id for course in requirements_data["elective_courses"]
     ]
-    verified_elective_count = verified_courses.filter(
-        id__in=elective_course_ids
-    ).count()
+    verified_elective_count = verified_courses.filter(id__in=elective_course_ids).count()
 
     if nim_elective_num is not None and verified_elective_count < nim_elective_num:
         return program_enrollment, False

--- a/courses/api.py
+++ b/courses/api.py
@@ -1722,6 +1722,8 @@ def rerun_course_run(  # noqa: PLR0913
         process_course_run_clone(new_run, base_run.courseware_id)
 
     return new_run
+
+
 def upgrade_program_enrollment_if_eligible(program_enrollment):
     """
     For a given program enrollment checks if learner is qualified for an upgrade
@@ -1756,7 +1758,9 @@ def upgrade_program_enrollment_if_eligible(program_enrollment):
     elective_course_ids = [
         course.id for course in requirements_data["elective_courses"]
     ]
-    verified_elective_count = verified_courses.filter(id__in=elective_course_ids).count()
+    verified_elective_count = verified_courses.filter(
+        id__in=elective_course_ids
+    ).count()
 
     if nim_elective_num is not None and verified_elective_count < nim_elective_num:
         return program_enrollment, False

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -16,7 +16,10 @@ import responses
 import reversion
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db import connection
+from django.db.models import Prefetch
 from django.test import RequestFactory
+from django.test.utils import CaptureQueriesContext
 from edx_api.course_detail import CourseDetail, CourseMode, CourseModes
 from mitol.common.utils.datetime import now_in_utc
 from requests import ConnectionError as RequestsConnectionError
@@ -83,7 +86,7 @@ from courses.models import (
     ProgramCertificate,
     ProgramEnrollment,
     ProgramRequirement,
-    ProgramRequirementNodeType,
+    ProgramRequirementNodeType, CourseRun,
 )
 from ecommerce.factories import LineFactory, OrderFactory, ProductFactory
 from ecommerce.models import Basket, OrderStatus
@@ -3167,6 +3170,58 @@ def test_upgrade_program_enrollment_if_eligible_upgrades_when_requirements_met(
     _, upgraded = upgrade_program_enrollment_if_eligible(program_enrollment)
 
     program_enrollment.refresh_from_db()
+    assert upgraded is True
+    assert program_enrollment.enrollment_mode == EDX_ENROLLMENT_VERIFIED_MODE
+
+
+def test_upgrade_program_enrollment_if_eligible_query_count(
+    user,
+    program_with_requirements,  # noqa: F811
+):
+    """The upgrade path should use a stable number of queries for an eligible enrollment."""
+    program = program_with_requirements.program
+    program_enrollment = ProgramEnrollmentFactory.create(
+        user=user,
+        program=program,
+        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+    )
+
+    for course in program.required_courses:
+        run = CourseRunFactory.create(course=course)
+        CourseRunEnrollmentFactory.create(
+            user=user,
+            run=run,
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+            active=True,
+        )
+
+    min_electives = program.minimum_elective_courses_requirement or 0
+    for course in program.elective_courses[:min_electives]:
+        run = CourseRunFactory.create(course=course)
+        CourseRunEnrollmentFactory.create(
+            user=user,
+            run=run,
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+            active=True,
+        )
+
+    program_enrollment = (
+        ProgramEnrollment.objects.select_related("program", "user")
+        .prefetch("certificate")
+        .prefetch_related(
+            Prefetch(
+                "program__all_requirements",
+                queryset=ProgramRequirement.objects.select_related("course"),
+            )
+        )
+        .get(pk=program_enrollment.pk)
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        _, upgraded = upgrade_program_enrollment_if_eligible(program_enrollment)
+
+    program_enrollment.refresh_from_db()
+    assert len(context) == 14
     assert upgraded is True
     assert program_enrollment.enrollment_mode == EDX_ENROLLMENT_VERIFIED_MODE
 

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -86,7 +86,7 @@ from courses.models import (
     ProgramCertificate,
     ProgramEnrollment,
     ProgramRequirement,
-    ProgramRequirementNodeType, CourseRun,
+    ProgramRequirementNodeType,
 )
 from ecommerce.factories import LineFactory, OrderFactory, ProductFactory
 from ecommerce.models import Basket, OrderStatus

--- a/courses/management/commands/upgrade_eligible_program_enrollments.py
+++ b/courses/management/commands/upgrade_eligible_program_enrollments.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             )
         )
 
-        for program_enrollment in enrollments.iterator():
+        for program_enrollment in enrollments:
             _, upgraded = upgrade_program_enrollment_if_eligible(program_enrollment)
 
             if upgraded:

--- a/courses/management/commands/upgrade_eligible_program_enrollments.py
+++ b/courses/management/commands/upgrade_eligible_program_enrollments.py
@@ -16,9 +16,11 @@ class Command(BaseCommand):
         processed_count = 0
         upgraded_count = 0
 
-        for program_enrollment in ProgramEnrollment.objects.filter(
+        enrollments = ProgramEnrollment.objects.filter(
             enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
-        ):
+        ).select_related("program", "user")
+
+        for program_enrollment in enrollments.iterator():
             _, upgraded = upgrade_program_enrollment_if_eligible(program_enrollment)
 
             if upgraded:

--- a/courses/management/commands/upgrade_eligible_program_enrollments.py
+++ b/courses/management/commands/upgrade_eligible_program_enrollments.py
@@ -1,7 +1,7 @@
 """Upgrade program enrollments that are eligible for verified mode."""
 
-from django.db.models import Prefetch
 from django.core.management.base import BaseCommand
+from django.db.models import Prefetch
 
 from courses.api import upgrade_program_enrollment_if_eligible
 from courses.models import ProgramEnrollment, ProgramRequirement
@@ -17,12 +17,15 @@ class Command(BaseCommand):
         processed_count = 0
         upgraded_count = 0
 
-        enrollments = ProgramEnrollment.objects.filter(
-            enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
-        ).select_related("program", "user").prefetch("certificate").prefetch_related(
-            Prefetch(
-                "program__all_requirements",
-                queryset=ProgramRequirement.objects.select_related("course"),
+        enrollments = (
+            ProgramEnrollment.objects.filter(enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE)
+            .select_related("program", "user")
+            .prefetch("certificate")
+            .prefetch_related(
+                Prefetch(
+                    "program__all_requirements",
+                    queryset=ProgramRequirement.objects.select_related("course"),
+                )
             )
         )
 

--- a/courses/management/commands/upgrade_eligible_program_enrollments.py
+++ b/courses/management/commands/upgrade_eligible_program_enrollments.py
@@ -1,9 +1,10 @@
 """Upgrade program enrollments that are eligible for verified mode."""
 
+from django.db.models import Prefetch
 from django.core.management.base import BaseCommand
 
 from courses.api import upgrade_program_enrollment_if_eligible
-from courses.models import ProgramEnrollment
+from courses.models import ProgramEnrollment, ProgramRequirement
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE
 
 
@@ -18,7 +19,12 @@ class Command(BaseCommand):
 
         enrollments = ProgramEnrollment.objects.filter(
             enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
-        ).select_related("program", "user")
+        ).select_related("program", "user").prefetch("certificate").prefetch_related(
+            Prefetch(
+                "program__all_requirements",
+                queryset=ProgramRequirement.objects.select_related("course"),
+            )
+        )
 
         for program_enrollment in enrollments.iterator():
             _, upgraded = upgrade_program_enrollment_if_eligible(program_enrollment)

--- a/courses/models.py
+++ b/courses/models.py
@@ -667,6 +667,43 @@ class Program(TimestampedModel, ValidateOnSaveMixin):
                 return op
         return None
 
+    @staticmethod
+    def _empty_course_requirements_data() -> dict:
+        """Return the default empty course-requirements payload."""
+        return {
+            "courses": [],
+            "required_courses": [],
+            "elective_courses": [],
+            "required_title": "Required Courses",
+            "elective_title": "Elective Courses",
+            "minimum_elective_requirement": None,
+        }
+
+    def get_courses_with_requirements_data(self, requirements=None) -> dict:
+        """
+        Return processed requirement data for this program.
+
+        If requirements are provided, they are assumed to already be loaded and
+        will be used directly. Otherwise this falls back to the cached-property
+        path, which may query the database.
+        """
+        if requirements is None:
+            return self._courses_with_requirements_data
+
+        main_ops = [req for req in requirements if req.depth == 2]  # noqa: PLR2004
+        if not main_ops:
+            return self._empty_course_requirements_data()
+
+        path_to_operator = {op.path: op for op in main_ops}
+        course_requirements = [
+            req
+            for req in requirements
+            if req.node_type == ProgramRequirementNodeType.COURSE
+            and any(req.path.startswith(op.path) for op in main_ops)
+        ]
+
+        return self._process_course_requirements(course_requirements, path_to_operator)
+
     @cached_property
     def _courses_with_requirements_data(self):
         """
@@ -676,18 +713,17 @@ class Program(TimestampedModel, ValidateOnSaveMixin):
         - dict: Contains 'courses', 'required_courses', 'elective_courses',
                 'required_title', 'elective_title', and 'minimum_elective_requirement'
         """
+        prefetched_requirements = getattr(self, "_prefetched_objects_cache", {}).get(
+            "all_requirements"
+        )
+        if prefetched_requirements is not None:
+            return self.get_courses_with_requirements_data(prefetched_requirements)
+
         # Get all operator nodes at depth 2 (direct children of root)
         main_ops = ProgramRequirement.objects.filter(program=self, depth=2).all()
 
         if not main_ops:
-            return {
-                "courses": [],
-                "required_courses": [],
-                "elective_courses": [],
-                "required_title": "Required Courses",
-                "elective_title": "Elective Courses",
-                "minimum_elective_requirement": None,
-            }
+            return self._empty_course_requirements_data()
 
         # Fetch all course requirements efficiently
         course_reqs = self._get_operator_course_requirements(main_ops)

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -4,6 +4,9 @@ from datetime import timedelta
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.db import connection
+from django.db.models import Prefetch
+from django.test.utils import CaptureQueriesContext
 from mitol.common.utils.datetime import now_in_utc
 from wagtail.models import Page
 
@@ -686,6 +689,45 @@ def test_courses_in_program(program_with_requirements):  # noqa: F811
         + program_with_requirements.elective_courses
         + program_with_requirements.mut_exclusive_courses
     )
+
+
+def test_program_requirement_properties_use_prefetched_all_requirements(
+    program_with_requirements,  # noqa: F811
+):
+    """Requirement properties should reuse prefetched requirement data."""
+    program = Program.objects.prefetch_related(
+        Prefetch(
+            "all_requirements",
+            queryset=ProgramRequirement.objects.select_related("course"),
+        )
+    ).get(pk=program_with_requirements.program.pk)
+
+    with CaptureQueriesContext(connection) as context:
+        course_pairs = program.courses
+        required_course_list = program.required_courses
+        elective_course_list = program.elective_courses
+        minimum_elective_requirement = program.minimum_elective_courses_requirement
+
+    assert len(context) == 0
+    assert [course.id for course, _ in course_pairs] == [
+        course.id
+        for course in (
+            program_with_requirements.required_courses
+            + program_with_requirements.elective_courses
+            + program_with_requirements.mut_exclusive_courses
+        )
+    ]
+    assert [course.id for course in required_course_list] == [
+        course.id for course in program_with_requirements.required_courses
+    ]
+    assert [course.id for course in elective_course_list] == [
+        course.id
+        for course in (
+            program_with_requirements.elective_courses
+            + program_with_requirements.mut_exclusive_courses
+        )
+    ]
+    assert minimum_elective_requirement == 2
 
 
 def test_program_requirements_is_operator():

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -8,6 +8,7 @@ import logging
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
+from courses.api import upgrade_program_enrollment_if_eligible
 from courses.models import (
     CourseRun,
     CourseRunEnrollment,
@@ -79,7 +80,6 @@ def send_partner_school_email(record_uuid):
 @app.task
 def upgrade_eligible_program_enrollments():
     """Upgrade eligible learners for all audit-mode program enrollments."""
-    from courses.api import upgrade_program_enrollment_if_eligible
 
     enrollments = ProgramEnrollment.objects.filter(
         enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -83,6 +83,6 @@ def upgrade_eligible_program_enrollments():
 
     enrollments = ProgramEnrollment.objects.filter(
         enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
-    )
+    ).select_related("program", "user")
     for enrollment in enrollments.iterator():
         upgrade_program_enrollment_if_eligible(enrollment)

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -82,12 +82,15 @@ def upgrade_eligible_program_enrollments():
     """Upgrade eligible learners for all audit-mode program enrollments."""
     from courses.api import upgrade_program_enrollment_if_eligible
 
-    enrollments = ProgramEnrollment.objects.filter(
-        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
-    ).select_related("program", "user").prefetch("certificate").prefetch_related(
-        Prefetch(
-            "program__all_requirements",
-            queryset=ProgramRequirement.objects.select_related("course"),
+    enrollments = (
+        ProgramEnrollment.objects.filter(enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE)
+        .select_related("program", "user")
+        .prefetch("certificate")
+        .prefetch_related(
+            Prefetch(
+                "program__all_requirements",
+                queryset=ProgramRequirement.objects.select_related("course"),
+            )
         )
     )
     for enrollment in enrollments:

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -5,7 +5,7 @@ Tasks for the courses app
 
 import logging
 
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from mitol.common.utils.datetime import now_in_utc
 
 from courses.models import (
@@ -13,6 +13,7 @@ from courses.models import (
     CourseRunEnrollment,
     LearnerProgramRecordShare,
     ProgramEnrollment,
+    ProgramRequirement,
 )
 from main.celery import app
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE
@@ -83,6 +84,11 @@ def upgrade_eligible_program_enrollments():
 
     enrollments = ProgramEnrollment.objects.filter(
         enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
-    ).select_related("program", "user")
+    ).select_related("program", "user").prefetch("certificate").prefetch_related(
+        Prefetch(
+            "program__all_requirements",
+            queryset=ProgramRequirement.objects.select_related("course"),
+        )
+    )
     for enrollment in enrollments.iterator():
         upgrade_program_enrollment_if_eligible(enrollment)

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -90,5 +90,5 @@ def upgrade_eligible_program_enrollments():
             queryset=ProgramRequirement.objects.select_related("course"),
         )
     )
-    for enrollment in enrollments.iterator():
+    for enrollment in enrollments:
         upgrade_program_enrollment_if_eligible(enrollment)

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -8,7 +8,6 @@ import logging
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
-from courses.api import upgrade_program_enrollment_if_eligible
 from courses.models import (
     CourseRun,
     CourseRunEnrollment,
@@ -80,6 +79,7 @@ def send_partner_school_email(record_uuid):
 @app.task
 def upgrade_eligible_program_enrollments():
     """Upgrade eligible learners for all audit-mode program enrollments."""
+    from courses.api import upgrade_program_enrollment_if_eligible
 
     enrollments = ProgramEnrollment.objects.filter(
         enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -80,5 +80,3 @@ def test_upgrade_eligible_program_enrollments_selects_related_program_and_user(
         upgrade_eligible_program_enrollments()
 
     assert upgrade_program_enrollment_if_eligible.call_count == len(audit_enrollments)
-
-

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -5,15 +5,12 @@ import pytest
 from courses.factories import (
     CourseRunEnrollmentFactory,
     LearnerProgramRecordShareFactory,
-    ProgramEnrollmentFactory,
 )
 from courses.tasks import (
     generate_course_certificates,
     send_partner_school_email,
     subscribe_edx_course_emails,
-    upgrade_eligible_program_enrollments,
 )
-from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
 pytestmark = pytest.mark.django_db
 
@@ -53,30 +50,3 @@ def test_send_partner_school_email(mocker):
     )
     send_partner_school_email.delay(record.share_uuid)
     send_partner_school_sharing_message.assert_called_once()
-
-
-def test_upgrade_eligible_program_enrollments_selects_related_program_and_user(
-    mocker,
-    django_assert_max_num_queries,
-):
-    """The task should not issue per-enrollment queries for user or program."""
-    audit_enrollments = ProgramEnrollmentFactory.create_batch(
-        3,
-        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
-    )
-    ProgramEnrollmentFactory.create(enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE)
-
-    def mock_upgrade(program_enrollment):
-        program_enrollment.program.title
-        program_enrollment.user.username
-        return program_enrollment, False
-
-    upgrade_program_enrollment_if_eligible = mocker.patch(
-        "courses.api.upgrade_program_enrollment_if_eligible",
-        side_effect=mock_upgrade,
-    )
-
-    with django_assert_max_num_queries(1):
-        upgrade_eligible_program_enrollments()
-
-    assert upgrade_program_enrollment_if_eligible.call_count == len(audit_enrollments)

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -5,12 +5,15 @@ import pytest
 from courses.factories import (
     CourseRunEnrollmentFactory,
     LearnerProgramRecordShareFactory,
+    ProgramEnrollmentFactory,
 )
 from courses.tasks import (
     generate_course_certificates,
     send_partner_school_email,
     subscribe_edx_course_emails,
+    upgrade_eligible_program_enrollments,
 )
+from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
 pytestmark = pytest.mark.django_db
 
@@ -50,3 +53,32 @@ def test_send_partner_school_email(mocker):
     )
     send_partner_school_email.delay(record.share_uuid)
     send_partner_school_sharing_message.assert_called_once()
+
+
+def test_upgrade_eligible_program_enrollments_selects_related_program_and_user(
+    mocker,
+    django_assert_max_num_queries,
+):
+    """The task should not issue per-enrollment queries for user or program."""
+    audit_enrollments = ProgramEnrollmentFactory.create_batch(
+        3,
+        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+    )
+    ProgramEnrollmentFactory.create(enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE)
+
+    def mock_upgrade(program_enrollment):
+        program_enrollment.program.title
+        program_enrollment.user.username
+        return program_enrollment, False
+
+    upgrade_program_enrollment_if_eligible = mocker.patch(
+        "courses.api.upgrade_program_enrollment_if_eligible",
+        side_effect=mock_upgrade,
+    )
+
+    with django_assert_max_num_queries(1):
+        upgrade_eligible_program_enrollments()
+
+    assert upgrade_program_enrollment_if_eligible.call_count == len(audit_enrollments)
+
+


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The upgrade_eligible_program_enrollments task and management command cause an N+1 query issue by not prefetching related program and user objects before iterating through enrollments.


### How can this be tested?
tests should pass
everything should work as expected
