### PR TITLE
Update discount code redemption to create codes if necessary

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -986,7 +986,7 @@ def _validate_b2b_enrollment_prerequisites(user, product: Product) -> Union[dict
 
     if (
         isinstance(purchasable_object, CourseRun)
-        and not purchasable_object.is_enrollable
+        and not purchasable_object.is_enrollable_for_b2b
     ):
         return {"result": main_constants.USER_MSG_TYPE_B2B_ERROR_NOT_ENROLLABLE}
 
@@ -1019,20 +1019,42 @@ def _prepare_basket_for_b2b_enrollment(request, product: Product) -> Basket:
 
 def _apply_available_discount(request, product: Product, basket: Basket) -> None:
     """Apply available discount to the basket if one exists."""
+
+    # TODO: this and the validate don't consider programs...
+
+    # Changed to only check redemption count if the discount isn't unlimited -
+    # which it will be if the contract has unlimited seats - and order by ID
+    # so it matches what we send out to people.
     applicable_discounts_qs = product.discounts.annotate(
         redemptions=Count("discount__order_redemptions")
-    ).filter(discount__is_bulk=True, redemptions=0, discount__products__product=product)
+    ).filter(discount__is_bulk=True, discount__products__product=product).filter(
+        Q(redemptions_gt=0) | Q(redemption_type=REDEMPTION_TYPE_UNLIMITED)
+    ).order_by("id")
 
     if applicable_discounts_qs.exists():
         # We have unused codes for this product, so we should apply one.
         discount = applicable_discounts_qs.first().discount
-        basket_discount = BasketDiscount.objects.create(
-            redemption_date=now_in_utc(),
-            redeemed_by=request.user,
-            redeemed_discount=discount,
-            redeemed_basket=basket,
-        )
-        basket_discount.save()
+    else:
+        # At this point we've checked for available seats, and we've checked for
+        # an appropriate discount, and we couldn't find one, so now we need to
+        # make one for the learner (or for the contract).
+
+        if not product.purchasable_object or product.purchasable_object.b2b_contract:
+            msg = f"Product {product} has no purchasable object or the purchasable object has no B2B contract"
+            raise ValueError(msg)
+
+        discount_amount = product.purchasable_object.b2b_contract.enrollment_fixed_price
+        redemption_type = REDEMPTION_TYPE_ONE_TIME if product.purchasable_object.b2b_contract.max_learners > 0 else REDEMPTION_TYPE_UNLIMITED
+
+        discount = _create_discount_with_product(product, discount_amount if discount_amount else Decimal(0), redemption_type)
+
+    basket_discount = BasketDiscount.objects.create(
+        redemption_date=now_in_utc(),
+        redeemed_by=request.user,
+        redeemed_discount=discount,
+        redeemed_basket=basket,
+    )
+    basket_discount.save()
 
 
 def create_b2b_enrollment(request, product: Product):

--- a/b2b/api.py
+++ b/b2b/api.py
@@ -1020,16 +1020,18 @@ def _prepare_basket_for_b2b_enrollment(request, product: Product) -> Basket:
 def _apply_available_discount(request, product: Product, basket: Basket) -> None:
     """Apply available discount to the basket if one exists."""
 
-    # TODO: this and the validate don't consider programs...
-
     # Changed to only check redemption count if the discount isn't unlimited -
     # which it will be if the contract has unlimited seats - and order by ID
     # so it matches what we send out to people.
-    applicable_discounts_qs = product.discounts.annotate(
-        redemptions=Count("discount__order_redemptions")
-    ).filter(discount__is_bulk=True, discount__products__product=product).filter(
-        Q(redemptions_gt=0) | Q(redemption_type=REDEMPTION_TYPE_UNLIMITED)
-    ).order_by("id")
+    applicable_discounts_qs = (
+        product.discounts.annotate(redemptions=Count("discount__order_redemptions"))
+        .filter(discount__is_bulk=True, discount__products__product=product)
+        .filter(
+            Q(redemptions__gt=0)
+            | Q(discount__redemption_type=REDEMPTION_TYPE_UNLIMITED)
+        )
+        .order_by("id")
+    )
 
     if applicable_discounts_qs.exists():
         # We have unused codes for this product, so we should apply one.
@@ -1044,9 +1046,15 @@ def _apply_available_discount(request, product: Product, basket: Basket) -> None
             raise ValueError(msg)
 
         discount_amount = product.purchasable_object.b2b_contract.enrollment_fixed_price
-        redemption_type = REDEMPTION_TYPE_ONE_TIME if product.purchasable_object.b2b_contract.max_learners > 0 else REDEMPTION_TYPE_UNLIMITED
+        redemption_type = (
+            REDEMPTION_TYPE_ONE_TIME
+            if product.purchasable_object.b2b_contract.max_learners > 0
+            else REDEMPTION_TYPE_UNLIMITED
+        )
 
-        discount = _create_discount_with_product(product, discount_amount if discount_amount else Decimal(0), redemption_type)
+        discount = _create_discount_with_product(
+            product, discount_amount if discount_amount else Decimal(0), redemption_type
+        )
 
     basket_discount = BasketDiscount.objects.create(
         redemption_date=now_in_utc(),

--- a/b2b/api.py
+++ b/b2b/api.py
@@ -1027,8 +1027,7 @@ def _apply_available_discount(request, product: Product, basket: Basket) -> None
         product.discounts.annotate(redemptions=Count("discount__order_redemptions"))
         .filter(discount__is_bulk=True, discount__products__product=product)
         .filter(
-            Q(redemptions__gt=0)
-            | Q(discount__redemption_type=REDEMPTION_TYPE_UNLIMITED)
+            Q(redemptions=0) | Q(discount__redemption_type=REDEMPTION_TYPE_UNLIMITED)
         )
         .order_by("id")
     )
@@ -1041,7 +1040,10 @@ def _apply_available_discount(request, product: Product, basket: Basket) -> None
         # an appropriate discount, and we couldn't find one, so now we need to
         # make one for the learner (or for the contract).
 
-        if not product.purchasable_object or product.purchasable_object.b2b_contract:
+        if (
+            not product.purchasable_object
+            or not product.purchasable_object.b2b_contract
+        ):
             msg = f"Product {product} has no purchasable object or the purchasable object has no B2B contract"
             raise ValueError(msg)
 

--- a/b2b/api.py
+++ b/b2b/api.py
@@ -1050,7 +1050,8 @@ def _apply_available_discount(request, product: Product, basket: Basket) -> None
         discount_amount = product.purchasable_object.b2b_contract.enrollment_fixed_price
         redemption_type = (
             REDEMPTION_TYPE_ONE_TIME
-            if product.purchasable_object.b2b_contract.max_learners > 0
+            if product.purchasable_object.b2b_contract.max_learners
+            and product.purchasable_object.b2b_contract.max_learners > 0
             else REDEMPTION_TYPE_UNLIMITED
         )
 

--- a/b2b/api_test.py
+++ b/b2b/api_test.py
@@ -17,6 +17,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from b2b import factories
 from b2b.api import (
+    _apply_available_discount,
     _handle_extra_enrollment_codes,
     create_b2b_enrollment,
     create_contract_run,
@@ -58,10 +59,17 @@ from ecommerce.factories import (
     BasketFactory,
     BasketItemFactory,
     OneTimeDiscountFactory,
+    OrderFactory,
     ProductFactory,
     UnlimitedUseDiscountFactory,
 )
-from ecommerce.models import Basket, BasketDiscount, DiscountProduct
+from ecommerce.models import (
+    Basket,
+    BasketDiscount,
+    DiscountProduct,
+    DiscountRedemption,
+    OrderStatus,
+)
 from main.constants import (
     USER_MSG_TYPE_B2B_DISALLOWED,
     USER_MSG_TYPE_B2B_ENROLL_SUCCESS,
@@ -1464,3 +1472,64 @@ def test_ensure_enrollment_codes_courseware_changes(
         contract.get_discounts().filter(products__product=product_2).count()
         == max_learners
     )
+
+
+def test_apply_available_discount_seat_limit():
+    """
+    Test that the internal _apply_available_discount function works as expected.
+
+    This should find an applicable discount to apply to the order. For a
+    seat-limited contract, this should be an unused discount linked to the
+    product in the cart. For an unlimited seat contract, this is the discount
+    linked to the product (ignoring use). If there's not a discount, then we
+    should make one if there's sufficient seats available.
+    """
+
+    contract = factories.ContractPageFactory.create(
+        max_learners=2,
+        membership_type=CONTRACT_MEMBERSHIP_NONSSO,
+        integration_type=CONTRACT_MEMBERSHIP_NONSSO,
+    )
+    CourseRunFactory.create_batch(2, b2b_contract=contract)
+    user_orgs = factories.UserOrganizationFactory.create_batch(
+        3, organization=contract.organization
+    )
+
+    products = ensure_contract_run_products(contract)
+    ensure_enrollment_codes_exist(contract)
+
+    assert contract.get_discounts().count() == 4
+
+    # For this we care about redemptions for enrollment, so we need to create
+    # some orders and throw some discounts on them.
+
+    for uo in user_orgs[:2]:
+        user = uo.user
+
+        for product in products:
+            order = OrderFactory.create(purchaser=user, state=OrderStatus.FULFILLED)
+            discount = (
+                contract.get_unused_discounts()
+                .filter(products__product=product)
+                .first()
+            )
+            DiscountRedemption.objects.create(
+                redemption_date=now_in_utc(),
+                redeemed_by=user,
+                redeemed_discount=discount,
+                redeemed_order=order,
+            )
+
+    assert contract.get_unused_discounts().count() == 0
+
+    # The _apply_available_discount function doesn't check for seats - space is
+    # expected to be checked before this gets called. So we should have just one
+    # new discount.
+
+    basket = Basket.objects.create(user=user_orgs[2].user)
+    request = RequestFactory()
+    request.user = user_orgs[2].user
+
+    _apply_available_discount(request, products[0], basket)
+
+    assert contract.get_discounts().count() == 5

--- a/b2b/api_test.py
+++ b/b2b/api_test.py
@@ -19,6 +19,7 @@ from b2b import factories
 from b2b.api import (
     _apply_available_discount,
     _handle_extra_enrollment_codes,
+    _validate_b2b_enrollment_prerequisites,
     create_b2b_enrollment,
     create_contract_run,
     create_contract_run_key,
@@ -75,6 +76,7 @@ from main.constants import (
     USER_MSG_TYPE_B2B_ENROLL_SUCCESS,
     USER_MSG_TYPE_B2B_ERROR_NO_CONTRACT,
     USER_MSG_TYPE_B2B_ERROR_NO_PRODUCT,
+    USER_MSG_TYPE_B2B_ERROR_NOT_ENROLLABLE,
     USER_MSG_TYPE_B2B_ERROR_REQUIRES_CHECKOUT,
 )
 from main.utils import date_to_datetime
@@ -1519,6 +1521,9 @@ def test_apply_available_discount_seat_limit():
                 redeemed_discount=discount,
                 redeemed_order=order,
             )
+            CourseRunEnrollment.objects.create(
+                run=product.purchasable_object, active=True, user=user
+            )
 
     assert contract.get_unused_discounts().count() == 0
 
@@ -1530,6 +1535,95 @@ def test_apply_available_discount_seat_limit():
     request = RequestFactory()
     request.user = user_orgs[2].user
 
+    # Test the validate step - this gets called before the apply call and should
+    # fail. (So, in real life, trying to add this third user should not work.)
+
+    user_orgs[2].user.b2b_contracts.add(contract)
+    user_orgs[2].user.save()
+
+    result = _validate_b2b_enrollment_prerequisites(user_orgs[2].user, products[0])
+
+    assert result == {"result": USER_MSG_TYPE_B2B_ERROR_NOT_ENROLLABLE}
+
+    # Calling this directly should result in a new discount being created.
+
     _apply_available_discount(request, products[0], basket)
 
     assert contract.get_discounts().count() == 5
+
+
+@pytest.mark.parametrize(
+    "existing_discounts",
+    [
+        True,
+        False,
+    ],
+)
+def test_apply_available_discount_unlimited_seats(existing_discounts):
+    """
+    Test that the internal _apply_available_discount function works as expected.
+
+    The other half of the above test - this checks for proper operation when the
+    contract has unlimited seats.
+    """
+
+    contract = factories.ContractPageFactory.create(
+        max_learners=0,
+        membership_type=CONTRACT_MEMBERSHIP_NONSSO,
+        integration_type=CONTRACT_MEMBERSHIP_NONSSO,
+    )
+    CourseRunFactory.create_batch(2, b2b_contract=contract)
+    user_orgs = factories.UserOrganizationFactory.create_batch(
+        3, organization=contract.organization
+    )
+
+    products = ensure_contract_run_products(contract)
+    if existing_discounts:
+        # Testing for existing discounts means we should create some orders where
+        # the discount is used, to make sure we don't end up with extras.
+
+        ensure_enrollment_codes_exist(contract)
+
+        assert contract.get_discounts().count() == 2
+
+        for uo in user_orgs[:2]:
+            user = uo.user
+
+            for product in products:
+                order = OrderFactory.create(purchaser=user, state=OrderStatus.FULFILLED)
+                discount = (
+                    contract.get_discounts().filter(products__product=product).first()
+                )
+                DiscountRedemption.objects.create(
+                    redemption_date=now_in_utc(),
+                    redeemed_by=user,
+                    redeemed_discount=discount,
+                    redeemed_order=order,
+                )
+                CourseRunEnrollment.objects.create(
+                    run=product.purchasable_object, active=True, user=user
+                )
+
+    assert contract.get_unused_discounts().count() == 0
+
+    # The _apply_available_discount function doesn't check for seats - space is
+    # expected to be checked before this gets called. So we should have just one
+    # new discount.
+
+    basket = Basket.objects.create(user=user_orgs[2].user)
+    request = RequestFactory()
+    request.user = user_orgs[2].user
+
+    # Test the validate step - this gets called before the apply call and should
+    # fail. (So, in real life, trying to add this third user should not work.)
+
+    user_orgs[2].user.b2b_contracts.add(contract)
+    user_orgs[2].user.save()
+
+    result = _validate_b2b_enrollment_prerequisites(user_orgs[2].user, products[0])
+
+    assert not result
+
+    _apply_available_discount(request, products[0], basket)
+
+    assert contract.get_discounts().count() == (2 if existing_discounts else 1)

--- a/b2b/factories.py
+++ b/b2b/factories.py
@@ -5,16 +5,23 @@ from uuid import uuid4
 import faker
 import wagtail_factories
 from factory import Factory, LazyAttribute, LazyFunction, SubFactory
+from factory.django import DjangoModelFactory
 
 from b2b.constants import CONTRACT_MEMBERSHIP_NONSSO, CONTRACT_MEMBERSHIP_SSO
 from b2b.keycloak_admin_dataclasses import (
     OrganizationRepresentation,
     RealmRepresentation,
 )
-from b2b.models import ContractPage, OrganizationIndexPage, OrganizationPage
+from b2b.models import (
+    ContractPage,
+    OrganizationIndexPage,
+    OrganizationPage,
+    UserOrganization,
+)
 from cms.factories import HomePageFactory
 from cms.models import HomePage
 from courses.constants import UAI_COURSEWARE_ID_PREFIX
+from users.factories import UserFactory
 
 FAKE = faker.Faker()
 
@@ -94,3 +101,19 @@ class OrganizationRepresentationFactory(Factory):
     alias = LazyAttribute(lambda _: FAKE.unique.word())
     description = LazyAttribute(lambda _: FAKE.text())
     enabled = True
+
+
+class UserOrganizationFactory(DjangoModelFactory):
+    """Factory for UserOrganizations"""
+
+    class Meta:
+        model = UserOrganization
+        django_get_or_create = (
+            "user",
+            "organization",
+        )
+
+    user = SubFactory(UserFactory)
+    organization = SubFactory(OrganizationPageFactory)
+    keep_until_seen = True
+    is_manager = False

--- a/courses/models.py
+++ b/courses/models.py
@@ -1294,9 +1294,17 @@ class CourseRun(TimestampedModel):
         if not self.b2b_contract:
             return False
 
-        contract_enrollments = self.enrollments.filter(is_active=True, change_status=None).count()
+        if self.b2b_contract.max_learners == 0:
+            return True
 
-        return self.b2b_contract.max_learners > 0 and self.b2b_contract.max_learners > contract_enrollments
+        contract_enrollments = self.enrollments.filter(
+            active=True, change_status=None
+        ).count()
+
+        return (
+            self.b2b_contract.max_learners > 0
+            and self.b2b_contract.max_learners > contract_enrollments
+        )
 
     @property
     def is_fake_course_run(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -1287,6 +1287,17 @@ class CourseRun(TimestampedModel):
             and self.start_date is not None
         )
 
+    @cached_property
+    def is_enrollable_for_b2b(self):
+        """Determine if the run is enrollable for B2B purchases."""
+
+        if not self.b2b_contract:
+            return False
+
+        contract_enrollments = self.enrollments.filter(is_active=True, change_status=None).count()
+
+        return self.b2b_contract.max_learners > 0 and self.b2b_contract.max_learners > contract_enrollments
+
     @property
     def is_fake_course_run(self):
         """

--- a/courses/models.py
+++ b/courses/models.py
@@ -1294,7 +1294,7 @@ class CourseRun(TimestampedModel):
         if not self.b2b_contract:
             return False
 
-        if self.b2b_contract.max_learners == 0:
+        if not self.b2b_contract.max_learners:
             return True
 
         contract_enrollments = self.enrollments.filter(

--- a/courses/models.py
+++ b/courses/models.py
@@ -1295,7 +1295,7 @@ class CourseRun(TimestampedModel):
             return False
 
         if not self.b2b_contract.max_learners:
-            return True
+            return self.is_enrollable
 
         contract_enrollments = self.enrollments.filter(
             active=True, change_status=None
@@ -1304,6 +1304,7 @@ class CourseRun(TimestampedModel):
         return (
             self.b2b_contract.max_learners > 0
             and self.b2b_contract.max_learners > contract_enrollments
+            and self.is_enrollable
         )
 
     @property


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#10810

### Description (What does it do?)

Adds some code to the apply discount step for B2B enrollments that will create a discount code if necessary. This involves adding an additional check to make sure the course run still has some seats available.

### How can this be tested?

Automated tests should pass.

Test with both a seat-limited contract and an unlimited contract. Both should be of "code" type (or non-sso). 

Test code creation: The easiest way to do this is to create the contract, allow it to create the discounts, then remove them (you can use `b2b_codes expire` for this). Then, try to enroll in a B2B run. The system should make a new discount code. This should work regardless of the seat limit but you should only ever have one discount code per product if there's no learner limit.

Test full contracts: Use up all the seats in a product in a contract, and then try to add another user to the product. this should fail.
