### PR TITLE
feat: mitxonline API to surface course modules metadata

### DIFF
--- a/courses/urls/v3/urls.py
+++ b/courses/urls/v3/urls.py
@@ -1,5 +1,6 @@
 """Course API v3 URL configuration."""
 
+from django.urls import path
 from rest_framework import routers
 
 from courses.views import v3
@@ -19,3 +20,10 @@ router.register(
 )
 
 urlpatterns = router.urls
+urlpatterns += [
+    path(
+        "courses/<str:course_id>/outline/",
+        v3.get_course_outline,
+        name="course_outline",
+    ),
+]

--- a/courses/urls/v3/urls.py
+++ b/courses/urls/v3/urls.py
@@ -22,7 +22,7 @@ router.register(
 urlpatterns = router.urls
 urlpatterns += [
     path(
-        "courses/<str:course_id>/outline/",
+        "courses/<str:course_id>/ol_openedx_outline/",
         v3.get_course_outline,
         name="course_outline",
     ),

--- a/courses/views/v3/__init__.py
+++ b/courses/views/v3/__init__.py
@@ -10,10 +10,12 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import (
     IsAuthenticated,
 )
 from rest_framework.response import Response
+from rest_framework_api_key.permissions import HasAPIKey
 
 from courses.api import create_program_enrollments, deactivate_run_enrollment
 from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
@@ -29,6 +31,7 @@ from courses.serializers.v3.programs import (
 )
 from ecommerce.models import Product
 from main import features
+from openedx.api import get_edx_course_outline
 
 
 class UserEnrollmentFilterSet(django_filters.FilterSet):
@@ -243,3 +246,17 @@ class UserProgramEnrollmentsViewSet(
             enrollment.deactivate_and_save(ENROLL_CHANGE_STATUS_UNENROLLED)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@extend_schema(
+    operation_id="course_outline_retrieve_v3",
+    description="Fetch course outline data for the given course key from Open edX.",
+)
+@api_view(["GET"])
+@permission_classes([IsAuthenticated | HasAPIKey])
+def get_course_outline(request, course_id):  # noqa: ARG001
+    """
+    Return course outline data from Open edX for the specified course key.
+    """
+    outline_data = get_edx_course_outline(course_id)
+    return Response(outline_data, status=status.HTTP_200_OK)

--- a/courses/views/v3/__init__.py
+++ b/courses/views/v3/__init__.py
@@ -7,7 +7,7 @@ import re
 
 import django_filters
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
@@ -342,10 +342,7 @@ def get_course_outline(request, course_id):  # noqa: ARG001
     """
     Return course outline data from Open edX for the specified course key.
     """
-    try:
-        if not re.fullmatch(COURSE_KEY_PATTERN, course_id):
-            raise ValidationError("Invalid course_id")
-    except ValidationError:
+    if not re.fullmatch(COURSE_KEY_PATTERN, course_id):
         return Response(
             {"detail": "Invalid course_id format. Expected an Open edX course key."},
             status=status.HTTP_400_BAD_REQUEST,

--- a/courses/views/v3/__init__.py
+++ b/courses/views/v3/__init__.py
@@ -8,8 +8,14 @@ from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
-from rest_framework import mixins, status, viewsets
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_view,
+    inline_serializer,
+)
+from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import (
     IsAuthenticated,
@@ -251,6 +257,65 @@ class UserProgramEnrollmentsViewSet(
 @extend_schema(
     operation_id="course_outline_retrieve_v3",
     description="Fetch course outline data for the given course key from Open edX.",
+    parameters=[
+        OpenApiParameter(
+            name="course_id",
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.PATH,
+            required=True,
+            description="Open edX course key (URL-encoded recommended), e.g. course-v1%3AOpenedX%2BDemoX%2BDemoCourse",
+        )
+    ],
+    responses={
+        200: inline_serializer(
+            name="CourseOutlineResponse",
+            fields={
+                "course_id": serializers.CharField(),
+                "generated_at": serializers.CharField(),
+                "modules": serializers.ListField(child=serializers.DictField()),
+            },
+        ),
+        403: inline_serializer(
+            name="CourseOutlineAuthErrorResponse",
+            fields={"detail": serializers.CharField()},
+        ),
+        500: inline_serializer(
+            name="CourseOutlineUpstreamErrorResponse",
+            fields={"detail": serializers.CharField()},
+        ),
+    },
+    examples=[
+        OpenApiExample(
+            "CourseOutlineSuccess",
+            value={
+                "course_id": "course-v1:OpenedX+DemoX+DemoCourse",
+                "generated_at": "2026-04-10T07:17:20Z",
+                "modules": [
+                    {
+                        "id": "block-v1:OpenedX+DemoX+DemoCourse+type@chapter+block@abc123",
+                        "title": "Module 1",
+                        "effort_time": 0,
+                        "effort_activities": 0,
+                        "counts": {
+                            "videos": 2,
+                            "readings": 1,
+                            "problems": 1,
+                            "assignments": 0,
+                            "app_items": 0,
+                        },
+                    }
+                ],
+            },
+            response_only=True,
+            status_codes=["200"],
+        ),
+        OpenApiExample(
+            "AuthError",
+            value={"detail": "Authentication credentials were not provided."},
+            response_only=True,
+            status_codes=["403"],
+        ),
+    ],
 )
 @api_view(["GET"])
 @permission_classes([IsAuthenticated | HasAPIKey])

--- a/courses/views/v3/__init__.py
+++ b/courses/views/v3/__init__.py
@@ -2,8 +2,12 @@
 Course API Views version 3
 """
 
+import logging
+import re
+
 import django_filters
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
@@ -18,13 +22,13 @@ from drf_spectacular.utils import (
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import (
+    AllowAny,
     IsAuthenticated,
 )
 from rest_framework.response import Response
-from rest_framework_api_key.permissions import HasAPIKey
 
 from courses.api import create_program_enrollments, deactivate_run_enrollment
-from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
+from courses.constants import COURSE_KEY_PATTERN, ENROLL_CHANGE_STATUS_UNENROLLED
 from courses.models import (
     CourseRunEnrollment,
     Program,
@@ -38,6 +42,9 @@ from courses.serializers.v3.programs import (
 from ecommerce.models import Product
 from main import features
 from openedx.api import get_edx_course_outline
+from openedx.exceptions import EdxApiCourseOutlineError
+
+log = logging.getLogger(__name__)
 
 
 class UserEnrollmentFilterSet(django_filters.FilterSet):
@@ -275,12 +282,16 @@ class UserProgramEnrollmentsViewSet(
                 "modules": serializers.ListField(child=serializers.DictField()),
             },
         ),
-        403: inline_serializer(
-            name="CourseOutlineAuthErrorResponse",
+        400: inline_serializer(
+            name="CourseOutlineBadRequestResponse",
+            fields={"detail": serializers.CharField()},
+        ),
+        502: inline_serializer(
+            name="CourseOutlineUpstreamErrorResponse",
             fields={"detail": serializers.CharField()},
         ),
         500: inline_serializer(
-            name="CourseOutlineUpstreamErrorResponse",
+            name="CourseOutlineServerErrorResponse",
             fields={"detail": serializers.CharField()},
         ),
     },
@@ -310,18 +321,48 @@ class UserProgramEnrollmentsViewSet(
             status_codes=["200"],
         ),
         OpenApiExample(
-            "AuthError",
-            value={"detail": "Authentication credentials were not provided."},
+            "InvalidCourseId",
+            value={
+                "detail": "Invalid course_id format. Expected an Open edX course key."
+            },
             response_only=True,
-            status_codes=["403"],
+            status_codes=["400"],
+        ),
+        OpenApiExample(
+            "UpstreamError",
+            value={"detail": "Unable to fetch course outline from Open edX."},
+            response_only=True,
+            status_codes=["502"],
         ),
     ],
 )
 @api_view(["GET"])
-@permission_classes([IsAuthenticated | HasAPIKey])
+@permission_classes([AllowAny])
 def get_course_outline(request, course_id):  # noqa: ARG001
     """
     Return course outline data from Open edX for the specified course key.
     """
-    outline_data = get_edx_course_outline(course_id)
+    try:
+        if not re.fullmatch(COURSE_KEY_PATTERN, course_id):
+            raise ValidationError("Invalid course_id")
+    except ValidationError:
+        return Response(
+            {"detail": "Invalid course_id format. Expected an Open edX course key."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        outline_data = get_edx_course_outline(course_id)
+    except EdxApiCourseOutlineError:
+        return Response(
+            {"detail": "Unable to fetch course outline from Open edX."},
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+    except ImproperlyConfigured:
+        log.exception("Course outline service is not configured")
+        return Response(
+            {"detail": "Course outline service is not configured."},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
     return Response(outline_data, status=status.HTTP_200_OK)

--- a/courses/views/v3/views_test.py
+++ b/courses/views/v3/views_test.py
@@ -20,6 +20,7 @@ from courses.test_utils import maybe_serialize_course_cert, maybe_serialize_prog
 from ecommerce.factories import OrderFactory
 from ecommerce.models import OrderStatus
 from main.test_utils import drf_datetime
+from openedx.exceptions import EdxApiCourseOutlineError
 
 pytestmark = [
     pytest.mark.django_db,
@@ -638,19 +639,25 @@ def test_destroy_program_enrollment_paid_fails(user_drf_client, user):
     assert enrollment.active is True
 
 
-def test_course_outline_v3_requires_auth():
-    """GET course outline endpoint without auth should be unauthorized/forbidden."""
+def test_course_outline_v3_public_success(mocker):
+    """GET course outline endpoint should succeed without authentication."""
     client = APIClient()
+    expected_outline = {
+        "course_id": "course-v1:OpenedX+DemoX+DemoCourse",
+        "blocks": [],
+    }
+    mocked_get_outline = mocker.patch(
+        "courses.views.v3.get_edx_course_outline", return_value=expected_outline
+    )
     resp = client.get(
         reverse(
             "v3:course_outline",
             kwargs={"course_id": "course-v1:OpenedX+DemoX+DemoCourse"},
         )
     )
-    assert resp.status_code in (
-        status.HTTP_401_UNAUTHORIZED,
-        status.HTTP_403_FORBIDDEN,
-    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_outline
+    mocked_get_outline.assert_called_once_with("course-v1:OpenedX+DemoX+DemoCourse")
 
 
 def test_course_outline_v3_authenticated_success(user_drf_client, mocker):
@@ -673,3 +680,46 @@ def test_course_outline_v3_authenticated_success(user_drf_client, mocker):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == expected_outline
     mocked_get_outline.assert_called_once_with("course-v1:OpenedX+DemoX+DemoCourse")
+
+
+def test_course_outline_v3_invalid_course_id():
+    """Invalid course IDs should return 400 before upstream call."""
+    client = APIClient()
+    resp = client.get(
+        reverse("v3:course_outline", kwargs={"course_id": "not-a-course-key"})
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json() == {
+        "detail": "Invalid course_id format. Expected an Open edX course key."
+    }
+
+
+@pytest.mark.parametrize(
+    "exception_instance,expected_detail",
+    [
+        (
+            EdxApiCourseOutlineError("boom"),
+            "Unable to fetch course outline from Open edX.",
+        ),
+        (
+            EdxApiCourseOutlineError("bad json"),
+            "Unable to fetch course outline from Open edX.",
+        ),
+    ],
+)
+def test_course_outline_v3_upstream_failures(
+    user_drf_client, mocker, exception_instance, expected_detail
+):
+    """Upstream errors should be mapped to 502 responses with safe messages."""
+    mocker.patch(
+        "courses.views.v3.get_edx_course_outline",
+        side_effect=exception_instance,
+    )
+    resp = user_drf_client.get(
+        reverse(
+            "v3:course_outline",
+            kwargs={"course_id": "course-v1:OpenedX+DemoX+DemoCourse"},
+        )
+    )
+    assert resp.status_code == status.HTTP_502_BAD_GATEWAY
+    assert resp.json() == {"detail": expected_detail}

--- a/courses/views/v3/views_test.py
+++ b/courses/views/v3/views_test.py
@@ -695,7 +695,7 @@ def test_course_outline_v3_invalid_course_id():
 
 
 @pytest.mark.parametrize(
-    "exception_instance,expected_detail",
+    ("exception_instance", "expected_detail"),
     [
         (
             EdxApiCourseOutlineError("boom"),

--- a/courses/views/v3/views_test.py
+++ b/courses/views/v3/views_test.py
@@ -636,3 +636,40 @@ def test_destroy_program_enrollment_paid_fails(user_drf_client, user):
 
     enrollment.refresh_from_db()
     assert enrollment.active is True
+
+
+def test_course_outline_v3_requires_auth():
+    """GET course outline endpoint without auth should be unauthorized/forbidden."""
+    client = APIClient()
+    resp = client.get(
+        reverse(
+            "v3:course_outline",
+            kwargs={"course_id": "course-v1:OpenedX+DemoX+DemoCourse"},
+        )
+    )
+    assert resp.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+def test_course_outline_v3_authenticated_success(user_drf_client, mocker):
+    """Authenticated request should return proxied Open edX outline data."""
+    expected_outline = {
+        "course_id": "course-v1:OpenedX+DemoX+DemoCourse",
+        "blocks": [],
+    }
+    mocked_get_outline = mocker.patch(
+        "courses.views.v3.get_edx_course_outline", return_value=expected_outline
+    )
+
+    resp = user_drf_client.get(
+        reverse(
+            "v3:course_outline",
+            kwargs={"course_id": "course-v1:OpenedX+DemoX+DemoCourse"},
+        )
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == expected_outline
+    mocked_get_outline.assert_called_once_with("course-v1:OpenedX+DemoX+DemoCourse")

--- a/main/settings.py
+++ b/main/settings.py
@@ -1203,6 +1203,11 @@ OPENEDX_COURSE_BASE_URL_SUFFIX = get_string(
     default="/home",
     description="The suffix (with leading slash) to append to a course URL.",
 )
+OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = get_string(
+    name="OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE",
+    default="/api/ol-course-outline/v0/{course_id}/",
+    description="Path template for Open edX course outline plugin endpoint.",
+)
 
 OPENEDX_BASE_REDIRECT_URL = get_string(
     name="OPENEDX_BASE_REDIRECT_URL",

--- a/main/settings.py
+++ b/main/settings.py
@@ -1203,8 +1203,8 @@ OPENEDX_COURSE_BASE_URL_SUFFIX = get_string(
     default="/home",
     description="The suffix (with leading slash) to append to a course URL.",
 )
-OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = get_string(
-    name="OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE",
+OL_OPENEDX_COURSE_OUTLINE_URL = get_string(
+    name="OL_OPENEDX_COURSE_OUTLINE_URL",
     default="/api/ol-course-outline/v0/{course_id}/",
     description="Path template for Open edX course outline plugin endpoint.",
 )

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3264,6 +3264,58 @@ paths:
           description: No response body
         '404':
           description: No response body
+  /api/v3/courses/{course_id}/outline/:
+    get:
+      operationId: course_outline_retrieve_v3
+      description: Fetch course outline data for the given course key from Open edX.
+      parameters:
+      - in: path
+        name: course_id
+        schema:
+          type: string
+        description: Open edX course key (URL-encoded recommended), e.g. course-v1%3AOpenedX%2BDemoX%2BDemoCourse
+        required: true
+      tags:
+      - courses
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineResponse'
+              examples:
+                CourseOutlineSuccess:
+                  value:
+                    course_id: course-v1:OpenedX+DemoX+DemoCourse
+                    generated_at: '2026-04-10T07:17:20Z'
+                    modules:
+                    - id: block-v1:OpenedX+DemoX+DemoCourse+type@chapter+block@abc123
+                      title: Module 1
+                      effort_time: 0
+                      effort_activities: 0
+                      counts:
+                        videos: 2
+                        readings: 1
+                        problems: 1
+                        assignments: 0
+                        app_items: 0
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineAuthErrorResponse'
+              examples:
+                AuthError:
+                  value:
+                    detail: Authentication credentials were not provided.
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+          description: ''
   /api/v3/enrollments/:
     get:
       operationId: user_enrollments_list_v3
@@ -4019,6 +4071,36 @@ components:
       - programs
       - readable_id
       - title
+    CourseOutlineAuthErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
+    CourseOutlineResponse:
+      type: object
+      properties:
+        course_id:
+          type: string
+        generated_at:
+          type: string
+        modules:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+      - course_id
+      - generated_at
+      - modules
+    CourseOutlineUpstreamErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     CoursePage:
       type: object
       description: Course page model serializer

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3277,6 +3277,8 @@ paths:
         required: true
       tags:
       - courses
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -3300,21 +3302,32 @@ paths:
                         assignments: 0
                         app_items: 0
           description: ''
-        '403':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CourseOutlineAuthErrorResponse'
+                $ref: '#/components/schemas/CourseOutlineBadRequestResponse'
               examples:
-                AuthError:
+                InvalidCourseId:
                   value:
-                    detail: Authentication credentials were not provided.
+                    detail: Invalid course_id format. Expected an Open edX course
+                      key.
+          description: ''
+        '502':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+              examples:
+                UpstreamError:
+                  value:
+                    detail: Unable to fetch course outline from Open edX.
           description: ''
         '500':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+                $ref: '#/components/schemas/CourseOutlineServerErrorResponse'
           description: ''
   /api/v3/enrollments/:
     get:
@@ -4071,7 +4084,7 @@ components:
       - programs
       - readable_id
       - title
-    CourseOutlineAuthErrorResponse:
+    CourseOutlineBadRequestResponse:
       type: object
       properties:
         detail:
@@ -4094,6 +4107,13 @@ components:
       - course_id
       - generated_at
       - modules
+    CourseOutlineServerErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     CourseOutlineUpstreamErrorResponse:
       type: object
       properties:

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3264,7 +3264,7 @@ paths:
           description: No response body
         '404':
           description: No response body
-  /api/v3/courses/{course_id}/outline/:
+  /api/v3/courses/{course_id}/ol_openedx_outline/:
     get:
       operationId: course_outline_retrieve_v3
       description: Fetch course outline data for the given course key from Open edX.

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3264,6 +3264,58 @@ paths:
           description: No response body
         '404':
           description: No response body
+  /api/v3/courses/{course_id}/outline/:
+    get:
+      operationId: course_outline_retrieve_v3
+      description: Fetch course outline data for the given course key from Open edX.
+      parameters:
+      - in: path
+        name: course_id
+        schema:
+          type: string
+        description: Open edX course key (URL-encoded recommended), e.g. course-v1%3AOpenedX%2BDemoX%2BDemoCourse
+        required: true
+      tags:
+      - courses
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineResponse'
+              examples:
+                CourseOutlineSuccess:
+                  value:
+                    course_id: course-v1:OpenedX+DemoX+DemoCourse
+                    generated_at: '2026-04-10T07:17:20Z'
+                    modules:
+                    - id: block-v1:OpenedX+DemoX+DemoCourse+type@chapter+block@abc123
+                      title: Module 1
+                      effort_time: 0
+                      effort_activities: 0
+                      counts:
+                        videos: 2
+                        readings: 1
+                        problems: 1
+                        assignments: 0
+                        app_items: 0
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineAuthErrorResponse'
+              examples:
+                AuthError:
+                  value:
+                    detail: Authentication credentials were not provided.
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+          description: ''
   /api/v3/enrollments/:
     get:
       operationId: user_enrollments_list_v3
@@ -4019,6 +4071,36 @@ components:
       - programs
       - readable_id
       - title
+    CourseOutlineAuthErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
+    CourseOutlineResponse:
+      type: object
+      properties:
+        course_id:
+          type: string
+        generated_at:
+          type: string
+        modules:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+      - course_id
+      - generated_at
+      - modules
+    CourseOutlineUpstreamErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     CoursePage:
       type: object
       description: Course page model serializer

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3277,6 +3277,8 @@ paths:
         required: true
       tags:
       - courses
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -3300,21 +3302,32 @@ paths:
                         assignments: 0
                         app_items: 0
           description: ''
-        '403':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CourseOutlineAuthErrorResponse'
+                $ref: '#/components/schemas/CourseOutlineBadRequestResponse'
               examples:
-                AuthError:
+                InvalidCourseId:
                   value:
-                    detail: Authentication credentials were not provided.
+                    detail: Invalid course_id format. Expected an Open edX course
+                      key.
+          description: ''
+        '502':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+              examples:
+                UpstreamError:
+                  value:
+                    detail: Unable to fetch course outline from Open edX.
           description: ''
         '500':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+                $ref: '#/components/schemas/CourseOutlineServerErrorResponse'
           description: ''
   /api/v3/enrollments/:
     get:
@@ -4071,7 +4084,7 @@ components:
       - programs
       - readable_id
       - title
-    CourseOutlineAuthErrorResponse:
+    CourseOutlineBadRequestResponse:
       type: object
       properties:
         detail:
@@ -4094,6 +4107,13 @@ components:
       - course_id
       - generated_at
       - modules
+    CourseOutlineServerErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     CourseOutlineUpstreamErrorResponse:
       type: object
       properties:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3264,7 +3264,7 @@ paths:
           description: No response body
         '404':
           description: No response body
-  /api/v3/courses/{course_id}/outline/:
+  /api/v3/courses/{course_id}/ol_openedx_outline/:
     get:
       operationId: course_outline_retrieve_v3
       description: Fetch course outline data for the given course key from Open edX.

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -3264,6 +3264,58 @@ paths:
           description: No response body
         '404':
           description: No response body
+  /api/v3/courses/{course_id}/outline/:
+    get:
+      operationId: course_outline_retrieve_v3
+      description: Fetch course outline data for the given course key from Open edX.
+      parameters:
+      - in: path
+        name: course_id
+        schema:
+          type: string
+        description: Open edX course key (URL-encoded recommended), e.g. course-v1%3AOpenedX%2BDemoX%2BDemoCourse
+        required: true
+      tags:
+      - courses
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineResponse'
+              examples:
+                CourseOutlineSuccess:
+                  value:
+                    course_id: course-v1:OpenedX+DemoX+DemoCourse
+                    generated_at: '2026-04-10T07:17:20Z'
+                    modules:
+                    - id: block-v1:OpenedX+DemoX+DemoCourse+type@chapter+block@abc123
+                      title: Module 1
+                      effort_time: 0
+                      effort_activities: 0
+                      counts:
+                        videos: 2
+                        readings: 1
+                        problems: 1
+                        assignments: 0
+                        app_items: 0
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineAuthErrorResponse'
+              examples:
+                AuthError:
+                  value:
+                    detail: Authentication credentials were not provided.
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+          description: ''
   /api/v3/enrollments/:
     get:
       operationId: user_enrollments_list_v3
@@ -4019,6 +4071,36 @@ components:
       - programs
       - readable_id
       - title
+    CourseOutlineAuthErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
+    CourseOutlineResponse:
+      type: object
+      properties:
+        course_id:
+          type: string
+        generated_at:
+          type: string
+        modules:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+      - course_id
+      - generated_at
+      - modules
+    CourseOutlineUpstreamErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     CoursePage:
       type: object
       description: Course page model serializer

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -3277,6 +3277,8 @@ paths:
         required: true
       tags:
       - courses
+      security:
+      - {}
       responses:
         '200':
           content:
@@ -3300,21 +3302,32 @@ paths:
                         assignments: 0
                         app_items: 0
           description: ''
-        '403':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CourseOutlineAuthErrorResponse'
+                $ref: '#/components/schemas/CourseOutlineBadRequestResponse'
               examples:
-                AuthError:
+                InvalidCourseId:
                   value:
-                    detail: Authentication credentials were not provided.
+                    detail: Invalid course_id format. Expected an Open edX course
+                      key.
+          description: ''
+        '502':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+              examples:
+                UpstreamError:
+                  value:
+                    detail: Unable to fetch course outline from Open edX.
           description: ''
         '500':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CourseOutlineUpstreamErrorResponse'
+                $ref: '#/components/schemas/CourseOutlineServerErrorResponse'
           description: ''
   /api/v3/enrollments/:
     get:
@@ -4071,7 +4084,7 @@ components:
       - programs
       - readable_id
       - title
-    CourseOutlineAuthErrorResponse:
+    CourseOutlineBadRequestResponse:
       type: object
       properties:
         detail:
@@ -4094,6 +4107,13 @@ components:
       - course_id
       - generated_at
       - modules
+    CourseOutlineServerErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     CourseOutlineUpstreamErrorResponse:
       type: object
       properties:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -3264,7 +3264,7 @@ paths:
           description: No response body
         '404':
           description: No response body
-  /api/v3/courses/{course_id}/outline/:
+  /api/v3/courses/{course_id}/ol_openedx_outline/:
     get:
       operationId: course_outline_retrieve_v3
       description: Fetch course outline data for the given course key from Open edX.

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -915,26 +915,24 @@ def get_edx_course_outline(course_id: str) -> dict:
         )
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
+        message = "Open edX course outline request failed"
         log.exception(
             "Failed to fetch Open edX course outline for course_id=%s url=%s",
             course_id,
             outline_url,
         )
-        raise EdxApiCourseOutlineError(
-            "Open edX course outline request failed"
-        ) from exc
+        raise EdxApiCourseOutlineError(message) from exc
 
     try:
         return response.json()
     except (ValueError, requests.exceptions.JSONDecodeError) as exc:
+        message = "Open edX course outline response was invalid"
         log.exception(
             "Open edX course outline response was not valid JSON for course_id=%s url=%s",
             course_id,
             outline_url,
         )
-        raise EdxApiCourseOutlineError(
-            "Open edX course outline response was invalid"
-        ) from exc
+        raise EdxApiCourseOutlineError(message) from exc
 
 
 def get_edx_api_jwt_client(

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -897,22 +897,15 @@ def get_edx_course_outline(course_id: str) -> dict:
     Returns:
         dict: Parsed JSON response from the outline API
     """
-    if settings.OPENEDX_SERVICE_WORKER_API_TOKEN is None:
-        raise ImproperlyConfigured("OPENEDX_SERVICE_WORKER_API_TOKEN is not set")  # noqa: EM101
-
+    edx_client = get_edx_api_service_client()
     encoded_course_id = quote(course_id, safe="")
-    outline_path = settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE.format(
+    outline_path = settings.OL_OPENEDX_COURSE_OUTLINE_URL.format(
         course_id=encoded_course_id
     )
     outline_url = edx_url(outline_path)
+    requester = edx_client.get_requester()
     try:
-        response = requests.get(
-            outline_url,
-            headers={
-                "Authorization": f"Bearer {settings.OPENEDX_SERVICE_WORKER_API_TOKEN}"
-            },
-            timeout=settings.EDX_API_CLIENT_TIMEOUT,
-        )
+        response = requester.get(outline_url)
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         message = "Open edX course outline request failed"

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -39,6 +39,7 @@ from openedx.constants import (
     PLATFORM_EDX,
 )
 from openedx.exceptions import (
+    EdxApiCourseOutlineError,
     EdxApiEmailSettingsErrorException,
     EdxApiEnrollErrorException,
     EdxApiRegistrationValidationException,
@@ -904,25 +905,36 @@ def get_edx_course_outline(course_id: str) -> dict:
         course_id=encoded_course_id
     )
     outline_url = edx_url(outline_path)
-    response = requests.get(
-        outline_url,
-        headers={
-            "Authorization": f"Bearer {settings.OPENEDX_SERVICE_WORKER_API_TOKEN}"
-        },
-        timeout=settings.EDX_API_CLIENT_TIMEOUT,
-    )
-
     try:
+        response = requests.get(
+            outline_url,
+            headers={
+                "Authorization": f"Bearer {settings.OPENEDX_SERVICE_WORKER_API_TOKEN}"
+            },
+            timeout=settings.EDX_API_CLIENT_TIMEOUT,
+        )
         response.raise_for_status()
-    except HTTPError:
+    except requests.exceptions.RequestException as exc:
         log.exception(
             "Failed to fetch Open edX course outline for course_id=%s url=%s",
             course_id,
             outline_url,
         )
-        raise
+        raise EdxApiCourseOutlineError(
+            "Open edX course outline request failed"
+        ) from exc
 
-    return response.json()
+    try:
+        return response.json()
+    except (ValueError, requests.exceptions.JSONDecodeError) as exc:
+        log.exception(
+            "Open edX course outline response was not valid JSON for course_id=%s url=%s",
+            course_id,
+            outline_url,
+        )
+        raise EdxApiCourseOutlineError(
+            "Open edX course outline response was invalid"
+        ) from exc
 
 
 def get_edx_api_jwt_client(

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -4,7 +4,7 @@ import logging
 import random
 from datetime import datetime, timedelta
 from functools import partial
-from urllib.parse import parse_qs, urljoin, urlparse
+from urllib.parse import parse_qs, quote, urljoin, urlparse
 
 import requests
 from django.conf import settings
@@ -885,6 +885,44 @@ def get_edx_api_service_client():
     )
 
     return edx_client  # noqa: RET504
+
+
+def get_edx_course_outline(course_id: str) -> dict:
+    """
+    Fetch course outline data from the Open edX course outline plugin endpoint.
+
+    Args:
+        course_id (str): edX course key (e.g., course-v1:MITx+1.00x+1T2026)
+    Returns:
+        dict: Parsed JSON response from the outline API
+    """
+    if settings.OPENEDX_SERVICE_WORKER_API_TOKEN is None:
+        raise ImproperlyConfigured("OPENEDX_SERVICE_WORKER_API_TOKEN is not set")  # noqa: EM101
+
+    encoded_course_id = quote(course_id, safe="")
+    outline_path = settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE.format(
+        course_id=encoded_course_id
+    )
+    outline_url = edx_url(outline_path)
+    response = requests.get(
+        outline_url,
+        headers={
+            "Authorization": f"Bearer {settings.OPENEDX_SERVICE_WORKER_API_TOKEN}"
+        },
+        timeout=settings.EDX_API_CLIENT_TIMEOUT,
+    )
+
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        log.exception(
+            "Failed to fetch Open edX course outline for course_id=%s url=%s",
+            course_id,
+            outline_url,
+        )
+        raise
+
+    return response.json()
 
 
 def get_edx_api_jwt_client(

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -10,6 +10,7 @@ import factory
 import pytest
 import responses
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
 from edx_api.course_runs.exceptions import CourseRunAPIError
 from freezegun import freeze_time
 from mitol.common.utils.datetime import now_in_utc
@@ -37,6 +38,7 @@ from openedx.api import (
     existing_edx_enrollment,
     generate_unique_username,
     get_edx_api_client,
+    get_edx_course_outline,
     get_edx_retirement_service_client,
     get_valid_edx_api_auth,
     process_course_run_clone,
@@ -777,6 +779,69 @@ def test_get_edx_api_client(mocker, settings, user):
     mock_refresh.assert_called_with(
         user, ttl_in_seconds=OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS
     )
+
+
+@responses.activate
+def test_get_edx_course_outline(settings):
+    """Tests that get_edx_course_outline fetches and returns outline JSON."""
+    settings.OPENEDX_API_BASE_URL = "http://example.com"
+    settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
+    settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = (
+        "/api/ol-course-outline/v0/{course_id}/"
+    )
+    settings.EDX_API_CLIENT_TIMEOUT = 30
+
+    course_id = "course-v1:OpenedX+DemoX+DemoCourse"
+    encoded_course_id = "course-v1%3AOpenedX%2BDemoX%2BDemoCourse"
+    expected_payload = {
+        "course_id": course_id,
+        "blocks": [{"id": "block-v1:demo+type@chapter+block@week1"}],
+    }
+    resp = responses.add(
+        responses.GET,
+        f"{settings.OPENEDX_API_BASE_URL}/api/ol-course-outline/v0/{encoded_course_id}/",
+        json=expected_payload,
+        status=status.HTTP_200_OK,
+    )
+
+    result = get_edx_course_outline(course_id)
+
+    assert result == expected_payload
+    assert resp.call_count == 1
+    assert (
+        resp.calls[0].request.headers["Authorization"]
+        == f"Bearer {settings.OPENEDX_SERVICE_WORKER_API_TOKEN}"
+    )
+
+
+@responses.activate
+def test_get_edx_course_outline_http_error(settings):
+    """Tests that get_edx_course_outline raises HTTPError on failure response."""
+    settings.OPENEDX_API_BASE_URL = "http://example.com"
+    settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
+    settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = (
+        "/api/ol-course-outline/v0/{course_id}/"
+    )
+
+    course_id = "course-v1:OpenedX+DemoX+DemoCourse"
+    encoded_course_id = "course-v1%3AOpenedX%2BDemoX%2BDemoCourse"
+    responses.add(
+        responses.GET,
+        f"{settings.OPENEDX_API_BASE_URL}/api/ol-course-outline/v0/{encoded_course_id}/",
+        json={"detail": "Not found"},
+        status=status.HTTP_404_NOT_FOUND,
+    )
+
+    with pytest.raises(HTTPError):
+        get_edx_course_outline(course_id)
+
+
+def test_get_edx_course_outline_missing_service_token(settings):
+    """Tests that get_edx_course_outline requires OPENEDX_SERVICE_WORKER_API_TOKEN."""
+    settings.OPENEDX_SERVICE_WORKER_API_TOKEN = None
+
+    with pytest.raises(ImproperlyConfigured):
+        get_edx_course_outline("course-v1:OpenedX+DemoX+DemoCourse")
 
 
 def test_get_edx_retirement_service_client(mocker, settings):

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -787,9 +787,7 @@ def test_get_edx_course_outline(settings):
     """Tests that get_edx_course_outline fetches and returns outline JSON."""
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
-    settings.OL_OPENEDX_COURSE_OUTLINE_URL = (
-        "/api/ol-course-outline/v0/{course_id}/"
-    )
+    settings.OL_OPENEDX_COURSE_OUTLINE_URL = "/api/ol-course-outline/v0/{course_id}/"
     settings.EDX_API_CLIENT_TIMEOUT = 30
 
     course_id = "course-v1:OpenedX+DemoX+DemoCourse"
@@ -820,9 +818,7 @@ def test_get_edx_course_outline_http_error(settings):
     """Tests that get_edx_course_outline raises upstream error on failure response."""
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
-    settings.OL_OPENEDX_COURSE_OUTLINE_URL = (
-        "/api/ol-course-outline/v0/{course_id}/"
-    )
+    settings.OL_OPENEDX_COURSE_OUTLINE_URL = "/api/ol-course-outline/v0/{course_id}/"
 
     course_id = "course-v1:OpenedX+DemoX+DemoCourse"
     encoded_course_id = "course-v1%3AOpenedX%2BDemoX%2BDemoCourse"
@@ -842,9 +838,7 @@ def test_get_edx_course_outline_invalid_json(settings):
     """Tests that get_edx_course_outline raises invalid response for bad JSON."""
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
-    settings.OL_OPENEDX_COURSE_OUTLINE_URL = (
-        "/api/ol-course-outline/v0/{course_id}/"
-    )
+    settings.OL_OPENEDX_COURSE_OUTLINE_URL = "/api/ol-course-outline/v0/{course_id}/"
 
     course_id = "course-v1:OpenedX+DemoX+DemoCourse"
     encoded_course_id = "course-v1%3AOpenedX%2BDemoX%2BDemoCourse"

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -66,6 +66,7 @@ from openedx.constants import (
     PLATFORM_EDX,
 )
 from openedx.exceptions import (
+    EdxApiCourseOutlineError,
     EdxApiEmailSettingsErrorException,
     EdxApiEnrollErrorException,
     EdxApiRegistrationValidationException,
@@ -816,7 +817,7 @@ def test_get_edx_course_outline(settings):
 
 @responses.activate
 def test_get_edx_course_outline_http_error(settings):
-    """Tests that get_edx_course_outline raises HTTPError on failure response."""
+    """Tests that get_edx_course_outline raises upstream error on failure response."""
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
     settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = (
@@ -832,7 +833,30 @@ def test_get_edx_course_outline_http_error(settings):
         status=status.HTTP_404_NOT_FOUND,
     )
 
-    with pytest.raises(HTTPError):
+    with pytest.raises(EdxApiCourseOutlineError):
+        get_edx_course_outline(course_id)
+
+
+@responses.activate
+def test_get_edx_course_outline_invalid_json(settings):
+    """Tests that get_edx_course_outline raises invalid response for bad JSON."""
+    settings.OPENEDX_API_BASE_URL = "http://example.com"
+    settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
+    settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = (
+        "/api/ol-course-outline/v0/{course_id}/"
+    )
+
+    course_id = "course-v1:OpenedX+DemoX+DemoCourse"
+    encoded_course_id = "course-v1%3AOpenedX%2BDemoX%2BDemoCourse"
+    responses.add(
+        responses.GET,
+        f"{settings.OPENEDX_API_BASE_URL}/api/ol-course-outline/v0/{encoded_course_id}/",
+        body="not-json",
+        content_type="text/plain",
+        status=status.HTTP_200_OK,
+    )
+
+    with pytest.raises(EdxApiCourseOutlineError):
         get_edx_course_outline(course_id)
 
 

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -787,7 +787,7 @@ def test_get_edx_course_outline(settings):
     """Tests that get_edx_course_outline fetches and returns outline JSON."""
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
-    settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = (
+    settings.OL_OPENEDX_COURSE_OUTLINE_URL = (
         "/api/ol-course-outline/v0/{course_id}/"
     )
     settings.EDX_API_CLIENT_TIMEOUT = 30
@@ -820,7 +820,7 @@ def test_get_edx_course_outline_http_error(settings):
     """Tests that get_edx_course_outline raises upstream error on failure response."""
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
-    settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = (
+    settings.OL_OPENEDX_COURSE_OUTLINE_URL = (
         "/api/ol-course-outline/v0/{course_id}/"
     )
 
@@ -842,7 +842,7 @@ def test_get_edx_course_outline_invalid_json(settings):
     """Tests that get_edx_course_outline raises invalid response for bad JSON."""
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "outline_token"  # noqa: S105
-    settings.OPENEDX_COURSE_OUTLINE_PATH_TEMPLATE = (
+    settings.OL_OPENEDX_COURSE_OUTLINE_URL = (
         "/api/ol-course-outline/v0/{course_id}/"
     )
 

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -128,3 +128,7 @@ class EdxApiRegistrationValidationException(Exception):  # noqa: N818
 
 class OpenEdxUserMissingError(Exception):
     """We tried to do something that requires an Open edX user, and there isn't one."""
+
+
+class EdxApiCourseOutlineError(Exception):  # noqa: N818
+    """Base exception for Open edX course outline fetch errors."""

--- a/openedx/exceptions.py
+++ b/openedx/exceptions.py
@@ -130,5 +130,5 @@ class OpenEdxUserMissingError(Exception):
     """We tried to do something that requires an Open edX user, and there isn't one."""
 
 
-class EdxApiCourseOutlineError(Exception):  # noqa: N818
+class EdxApiCourseOutlineError(Exception):
     """Base exception for Open edX course outline fetch errors."""


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10907

### Description (What does it do?)
Adds MITxOnline support for fetching Open edX course outline data and exposing it through a course-scoped v3 API endpoint for downstream consumers (MIT Learn).

- Added Open edX outline fetch helper in openedx/api.py
- Added config for outline path template in main/settings.py
- Exposed endpoint: GET /api/v3/courses/<course_id>/ol_openedx_outline/
- Added/updated tests


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- Ensure Open edX is running and reachable from MITxOnline.

- Set required MITxOnline env vars:

```
OPENEDX_API_BASE_URL (local: http://local.openedx.io:8000)
OPENEDX_SERVICE_WORKER_API_TOKEN
OPENEDX_SERVICE_WORKER_USERNAME
```

- Recreate services after env changes:

```
docker compose up -d --force-recreate web celery
docker compose restart nginx varnish
```

- Create MITxOnline API key (or use logged-in session):

`docker compose exec web /bin/bash -lc '/opt/venv/bin/python manage.py shell -c "from rest_framework_api_key.models import APIKey; _, key = APIKey.objects.create_key(name=\"mit-learn-outline-test\"); print(key)"'`

- Call endpoint with encoded course key:

`curl -i -H "Authorization: Api-Key <KEY>" "http://mitxonline.odl.local:8013/api/v3/courses/course-v1%3AOpenedX%2BDemoX%2BDemoCourse/ol_openedx_outline/"`

- Expected:

```
200 with JSON outline payload (course_id, generated_at, modules)
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
