### PR TITLE
Fix deleted items issues in ProductAdmin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -94,7 +94,10 @@ class ProductAdmin(VersionAdmin):
         """Soft-delete using the queryset."""
 
         with reversion.create_revision():
-            queryset.update(is_active=False)
+            for item in queryset:
+                item.is_active = False
+                item.save()
+
             reversion.set_user(request.user)
 
 

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -82,16 +82,20 @@ class ProductAdmin(VersionAdmin):
             super().save_model(request, obj, form, change)
             reversion.set_user(request.user)
 
-    def delete_model(self, request, obj):  # noqa: ARG002
+    def delete_model(self, request, obj):
         """Soft-delete the model."""
 
-        obj.is_active = False
-        obj.save()
+        with reversion.create_revision():
+            obj.is_active = False
+            obj.save()
+            reversion.set_user(request.user)
 
-    def delete_queryset(self, request, queryset):  # noqa: ARG002
+    def delete_queryset(self, request, queryset):
         """Soft-delete using the queryset."""
 
-        queryset.update(is_active=False)
+        with reversion.create_revision():
+            queryset.update(is_active=False)
+            reversion.set_user(request.user)
 
 
 @admin.register(Basket)

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -60,7 +60,7 @@ class ProductAdmin(VersionAdmin):
     list_filter = ("content_type", "is_active")
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
-        product = Product.objects.get(id=object_id)
+        product = Product.all_objects.get(id=object_id)
         extra_context = {"subtitle": self.content_object(product)}
         return super(ProductAdmin, self).change_view(  # noqa: UP008
             request, object_id, form_url, extra_context
@@ -69,10 +69,6 @@ class ProductAdmin(VersionAdmin):
     def content_object(self, obj):
         """Return the content object details"""
         return str(obj.purchasable_object)
-
-    def has_delete_permission(self, request, obj=None):  # noqa: ARG002
-        """Disable the delete permission for Product models"""
-        return False
 
     def get_queryset(self, request):  # noqa: ARG002
         """
@@ -85,6 +81,17 @@ class ProductAdmin(VersionAdmin):
         with reversion.create_revision():
             super().save_model(request, obj, form, change)
             reversion.set_user(request.user)
+
+    def delete_model(self, request, obj):  # noqa: ARG002
+        """Soft-delete the model."""
+
+        obj.is_active = False
+        obj.save()
+
+    def delete_queryset(self, request, queryset):  # noqa: ARG002
+        """Soft-delete using the queryset."""
+
+        queryset.update(is_active=False)
 
 
 @admin.register(Basket)


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#10771

### Description (What does it do?)

Updates the ProductAdmin's `change_view` function to use the proper manager. It was using `objects` and not `all_objects`, so if you tried to load a deleted item, you'd get a 500 error.

Also, makes soft-deletion work better. The `PartnerSchoolAdmin` is set up to treat deletions as deactivations, so just grabbed that code and put it in here too, with the requisite version creation.

### How can this be tested?

Delete a product (set it to be inactive). You should still be able to pull it up in Django Admin.

Delete a product in Django Admin. It should just deactivate the product, and you should get a new product version out of that.

Delete a few products in Django Admin. They should all get new versions and they should all just be deactivated.
