### PR TITLE
fix: if user is not sync'd with edX yet, don't raise

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -407,6 +407,19 @@ def _create_edx_user_request(open_edx_user, user, access_token):  # noqa: C901, 
         lock.release()
 
 
+def _edx_user_exists(user):
+    """
+    Returns True if the user can be verified to exist in edX, False otherwise.
+    """
+    try:
+        client = get_edx_api_client(user)
+        if client is not None:
+            client.user_info.get_user_info()
+    except:  # noqa: E722
+        return False
+    return True
+
+
 def create_edx_user(user, edx_username=None):
     """
     Makes a request to create an equivalent user in Open edX
@@ -442,17 +455,11 @@ def create_edx_user(user, edx_username=None):
         log.warning("create_edx_user: skipping create for %s, no edx_username", user)
         return False
 
-    if open_edx_user.has_been_synced:
-        # Here we should check with edx that the user exists on that end.
-        try:
-            client = get_edx_api_client(user)
-            client.user_info.get_user_info()
-        except:  # noqa: S110, E722
-            pass
-        else:
-            open_edx_user.has_been_synced = True
-            open_edx_user.save()
-            return False
+    if open_edx_user.has_been_synced and _edx_user_exists(user):
+        # User already exists in edX, mark as synced and skip creation
+        open_edx_user.has_been_synced = True
+        open_edx_user.save()
+        return False
 
     try:
         return _create_edx_user_request(open_edx_user, user, access_token)
@@ -857,7 +864,14 @@ def get_edx_api_client(user, ttl_in_seconds=OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS)
     # has an OpenEdxApiAuth record before we try to read it. It is idempotent: internally
     # it uses get_or_create, so calling it on every request is safe and causes no side
     # effects when the record already exists.
-    create_edx_auth_token(user)
+    if create_edx_auth_token(user) is None:
+        if settings.FEATURES.get(features.IGNORE_EDX_FAILURES, False):
+            log.warning(
+                "get_edx_api_client: user %s is not yet synced with edX, skipping", user
+            )
+            return None
+        raise NoEdxApiAuthError(f"{user!s} is not yet synced with edX")  # noqa: EM102
+
     try:
         auth = get_valid_edx_api_auth(user, ttl_in_seconds=ttl_in_seconds)
     except OpenEdxApiAuth.DoesNotExist:
@@ -1284,6 +1298,8 @@ def update_edx_user_name(user):
         UserNameUpdateFailedException: Raised if underlying edX API request fails due to any reason
     """
     edx_client = get_edx_api_client(user)
+    if edx_client is None:
+        return None
     try:
         return edx_client.user_info.update_user_name(user.edx_username, user.name)
     except Exception as exc:  # noqa: BLE001
@@ -1298,6 +1314,8 @@ def sync_enrollments_with_edx(
 ) -> SyncResult[courses.models.CourseRunEnrollment]:
     """Syncs enrollment records so that local enrollments match the enrollment data in edX"""
     client = get_edx_api_client(user)
+    if client is None:
+        return SyncResult()
     edx_enrollments = client.enrollments.get_student_enrollments()
     local_enrollments = (
         user.courserunenrollment_set(manager="all_objects")
@@ -1374,6 +1392,8 @@ def subscribe_to_edx_course_emails(user, course_run):
         EdxApiChangeEmailSettingsException: Raised if an unknown error was encountered during the edX API request
     """
     edx_client = get_edx_api_client(user)
+    if edx_client is None:
+        return None
     try:
         result = edx_client.email_settings.subscribe(course_run.courseware_id)
     except HTTPError as exc:
@@ -1400,6 +1420,8 @@ def unsubscribe_from_edx_course_emails(user, course_run):
         EdxApiChangeEmailSettingsException: Raised if an unknown error was encountered during the edX API request
     """
     edx_client = get_edx_api_client(user)
+    if edx_client is None:
+        return None
     try:
         result = edx_client.email_settings.unsubscribe(course_run.courseware_id)
     except HTTPError as exc:

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -413,8 +413,9 @@ def _edx_user_exists(user):
     """
     try:
         client = get_edx_api_client(user)
-        if client is not None:
-            client.user_info.get_user_info()
+        if client is None:
+            return False
+        client.user_info.get_user_info()
     except:  # noqa: E722
         return False
     return True

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -457,9 +457,7 @@ def create_edx_user(user, edx_username=None):
         return False
 
     if open_edx_user.has_been_synced and _edx_user_exists(user):
-        # User already exists in edX, mark as synced and skip creation
-        open_edx_user.has_been_synced = True
-        open_edx_user.save()
+        # User already exists in edX, skip creation
         return False
 
     try:

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -1357,6 +1357,14 @@ def test_sync_enrollments_with_edx_missing(mocker, user):
     assert results == SyncResult()
 
 
+def test_sync_enrollments_with_edx_not_synced(mocker, user):
+    """sync_enrollments_with_edx returns an empty SyncResult without calling edX when client is None"""
+    CourseRunEnrollmentFactory.create(user=user, active=True)
+    mocker.patch("openedx.api.get_edx_api_client", return_value=None)
+    result = sync_enrollments_with_edx(user)
+    assert result == SyncResult()
+
+
 def test_subscribe_to_edx_course_emails(mocker, user):
     """Tests that subscribe_to_edx_course_emails makes a call to subscribe for course emails in edX via api client"""
     mock_client = mocker.MagicMock()
@@ -1373,6 +1381,14 @@ def test_subscribe_to_edx_course_emails(mocker, user):
 
     mock_client.email_settings.subscribe.assert_called_once_with(courseware_id)
     assert subscribe_to_course_emails == subscribe_return_value
+
+
+def test_subscribe_to_edx_course_emails_not_synced(mocker, user):
+    """subscribe_to_edx_course_emails returns None without calling edX when client is None"""
+    run_enrollment = CourseRunEnrollmentFactory()
+    mocker.patch("openedx.api.get_edx_api_client", return_value=None)
+    result = subscribe_to_edx_course_emails(user, run_enrollment.run)
+    assert result is None
 
 
 @pytest.mark.parametrize(
@@ -1414,6 +1430,14 @@ def test_unsubscribe_from_edx_course_emails(mocker, user):
 
     mock_client.email_settings.unsubscribe.assert_called_once_with(courseware_id)
     assert unsubscribe_to_course_emails == unsubscribe_return_value
+
+
+def test_unsubscribe_from_edx_course_emails_not_synced(mocker, user):
+    """unsubscribe_from_edx_course_emails returns None without calling edX when client is None"""
+    run_enrollment = CourseRunEnrollmentFactory()
+    mocker.patch("openedx.api.get_edx_api_client", return_value=None)
+    result = unsubscribe_from_edx_course_emails(user, run_enrollment.run)
+    assert result is None
 
 
 @pytest.mark.parametrize(

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -71,6 +71,7 @@ from openedx.exceptions import (
     EdxApiEnrollErrorException,
     EdxApiRegistrationValidationException,
     EdxApiUserUpdateError,
+    NoEdxApiAuthError,
     UnknownEdxApiEmailSettingsException,
     UnknownEdxApiEnrollException,
     UserNameUpdateFailedException,
@@ -862,9 +863,22 @@ def test_get_edx_course_outline_missing_service_token(settings):
         get_edx_course_outline("course-v1:OpenedX+DemoX+DemoCourse")
 
 
+def test_get_edx_api_client_not_synced_raises(mocker, user):
+    """get_edx_api_client raises NoEdxApiAuthError when user is not synced and IGNORE_EDX_FAILURES is False"""
+    mocker.patch("openedx.api.create_edx_auth_token", return_value=None)
+    with pytest.raises(NoEdxApiAuthError):
+        get_edx_api_client(user)
+
+
+def test_get_edx_api_client_not_synced_ignore_failures(mocker, settings, user):
+    """get_edx_api_client returns None when user is not synced and IGNORE_EDX_FAILURES is True"""
+    settings.FEATURES = {"IGNORE_EDX_FAILURES": True}
+    mocker.patch("openedx.api.create_edx_auth_token", return_value=None)
+    assert get_edx_api_client(user) is None
+
+
 def test_get_edx_retirement_service_client(mocker, settings):
     """Tests that get_edx_retirement_service_client returns an EdxApi client"""
-
     settings.OPENEDX_API_BASE_URL = "http://example.com"
     settings.OPENEDX_RETIREMENT_SERVICE_WORKER_CLIENT_ID = (
         "OPENEDX_RETIREMENT_SERVICE_WORKER_CLIENT_ID"
@@ -1235,6 +1249,22 @@ def test_update_edx_user_name_creates_missing_auth(mocker, user):
         user.edx_username, user.name
     )
     assert result == update_name_return_value
+
+
+def test_update_edx_user_name_not_synced(mocker, user):
+    """update_edx_user_name returns None without calling edX when user is not yet synced"""
+    mocker.patch("openedx.api.get_edx_api_client", return_value=None)
+    result = update_edx_user_name(user)
+    assert result is None
+
+
+def test_update_edx_user_name_not_synced_raises(mocker, user):
+    """update_edx_user_name propagates NoEdxApiAuthError when user is not synced and IGNORE_EDX_FAILURES is False"""
+    mocker.patch(
+        "openedx.api.get_edx_api_client", side_effect=NoEdxApiAuthError("not synced")
+    )
+    with pytest.raises(NoEdxApiAuthError):
+        update_edx_user_name(user)
 
 
 def test_sync_enrollments_with_edx_active(mocker, user):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10624#issuecomment-4259248487

### Description (What does it do?)
This pull request improves the reliability and safety of Open edX user synchronization by adding explicit checks for user existence in edX and handling cases where the user is not yet synced. It introduces a helper function to verify user existence, updates several functions to gracefully handle missing users, and ensures that API clients are only created when appropriate.

**API client creation and error handling:**

* Modified `get_edx_api_client` to return `None` (instead of raising an error) when a user is not yet synced with edX, if the `IGNORE_EDX_FAILURES` feature is enabled; otherwise, it raises a specific exception.

### How can this be tested?
1. Ensure a user exists who has not been synced to edX (`has_been_synced=False` on their `OpenEdxUser` record)
2. Go to Django admin → OpenEdx Users → find the user → confirm `has_been_synced` is unchecked
3. In `.env`, ensure `IGNORE_EDX_FAILURES` is set to True
4. Get into django shell `docker compose run --rm web python manage.py shell` and run:
```python
from django.contrib.auth import get_user_model
from openedx.api import get_edx_api_client

user = get_user_model().objects.get(email="your-unsynced-user@example.com")
get_edx_api_client(user)  # should raise NoEdxApiAuthError if IGNORE_EDX_FAILURES is set to False
```
5. WARNING "get_edx_api_client: user <email> is not yet synced with edX, skipping"

### Additional Context
There are scenarios when `change_edx_user_name_async` tasks fails when the user is not yet sync'd with edX.
We have confirmed it only happens once for a single user.