### PR TITLE
Force explicit calls to generate enrollment codes for B2B contracts

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -32,7 +32,7 @@ from b2b.models import (
     OrganizationPage,
     UserOrganization,
 )
-from b2b.tasks import queue_contract_sheet_update_post_save
+from b2b.tasks import queue_contract_sheet_update_post_save, queue_enrollment_code_check
 from cms.api import get_home_page
 from courses.constants import UAI_COURSEWARE_ID_PREFIX
 from courses.models import Course, CourseRun, Department, EnrollmentMode
@@ -286,6 +286,7 @@ def create_contract_run(  # noqa: PLR0913
     require_designated_source_run=True,
     org_prefix: str | None = UAI_COURSEWARE_ID_PREFIX,
     no_reruns: bool = False,
+    queue_codes: bool = False,
 ) -> tuple[CourseRun, Product]:
     """
     Create a run for the specified contract.
@@ -435,9 +436,8 @@ def create_contract_run(  # noqa: PLR0913
             contract,
         )
 
-    # Saving the contract here triggers any shoring up of related data that we
-    # need to do, like generating enrollment codes.
-    contract.save()
+    if queue_codes:
+        queue_enrollment_code_check.delay(contract.id)
 
     return course_run, course_run_product
 

--- a/b2b/api_test.py
+++ b/b2b/api_test.py
@@ -39,7 +39,6 @@ from b2b.api import (
 )
 from b2b.constants import (
     B2B_RUN_TAG_FORMAT,
-    CONTRACT_MEMBERSHIP_CODE,
     CONTRACT_MEMBERSHIP_NONSSO,
     CONTRACT_MEMBERSHIP_SSO,
 )
@@ -310,7 +309,7 @@ def test_ensure_enrollment_codes(  # noqa: PLR0913
 
     assert contract.get_discounts().count() == 0
 
-    _, product = create_contract_run(contract, course)
+    _, product = create_contract_run(contract, course, queue_codes=True)
     assert mocked_ensure_call.called
 
     ensure_enrollment_codes_exist(contract)
@@ -429,6 +428,7 @@ def test_create_b2b_enrollment(  # noqa: PLR0913, C901, PLR0915
     mocker.patch("openedx.api.enroll_in_edx_course_runs")
     mocker.patch("hubspot_sync.task_helpers.sync_hubspot_deal")
     mocker.patch("hubspot_sync.tasks.sync_deal_with_hubspot.apply_async")
+    mocker.patch("hubspot_sync.tasks.sync_cart_add_event_with_hubspot.apply_async")
     if not user_has_valid_edx_user:
         mocked_create_user = mocker.patch("openedx.api._create_edx_user_request")
     settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "a token"  # noqa: S105
@@ -442,7 +442,7 @@ def test_create_b2b_enrollment(  # noqa: PLR0913, C901, PLR0915
         else FAKE.pydecimal(left_digits=2, right_digits=2, positive=True),
     )
     (course, _) = contract_ready_course
-    run, product = create_contract_run(contract, course)
+    run, product = create_contract_run(contract, course, queue_codes=True)
 
     if not product_in_contract:
         # just create something random - this is like someone fuzzing the API
@@ -1419,61 +1419,6 @@ def test_create_contract_run_key():
         assert new_course_key.run == B2B_RUN_TAG_FORMAT.format(
             run_idx=run_idx, contract_id=contract_id, year=next_year.year
         )
-
-
-@pytest.mark.parametrize("has_learner_cap", [True, False])
-def test_ensure_enrollment_codes_courseware_changes(
-    mocker, make_contract_ready_course, has_learner_cap
-):
-    """
-    Test that ensure_enrollment_codes works properly when there are courseware changes.
-
-    If a course is added to the contract, then the system should make an
-    appropriate amount of new codes for the contract.
-    """
-
-    mocker.patch("openedx.tasks.clone_courserun.delay")
-    mocked_ensure_call = mocker.patch("b2b.tasks.queue_enrollment_code_check.delay")
-    max_learners = FAKE.random_int(min=10, max=15) if has_learner_cap else None
-
-    contract = factories.ContractPageFactory(
-        integration_type=CONTRACT_MEMBERSHIP_CODE,
-        membership_type=CONTRACT_MEMBERSHIP_CODE,
-        max_learners=max_learners,
-    )
-
-    max_learners = max_learners if max_learners else 1
-
-    (course, _) = make_contract_ready_course()
-
-    assert contract.get_discounts().count() == 0
-
-    _, product = create_contract_run(contract, course)
-    assert mocked_ensure_call.called
-
-    ensure_enrollment_codes_exist(contract)
-
-    assert contract.get_discounts().count() == max_learners
-    assert (
-        contract.get_discounts().filter(products__product=product).count()
-        == max_learners
-    )
-
-    (course, _) = make_contract_ready_course()
-    _, product_2 = create_contract_run(contract, course)
-    assert mocked_ensure_call.called
-
-    ensure_enrollment_codes_exist(contract)
-
-    assert contract.get_discounts().count() == (2 * max_learners)
-    assert (
-        contract.get_discounts().filter(products__product=product).count()
-        == max_learners
-    )
-    assert (
-        contract.get_discounts().filter(products__product=product_2).count()
-        == max_learners
-    )
 
 
 def test_apply_available_discount_seat_limit():

--- a/b2b/management/commands/b2b_courseware.py
+++ b/b2b/management/commands/b2b_courseware.py
@@ -14,6 +14,7 @@ from opaque_keys import InvalidKeyError
 
 from b2b.api import create_contract_run, import_and_create_contract_run
 from b2b.models import ContractPage, ContractProgramItem
+from b2b.tasks import queue_enrollment_code_check
 from courses.api import resolve_courseware_object_from_id
 from courses.constants import UAI_COURSEWARE_ID_PREFIX
 from courses.models import CourseRun, CourseRunEnrollment
@@ -33,7 +34,7 @@ Courseware objects can be course runs, courses, or programs. specified by their 
 Specifying courseware: You must specify one courseware item (of any type). You can specify more than one by adding "--also <courseware id>" to the end of the command. You can repeat this as many times as necessary.
 
 To add courseware:
-   b2b_courseware add [--import <departments>] [--no-create-runs] [--force] [--prefix <prefix>] <contract> <courseware> [--also <courseware>] [--also <courseware>...]
+   b2b_courseware add [--import <departments>] [--no-create-runs] [--force] [--prefix <prefix>] [--make-codes] <contract> <courseware> [--also <courseware>] [--also <courseware>...]
 
 Example: b2b_courseware add contract-100-101 program-v1:UAI+Fundamentals --also course-v1:UAI_C100+14.314x+2025_C101
 
@@ -153,6 +154,11 @@ Specifying a program will only unlink the program from the contract, unless "--r
             help=f"Organization prefix for the resulting course run. (Defaults to the org setting, or {UAI_COURSEWARE_ID_PREFIX}.)",
             type=str,
         )
+        add_subparser.add_argument(
+            "--make-codes",
+            action="store_true",
+            help="Create enrollment codes after adding course(s) to the contract. (Skips this by default; run b2b_codes validate afterward if the contract requires codes.)",
+        )
 
         remove_subparser = subparsers.add_parser(
             "remove",
@@ -174,6 +180,7 @@ Specifying a program will only unlink the program from the contract, unless "--r
         force_associate = kwargs.pop("force")
         can_import = kwargs.pop("can_import")
         org_prefix = kwargs.pop("prefix")
+        make_codes = kwargs.pop("make_codes", False)
 
         managed = skipped = 0
 
@@ -296,7 +303,9 @@ Specifying a program will only unlink the program from the contract, unless "--r
                 )
                 skipped += 1
 
-        contract.save()
+        if managed > 0 and make_codes:
+            self.stdout.write("Queueing enrollment code check for {contract}")
+            queue_enrollment_code_check.delay(contract.id)
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/b2b/management/commands/b2b_courseware.py
+++ b/b2b/management/commands/b2b_courseware.py
@@ -303,8 +303,8 @@ Specifying a program will only unlink the program from the contract, unless "--r
                 )
                 skipped += 1
 
-        if managed > 0 and make_codes:
-            self.stdout.write("Queueing enrollment code check for {contract}")
+        if make_codes:
+            self.stdout.write(f"Queueing enrollment code check for {contract}")
             queue_enrollment_code_check.delay(contract.id)
 
         self.stdout.write(

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -26,7 +26,6 @@ from b2b.constants import (
     ORG_INDEX_SLUG,
 )
 from b2b.exceptions import TargetCourseRunExistsError
-from b2b.tasks import queue_enrollment_code_check
 from courses.constants import UAI_COURSEWARE_ID_PREFIX
 from courses.models import Program
 
@@ -430,7 +429,6 @@ class ContractPage(Page, ClusterableModel):
         self.membership_type = self.integration_type
 
         Page.save(self, clean=clean, user=user, log_action=log_action, **kwargs)
-        queue_enrollment_code_check.delay(self.id)
 
     def get_learners(self):
         """Get the learners associated with this organization."""

--- a/b2b/views/v0/views_test.py
+++ b/b2b/views/v0/views_test.py
@@ -337,6 +337,7 @@ def test_b2b_contract_attachment_full_contract_with_used_code(mocker):
 def test_b2b_enroll(mocker, settings, user_has_edx_user, has_price, run_is_enrollable):
     """Make sure that hitting the enroll endpoint actually results in enrollments"""
 
+    mocker.patch("hubspot_sync.tasks.sync_cart_add_event_with_hubspot.apply_async")
     mocked_create_from_id = mocker.patch("openedx.tasks.create_user_from_id")
     mocker.patch("openedx.tasks.clone_courserun.delay")
     mocked_create_user_request = mocker.patch("openedx.api._create_edx_user_request")
@@ -349,7 +350,9 @@ def test_b2b_enroll(mocker, settings, user_has_edx_user, has_price, run_is_enrol
     )
     source_courserun = CourseRunFactory.create(is_source_run=True)
 
-    courserun, _ = create_contract_run(contract, source_courserun.course)
+    courserun, _ = create_contract_run(
+        contract, source_courserun.course, queue_codes=True
+    )
 
     if not run_is_enrollable:
         courserun.live = False


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#10708

### Description (What does it do?)

It seems like the problem we have with enrollment code generation is caused by excessive calls to the reconciliation code. The `save` method on the `ContractPage` calls the enrollment code check and we do that pretty frequently especially when we're adding courses to contracts.

Instead of doing that, this PR removes the call to `ensure_enrollment_codes_exist` in the `ContractPage.save` function. If we need to generate codes for a contract, we'll do it explicitly.

This PR also adds a `queue_codes` arg to the `create_contract_run` function; if set to True, the function will queue up the enrollment code check call. Additionally, there's a new `--make-codes` flag for the `b2b_courseware add` command which will also queue the code check at the end of the process if specified. 

However, the `b2b_codes validate --fix` command has existed for a bit now; we should change our process to add the courseware items to the contract, and then call that command when we've completed that task. This ensures the code check call happens once, when it's necessary.

### How can this be tested?

Automated tests should pass. Specifically, some of the automated tests for the `b2b` app call `create_contract_run` with the code check option turned on, so they should trigger the enrollment code check. (See the diff for specifics.)

Any operation that involves saving the contract should no longer trigger the enrollment code check - so, creating or modifying a contract (either on the command line or via Wagtail), or adding courseware to a contract, should be tested.

Test the `b2b_courseware add --make-codes` flag - add a course to the contract with that flag specified and it should trigger the code check. Without the `--make-codes` flag, it shouldn't try to queue it.

Test that `b2b_codes validate --fix` works as expected. It was not changed but it'd be good to sanity check it now, since we'll depend on it once this gets released.
