### PR TITLE
Add skip_certificates flag to HubSpot property setup

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1699,7 +1699,7 @@ def _normalize_line_item_properties_for_target_account(
             line_item_properties["status"] = resolved_status
 
 
-def _ensure_target_hubspot_custom_properties(hubspot_client: HubspotApi) -> None:
+def _ensure_target_hubspot_custom_properties(hubspot_client: HubspotApi, *, skip_certificates: bool = False) -> None:
     """Ensure custom MITx e-commerce properties and groups exist in the target account."""
     object_configs = {
         object_type: {
@@ -1708,12 +1708,14 @@ def _ensure_target_hubspot_custom_properties(hubspot_client: HubspotApi) -> None
         }
         for object_type, config in CUSTOM_ECOMMERCE_PROPERTIES.items()
     }
-    object_configs[HubspotObjectType.CONTACTS.value]["properties"].extend(
-        [
-            _get_course_run_certificate_hubspot_property(),
-            _get_program_certificate_hubspot_property(),
-        ]
-    )
+    # Skip certificate properties for UAI courses since they don't need them
+    if not skip_certificates:
+        object_configs[HubspotObjectType.CONTACTS.value]["properties"].extend(
+            [
+                _get_course_run_certificate_hubspot_property(),
+                _get_program_certificate_hubspot_property(),
+            ]
+        )
 
     for object_type, config in object_configs.items():
         wait_for_hubspot_rate_limit()
@@ -1978,9 +1980,9 @@ def _ensure_target_hubspot_product_for_line(
     return created_product.id
 
 
-def _ensure_target_hubspot_contact_properties(hubspot_client: HubspotApi) -> None:
+def _ensure_target_hubspot_contact_properties(hubspot_client: HubspotApi, *, skip_certificates: bool = False) -> None:
     """Backward-compatible wrapper retained for tests/callers."""
-    _ensure_target_hubspot_custom_properties(hubspot_client)
+    _ensure_target_hubspot_custom_properties(hubspot_client, skip_certificates=skip_certificates)
 
 
 def _ensure_hubspot_contact_for_user(
@@ -2085,7 +2087,7 @@ def track_cart_add_with_hubspot(
 
     try:
         hubspot_client = HubspotApi(access_token=token)
-        _ensure_target_hubspot_contact_properties(hubspot_client)
+        _ensure_target_hubspot_contact_properties(hubspot_client, skip_certificates=is_uai_course)
 
         # UAI deals must have a contact in the same HubSpot account.
         contact_id = _ensure_hubspot_contact_for_user(user, hubspot_client)

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1699,7 +1699,9 @@ def _normalize_line_item_properties_for_target_account(
             line_item_properties["status"] = resolved_status
 
 
-def _ensure_target_hubspot_custom_properties(hubspot_client: HubspotApi, *, skip_certificates: bool = False) -> None:
+def _ensure_target_hubspot_custom_properties(
+    hubspot_client: HubspotApi, *, skip_certificates: bool = False
+) -> None:
     """Ensure custom MITx e-commerce properties and groups exist in the target account."""
     object_configs = {
         object_type: {
@@ -1980,9 +1982,13 @@ def _ensure_target_hubspot_product_for_line(
     return created_product.id
 
 
-def _ensure_target_hubspot_contact_properties(hubspot_client: HubspotApi, *, skip_certificates: bool = False) -> None:
+def _ensure_target_hubspot_contact_properties(
+    hubspot_client: HubspotApi, *, skip_certificates: bool = False
+) -> None:
     """Backward-compatible wrapper retained for tests/callers."""
-    _ensure_target_hubspot_custom_properties(hubspot_client, skip_certificates=skip_certificates)
+    _ensure_target_hubspot_custom_properties(
+        hubspot_client, skip_certificates=skip_certificates
+    )
 
 
 def _ensure_hubspot_contact_for_user(
@@ -2087,7 +2093,9 @@ def track_cart_add_with_hubspot(
 
     try:
         hubspot_client = HubspotApi(access_token=token)
-        _ensure_target_hubspot_contact_properties(hubspot_client, skip_certificates=is_uai_course)
+        _ensure_target_hubspot_contact_properties(
+            hubspot_client, skip_certificates=is_uai_course
+        )
 
         # UAI deals must have a contact in the same HubSpot account.
         contact_id = _ensure_hubspot_contact_for_user(user, hubspot_client)

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -609,7 +609,7 @@ def test_track_cart_add_with_hubspot_syncs_missing_contact(settings, mocker, use
     mock_sync_deal = mocker.patch("hubspot_sync.api._sync_cart_add_deal_with_hubspot")
 
     assert api.track_cart_add_with_hubspot(user, product, is_uai_course=True) is True
-    mock_ensure_props.assert_called_once_with(mock_client.return_value)
+    mock_ensure_props.assert_called_once_with(mock_client.return_value, skip_certificates=True)
     mock_ensure_contact.assert_called_once_with(user, mock_client.return_value)
     mock_sync_deal.assert_called_once()
 

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -609,7 +609,9 @@ def test_track_cart_add_with_hubspot_syncs_missing_contact(settings, mocker, use
     mock_sync_deal = mocker.patch("hubspot_sync.api._sync_cart_add_deal_with_hubspot")
 
     assert api.track_cart_add_with_hubspot(user, product, is_uai_course=True) is True
-    mock_ensure_props.assert_called_once_with(mock_client.return_value, skip_certificates=True)
+    mock_ensure_props.assert_called_once_with(
+        mock_client.return_value, skip_certificates=True
+    )
     mock_ensure_contact.assert_called_once_with(user, mock_client.return_value)
     mock_sync_deal.assert_called_once()
 


### PR DESCRIPTION
Introduce a skip_certificates keyword flag to _ensure_target_hubspot_custom_properties and thread it through the backward-compatible wrapper _ensure_target_hubspot_contact_properties. When skip_certificates is True the contact certificate properties are not added to the target account (used for UAI courses that don't need them). Default behavior remains unchanged (flag defaults to False) and the call in track_cart_add_with_hubspot now passes is_uai_course to avoid creating certificate properties for UAI deals.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Introduce a skip_certificates keyword flag to _ensure_target_hubspot_custom_properties and thread it through the backward-compatible wrapper _ensure_target_hubspot_contact_properties. When skip_certificates is True the contact certificate properties are not added to the target account (used for UAI courses that don't need them). Default behavior remains unchanged (flag defaults to False) and the call in track_cart_add_with_hubspot now passes is_uai_course to avoid creating certificate properties for UAI deals.


### How can this be tested?
Not really sure.  I'm not sure why the data is so large in mitx online when syncing with hubspot.