### PR TITLE
fix: links on cart page point to learn

### DIFF
--- a/frontend/public/src/components/OrderSummaryCard.js
+++ b/frontend/public/src/components/OrderSummaryCard.js
@@ -250,13 +250,10 @@ export class OrderSummaryCard extends React.Component<Props, State> {
           {(totalPrice > 0 || discounts) && !orderFulfilled ? (
             <div className="cart-text-smaller">
               By placing my order I agree to the{" "}
-              <a href="/terms-of-service/" target="_blank" rel="noreferrer">
-                Terms of Service
+              <a href="https://learn.mit.edu/terms/" target="_blank" rel="noreferrer">
+                MIT Learn Terms of Service
               </a>
-              , and{" "}
-              <a href="/privacy-policy/" target="_blank" rel="noreferrer">
-                Privacy Policy.
-              </a>
+              .
             </div>
           ) : null}
         </div>

--- a/frontend/public/src/components/OrderSummaryCard.js
+++ b/frontend/public/src/components/OrderSummaryCard.js
@@ -250,7 +250,11 @@ export class OrderSummaryCard extends React.Component<Props, State> {
           {(totalPrice > 0 || discounts) && !orderFulfilled ? (
             <div className="cart-text-smaller">
               By placing my order I agree to the{" "}
-              <a href="https://learn.mit.edu/terms/" target="_blank" rel="noreferrer">
+              <a
+                href="https://learn.mit.edu/terms/"
+                target="_blank"
+                rel="noreferrer"
+              >
                 MIT Learn Terms of Service
               </a>
               .

--- a/frontend/public/src/containers/pages/checkout/CartPage.js
+++ b/frontend/public/src/containers/pages/checkout/CartPage.js
@@ -173,7 +173,7 @@ export class CartPage extends React.Component<Props, CartState> {
                   <div>{this.renderFinancialAssistanceOffer()}</div>
                   <div className="text-right ms-auto">
                     <a
-                      href="https://mitxonline.zendesk.com/hc/en-us"
+                      href="https://support.learn.mit.edu/"
                       target="_blank"
                       rel="noreferrer"
                     >


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10994

### Description (What does it do?)
This PR updates the `Help and FAQs` link to "https://support.learn.mit.edu/", the Terms of Service link to https://learn.mit.edu/terms/, and the wording from "By placing my order I agree to the [Terms of Service](https://mitxonline.mit.edu/terms-of-service/), and [Privacy Policy.](https://mitxonline.mit.edu/privacy-policy/)" to "By placing my order, I agree to the [MIT Learn Terms of Service](https://learn.mit.edu/terms/)" on the cart page.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- Visit the cart page with an item added (e.g., http://mitxonline.odl.local:9080/cart/).
- Verify that the links on the cart page match those specified in the issue description: https://github.com/mitodl/hq/issues/10994.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
