### PR TITLE
Make basket serializer test deterministic

### DIFF
--- a/ecommerce/serializers/serializers_test.py
+++ b/ecommerce/serializers/serializers_test.py
@@ -214,21 +214,20 @@ def test_basket_with_product_serializer():
     """
     Tests serialization of a basket with the attached products (and any
     discounts applied).
-    
+
     Uses deterministic test values and consistent rounding to prevent
     flaky behavior caused by floating-point precision differences.
     """
 
     # Create product with deterministic price that avoids precision edge cases
     product = ProductFactory.create(price=Decimal("100.00"))
-    
+
     # Create discount with deterministic percentage that results in clean calculation
     # 20% discount on $100.00 = $20.00 discount, final price $80.00
     discount = UnlimitedUseDiscountFactory.create(
-        discount_type=DISCOUNT_TYPE_PERCENT_OFF,
-        amount=20
+        discount_type=DISCOUNT_TYPE_PERCENT_OFF, amount=20
     )
-    
+
     basket_item = BasketItemFactory.create(product=product)
     user = UserFactory.create()
 
@@ -251,7 +250,7 @@ def test_basket_with_product_serializer():
     assert serialized_basket["total_price"] == basket_item.product.price
     assert serialized_basket["discounted_price"] == expected_discount_price
     assert len(serialized_basket["discounts"]) == 1
-    
+
     # Additional verification: ensure the discount calculation is correct
     # 20% discount on $100.00 should result in $80.00
     assert expected_discount_price == Decimal("80.00")

--- a/ecommerce/serializers/serializers_test.py
+++ b/ecommerce/serializers/serializers_test.py
@@ -214,10 +214,22 @@ def test_basket_with_product_serializer():
     """
     Tests serialization of a basket with the attached products (and any
     discounts applied).
+    
+    Uses deterministic test values and consistent rounding to prevent
+    flaky behavior caused by floating-point precision differences.
     """
 
-    basket_item = BasketItemFactory.create()
-    discount = UnlimitedUseDiscountFactory.create()
+    # Create product with deterministic price that avoids precision edge cases
+    product = ProductFactory.create(price=Decimal("100.00"))
+    
+    # Create discount with deterministic percentage that results in clean calculation
+    # 20% discount on $100.00 = $20.00 discount, final price $80.00
+    discount = UnlimitedUseDiscountFactory.create(
+        discount_type=DISCOUNT_TYPE_PERCENT_OFF,
+        amount=20
+    )
+    
+    basket_item = BasketItemFactory.create(product=product)
     user = UserFactory.create()
 
     basket_discount = BasketDiscount(
@@ -230,12 +242,19 @@ def test_basket_with_product_serializer():
 
     serialized_basket = BasketWithProductSerializer(basket_item.basket).data
 
+    # Use the same rounding method that the serializer uses for consistent comparison
     logic = DiscountType.for_discount(discount)
-    discount_price = logic.get_discounted_price([discount], basket_item.product)
+    raw_discount_price = logic.get_discounted_price([discount], basket_item.product)
+    # Apply quantize to match the serializer's rounding method
+    expected_discount_price = raw_discount_price.quantize(Decimal("0.01"))
 
     assert serialized_basket["total_price"] == basket_item.product.price
-    assert serialized_basket["discounted_price"] == discount_price
+    assert serialized_basket["discounted_price"] == expected_discount_price
     assert len(serialized_basket["discounts"]) == 1
+    
+    # Additional verification: ensure the discount calculation is correct
+    # 20% discount on $100.00 should result in $80.00
+    assert expected_discount_price == Decimal("80.00")
 
 
 def test_basket_with_program_product_serializer():


### PR DESCRIPTION
Replace non-deterministic factory defaults with explicit values and consistent rounding to avoid flaky failures. The test now creates a Product with a fixed price Decimal("100.00") and a 20% percent-off discount (DISCOUNT_TYPE_PERCENT_OFF, amount=20), attaches the product to the BasketItem, and computes the discounted price via DiscountType.for_discount(...). The raw result is quantized to Decimal("0.01") to match the serializer's rounding, and assertions verify the serialized total_price, discounted_price, and that the final price equals Decimal("80.00"). Comments were added to clarify the deterministic intent and the rounding behavior.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
