### PR TITLE
Fix transaction race condition with hubspot sync

### DIFF
--- a/users/signals.py
+++ b/users/signals.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -12,4 +13,4 @@ def sync_user_to_hubspot_on_create(sender, instance, created, **kwargs):  # noqa
 
     """
     if created:
-        sync_hubspot_user(instance)
+        transaction.on_commit(lambda: sync_hubspot_user(instance))

--- a/users/signals_test.py
+++ b/users/signals_test.py
@@ -5,7 +5,7 @@ import pytest
 from users.factories import UserFactory
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_user_creation_triggers_hubspot_sync(mocker):
     """
     Test that creating a user triggers the Hubspot sync.


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/11012

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes an issue that happens when there's a race condition between the middleware and SCIM and the transaction that created a user in the middleware hits a conflict and rolls back. Will deal with the rollback separately but this will make this area of code more robust to this kind of error should it ever come up in another way.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass. This is incredibly hard to reproduce because it requires sub-second timing.