### PR TITLE
Fixes 500 errors when viewing an Organization in the Django Admin

### DIFF
--- a/b2b/admin.py
+++ b/b2b/admin.py
@@ -20,11 +20,41 @@ class UserOrganizationAdminInline(admin.TabularInline):
     model = UserOrganization
     extra = 0
     verbose_name = "Organization Admin"
+    fields = [
+        "user_email",
+        "keep_until_seen",
+        "is_manager",
+    ]
+    readonly_fields = [
+        "user_email",
+        "keep_until_seen",
+        "is_manager",
+    ]
 
     def get_queryset(self, request):
         """Filter the queryset to just users with Manager access."""
 
-        return super().get_queryset(request).filter(is_manager=True)
+        return (
+            super()
+            .get_queryset(request)
+            .prefetch_related("user")
+            .filter(is_manager=True)
+        )
+
+    def has_add_permission(self, request, obj):  # noqa: ARG002
+        """Determine if the user can add new ones from here (no, they cannot)"""
+
+        return False
+
+    def has_change_permission(self, request, obj=None):  # noqa: ARG002
+        """Determine if the user can add new ones from here (no, they cannot)"""
+
+        return False
+
+    def has_delete_permission(self, request, obj=None):  # noqa: ARG002
+        """Determine if the user can add new ones from here (no, they cannot)"""
+
+        return False
 
 
 class ReadOnlyModelAdmin(admin.ModelAdmin):

--- a/b2b/admin.py
+++ b/b2b/admin.py
@@ -20,7 +20,7 @@ class UserOrganizationAdminInline(admin.TabularInline):
     model = UserOrganization
     extra = 0
     verbose_name = "Organization Admin"
-    fields = [
+    list_display = [
         "user_email",
         "keep_until_seen",
         "is_manager",
@@ -55,6 +55,12 @@ class UserOrganizationAdminInline(admin.TabularInline):
         """Determine if the user can add new ones from here (no, they cannot)"""
 
         return False
+
+    @admin.display(description="User Email")
+    def user_email(self, obj):
+        """Return the user's email address."""
+
+        return obj.user.email
 
 
 class ReadOnlyModelAdmin(admin.ModelAdmin):

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -643,11 +643,6 @@ class UserOrganization(models.Model):
 
         return f"UserOrganization: {self.user} in {self.organization}"
 
-    def user_email(self):
-        """Return the user's email address."""
-
-        return self.user.email
-
 
 def is_organization_manager(user, org_id):
     """

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -643,6 +643,11 @@ class UserOrganization(models.Model):
 
         return f"UserOrganization: {self.user} in {self.organization}"
 
+    def user_email(self):
+        """Return the user's email address."""
+
+        return self.user.email
+
 
 def is_organization_manager(user, org_id):
     """


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

Noticed that the Django Admin consistently returns a 500 when viewing a B2B organization in the Django Admin in production. This hopefully fixes that by prefetching the user and specifically displaying only the user email for the `UserOrganizationAdminInline`. 

This also removes the add/change/delete permission from the inline. If you want to manage admins, you can do that from the individual user's edit screen in the Django Admin. 

### How can this be tested?

View an organization page in the Django Admin. It should work as expected. Ideally, use an org that has some managers set up in it. You can set that up in the user record.

### Additional Context

Assuming this will help - the page takes a while to load and then errors out with a 502, but the Django process doesn't ever fail really so there's no Sentry error pointing to something specific. I can't reproduce this on RC or locally. But, the User model can be pretty unwieldy to load so this seemed like a good place to start.