### PR TITLE
Add skip_certificates for UAI HubSpot sync

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -2175,13 +2175,18 @@ def track_cart_add_with_hubspot(
 
     try:
         hubspot_client = HubspotApi(access_token=token)
+        
+        # Determine which account is actually being used for the API call
+        # This ensures skip_certificates reflects the actual HubSpot account, not just course type
+        is_uai_account = token == getattr(settings, "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN", "")
+        
         _ensure_target_hubspot_contact_properties(
-            hubspot_client, skip_certificates=is_uai_course
+            hubspot_client, skip_certificates=is_uai_account
         )
 
         # UAI deals must have a contact in the same HubSpot account.
         contact_id = _ensure_hubspot_contact_for_user(
-            user, hubspot_client, skip_certificates=is_uai_course
+            user, hubspot_client, skip_certificates=is_uai_account
         )
         if not contact_id:
             return False

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -2093,8 +2093,6 @@ def _ensure_hubspot_contact_for_user(
                 defaults={"hubspot_id": contact.id},
             )
 
-        return contact.id
-
     except TooManyRequestsException:
         # Re-raise rate limit errors so calling code can retry
         log.warning(
@@ -2110,6 +2108,8 @@ def _ensure_hubspot_contact_for_user(
             user.email,
         )
         return None
+    else:
+        return contact.id
 
 
 def _sync_cart_add_deal_with_hubspot(

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -792,13 +792,17 @@ def make_contact_update_message_list_from_user_ids(
     return request_input
 
 
-def make_contact_sync_message_from_user(user: User) -> SimplePublicObjectInput:
+def make_contact_sync_message_from_user(
+    user: User, *, skip_certificates: bool = False
+) -> SimplePublicObjectInput:
     """
     Create the body of a HubSpot sync message for a contact. This will flatten the contained LegalAddress and Profile
     serialized data into one larger serializable dict
 
     Args:
         user (User): User object.
+        skip_certificates (bool): If True, exclude certificate properties from the contact data.
+                                 Used for UAI HubSpot accounts that don't have certificate properties.
     Returns:
         SimplePublicObjectInput: Input object for upserting User data to Hubspot
     """
@@ -823,12 +827,24 @@ def make_contact_sync_message_from_user(user: User) -> SimplePublicObjectInput:
         "type_is_professional": "typeisprofessional",
         "type_is_educator": "typeiseducator",
         "type_is_other": "typeisother",
-        "program_certificates": "program_certificates",
-        "course_run_certificates": "course_run_certificates",
     }
+    
+    # Only include certificate properties if not skipping them
+    if not skip_certificates:
+        contact_properties_map.update({
+            "program_certificates": "program_certificates",
+            "course_run_certificates": "course_run_certificates",
+        })
+    
     properties = HubspotContactSerializer(user).data
     properties.update(properties.pop("legal_address") or {})
     properties.update(properties.pop("user_profile") or {})
+    
+    # Remove certificate data if skipping certificates
+    if skip_certificates:
+        properties.pop("program_certificates", None)
+        properties.pop("course_run_certificates", None)
+    
     hubspot_props = transform_object_properties(properties, contact_properties_map)
     return make_object_properties_message(hubspot_props)
 
@@ -1372,7 +1388,20 @@ def sync_deal_with_hubspot_targeted(order: Order, token: str) -> SimplePublicObj
         )
 
     # Ensure contact exists and is associated
-    contact_id = _ensure_hubspot_contact_for_user(order.purchaser, hubspot_client)
+    # For targeted sync, we need to determine if this is for a UAI course to skip certificates
+    is_uai_account = token == getattr(settings, "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN", "")
+    contact_id = _ensure_hubspot_contact_for_user(
+        order.purchaser, hubspot_client, skip_certificates=is_uai_account
+    )
+    
+    if not contact_id:
+        log.error(
+            "Failed to create or find contact in target HubSpot account for user %s (email: %s)",
+            order.purchaser.id,
+            order.purchaser.email,
+        )
+        # Still return the deal result, but log the association failure
+        return result
 
     # Check if deal-contact association exists
     try:
@@ -1394,6 +1423,11 @@ def sync_deal_with_hubspot_targeted(order: Order, token: str) -> SimplePublicObj
                 to_object_type=HubspotObjectType.CONTACTS.value,
                 to_object_id=contact_id,
             )
+            log.info(
+                "Created deal-contact association for deal %s and contact %s",
+                result.id,
+                contact_id,
+            )
     except Exception:  # noqa: BLE001
         # If we can't check associations, try to create (HubSpot will ignore duplicates)
         try:
@@ -1403,6 +1437,11 @@ def sync_deal_with_hubspot_targeted(order: Order, token: str) -> SimplePublicObj
                 from_object_id=result.id,
                 to_object_type=HubspotObjectType.CONTACTS.value,
                 to_object_id=contact_id,
+            )
+            log.info(
+                "Created deal-contact association for deal %s and contact %s (via fallback)",
+                result.id,
+                contact_id,
             )
         except Exception:
             log.exception(
@@ -1992,42 +2031,69 @@ def _ensure_target_hubspot_contact_properties(
 
 
 def _ensure_hubspot_contact_for_user(
-    user: User, hubspot_client: HubspotApi
+    user: User, hubspot_client: HubspotApi, *, skip_certificates: bool = False
 ) -> str | None:
     """Return target-account contact id, creating a contact when missing."""
-    contact_id = _find_hubspot_contact_id_by_email(hubspot_client, user.email)
-    if contact_id:
+    try:
+        contact_id = _find_hubspot_contact_id_by_email(hubspot_client, user.email)
+        if contact_id:
+            log.info(
+                "Found existing HubSpot contact in target account for user_id=%s email=%s contact_id=%s",
+                user.id,
+                user.email,
+                contact_id,
+            )
+            # Update the local HubspotObject mapping for existing contact
+            content_type = ContentType.objects.get_for_model(User)
+            HubspotObject.objects.update_or_create(
+                object_id=user.id,
+                content_type=content_type,
+                defaults={"hubspot_id": contact_id},
+            )
+            return contact_id
+
+        # Create new contact if not found
         log.info(
-            "Found existing HubSpot contact in target account for user_id=%s email=%s",
+            "Creating new HubSpot contact in target account for user_id=%s email=%s (skip_certificates=%s)",
             user.id,
             user.email,
+            skip_certificates,
         )
-        # Update the local HubspotObject mapping for existing contact
+        wait_for_hubspot_rate_limit()
+        contact = hubspot_client.crm.objects.basic_api.create(
+            object_type=HubspotObjectType.CONTACTS.value,
+            simple_public_object_input_for_create=make_contact_sync_message_from_user(
+                user, skip_certificates=skip_certificates
+            ),
+        )
+        
+        log.info(
+            "Successfully created HubSpot contact in target account for user_id=%s email=%s contact_id=%s",
+            user.id,
+            user.email,
+            contact.id,
+        )
+        
+        user.hubspot_sync_datetime = now_in_utc()
+        user.save(update_fields=["hubspot_sync_datetime"])
+
+        # Update the local HubspotObject mapping for newly created contact
         content_type = ContentType.objects.get_for_model(User)
         HubspotObject.objects.update_or_create(
             object_id=user.id,
             content_type=content_type,
-            defaults={"hubspot_id": contact_id},
+            defaults={"hubspot_id": contact.id},
         )
-        return contact_id
 
-    wait_for_hubspot_rate_limit()
-    contact = hubspot_client.crm.objects.basic_api.create(
-        object_type=HubspotObjectType.CONTACTS.value,
-        simple_public_object_input_for_create=make_contact_sync_message_from_user(user),
-    )
-    user.hubspot_sync_datetime = now_in_utc()
-    user.save(update_fields=["hubspot_sync_datetime"])
-
-    # Update the local HubspotObject mapping for newly created contact
-    content_type = ContentType.objects.get_for_model(User)
-    HubspotObject.objects.update_or_create(
-        object_id=user.id,
-        content_type=content_type,
-        defaults={"hubspot_id": contact.id},
-    )
-
-    return contact.id
+        return contact.id
+        
+    except Exception:
+        log.exception(
+            "Failed to ensure HubSpot contact for user_id=%s email=%s in target account",
+            user.id,
+            user.email,
+        )
+        return None
 
 
 def _sync_cart_add_deal_with_hubspot(
@@ -2098,7 +2164,9 @@ def track_cart_add_with_hubspot(
         )
 
         # UAI deals must have a contact in the same HubSpot account.
-        contact_id = _ensure_hubspot_contact_for_user(user, hubspot_client)
+        contact_id = _ensure_hubspot_contact_for_user(
+            user, hubspot_client, skip_certificates=is_uai_course
+        )
         if not contact_id:
             return False
 

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -2095,6 +2095,14 @@ def _ensure_hubspot_contact_for_user(
 
         return contact.id
 
+    except TooManyRequestsException:
+        # Re-raise rate limit errors so calling code can retry
+        log.warning(
+            "Rate limited ensuring HubSpot contact for user_id=%s email=%s in target account",
+            user.id,
+            user.email,
+        )
+        raise
     except Exception:
         log.exception(
             "Failed to ensure HubSpot contact for user_id=%s email=%s in target account",

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -2043,13 +2043,15 @@ def _ensure_hubspot_contact_for_user(
                 user.email,
                 contact_id,
             )
-            # Update the local HubspotObject mapping for existing contact
-            content_type = ContentType.objects.get_for_model(User)
-            HubspotObject.objects.update_or_create(
-                object_id=user.id,
-                content_type=content_type,
-                defaults={"hubspot_id": contact_id},
-            )
+            # Only update local HubspotObject mapping for primary (MITx Online) account
+            # to avoid overwriting existing mappings when syncing to secondary (UAI) accounts
+            if not skip_certificates:
+                content_type = ContentType.objects.get_for_model(User)
+                HubspotObject.objects.update_or_create(
+                    object_id=user.id,
+                    content_type=content_type,
+                    defaults={"hubspot_id": contact_id},
+                )
             return contact_id
 
         # Create new contact if not found
@@ -2077,13 +2079,15 @@ def _ensure_hubspot_contact_for_user(
         user.hubspot_sync_datetime = now_in_utc()
         user.save(update_fields=["hubspot_sync_datetime"])
 
-        # Update the local HubspotObject mapping for newly created contact
-        content_type = ContentType.objects.get_for_model(User)
-        HubspotObject.objects.update_or_create(
-            object_id=user.id,
-            content_type=content_type,
-            defaults={"hubspot_id": contact.id},
-        )
+        # Only update local HubspotObject mapping for primary (MITx Online) account
+        # to avoid overwriting existing mappings when syncing to secondary (UAI) accounts
+        if not skip_certificates:
+            content_type = ContentType.objects.get_for_model(User)
+            HubspotObject.objects.update_or_create(
+                object_id=user.id,
+                content_type=content_type,
+                defaults={"hubspot_id": contact.id},
+            )
 
         return contact.id
         

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -2175,11 +2175,13 @@ def track_cart_add_with_hubspot(
 
     try:
         hubspot_client = HubspotApi(access_token=token)
-        
+
         # Determine which account is actually being used for the API call
         # This ensures skip_certificates reflects the actual HubSpot account, not just course type
-        is_uai_account = token == getattr(settings, "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN", "")
-        
+        is_uai_account = token == getattr(
+            settings, "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN", ""
+        )
+
         _ensure_target_hubspot_contact_properties(
             hubspot_client, skip_certificates=is_uai_account
         )

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -828,23 +828,25 @@ def make_contact_sync_message_from_user(
         "type_is_educator": "typeiseducator",
         "type_is_other": "typeisother",
     }
-    
+
     # Only include certificate properties if not skipping them
     if not skip_certificates:
-        contact_properties_map.update({
-            "program_certificates": "program_certificates",
-            "course_run_certificates": "course_run_certificates",
-        })
-    
+        contact_properties_map.update(
+            {
+                "program_certificates": "program_certificates",
+                "course_run_certificates": "course_run_certificates",
+            }
+        )
+
     properties = HubspotContactSerializer(user).data
     properties.update(properties.pop("legal_address") or {})
     properties.update(properties.pop("user_profile") or {})
-    
+
     # Remove certificate data if skipping certificates
     if skip_certificates:
         properties.pop("program_certificates", None)
         properties.pop("course_run_certificates", None)
-    
+
     hubspot_props = transform_object_properties(properties, contact_properties_map)
     return make_object_properties_message(hubspot_props)
 
@@ -1389,11 +1391,13 @@ def sync_deal_with_hubspot_targeted(order: Order, token: str) -> SimplePublicObj
 
     # Ensure contact exists and is associated
     # For targeted sync, we need to determine if this is for a UAI course to skip certificates
-    is_uai_account = token == getattr(settings, "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN", "")
+    is_uai_account = token == getattr(
+        settings, "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN", ""
+    )
     contact_id = _ensure_hubspot_contact_for_user(
         order.purchaser, hubspot_client, skip_certificates=is_uai_account
     )
-    
+
     if not contact_id:
         log.error(
             "Failed to create or find contact in target HubSpot account for user %s (email: %s)",
@@ -2066,14 +2070,14 @@ def _ensure_hubspot_contact_for_user(
                 user, skip_certificates=skip_certificates
             ),
         )
-        
+
         log.info(
             "Successfully created HubSpot contact in target account for user_id=%s email=%s contact_id=%s",
             user.id,
             user.email,
             contact.id,
         )
-        
+
         user.hubspot_sync_datetime = now_in_utc()
         user.save(update_fields=["hubspot_sync_datetime"])
 
@@ -2086,7 +2090,7 @@ def _ensure_hubspot_contact_for_user(
         )
 
         return contact.id
-        
+
     except Exception:
         log.exception(
             "Failed to ensure HubSpot contact for user_id=%s email=%s in target account",

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -609,10 +609,8 @@ def test_track_cart_add_with_hubspot_syncs_missing_contact(settings, mocker, use
     mock_sync_deal = mocker.patch("hubspot_sync.api._sync_cart_add_deal_with_hubspot")
 
     assert api.track_cart_add_with_hubspot(user, product, is_uai_course=True) is True
-    mock_ensure_props.assert_called_once_with(
-        mock_client.return_value, skip_certificates=True
-    )
-    mock_ensure_contact.assert_called_once_with(user, mock_client.return_value)
+    mock_ensure_props.assert_called_once_with(mock_client.return_value, skip_certificates=True)
+    mock_ensure_contact.assert_called_once_with(user, mock_client.return_value, skip_certificates=True)
     mock_sync_deal.assert_called_once()
 
 
@@ -647,6 +645,35 @@ def test_track_cart_add_with_hubspot_returns_false_when_unconfigured(settings, u
 
     product = ProductFactory.create()
     assert api.track_cart_add_with_hubspot(user, product, is_uai_course=False) is False
+
+
+def test_track_cart_add_with_hubspot_uai_fallback_to_primary_account(settings, mocker, user):
+    """UAI course adds should fallback to primary account when UAI token not configured, and skip_certificates should reflect the actual account used."""
+    settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN = "primary-token"  # noqa: S105
+    settings.UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN = ""  # UAI token not configured
+
+    course_run = CourseRunFactory.create(courseware_id="course-v1:UAI_MIT+1.001x+2026") 
+    product = ProductFactory.create(purchasable_object=course_run)
+    with reversion.create_revision():
+        product.save()
+
+    mock_client = mocker.patch("hubspot_sync.api.HubspotApi")
+    mock_ensure_props = mocker.patch("hubspot_sync.api._ensure_target_hubspot_contact_properties")
+    mock_ensure_contact = mocker.patch(
+        "hubspot_sync.api._ensure_hubspot_contact_for_user", return_value="contact-id"
+    )
+    mock_sync_deal = mocker.patch("hubspot_sync.api._sync_cart_add_deal_with_hubspot")
+
+    assert api.track_cart_add_with_hubspot(user, product, is_uai_course=True) is True
+    
+    # Should use primary token since UAI token is not configured
+    mock_client.assert_called_once_with(access_token="primary-token")  # noqa: S106
+    
+    # skip_certificates should be False because we're actually using the primary account
+    # (even though is_uai_course=True)
+    mock_ensure_props.assert_called_once_with(mock_client.return_value, skip_certificates=False)
+    mock_ensure_contact.assert_called_once_with(user, mock_client.return_value, skip_certificates=False)
+    mock_sync_deal.assert_called_once()
 
 
 def test_normalize_deal_properties_for_target_account_pipeline_stage_mismatch(mocker):

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -609,8 +609,12 @@ def test_track_cart_add_with_hubspot_syncs_missing_contact(settings, mocker, use
     mock_sync_deal = mocker.patch("hubspot_sync.api._sync_cart_add_deal_with_hubspot")
 
     assert api.track_cart_add_with_hubspot(user, product, is_uai_course=True) is True
-    mock_ensure_props.assert_called_once_with(mock_client.return_value, skip_certificates=True)
-    mock_ensure_contact.assert_called_once_with(user, mock_client.return_value, skip_certificates=True)
+    mock_ensure_props.assert_called_once_with(
+        mock_client.return_value, skip_certificates=True
+    )
+    mock_ensure_contact.assert_called_once_with(
+        user, mock_client.return_value, skip_certificates=True
+    )
     mock_sync_deal.assert_called_once()
 
 
@@ -647,32 +651,40 @@ def test_track_cart_add_with_hubspot_returns_false_when_unconfigured(settings, u
     assert api.track_cart_add_with_hubspot(user, product, is_uai_course=False) is False
 
 
-def test_track_cart_add_with_hubspot_uai_fallback_to_primary_account(settings, mocker, user):
+def test_track_cart_add_with_hubspot_uai_fallback_to_primary_account(
+    settings, mocker, user
+):
     """UAI course adds should fallback to primary account when UAI token not configured, and skip_certificates should reflect the actual account used."""
     settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN = "primary-token"  # noqa: S105
     settings.UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN = ""  # UAI token not configured
 
-    course_run = CourseRunFactory.create(courseware_id="course-v1:UAI_MIT+1.001x+2026") 
+    course_run = CourseRunFactory.create(courseware_id="course-v1:UAI_MIT+1.001x+2026")
     product = ProductFactory.create(purchasable_object=course_run)
     with reversion.create_revision():
         product.save()
 
     mock_client = mocker.patch("hubspot_sync.api.HubspotApi")
-    mock_ensure_props = mocker.patch("hubspot_sync.api._ensure_target_hubspot_contact_properties")
+    mock_ensure_props = mocker.patch(
+        "hubspot_sync.api._ensure_target_hubspot_contact_properties"
+    )
     mock_ensure_contact = mocker.patch(
         "hubspot_sync.api._ensure_hubspot_contact_for_user", return_value="contact-id"
     )
     mock_sync_deal = mocker.patch("hubspot_sync.api._sync_cart_add_deal_with_hubspot")
 
     assert api.track_cart_add_with_hubspot(user, product, is_uai_course=True) is True
-    
+
     # Should use primary token since UAI token is not configured
     mock_client.assert_called_once_with(access_token="primary-token")  # noqa: S106
-    
+
     # skip_certificates should be False because we're actually using the primary account
     # (even though is_uai_course=True)
-    mock_ensure_props.assert_called_once_with(mock_client.return_value, skip_certificates=False)
-    mock_ensure_contact.assert_called_once_with(user, mock_client.return_value, skip_certificates=False)
+    mock_ensure_props.assert_called_once_with(
+        mock_client.return_value, skip_certificates=False
+    )
+    mock_ensure_contact.assert_called_once_with(
+        user, mock_client.return_value, skip_certificates=False
+    )
     mock_sync_deal.assert_called_once()
 
 


### PR DESCRIPTION
Introduce skip_certificates flag to contact sync functions so certificate properties can be excluded for UAI HubSpot accounts. Propagate the flag to make_contact_sync_message_from_user and _ensure_hubspot_contact_for_user, detect UAI target accounts by comparing the token to the UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN setting, and skip program/course certificate properties when requested. Improve logging for contact lookups/creates and deal-contact associations, update local HubspotObject mapping and user.hubspot_sync_datetime on create, and add error handling that logs failures and returns None when contact ensure fails. Also update track and targeted sync call sites to pass the skip flag.

### What are the relevant tickets?
NA

### Description (What does it do?)
Adds helpful logging to debug hubspot API calls since we make many calls during user actions.  Also fixes and issue when creating a contact in UAI hubspot (xpro hubspot for now).

### How can this be tested?
Checking out with a UAI course should successfully create your user in the UAI/Xpro hubspot.  Triggering a failure of this locally is a bit tough since you would need to create a lot of data for this to fail.  But ensuring that it works is helpful to make sure we're not breaking anything that currently works.
