### PR TITLE
Add pytest.mark.django_db to image test

### DIFF
--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -89,7 +89,7 @@ def test_ensure_home_page_and_site():
     ensure_home_page_and_site()
     assert home_page_qset.count() == 1
 
-
+@pytest.mark.django_db
 def test_get_wagtail_img_src(settings):
     """get_wagtail_img_src should return the correct image URL"""
     settings.MEDIA_URL = "/mediatest/"

--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -89,6 +89,7 @@ def test_ensure_home_page_and_site():
     ensure_home_page_and_site()
     assert home_page_qset.count() == 1
 
+
 @pytest.mark.django_db
 def test_get_wagtail_img_src(settings):
     """get_wagtail_img_src should return the correct image URL"""


### PR DESCRIPTION
Add the @pytest.mark.django_db decorator to test_get_wagtail_img_src in cms/api_test.py so the test can access the database (and related Django settings) when run.

### What are the relevant tickets?
NA

### Description (What does it do?)
Add the @pytest.mark.django_db decorator to test_get_wagtail_img_src in cms/api_test.py so the test can access the database (and related Django settings) when run.


### How can this be tested?

Tests should pass.  Noticed this in https://github.com/mitodl/mitxonline/actions/runs/24854375159/job/72763171056?pr=3522
