### PR TITLE
Validate MIN_NUMBER_OF operator values

### DIFF
--- a/courses/forms.py
+++ b/courses/forms.py
@@ -312,7 +312,7 @@ class ProgramAdminForm(ModelForm):
                 except (ValueError, TypeError):
                     raise ValidationError(
                         '"Minimum # of" operator must have a valid numeric Value equal to 1 or more.'  # noqa: EM101
-                    )
+                    ) from None
 
         def _validate_operator_title(operator):
             """Ensure Title is defined for every operator.

--- a/courses/forms.py
+++ b/courses/forms.py
@@ -141,6 +141,7 @@ def program_requirements_schema():
                                 "format": "number",
                                 "title": "Value",
                                 "default": 1,
+                                "minimum": 1,
                                 "options": {
                                     "dependencies": {
                                         "node_type": ProgramRequirementNodeType.OPERATOR.value,
@@ -269,7 +270,7 @@ class ProgramAdminForm(ModelForm):
         def _validate_elective_value_presence(operator):
             """
             Verifies that a Program's elective operator contains
-            a defined Value field.
+            a defined Value field that is not negative.
 
             Args:
                 operator (dict):
@@ -286,6 +287,7 @@ class ProgramAdminForm(ModelForm):
                 }
             ValidationError: operator_value does not exist.
             ValidationError: operator_value does exist but is empty.
+            ValidationError: operator_value is negative.
             """
             if (
                 operator["data"]["operator"]
@@ -299,6 +301,17 @@ class ProgramAdminForm(ModelForm):
                 if operator["data"]["operator_value"] == "":
                     raise ValidationError(
                         '"Minimum # of" operator must have Value equal to 1 or more.'  # noqa: EM101
+                    )
+                # Ensure the value is not negative
+                try:
+                    value = int(operator["data"]["operator_value"])
+                    if value < 1:
+                        raise ValidationError(
+                            '"Minimum # of" operator must have Value equal to 1 or more.'  # noqa: EM101
+                        )
+                except (ValueError, TypeError):
+                    raise ValidationError(
+                        '"Minimum # of" operator must have a valid numeric Value equal to 1 or more.'  # noqa: EM101
                     )
 
         def _validate_operator_title(operator):
@@ -363,7 +376,7 @@ class ProgramAdminForm(ModelForm):
                         if child["data"]["node_type"] == "operator":
                             _validate_operator_title(child)
                             if (
-                                operator["data"]["operator"]
+                                child["data"]["operator"]
                                 == ProgramRequirement.Operator.MIN_NUMBER_OF.value
                             ):
                                 _validate_elective_value_presence(child)

--- a/courses/models.py
+++ b/courses/models.py
@@ -2291,13 +2291,13 @@ class ProgramRequirement(MP_Node):
             try:
                 value = int(self.operator_value)
                 if value < 1:
-                    raise ValidationError({
-                        'operator_value': 'Minimum # of value must be 1 or greater.'
-                    })
+                    raise ValidationError(
+                        {"operator_value": "Minimum # of value must be 1 or greater."}
+                    )
             except (ValueError, TypeError):
-                raise ValidationError({
-                    'operator_value': 'Minimum # of value must be a valid number.'
-                }) from None
+                raise ValidationError(
+                    {"operator_value": "Minimum # of value must be a valid number."}
+                ) from None
 
     @property
     def is_course(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -2279,6 +2279,28 @@ class ProgramRequirement(MP_Node):
         """True if the node is an operator"""
         return self.node_type == ProgramRequirementNodeType.OPERATOR
 
+    def clean(self):
+        """Validate the program requirement fields"""
+        super().clean()
+        
+        # Validate operator_value for MIN_NUMBER_OF operators
+        if (
+            self.operator == self.Operator.MIN_NUMBER_OF
+            and self.operator_value is not None
+        ):
+            try:
+                value = int(self.operator_value)
+                if value < 1:
+                    from django.core.exceptions import ValidationError
+                    raise ValidationError({
+                        'operator_value': 'Minimum # of value must be 1 or greater.'
+                    })
+            except (ValueError, TypeError):
+                from django.core.exceptions import ValidationError
+                raise ValidationError({
+                    'operator_value': 'Minimum # of value must be a valid number.'
+                })
+
     @property
     def is_course(self):
         """True if the node references a course"""

--- a/courses/models.py
+++ b/courses/models.py
@@ -2291,15 +2291,13 @@ class ProgramRequirement(MP_Node):
             try:
                 value = int(self.operator_value)
                 if value < 1:
-                    from django.core.exceptions import ValidationError
                     raise ValidationError({
                         'operator_value': 'Minimum # of value must be 1 or greater.'
                     })
             except (ValueError, TypeError):
-                from django.core.exceptions import ValidationError
                 raise ValidationError({
                     'operator_value': 'Minimum # of value must be a valid number.'
-                })
+                }) from None
 
     @property
     def is_course(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -2282,7 +2282,7 @@ class ProgramRequirement(MP_Node):
     def clean(self):
         """Validate the program requirement fields"""
         super().clean()
-        
+
         # Validate operator_value for MIN_NUMBER_OF operators
         if (
             self.operator == self.Operator.MIN_NUMBER_OF
@@ -2292,14 +2292,16 @@ class ProgramRequirement(MP_Node):
                 value = int(self.operator_value)
                 if value < 1:
                     from django.core.exceptions import ValidationError
-                    raise ValidationError({
-                        'operator_value': 'Minimum # of value must be 1 or greater.'
-                    })
+
+                    raise ValidationError(
+                        {"operator_value": "Minimum # of value must be 1 or greater."}
+                    )
             except (ValueError, TypeError):
                 from django.core.exceptions import ValidationError
-                raise ValidationError({
-                    'operator_value': 'Minimum # of value must be a valid number.'
-                })
+
+                raise ValidationError(
+                    {"operator_value": "Minimum # of value must be a valid number."}
+                )
 
     @property
     def is_course(self):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11010

### Description (What does it do?)
Add validation to ensure MIN_NUMBER_OF operator values are numeric and >= 1. In courses/forms.py: add a minimum: 1 to the schema default, enforce presence and numeric/positive checks in ProgramAdminForm._validate_elective_value_presence, and fix a traversal bug to check the child's operator field. In courses/models.py: add ProgramRequirement.clean() to validate operator_value at the model level and raise descriptive ValidationError messages for non-numeric or <1 values. These changes prevent invalid/negative elective minimums at both form and model layers.

### How can this be tested?
Attempt to create a new program or edit an existing program.  Enter a negative number for the "minimum number" option in the electives section of the program in Django Admin.
