### PR TITLE
fix: make DiscountFactory defaults evaluate per-instance to prevent flaky test_create_basket_with_product

### DIFF
--- a/ecommerce/factories.py
+++ b/ecommerce/factories.py
@@ -1,5 +1,3 @@
-import random
-
 import faker
 from factory import SubFactory, fuzzy
 from factory.django import DjangoModelFactory
@@ -41,12 +39,10 @@ class ProgramProductFactory(DjangoModelFactory):
 
 
 class DiscountFactory(DjangoModelFactory):
-    amount = random.randrange(1, 50, 1)  # noqa: S311
-    discount_type = ALL_DISCOUNT_TYPES[random.randrange(0, len(ALL_DISCOUNT_TYPES), 1)]  # noqa: S311
+    amount = fuzzy.FuzzyInteger(1, 49)
+    discount_type = fuzzy.FuzzyChoice(ALL_DISCOUNT_TYPES)
     discount_code = fuzzy.FuzzyText(length=20)
-    redemption_type = ALL_REDEMPTION_TYPES[
-        random.randrange(0, len(ALL_REDEMPTION_TYPES), 1)  # noqa: S311
-    ]
+    redemption_type = fuzzy.FuzzyChoice(ALL_REDEMPTION_TYPES)
     payment_type = None
 
     class Meta:
@@ -57,8 +53,8 @@ class DiscountFactory(DjangoModelFactory):
 
 
 class OneTimeDiscountFactory(DjangoModelFactory):
-    amount = random.randrange(1, 50, 1)  # noqa: S311
-    discount_type = ALL_DISCOUNT_TYPES[random.randrange(0, len(ALL_DISCOUNT_TYPES), 1)]  # noqa: S311
+    amount = fuzzy.FuzzyInteger(1, 49)
+    discount_type = fuzzy.FuzzyChoice(ALL_DISCOUNT_TYPES)
     discount_code = fuzzy.FuzzyText(length=20)
     redemption_type = REDEMPTION_TYPE_ONE_TIME
 
@@ -67,8 +63,8 @@ class OneTimeDiscountFactory(DjangoModelFactory):
 
 
 class OneTimePerUserDiscountFactory(DjangoModelFactory):
-    amount = random.randrange(1, 50, 1)  # noqa: S311
-    discount_type = ALL_DISCOUNT_TYPES[random.randrange(0, len(ALL_DISCOUNT_TYPES), 1)]  # noqa: S311
+    amount = fuzzy.FuzzyInteger(1, 49)
+    discount_type = fuzzy.FuzzyChoice(ALL_DISCOUNT_TYPES)
     discount_code = fuzzy.FuzzyText(length=20)
     redemption_type = REDEMPTION_TYPE_ONE_TIME_PER_USER
 
@@ -77,8 +73,8 @@ class OneTimePerUserDiscountFactory(DjangoModelFactory):
 
 
 class UnlimitedUseDiscountFactory(DjangoModelFactory):
-    amount = random.randrange(1, 50, 1)  # noqa: S311
-    discount_type = ALL_DISCOUNT_TYPES[random.randrange(0, len(ALL_DISCOUNT_TYPES), 1)]  # noqa: S311
+    amount = fuzzy.FuzzyInteger(1, 49)
+    discount_type = fuzzy.FuzzyChoice(ALL_DISCOUNT_TYPES)
     discount_code = fuzzy.FuzzyText(length=20)
     redemption_type = REDEMPTION_TYPE_UNLIMITED
 
@@ -87,11 +83,11 @@ class UnlimitedUseDiscountFactory(DjangoModelFactory):
 
 
 class SetLimitDiscountFactory(DjangoModelFactory):
-    amount = random.randrange(1, 50, 1)  # noqa: S311
-    discount_type = ALL_DISCOUNT_TYPES[random.randrange(0, len(ALL_DISCOUNT_TYPES), 1)]  # noqa: S311
+    amount = fuzzy.FuzzyInteger(1, 49)
+    discount_type = fuzzy.FuzzyChoice(ALL_DISCOUNT_TYPES)
     discount_code = fuzzy.FuzzyText(length=20)
     redemption_type = REDEMPTION_TYPE_UNLIMITED
-    max_redemptions = random.randrange(1, 5, 1)  # noqa: S311
+    max_redemptions = fuzzy.FuzzyInteger(1, 4)
 
     class Meta:
         model = models.Discount

--- a/ecommerce/views/v0/views_test.py
+++ b/ecommerce/views/v0/views_test.py
@@ -30,6 +30,7 @@ from ecommerce.constants import (
     PAYMENT_TYPE_CUSTOMER_SUPPORT,
     PAYMENT_TYPE_FINANCIAL_ASSISTANCE,
     REDEMPTION_TYPE_ONE_TIME,
+    REDEMPTION_TYPE_UNLIMITED,
     ZERO_PAYMENT_DATA,
 )
 from ecommerce.discounts import DiscountType
@@ -432,7 +433,7 @@ def test_create_basket_with_product(  # noqa: PLR0913
             ex_discount = DiscountFactory(
                 discount_type=DISCOUNT_TYPE_PERCENT_OFF,
                 amount=10 if existing_discount == "worse" else 60,
-                redemption_type="unlimited",
+                redemption_type=REDEMPTION_TYPE_UNLIMITED,
             )
             BasketDiscount.objects.create(
                 redeemed_basket=basket,
@@ -446,7 +447,7 @@ def test_create_basket_with_product(  # noqa: PLR0913
                 discount_type=DISCOUNT_TYPE_PERCENT_OFF,
                 amount=50,
                 max_redemptions=1,
-                redemption_type="unlimited",
+                redemption_type=REDEMPTION_TYPE_UNLIMITED,
             )
             order = OrderFactory.create()
             DiscountRedemption.objects.create(
@@ -459,7 +460,7 @@ def test_create_basket_with_product(  # noqa: PLR0913
             discount = DiscountFactory(
                 discount_type=DISCOUNT_TYPE_PERCENT_OFF,
                 amount=50,
-                redemption_type="unlimited",
+                redemption_type=REDEMPTION_TYPE_UNLIMITED,
             )
 
         url = reverse(

--- a/ecommerce/views/v0/views_test.py
+++ b/ecommerce/views/v0/views_test.py
@@ -409,7 +409,10 @@ def test_create_basket_with_product(  # noqa: PLR0913
 ):
     """Test creating a basket with a single product, and/or a discount."""
 
-    product = ProductFactory.create()
+    # Use a fixed price well above any discount amount so that the discount
+    # comparison logic works correctly regardless of discount type (percent-off,
+    # dollars-off, or fixed-price).
+    product = ProductFactory.create(price=Decimal("1000.00"))
 
     basket = BasketFactory(user=user) if existing_basket else None
 

--- a/ecommerce/views/v0/views_test.py
+++ b/ecommerce/views/v0/views_test.py
@@ -423,12 +423,16 @@ def test_create_basket_with_product(  # noqa: PLR0913
 
     if add_discount:
         if existing_discount in ["better", "worse"]:
-            # Create and apply a discount that is either better or worse than
-            # the one that'll be "supplied" below.
+            # Create and apply a percent-off discount that is either better or
+            # worse than the supplied 50% discount below. "better" = 60% off
+            # (lower final price), "worse" = 10% off (higher final price).
+            # redemption_type is set explicitly to avoid import-time randomness
+            # from DiscountFactory affecting discount validity checks.
 
             ex_discount = DiscountFactory(
-                discount_type="percent-off",
+                discount_type=DISCOUNT_TYPE_PERCENT_OFF,
                 amount=10 if existing_discount == "worse" else 60,
+                redemption_type="unlimited",
             )
             BasketDiscount.objects.create(
                 redeemed_basket=basket,
@@ -439,7 +443,10 @@ def test_create_basket_with_product(  # noqa: PLR0913
 
         if bad_discount:
             discount = DiscountFactory(
-                discount_type="percent-off", amount=50, max_redemptions=1
+                discount_type=DISCOUNT_TYPE_PERCENT_OFF,
+                amount=50,
+                max_redemptions=1,
+                redemption_type="unlimited",
             )
             order = OrderFactory.create()
             DiscountRedemption.objects.create(
@@ -449,7 +456,11 @@ def test_create_basket_with_product(  # noqa: PLR0913
                 redeemed_order=order,
             )
         else:
-            discount = DiscountFactory(discount_type="percent-off", amount=50)
+            discount = DiscountFactory(
+                discount_type=DISCOUNT_TYPE_PERCENT_OFF,
+                amount=50,
+                redemption_type="unlimited",
+            )
 
         url = reverse(
             "v0:baskets_api-create_from_product_with_discount",

--- a/flexiblepricing/api_test.py
+++ b/flexiblepricing/api_test.py
@@ -445,6 +445,8 @@ class FlexiblePriceAPITests(FlexiblePriceBaseTestCase):
             else ContentType.objects.get(app_label="courses", model="course")
         )
 
+        courseware_tier = determine_tier_courseware(courseware_object, income_usd)
+
         if not FlexiblePrice.objects.filter(
             user=user,
             courseware_content_type=content_type,
@@ -455,12 +457,11 @@ class FlexiblePriceAPITests(FlexiblePriceBaseTestCase):
                 country_of_income=country_code,
                 user=user,
                 courseware_object=courseware_object,
+                tier=courseware_tier,
                 status=FlexiblePriceStatus.APPROVED
                 if expected
                 else FlexiblePriceStatus.PENDING_MANUAL_APPROVAL,
             )
-
-        courseware_tier = determine_tier_courseware(courseware_object, income_usd)
         discount = self.create_run_and_product_and_discount(user, courseware_object)
 
         return courseware_tier, discount

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=redefined-outer-name
 import itertools
+import logging
 from datetime import timedelta
 from unittest.mock import ANY, call, patch
 from urllib.parse import parse_qsl
@@ -1567,7 +1568,8 @@ def test_update_edx_user_profile_no_openedx_user(
     Test that update_edx_user_profile does not attempt to update the user profile in Open edX when Open edX user is not synced
     """
     user.openedx_users.all().delete()
-    update_edx_user_profile(user)
+    with caplog.at_level(logging.INFO):
+        update_edx_user_profile(user)
     assert "Skipping user profile update" in caplog.text
 
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10549

### Description (What does it do?)

#### Issue

`DiscountFactory` and its variants (`OneTimeDiscountFactory`, `OneTimePerUserDiscountFactory`, `UnlimitedUseDiscountFactory`, `SetLimitDiscountFactory`) used `random.randrange()` to set defaults for `amount`, `discount_type`, and `redemption_type`. These evaluate once at module import time, freezing a single value for every factory instance in the process. This made `test_create_basket_with_product` flaky because the frozen `redemption_type` (which the test never pinned explicitly) could vary across test runs, affecting discount validation and comparison behavior.

#### Solution

- Replace import-time `random.randrange()` calls in all five discount factories with `fuzzy.FuzzyInteger` / `fuzzy.FuzzyChoice`, which generate fresh values per instance.
- Pin explicit `discount_type` and `redemption_type` values in `test_create_basket_with_product` so the test controls all variables that affect discount comparison.
- Fix product price to `$1000.00` so product price randomness doesn't factor into discount comparisons.
- Fix unrelated test breakage in `flexiblepricing/api_test.py` (tier linkage) and `openedx/api_test.py` (caplog level).


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
