### PR TITLE
Fixes some additional issues with the language support

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -22,7 +22,7 @@ from b2b.constants import (
     CONTRACT_MEMBERSHIP_AUTOS,
     ORG_KEY_MAX_LENGTH,
 )
-from b2b.exceptions import SourceCourseIncompleteError, TargetCourseRunExistsError
+from b2b.exceptions import SourceCourseIncompleteError
 from b2b.keycloak_admin_api import KCAM_ORGANIZATIONS, get_keycloak_model
 from b2b.keycloak_admin_dataclasses import OrganizationRepresentation
 from b2b.models import (
@@ -450,14 +450,17 @@ def create_contract_run(  # noqa: PLR0913
         new_run_tag = new_course_key.run
 
         if (
-            CourseRun.objects.filter(course=course, b2b_contract=contract).exists()
+            CourseRun.objects.filter(
+                course=course, b2b_contract=contract, language=clone_course_run.language
+            ).exists()
             and no_reruns
         ):
             msg = (
                 f"Can't create a run for {course} and contract {contract}: "
                 f"courseware ID {new_readable_id} already exists."
             )
-            raise TargetCourseRunExistsError(msg)
+            log.warning(msg)
+            continue
 
         course_run = CourseRun(
             course=course,
@@ -485,7 +488,7 @@ def create_contract_run(  # noqa: PLR0913
         if not skip_edx:
             clone_courserun.delay(course_run.id, clone_course_run.courseware_id)
 
-        log.debug(
+        log.info(
             "Created run %s (language=%s) for course %s in contract %s from %s",
             course_run,
             course_run.language,

--- a/b2b/management/commands/b2b_courseware.py
+++ b/b2b/management/commands/b2b_courseware.py
@@ -137,14 +137,14 @@ Specifying a program will only unlink the program from the contract, unless "--r
         add_subparser.add_argument(
             "--no-create-runs",
             help="Don't create contract runs in edX for the specified course, just add it to the contract.",
-            dest="create_runs",
-            action="store_false",
+            dest="no_create_runs",
+            action="store_true",
         )
         add_subparser.add_argument(
             "--allow-reruns",
-            help="Don't re-run courses that already have a run, skip over them instead. (Use if adding a language to an existing course, or cleaning up.)",
+            help="Allow courses to be re-run.",
             dest="allow_reruns",
-            action="store_false",
+            action="store_true",
         )
         add_subparser.add_argument(
             "--force",
@@ -182,17 +182,17 @@ Specifying a program will only unlink the program from the contract, unless "--r
 
         return super().add_arguments(parser)
 
-    def handle_add(self, contract, coursewares, **kwargs):  # noqa: PLR0915, C901
+    def handle_add(self, contract, coursewares, **kwargs):  # noqa: C901
         """Handle the add subcommand."""
 
-        create_runs = kwargs.pop("create_runs")
+        skip_edx = kwargs.pop("no_create_runs", False)
         force_associate = kwargs.pop("force")
         can_import = kwargs.pop("can_import")
         org_prefix = kwargs.pop("prefix")
         make_codes = kwargs.pop("make_codes", False)
-        no_reruns = kwargs.pop("allow_reruns")
+        no_reruns = not kwargs.pop("allow_reruns", True)
 
-        managed = skipped = 0
+        managed = 0
 
         if can_import:
             # Get the courseware IDs we got passed in that weren't matched to
@@ -249,8 +249,8 @@ Specifying a program will only unlink the program from the contract, unless "--r
                     )
                 )
 
-                prog_add, prog_skip, prog_no_source = contract.add_program_courses(
-                    courseware
+                prog_add, prog_no_source = contract.add_program_courses(
+                    courseware, skip_edx=skip_edx, no_reruns=no_reruns
                 )
                 if prog_no_source > 0:
                     self.stdout.write(
@@ -260,7 +260,6 @@ Specifying a program will only unlink the program from the contract, unless "--r
                     )
                 contract.save()
                 managed += prog_add
-                skipped += prog_skip
                 self.stdout.write(
                     self.style.SUCCESS(f"Added {courseware.readable_id} to {contract}.")
                 )
@@ -281,7 +280,6 @@ Specifying a program will only unlink the program from the contract, unless "--r
                             f"Run '{courseware.courseware_id}' is already owned by {courseware.b2b_contract}."
                         )
                     )
-                    skipped += 1
                     continue
                 elif courseware.b2b_contract == contract:
                     # Already owned by this contract, so skip
@@ -290,33 +288,22 @@ Specifying a program will only unlink the program from the contract, unless "--r
                             f"Run '{courseware.courseware_id}' is already owned by this contract."
                         )
                     )
-                    skipped += 1
                     continue
 
                 # Add the run to the contract
                 courseware.b2b_contract = contract
                 courseware.save()
                 managed += 1
-            elif create_runs:
+            elif self.create_run(
+                contract,
+                courseware,
+                skip_edx=skip_edx,
+                org_prefix=org_prefix,
+                no_reruns=no_reruns,
+            ):
                 # This is a course, so create a run (unless we've been told not to).
 
-                if self.create_run(
-                    contract,
-                    courseware,
-                    skip_edx=create_runs,
-                    org_prefix=org_prefix,
-                    no_reruns=no_reruns,
-                ):
-                    managed += 1
-                else:
-                    skipped += 1
-            else:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"Skipped run creation for for course {courseware.readable_id} for contract {contract}."
-                    )
-                )
-                skipped += 1
+                managed += 1
 
         if make_codes:
             self.stdout.write(f"Queueing enrollment code check for {contract}")
@@ -324,7 +311,7 @@ Specifying a program will only unlink the program from the contract, unless "--r
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Managed {managed} courseware items and skipped {skipped} courseware items for {len(coursewares)} specified courseware IDs."
+                f"Managed {managed} courseware items for {len(coursewares)} specified courseware IDs."
             )
         )
 

--- a/b2b/management/commands/b2b_courseware.py
+++ b/b2b/management/commands/b2b_courseware.py
@@ -67,6 +67,7 @@ Specifying a program will only unlink the program from the contract, unless "--r
         *,
         skip_edx=False,
         org_prefix=None,
+        no_reruns=False,
     ):
         """Create a run for the specified contract."""
         try:
@@ -75,6 +76,7 @@ Specifying a program will only unlink the program from the contract, unless "--r
                 course=courseware,
                 skip_edx=skip_edx,
                 org_prefix=org_prefix,
+                no_reruns=no_reruns,
             )
         except InvalidKeyError:
             self.stderr.write(
@@ -139,6 +141,12 @@ Specifying a program will only unlink the program from the contract, unless "--r
             action="store_false",
         )
         add_subparser.add_argument(
+            "--allow-reruns",
+            help="Don't re-run courses that already have a run, skip over them instead. (Use if adding a language to an existing course, or cleaning up.)",
+            dest="allow_reruns",
+            action="store_false",
+        )
+        add_subparser.add_argument(
             "--force",
             help="Force adding any specified runs to the contract (overwrite existing contract associations).",
             dest="force",
@@ -182,6 +190,7 @@ Specifying a program will only unlink the program from the contract, unless "--r
         can_import = kwargs.pop("can_import")
         org_prefix = kwargs.pop("prefix")
         make_codes = kwargs.pop("make_codes", False)
+        no_reruns = kwargs.pop("allow_reruns")
 
         managed = skipped = 0
 
@@ -292,7 +301,11 @@ Specifying a program will only unlink the program from the contract, unless "--r
                 # This is a course, so create a run (unless we've been told not to).
 
                 if self.create_run(
-                    contract, courseware, skip_edx=create_runs, org_prefix=org_prefix
+                    contract,
+                    courseware,
+                    skip_edx=create_runs,
+                    org_prefix=org_prefix,
+                    no_reruns=no_reruns,
                 ):
                     managed += 1
                 else:

--- a/b2b/management/tests/b2b_courseware_test.py
+++ b/b2b/management/tests/b2b_courseware_test.py
@@ -1,0 +1,264 @@
+"""Tests for the b2b_courseware command."""
+
+import pytest
+
+from b2b.factories import ContractPageFactory
+from b2b.management.commands import b2b_courseware
+from courses.factories import CourseRunFactory, ProgramFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+def _create_usable_program():
+    """Create a usable program with a handful of courses."""
+
+    program = ProgramFactory.create()
+    runs = CourseRunFactory.create_batch(4, is_source_run=True)
+
+    [program.add_requirement(run.course) for run in runs[:2]]
+    [program.add_elective(run.course) for run in runs[2:]]
+
+    return program, runs
+
+
+def _add_run_languages(run):
+    """Add some language runs to the specified runs. Make the run specified "en"."""
+
+    langs = (
+        "fr",
+        "sw",
+    )
+
+    run.language = "en"
+    run.is_primary_language = True
+    run.save()
+
+    return [
+        CourseRunFactory.create(
+            course=run.course,
+            courseware_id=f"{run.courseware_id}_{lang}",
+            run_tag=run.run_tag,
+            language=lang,
+            is_primary_language=False,
+            is_source_run=run.is_source_run,
+            b2b_contract=run.b2b_contract,
+            start_date=run.start_date,
+            end_date=run.end_date,
+            enrollment_start=run.enrollment_start,
+            enrollment_end=run.enrollment_end,
+            live=run.live,
+        )
+        for lang in langs
+    ]
+
+
+@pytest.fixture
+def mock_clone_courserun(mocker):
+    """Mock out the edX API call to clone the course run."""
+
+    return mocker.patch("openedx.tasks.clone_courserun.delay")
+
+
+@pytest.mark.parametrize(
+    "try_reruns",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "no_create_runs",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "with_languages",
+    [
+        False,
+        True,
+    ],
+)
+def test_add_program(mock_clone_courserun, with_languages, no_create_runs, try_reruns):
+    """
+    Test that adding a program to a contract works as expected.
+
+    This should add all the courses, and grab all the languages that are set up
+    as well.
+    """
+
+    contract = ContractPageFactory.create()
+    program, runs = _create_usable_program()
+    command = b2b_courseware.Command()
+
+    if with_languages:
+        [_add_run_languages(run) for run in runs]
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(program.readable_id),
+        no_create_runs=no_create_runs,
+        allow_reruns=True,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+    )
+
+    expected_run_count = 12 if with_languages else 4
+    assert contract.get_course_runs().count() == expected_run_count
+
+    if no_create_runs:
+        mock_clone_courserun.assert_not_called()
+    else:
+        mock_clone_courserun.assert_called()
+
+    # Try to re-run the program - depending on what try_runs is set to, there
+    # either should or shouldn't be a new set of runs.
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(program.readable_id),
+        no_create_runs=no_create_runs,
+        allow_reruns=try_reruns,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+    )
+
+    assert contract.get_course_runs().count() == expected_run_count * (
+        2 if try_reruns else 1
+    )
+
+
+@pytest.mark.parametrize(
+    "with_languages",
+    [
+        False,
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "no_create_runs",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "try_reruns",
+    [
+        True,
+        False,
+    ],
+)
+def test_add_course(mock_clone_courserun, with_languages, no_create_runs, try_reruns):
+    """Test that adding a single course works as expected."""
+
+    contract = ContractPageFactory.create()
+    run = CourseRunFactory.create(
+        is_source_run=True,
+        language="en" if with_languages else "",
+        is_primary_language=with_languages,
+    )
+    command = b2b_courseware.Command()
+
+    if with_languages:
+        _add_run_languages(run)
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(run.course.readable_id),
+        no_create_runs=no_create_runs,
+        allow_reruns=True,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+    )
+
+    expected_run_count = 3 if with_languages else 1
+    assert contract.get_course_runs().count() == expected_run_count
+
+    if no_create_runs:
+        mock_clone_courserun.assert_not_called()
+    else:
+        mock_clone_courserun.assert_called()
+
+    # Try to re-run the course - depending on what try_runs is set to, there
+    # either should or shouldn't be a new course run.
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(run.course.readable_id),
+        no_create_runs=no_create_runs,
+        allow_reruns=try_reruns,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+    )
+
+    assert contract.get_course_runs().count() == expected_run_count * (
+        2 if try_reruns else 1
+    )
+
+
+def test_add_courserun():
+    """Test adding an extant courserun to a contract."""
+
+    contract = ContractPageFactory.create()
+    run = CourseRunFactory.create(b2b_contract=None)
+    command = b2b_courseware.Command()
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(run.courseware_id),
+        no_create_runs=False,
+        allow_reruns=True,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+    )
+
+    run.refresh_from_db()
+    assert run.b2b_contract == contract
+
+
+@pytest.mark.parametrize(
+    "force",
+    [
+        True,
+        False,
+    ],
+)
+def test_add_courserun_existing_contract(force):
+    """Test adding an extant courserun to a contract."""
+
+    contract = ContractPageFactory.create()
+    existing_contract = ContractPageFactory.create()
+    run = CourseRunFactory.create(b2b_contract=existing_contract)
+    command = b2b_courseware.Command()
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(run.courseware_id),
+        no_create_runs=False,
+        allow_reruns=True,
+        force=force,
+        can_import="",
+        prefix="",
+        make_code=False,
+    )
+
+    run.refresh_from_db()
+    assert run.b2b_contract == (contract if force else existing_contract)

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -529,9 +529,13 @@ class ContractPage(Page, ClusterableModel):
             .all()
         )
 
-    def add_program_courses(self, program, order=None):
+    def add_program_courses(
+        self, program, order=None, *, skip_edx=False, no_reruns=True
+    ):
         """
         Add a program, and then queue adding all its courses.
+
+        This defaults to not allowing re-runs to happen.
 
         Args:
         - program (courses.Program): the program to add
@@ -539,7 +543,6 @@ class ContractPage(Page, ClusterableModel):
         Returns:
         - tuple: Tuple with three integers:
             - number of course runs created
-            - number of course runs skipped (already existed)
             - number of courses with no source run
         """
 
@@ -550,7 +553,6 @@ class ContractPage(Page, ClusterableModel):
             delattr(program, "_courses_with_requirements_data")
 
         managed = 0
-        skipped_run_creation = 0
         no_source = program.courses_qset.exclude(
             models.Q(courseruns__is_source_run=True)
             | models.Q(courseruns__run_tag="SOURCE")
@@ -560,7 +562,9 @@ class ContractPage(Page, ClusterableModel):
             models.Q(courseruns__is_source_run=True)
             | models.Q(courseruns__run_tag="SOURCE")
         ).all():
-            created_runs = create_contract_run(self, course, no_reruns=True)
+            created_runs = create_contract_run(
+                self, course, no_reruns=no_reruns, skip_edx=skip_edx
+            )
             managed += len(created_runs)
 
         if order is None:
@@ -575,7 +579,7 @@ class ContractPage(Page, ClusterableModel):
             item = ContractProgramItem(contract=self, program=program, sort_order=order)
             item.save(skip_run_creation=True)
 
-        return (managed, skipped_run_creation, no_source)
+        return (managed, no_source)
 
     class Meta:
         """Meta options for the ContractPage."""

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -25,7 +25,6 @@ from b2b.constants import (
     CONTRACT_MEMBERSHIP_TYPE_CHOICES,
     ORG_INDEX_SLUG,
 )
-from b2b.exceptions import TargetCourseRunExistsError
 from courses.constants import UAI_COURSEWARE_ID_PREFIX
 from courses.models import Program
 
@@ -561,11 +560,8 @@ class ContractPage(Page, ClusterableModel):
             models.Q(courseruns__is_source_run=True)
             | models.Q(courseruns__run_tag="SOURCE")
         ).all():
-            try:
-                create_contract_run(self, course, no_reruns=True)
-                managed += 1
-            except TargetCourseRunExistsError:  # noqa: PERF203
-                skipped_run_creation += 1
+            created_runs = create_contract_run(self, course, no_reruns=True)
+            managed += len(created_runs)
 
         if order is None:
             last_item = self.contract_programs.order_by("-sort_order").first()

--- a/b2b/models_test.py
+++ b/b2b/models_test.py
@@ -54,7 +54,6 @@ def test_add_program_courses_to_contract(mocker):
     created, skipped, no_source = contract.add_program_courses(program)
 
     assert created == 1
-    assert skipped == 3
     assert no_source == 0
 
     contract.save()

--- a/b2b/models_test.py
+++ b/b2b/models_test.py
@@ -34,10 +34,9 @@ def test_add_program_courses_to_contract(mocker):
 
     program.refresh_from_db()
 
-    created, skipped, no_source = contract.add_program_courses(program)
+    created, no_source = contract.add_program_courses(program)
 
     assert created == 3
-    assert skipped == 0
     assert no_source == 0
 
     contract.save()
@@ -51,7 +50,7 @@ def test_add_program_courses_to_contract(mocker):
     program.save()
     program.refresh_from_db()
 
-    created, skipped, no_source = contract.add_program_courses(program)
+    created, no_source = contract.add_program_courses(program)
 
     assert created == 1
     assert no_source == 0

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -71,6 +71,36 @@ class ProgramContractPageInline(admin.TabularInline):
     extra = 0
 
 
+class CourseRunInline(admin.TabularInline):
+    """Inline for course runs for a given course"""
+
+    model = CourseRun
+    extra = 0
+    fields = (
+        "id",
+        "title",
+        "courseware_id",
+        "run_tag",
+        "language",
+        "is_primary_language",
+        "is_source_run",
+        "b2b_contract",
+        "start_date",
+        "end_date",
+        "enrollment_start",
+        "upgrade_deadline",
+    )
+
+    def has_add_permission(self, *args, **kwargs):  # noqa: ARG002
+        return False
+
+    def has_change_permission(self, *args, **kwargs):  # noqa: ARG002
+        return False
+
+    def has_delete_permission(self, *args, **kwargs):  # noqa: ARG002
+        return False
+
+
 @admin.register(Program)
 class ProgramAdmin(VerifiableCredentialBackfillAdminMixin, admin.ModelAdmin):
     """Admin for Program"""
@@ -129,6 +159,7 @@ class CourseAdmin(admin.ModelAdmin):
         "readable_id",
     )
     list_filter = ["live", "departments"]
+    inlines = [CourseRunInline]
 
     formfield_overrides = {
         models.CharField: {"widget": TextInput(attrs={"size": "80"})}
@@ -173,6 +204,9 @@ class CourseRunAdmin(VerifiableCredentialBackfillAdminMixin, TimestampedModelAdm
         "courseware_id",
         "run_tag",
         "language",
+        "primary",
+        "source",
+        "contract",
         "start_date",
         "end_date",
         "enrollment_start",
@@ -212,6 +246,21 @@ class CourseRunAdmin(VerifiableCredentialBackfillAdminMixin, TimestampedModelAdm
         """Use the all_objects manager so we can see source runs."""
 
         return self.model.all_objects
+
+    @admin.display(description="Primary?", ordering="is_primary_language")
+    def primary(self, obj):
+        """Return the primary language run flag."""
+        return obj.is_primary_language
+
+    @admin.display(description="Source?", ordering="is_source_run")
+    def source(self, obj):
+        """Return the source run flag."""
+        return obj.is_source_run
+
+    @admin.display(description="Contract", ordering="b2b_contract")
+    def contract(self, obj):
+        """Return the B2B contract title."""
+        return obj.b2b_contract.name if obj.b2b_contract else ""
 
 
 @admin.register(ProgramEnrollment)

--- a/courses/models.py
+++ b/courses/models.py
@@ -165,6 +165,10 @@ class CourseRunQuerySet(models.QuerySet):  # pylint: disable=missing-docstring
         """Applies a filter for the CourseRun's courseware_id"""
         return self.filter(courseware_id=text_id)
 
+    def source(self):
+        """Filter for source runs"""
+        return self.filter(Q(is_source_run=True) | Q(run_tag="SOURCE"))
+
 
 class UsableCourseRunManager(models.Manager):
     """Simple manager to filter out source runs."""

--- a/openedx/tasks.py
+++ b/openedx/tasks.py
@@ -109,6 +109,6 @@ def clone_courserun(target_id: int, base_key: str):
 
     from courses.models import CourseRun  # noqa: PLC0415
 
-    target_course = CourseRun.objects.get(pk=target_id)
+    target_course = CourseRun.all_objects.get(pk=target_id)
 
     api.process_course_run_clone(target_course, base_key)


### PR DESCRIPTION
### What are the relevant tickets?

Related to mitodl/hq#11100

### Description (What does it do?)

There were a couple of other issues that needed fixing for course translations:

- The course run clone task wasn't firing - this was because the task hadn't been updated to use `CourseRun.all_objects` and we only really clone source courses, so it wasn't seeing anything to clone.
- The `create_contract_run` code needed a couple of updates to consider the language when checking for an existing run
- The `create_contract_run` code also needed to continue on if `no_reruns` is set (which it is for programs) - if you added a program, it'd end up adding one, then looping and determining that the course run already was there and then stopping

Also, adds some minor creature comfort things:
- The Course Run admin in Django Admin now shows primary language and source run flags, and the contract if there is one
- The Course admin in Django Admin now lists out the course's runs
- Using `b2b_courseware add <course>`, you can now specify `--allow-reruns` to explicitly tell it to re-run a particular course (it would default to doing this whether you wanted to or not; it now defaults to _not_ rerun courses).

### How can this be tested?

Automated test should work.

Adding a course or a program to a contract should kick off a clone task, and that should actually succeed now. You should at least see it be queued if you don't have edX set up.

Adding a course that has multiple languages via a program should work properly. You should be able to re-add a program to an existing contract where it hasn't worked right, and it should create the runs you're missing for it.