### PR TITLE
feat: removes the MITx site header from all checkout-related views

### DIFF
--- a/frontend/public/src/containers/App.js
+++ b/frontend/public/src/containers/App.js
@@ -73,7 +73,7 @@ export class App extends React.Component<Props, void> {
     return searchParams.has("ecom-service")
   }
 
-  isCheckoutPage() {
+  isCheckoutRelatedPage() {
     const { match, location } = this.props
     return (
       !!matchPath(location.pathname, {
@@ -104,7 +104,7 @@ export class App extends React.Component<Props, void> {
 
     return (
       <div className="app" aria-flowto="notifications-container">
-        {!this.isEcomServiceMode() && !this.isCheckoutPage() && (
+        {!this.isEcomServiceMode() && !this.isCheckoutRelatedPage() && (
           <Header
             currentUser={currentUser}
             cartItemsCount={currentUser.is_authenticated ? cartItemsCount : 0}

--- a/frontend/public/src/containers/App.js
+++ b/frontend/public/src/containers/App.js
@@ -73,12 +73,26 @@ export class App extends React.Component<Props, void> {
     return searchParams.has("ecom-service")
   }
 
-  isOrderReceiptPage() {
+  isCheckoutPage() {
     const { match, location } = this.props
-    return !!matchPath(location.pathname, {
-      path:  urljoin(match.url, String(routes.orderReceipt)),
-      exact: true
-    })
+    return (
+      !!matchPath(location.pathname, {
+        path:  urljoin(match.url, String(routes.cart)),
+        exact: false
+      }) ||
+      !!matchPath(location.pathname, {
+        path:  urljoin(match.url, String(routes.orderHistory)),
+        exact: false
+      }) ||
+      !!matchPath(location.pathname, {
+        path:  urljoin(match.url, String(routes.orderReceipt)),
+        exact: false
+      }) ||
+      !!matchPath(location.pathname, {
+        path:  "/checkout/",
+        exact: false
+      })
+    )
   }
 
   render() {
@@ -90,7 +104,7 @@ export class App extends React.Component<Props, void> {
 
     return (
       <div className="app" aria-flowto="notifications-container">
-        {!this.isEcomServiceMode() && !this.isOrderReceiptPage() && (
+        {!this.isEcomServiceMode() && !this.isCheckoutPage() && (
           <Header
             currentUser={currentUser}
             cartItemsCount={currentUser.is_authenticated ? cartItemsCount : 0}

--- a/frontend/public/src/containers/App_test.js
+++ b/frontend/public/src/containers/App_test.js
@@ -10,6 +10,20 @@ import IntegrationTestHelper from "../util/integration_test_helper"
 describe("Top-level App", () => {
   let helper, renderPage, getStoredUserMessageStub, removeStoredUserMessageStub
 
+  const anonymousUser = {
+    id:               null,
+    username:         "",
+    email:            null,
+    legal_address:    null,
+    user_profile:     null,
+    is_anonymous:     true,
+    is_authenticated: false,
+    is_staff:         false,
+    is_superuser:     false,
+    grants:           [],
+    is_active:        false
+  }
+
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     getStoredUserMessageStub = helper.sandbox
@@ -53,19 +67,7 @@ describe("Top-level App", () => {
   })
 
   it("fetches user data on load and renders user in the header", async () => {
-    helper.handleRequestStub.returns({
-      id:               null,
-      username:         "",
-      email:            null,
-      legal_address:    null,
-      user_profile:     null,
-      is_anonymous:     true,
-      is_authenticated: false,
-      is_staff:         false,
-      is_superuser:     false,
-      grants:           [],
-      is_active:        false
-    })
+    helper.handleRequestStub.returns(anonymousUser)
     const { inner } = await renderPage()
     // So we look to be sure the next child is there, which is <Header />, which is not there otherwise
     assert.exists(inner.find("Header"))
@@ -97,19 +99,7 @@ describe("Top-level App", () => {
   })
 
   it("does not call cartItemsCountQuery for unauthenticated users", async () => {
-    helper.handleRequestStub.returns({
-      id:               null,
-      username:         "",
-      email:            null,
-      legal_address:    null,
-      user_profile:     null,
-      is_anonymous:     true,
-      is_authenticated: false,
-      is_staff:         false,
-      is_superuser:     false,
-      grants:           [],
-      is_active:        false
-    })
+    helper.handleRequestStub.returns(anonymousUser)
     await renderPage()
     // Should call /api/users/me to get user data
     sinon.assert.calledWith(
@@ -123,5 +113,90 @@ describe("Top-level App", () => {
       "/api/checkout/basket_items_count/",
       "GET"
     )
+  })
+
+  it("does not render header on cart page", async () => {
+    helper.handleRequestStub.returns(anonymousUser)
+    renderPage = helper.configureMountRenderer(
+      App,
+      InnerApp,
+      {},
+      {
+        match:    { url: routes.root },
+        location: {
+          pathname: "/cart/"
+        }
+      }
+    )
+    const { inner } = await renderPage()
+    assert.isFalse(inner.find("Header").exists())
+  })
+
+  it("does not render header on checkout page", async () => {
+    helper.handleRequestStub.returns(anonymousUser)
+    renderPage = helper.configureMountRenderer(
+      App,
+      InnerApp,
+      {},
+      {
+        match:    { url: routes.root },
+        location: {
+          pathname: "/checkout/"
+        }
+      }
+    )
+    const { inner } = await renderPage()
+    assert.isFalse(inner.find("Header").exists())
+  })
+
+  it("does not render header on order history page", async () => {
+    helper.handleRequestStub.returns(anonymousUser)
+    renderPage = helper.configureMountRenderer(
+      App,
+      InnerApp,
+      {},
+      {
+        match:    { url: routes.root },
+        location: {
+          pathname: "/orders/history"
+        }
+      }
+    )
+    const { inner } = await renderPage()
+    assert.isFalse(inner.find("Header").exists())
+  })
+
+  it("does not render header on order receipt page", async () => {
+    helper.handleRequestStub.returns(anonymousUser)
+    renderPage = helper.configureMountRenderer(
+      App,
+      InnerApp,
+      {},
+      {
+        match:    { url: routes.root },
+        location: {
+          pathname: "/orders/receipt/123"
+        }
+      }
+    )
+    const { inner } = await renderPage()
+    assert.isFalse(inner.find("Header").exists())
+  })
+
+  it("renders header on dashboard page", async () => {
+    helper.handleRequestStub.returns(anonymousUser)
+    renderPage = helper.configureMountRenderer(
+      App,
+      InnerApp,
+      {},
+      {
+        match:    { url: routes.root },
+        location: {
+          pathname: "/dashboard/"
+        }
+      }
+    )
+    const { inner } = await renderPage()
+    assert.exists(inner.find("Header"))
   })
 })

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -34,7 +34,7 @@
     {% include "partials/gtm_body.html" %}
 
     {% include 'hijack/notification.html' %}
-    {% if not request.path|startswith:'/certificate/' and 'ecom-service' not in request.GET %}
+    {% if not request.path|startswith:'/certificate/' and not request.path|startswith:'/cart/' and not request.path|startswith:'/checkout/' and not request.path|startswith:'/orders/' and 'ecom-service' not in request.GET %}
       {% banner %}
       {% block headercontent %}
         <div id="header"></div>
@@ -48,7 +48,7 @@
     {% block contact-us %}
     {% endblock %}
   </div>
-    {% if 'ecom-service' not in request.GET %}
+    {% if 'ecom-service' not in request.GET and not request.path|startswith:'/cart/' and not request.path|startswith:'/checkout/' and not request.path|startswith:'/orders/' %}
     {% block footer %}
         {% include "footer.html" %}
     {% endblock %}


### PR DESCRIPTION

### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11122

### Description (What does it do?)
Removes the MITx site header from all checkout-related views unconditionally (without depending on ?ecom-service=true), so branding stays consistent through cart/checkout flows including payment-cancel return paths.


### Screenshots (if appropriate):

<img width="1471" height="954" alt="Screenshot 2026-05-05 at 2 31 37 PM" src="https://github.com/user-attachments/assets/c3103bbf-cc07-49ac-91f7-fbd373f38d58" />

<img width="1561" height="952" alt="Screenshot 2026-05-05 at 2 31 09 PM" src="https://github.com/user-attachments/assets/92bd2292-d821-4e0f-8a13-d60e7121823c" />

<img width="1554" height="895" alt="Screenshot 2026-05-05 at 2 31 00 PM" src="https://github.com/user-attachments/assets/bd69d294-5129-4d26-a103-bb13baa1ade3" />


### How can this be tested?
Confirm MITx site header is not visible at all the following urls.

- Open /cart/ (without ecom-service query param)


- Open /orders/history

   

- Open /orders/receipt/<any-id>

- Trigger checkout from cart (Place your order)

- In local, CyberSource may return 403 due to gateway auth/session config.
- Even after returning to /cart/ without query params, header remains hidden (regression target).

**In the end:**

Open /dashboard/ (control route)

_Confirm MITx site header is visible._


