### PR TITLE
only respond with enrolled contract on enrollment code redemption

### DIFF
--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -121,7 +121,7 @@ class AttachContractApi(APIView):
 
     @extend_schema(
         request=None,
-        responses=ContractPageSerializer(many=True),
+        responses=ContractPageSerializer,
     )
     def post(self, request, enrollment_code: str, format=None):  # noqa: A002, ARG002
         """
@@ -144,7 +144,7 @@ class AttachContractApi(APIView):
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - list of ContractPageSerializer - the contracts for the user
+        - ContractPageSerializer (or null) - the active contract associated with the code
         """
         now = now_in_utc()
 
@@ -199,11 +199,17 @@ class AttachContractApi(APIView):
             request.user, contracts, code
         )
 
-        active_contracts = self._get_active_user_contracts(request.user, now)
-        serialized_contracts = ContractPageSerializer(active_contracts, many=True).data
+        active_code_contract = self._get_active_code_user_contract(
+            request.user, code, now
+        )
+        serialized_contract = (
+            ContractPageSerializer(active_code_contract).data
+            if active_code_contract
+            else None
+        )
 
         if contracts_attached:
-            return Response(serialized_contracts, status=status.HTTP_201_CREATED)
+            return Response(serialized_contract, status=status.HTTP_201_CREATED)
 
         if contract_full:
             return Response(
@@ -211,12 +217,16 @@ class AttachContractApi(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        return Response(serialized_contracts, status=status.HTTP_200_OK)
+        return Response(serialized_contract, status=status.HTTP_200_OK)
 
-    def _get_active_user_contracts(self, user, now):
-        """Return active contracts for a user at the given time."""
-        return user.b2b_contracts.filter(active=True).exclude(
-            Q(contract_start__gt=now) | Q(contract_end__lt=now)
+    def _get_active_code_user_contract(self, user, code, now):
+        """Return the user's active contract associated with the redeemed code."""
+        code_contract_ids = code.b2b_contracts().values_list("id", flat=True)
+        return (
+            user.b2b_contracts.filter(active=True)
+            .exclude(Q(contract_start__gt=now) | Q(contract_end__lt=now))
+            .filter(pk__in=code_contract_ids)
+            .first()
         )
 
     def _get_valid_discount(self, enrollment_code, now):

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -121,7 +121,7 @@ class AttachContractApi(APIView):
 
     @extend_schema(
         request=None,
-        responses=ContractPageSerializer,
+        responses=ContractPageSerializer(many=True),
     )
     def post(self, request, enrollment_code: str, format=None):  # noqa: A002, ARG002
         """
@@ -144,7 +144,7 @@ class AttachContractApi(APIView):
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - ContractPageSerializer (or null) - the active contract associated with the code
+        - list of ContractPageSerializer - the active contract associated with the code
         """
         now = now_in_utc()
 
@@ -202,14 +202,17 @@ class AttachContractApi(APIView):
         active_code_contract = self._get_active_code_user_contract(
             request.user, code, now
         )
-        serialized_contract = (
-            ContractPageSerializer(active_code_contract).data
+        # Keep v0 response signature stable (array payload) for existing clients.
+        # When we ship a new API version, switch this endpoint to return a single
+        # contract object instead of a one-item list.
+        serialized_contracts = (
+            [ContractPageSerializer(active_code_contract).data]
             if active_code_contract
-            else None
+            else []
         )
 
         if contracts_attached:
-            return Response(serialized_contract, status=status.HTTP_201_CREATED)
+            return Response(serialized_contracts, status=status.HTTP_201_CREATED)
 
         if contract_full:
             return Response(
@@ -217,7 +220,7 @@ class AttachContractApi(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        return Response(serialized_contract, status=status.HTTP_200_OK)
+        return Response(serialized_contracts, status=status.HTTP_200_OK)
 
     def _get_active_code_user_contract(self, user, code, now):
         """Return the user's active contract associated with the redeemed code."""

--- a/b2b/views/v0/views_test.py
+++ b/b2b/views/v0/views_test.py
@@ -115,6 +115,76 @@ def test_b2b_contract_attachment(mocker, max_learners, code_used):
         assert DiscountContractAttachmentRedemption.objects.filter(
             contract=contract, user=user, discount=contract_codes[0]
         ).exists()
+        assert resp.json()["id"] == contract.id
+
+
+def test_b2b_contract_attachment_response_excludes_unrelated_contracts(mocker):
+    """The attach response should only include contracts tied to the redeemed code."""
+
+    mocker.patch("b2b.models.OrganizationPage.attach_user", return_value=True)
+
+    user = UserFactory.create()
+    unrelated_contract = ContractPageFactory.create()
+    user.b2b_contracts.add(unrelated_contract)
+
+    contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_NONSSO,
+        integration_type=CONTRACT_MEMBERSHIP_NONSSO,
+    )
+    courserun = CourseRunFactory.create(b2b_contract=contract)
+    ProductFactory.create(purchasable_object=courserun)
+
+    ensure_enrollment_codes_exist(contract)
+    contract_code = contract.get_discounts().first()
+
+    client = APIClient()
+    client.force_login(user)
+
+    url = reverse(
+        "b2b:attach-user", kwargs={"enrollment_code": contract_code.discount_code}
+    )
+    resp = client.post(url)
+
+    assert resp.status_code == 201
+    assert resp.json()["id"] == contract.id
+
+
+def test_b2b_contract_attachment_returns_matching_contract_when_already_attached(
+    mocker,
+):
+    """A valid code should return its matching contract even if already attached."""
+
+    mocked_attach_user = mocker.patch(
+        "b2b.models.OrganizationPage.attach_user", return_value=True
+    )
+
+    user = UserFactory.create()
+    unrelated_contract = ContractPageFactory.create()
+    user.b2b_contracts.add(unrelated_contract)
+
+    contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_NONSSO,
+        integration_type=CONTRACT_MEMBERSHIP_NONSSO,
+    )
+    courserun = CourseRunFactory.create(b2b_contract=contract)
+    ProductFactory.create(purchasable_object=courserun)
+
+    ensure_enrollment_codes_exist(contract)
+    contract_code = contract.get_discounts().first()
+
+    user.b2b_contracts.add(contract)
+
+    client = APIClient()
+    client.force_login(user)
+
+    url = reverse(
+        "b2b:attach-user", kwargs={"enrollment_code": contract_code.discount_code}
+    )
+    resp = client.post(url)
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == contract.id
+    mocked_attach_user.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -220,6 +290,7 @@ def test_b2b_contract_attachment_invalid_contract_dates(user, bad_start_or_end):
 
     # Contract dates are invalid - code is valid but no contracts to attach - should return 200
     assert resp.status_code == 200
+    assert resp.data is None
 
     user.refresh_from_db()
     assert not user.b2b_contracts.filter(pk=contract.id).exists()

--- a/b2b/views/v0/views_test.py
+++ b/b2b/views/v0/views_test.py
@@ -115,7 +115,7 @@ def test_b2b_contract_attachment(mocker, max_learners, code_used):
         assert DiscountContractAttachmentRedemption.objects.filter(
             contract=contract, user=user, discount=contract_codes[0]
         ).exists()
-        assert resp.json()["id"] == contract.id
+        assert resp.json()[0]["id"] == contract.id
 
 
 def test_b2b_contract_attachment_response_excludes_unrelated_contracts(mocker):
@@ -146,7 +146,7 @@ def test_b2b_contract_attachment_response_excludes_unrelated_contracts(mocker):
     resp = client.post(url)
 
     assert resp.status_code == 201
-    assert resp.json()["id"] == contract.id
+    assert resp.json()[0]["id"] == contract.id
 
 
 def test_b2b_contract_attachment_returns_matching_contract_when_already_attached(
@@ -183,7 +183,7 @@ def test_b2b_contract_attachment_returns_matching_contract_when_already_attached
     resp = client.post(url)
 
     assert resp.status_code == 200
-    assert resp.json()["id"] == contract.id
+    assert resp.json()[0]["id"] == contract.id
     mocked_attach_user.assert_not_called()
 
 
@@ -290,7 +290,7 @@ def test_b2b_contract_attachment_invalid_contract_dates(user, bad_start_or_end):
 
     # Contract dates are invalid - code is valid but no contracts to attach - should return 200
     assert resp.status_code == 200
-    assert resp.data is None
+    assert resp.json() == []
 
     user.refresh_from_db()
     assert not user.b2b_contracts.filter(pk=contract.id).exists()

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -121,7 +121,7 @@ paths:
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - list of ContractPageSerializer - the contracts for the user
+        - ContractPageSerializer (or null) - the active contract associated with the code
       parameters:
       - in: path
         name: enrollment_code
@@ -135,9 +135,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractPage'
+                $ref: '#/components/schemas/ContractPage'
           description: ''
   /api/v0/b2b/contracts/:
     get:

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -121,7 +121,7 @@ paths:
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - ContractPageSerializer (or null) - the active contract associated with the code
+        - list of ContractPageSerializer - the active contract associated with the code
       parameters:
       - in: path
         name: enrollment_code
@@ -135,7 +135,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractPage'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractPage'
           description: ''
   /api/v0/b2b/contracts/:
     get:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -121,7 +121,7 @@ paths:
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - list of ContractPageSerializer - the contracts for the user
+        - ContractPageSerializer (or null) - the active contract associated with the code
       parameters:
       - in: path
         name: enrollment_code
@@ -135,9 +135,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractPage'
+                $ref: '#/components/schemas/ContractPage'
           description: ''
   /api/v0/b2b/contracts/:
     get:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -121,7 +121,7 @@ paths:
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - ContractPageSerializer (or null) - the active contract associated with the code
+        - list of ContractPageSerializer - the active contract associated with the code
       parameters:
       - in: path
         name: enrollment_code
@@ -135,7 +135,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractPage'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractPage'
           description: ''
   /api/v0/b2b/contracts/:
     get:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -121,7 +121,7 @@ paths:
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - list of ContractPageSerializer - the contracts for the user
+        - ContractPageSerializer (or null) - the active contract associated with the code
       parameters:
       - in: path
         name: enrollment_code
@@ -135,9 +135,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractPage'
+                $ref: '#/components/schemas/ContractPage'
           description: ''
   /api/v0/b2b/contracts/:
     get:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -121,7 +121,7 @@ paths:
         - 200: Code valid but user already attached to all associated contracts
         - 404: Invalid or expired enrollment code
         - 409: Code valid but no available seats in associated contract(s)
-        - ContractPageSerializer (or null) - the active contract associated with the code
+        - list of ContractPageSerializer - the active contract associated with the code
       parameters:
       - in: path
         name: enrollment_code
@@ -135,7 +135,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractPage'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractPage'
           description: ''
   /api/v0/b2b/contracts/:
     get:


### PR DESCRIPTION
### What are the relevant tickets?
Pre-requisite for https://github.com/mitodl/hq/issues/11112

### Description (What does it do?)
This PR changes the B2B enrollment code attach endpoint to return only the contract that you have enrolled in that is tied to the enrollment code you are redeeming. Previously it returned a list of all the users contracts every time.

### How can this be tested?
- Generate an enrollment code using the b2b management commands
- Redeem the code using the API and ensure that you only get the contract tied to the code in the response
