### PR TITLE
Log if theres a misconfigured enrollment code given in attach API, return 404

### DIFF
--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -248,6 +248,15 @@ class AttachContractApi(APIView):
     def _get_eligible_contracts(self, user, code, now):
         """Return contracts associated with the code that the user can join."""
         contract_ids = list(code.b2b_contracts().values_list("id", flat=True))
+        if not contract_ids:
+            # Log an error here. We found a code, but it isn't associated with any contracts, which is generally confusing for operators.
+            # We could also surface this to the user by checking in the caller for an empty return.
+            log.error(
+                "B2B attach: code %s is valid but not associated with any contracts",
+                code,
+            )
+            return ContractPage.objects.none()
+
         return (
             ContractPage.objects.filter(pk__in=contract_ids)
             .exclude(pk__in=user.b2b_contracts.all())

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -194,7 +194,7 @@ class AttachContractApi(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        b2b_contract_ids = list(code.b2b_contracts.values_list("id", flat=True))
+        b2b_contract_ids = list(code.b2b_contracts().values_list("id", flat=True))
         if not b2b_contract_ids:
             # Log an error here. We found a code, but it isn't associated with any contracts, which is generally confusing for operators.
             # We could also surface this to the user by checking in the caller for an empty return.

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -194,12 +194,20 @@ class AttachContractApi(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        contracts = self._get_eligible_contracts(request.user, code, now)
-        if not contracts:
+        b2b_contract_ids = list(code.b2b_contracts.values_list("id", flat=True))
+        if not b2b_contract_ids:
+            # Log an error here. We found a code, but it isn't associated with any contracts, which is generally confusing for operators.
+            # We could also surface this to the user by checking in the caller for an empty return.
+            log.error(
+                "B2B attach: code %s is valid but not associated with any contracts",
+                code,
+            )
             return Response(
-                {"detail": "No eligible contracts found for this code."},
+                {"detail": "No contracts found for this code."},
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        contracts = self._get_eligible_contracts(request.user, b2b_contract_ids, now)
 
         contracts_attached, contract_full = self._attach_user_to_contracts(
             request.user, contracts, code
@@ -251,17 +259,8 @@ class AttachContractApi(APIView):
             .get(discount_code=enrollment_code)
         )
 
-    def _get_eligible_contracts(self, user, code, now):
+    def _get_eligible_contracts(self, user, contract_ids, now):
         """Return contracts associated with the code that the user can join."""
-        contract_ids = list(code.b2b_contracts().values_list("id", flat=True))
-        if not contract_ids:
-            # Log an error here. We found a code, but it isn't associated with any contracts, which is generally confusing for operators.
-            # We could also surface this to the user by checking in the caller for an empty return.
-            log.error(
-                "B2B attach: code %s is valid but not associated with any contracts",
-                code,
-            )
-            return ContractPage.objects.none()
 
         return (
             ContractPage.objects.filter(pk__in=contract_ids)

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -123,7 +123,7 @@ class AttachContractApi(APIView):
         request=None,
         responses=ContractPageSerializer(many=True),
     )
-    def post(self, request, enrollment_code: str, format=None):  # noqa: A002, ARG002
+    def post(self, request, enrollment_code: str, format=None):  # noqa: A002, ARG002, C901
         """
         Use the provided enrollment code to attach the user to a B2B contract.
 
@@ -195,6 +195,12 @@ class AttachContractApi(APIView):
             )
 
         contracts = self._get_eligible_contracts(request.user, code, now)
+        if not contracts:
+            return Response(
+                {"detail": "No eligible contracts found for this code."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         contracts_attached, contract_full = self._attach_user_to_contracts(
             request.user, contracts, code
         )

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -197,7 +197,6 @@ class AttachContractApi(APIView):
         b2b_contract_ids = list(code.b2b_contracts().values_list("id", flat=True))
         if not b2b_contract_ids:
             # Log an error here. We found a code, but it isn't associated with any contracts, which is generally confusing for operators.
-            # We could also surface this to the user by checking in the caller for an empty return.
             log.error(
                 "B2B attach: code %s is valid but not associated with any contracts",
                 code,

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -214,7 +214,7 @@ class AttachContractApi(APIView):
         )
 
         active_code_contract = self._get_active_code_user_contract(
-            request.user, code, now
+            request.user, b2b_contract_ids, now
         )
         # Keep v0 response signature stable (array payload) for existing clients.
         # When we ship a new API version, switch this endpoint to return a single
@@ -236,13 +236,12 @@ class AttachContractApi(APIView):
 
         return Response(serialized_contracts, status=status.HTTP_200_OK)
 
-    def _get_active_code_user_contract(self, user, code, now):
+    def _get_active_code_user_contract(self, user, contract_ids_for_code, now):
         """Return the user's active contract associated with the redeemed code."""
-        code_contract_ids = code.b2b_contracts().values_list("id", flat=True)
         return (
             user.b2b_contracts.filter(active=True)
             .exclude(Q(contract_start__gt=now) | Q(contract_end__lt=now))
-            .filter(pk__in=code_contract_ids)
+            .filter(pk__in=contract_ids_for_code)
             .first()
         )
 
@@ -259,11 +258,11 @@ class AttachContractApi(APIView):
             .get(discount_code=enrollment_code)
         )
 
-    def _get_eligible_contracts(self, user, contract_ids, now):
+    def _get_eligible_contracts(self, user, contract_ids_for_code, now):
         """Return contracts associated with the code that the user can join."""
 
         return (
-            ContractPage.objects.filter(pk__in=contract_ids)
+            ContractPage.objects.filter(pk__in=contract_ids_for_code)
             .exclude(pk__in=user.b2b_contracts.all())
             .exclude(Q(contract_end__lt=now) | Q(contract_start__gt=now))
             .all()

--- a/b2b/views/v0/views_test.py
+++ b/b2b/views/v0/views_test.py
@@ -52,7 +52,7 @@ def test_b2b_contract_attachment_code_with_no_contracts(user):
     resp = client.post(url)
 
     assert resp.status_code == 404
-    assert resp.json()["detail"] == "No eligible contracts found for this code."
+    assert resp.json()["detail"] == "No contracts found for this code."
     assert user.b2b_contracts.count() == 0
 
 

--- a/b2b/views/v0/views_test.py
+++ b/b2b/views/v0/views_test.py
@@ -16,7 +16,7 @@ from b2b.factories import ContractPageFactory
 from b2b.models import DiscountContractAttachmentRedemption
 from courses.factories import CourseRunFactory
 from courses.models import CourseRunEnrollment
-from ecommerce.factories import ProductFactory
+from ecommerce.factories import ProductFactory, UnlimitedUseDiscountFactory
 from main.constants import (
     USER_MSG_TYPE_B2B_ENROLL_SUCCESS,
     USER_MSG_TYPE_B2B_ERROR_NOT_ENROLLABLE,
@@ -38,6 +38,21 @@ def test_b2b_contract_attachment_bad_code(user):
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Invalid or expired enrollment code."
+    assert user.b2b_contracts.count() == 0
+
+
+def test_b2b_contract_attachment_code_with_no_contracts(user):
+    """Ensure a code not tied to any B2B contracts returns 404."""
+    client = APIClient()
+    client.force_login(user)
+
+    discount = UnlimitedUseDiscountFactory.create()
+
+    url = reverse("b2b:attach-user", kwargs={"enrollment_code": discount.discount_code})
+    resp = client.post(url)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "No eligible contracts found for this code."
     assert user.b2b_contracts.count() == 0
 
 


### PR DESCRIPTION
### Description (What does it do?)
Adds a log message for the misconfiguration encountered [here](https://mitodl.slack.com/archives/C03K5HYGPT9/p1778008858760089)

Essentially, the code existed, but it was not linked up such that Discount.b2b_contracts() returned an empty list. In this codepath, that's not really expected, so it dropped through after performing no attachment and returned a 200. 

With this change we emit an error to sentry and return a 404.

### Screenshots (if appropriate):
Code in question on production:
<img width="872" height="113" alt="Screenshot 2026-05-05 at 5 18 39 PM" src="https://github.com/user-attachments/assets/cbe6cbd4-d843-4674-a80e-4dd30877ead8" />


### How can this be tested?
- Add a Discount in the admin page. I used the following minimal settings.
<img width="896" height="859" alt="Screenshot 2026-05-06 at 12 36 33 PM" src="https://github.com/user-attachments/assets/9562072a-4976-4f3c-b06a-d82004937688" />
- Visit `http://mitxonline.odl.local:9080/api/v0/b2b/attach/test/` and hit POST. 
- You should get back 404 with a descriptive message and in the web container's UI, we should see an error like the following:
<img width="1726" height="28" alt="Screenshot 2026-05-06 at 12 39 27 PM" src="https://github.com/user-attachments/assets/dd65ffd9-0591-4345-bbc4-22c665c9407a" />


### Additional Context
- There were a few calls to `code.b2b_contracts().values_list("id", flat=True)` repeated in helper functions. Since `b2b_contracts()` isn't cached, I figured I'd pull that logic into the caller to try and reduce duplicative DB calls. That said, a quick look at the codebase makes it seem like Discount.b2b_contracts is only used in this api end point and a single management command, so an alternative approach would be to just make it a cached_property