### PR TITLE
feat: add cron job for program certificates

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -1233,6 +1233,180 @@ def generate_multiple_programs_certificate(user, programs):
     return results
 
 
+def get_eligible_program_certificate_candidates():
+    """
+    Return a queryset of ProgramEnrollment rows that are eligible for a program
+    certificate but do not yet have one.
+
+    Filters applied:
+    - Enrollment is active
+    - Enrollment mode is verified
+    - Program is live
+    - No existing ProgramCertificate (including revoked) for the same user+program pair
+
+    The queryset is ordered by primary key for stable pk-windowed batching and
+    annotated with `has_program_cert` for transparency.
+
+    Returns:
+        QuerySet[ProgramEnrollment]
+    """
+    from django.db.models import Exists, OuterRef, Prefetch  # noqa: PLC0415
+
+    existing_cert = ProgramCertificate.all_objects.filter(
+        user_id=OuterRef("user_id"),
+        program_id=OuterRef("program_id"),
+    )
+
+    return (
+        ProgramEnrollment.objects.filter(
+            active=True,
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+            program__live=True,
+        )
+        .annotate(has_program_cert=Exists(existing_cert))
+        .filter(has_program_cert=False)
+        .select_related("user", "program")
+        .prefetch_related(
+            Prefetch(
+                "program__all_requirements",
+                queryset=ProgramRequirement.objects.select_related(
+                    "course", "required_program"
+                ),
+            )
+        )
+        .order_by("id")
+    )
+
+
+def generate_missing_program_certificates(
+    dry_run=True,  # noqa: FBT002
+    batch_size=500,
+):
+    """
+    Reconciliation job that creates program certificates for every verified,
+    live-program enrollment that is missing one and has earned it.
+
+    Processes candidates in pk-windowed batches so the full result set is never
+    materialised in memory at once.  Each enrollment is handled independently so
+    a single bad record does not abort the entire run.
+
+    Args:
+        dry_run (bool): When True (default) no certificates are written to the
+            database; counters reflect what *would* happen.
+        batch_size (int): Number of enrollments to process per iteration.
+
+    Returns:
+        dict: Summary counters:
+            - processed (int): total enrollments evaluated
+            - would_create (int): eligible enrollments in dry-run mode
+            - created (int): certificates actually written (write mode only)
+            - ineligible (int): enrollments that did not pass _has_earned_program_cert
+            - failed (int): enrollments skipped due to an unexpected exception
+    """
+    stats = {
+        "processed": 0,
+        "would_create": 0,
+        "created": 0,
+        "ineligible": 0,
+        "failed": 0,
+    }
+
+    if dry_run:
+        log.info(
+            "generate_missing_program_certificates starting in DRY-RUN mode "
+            "(no certificates will be written)."
+        )
+    else:
+        log.info(
+            "generate_missing_program_certificates starting in WRITE mode "
+            "(missing certificates will be created)."
+        )
+
+    candidate_qs = get_eligible_program_certificate_candidates()
+    last_id = 0
+
+    while True:
+        batch = list(candidate_qs.filter(id__gt=last_id)[:batch_size])
+        if not batch:
+            break
+
+        batch_stats = {
+            "would_create": 0,
+            "created": 0,
+            "ineligible": 0,
+            "failed": 0,
+        }
+
+        for enrollment in batch:
+            last_id = enrollment.id
+            stats["processed"] += 1
+
+            try:
+                if dry_run:
+                    eligible = _has_earned_program_cert(
+                        enrollment.user, enrollment.program
+                    )
+                    if eligible:
+                        stats["would_create"] += 1
+                        batch_stats["would_create"] += 1
+                        log.debug(
+                            "DRY-RUN would create program certificate: user=%s program=%s",
+                            enrollment.user.edx_username,
+                            enrollment.program.readable_id,
+                        )
+                    else:
+                        stats["ineligible"] += 1
+                        batch_stats["ineligible"] += 1
+                else:
+                    _, created = generate_program_certificate(
+                        user=enrollment.user,
+                        program=enrollment.program,
+                        force_create=False,
+                    )
+                    if created:
+                        stats["created"] += 1
+                        batch_stats["created"] += 1
+                    else:
+                        stats["ineligible"] += 1
+                        batch_stats["ineligible"] += 1
+
+            except Exception:
+                stats["failed"] += 1
+                batch_stats["failed"] += 1
+                log.exception(
+                    "Error processing program certificate for user=%s program=%s",
+                    enrollment.user_id,
+                    enrollment.program_id,
+                )
+
+        would_create_msg = (
+            f"would_create={batch_stats['would_create']}" if dry_run else ""
+        )
+        log.info(
+            "generate_missing_program_certificates batch finished: "
+            "last_id=%d batch_size=%d %s created=%d ineligible=%d failed=%d",
+            last_id,
+            len(batch),
+            would_create_msg,
+            batch_stats["created"],
+            batch_stats["ineligible"],
+            batch_stats["failed"],
+        )
+
+    log.info(
+        "generate_missing_program_certificates complete: dry_run=%s processed=%d "
+        "would_create=%d created=%d ineligible=%d failed=%d",
+        dry_run,
+        stats["processed"],
+        stats["would_create"],
+        stats["created"],
+        stats["ineligible"],
+        stats["failed"],
+    )
+
+    return stats
+
+
 def manage_program_certificate_access(user, program, revoke_state):
     """
     Revokes/Un-Revokes a program certificate.

--- a/courses/api.py
+++ b/courses/api.py
@@ -1259,7 +1259,6 @@ def get_eligible_program_certificate_candidates():
 
     return (
         ProgramEnrollment.objects.filter(
-            active=True,
             enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
             program__live=True,
         )

--- a/courses/api.py
+++ b/courses/api.py
@@ -1303,11 +1303,6 @@ def generate_missing_program_certificates(
         "failed": 0,
     }
 
-    log.info(
-        "generate_missing_program_certificates starting in WRITE mode "
-        "(missing certificates will be created)."
-    )
-
     candidate_qs = get_eligible_program_certificate_candidates()
     last_id = 0
     while True:

--- a/courses/api.py
+++ b/courses/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections import namedtuple
+from collections import Counter, namedtuple
 from datetime import datetime, timedelta
 from decimal import Decimal
 from traceback import format_exc
@@ -1296,13 +1296,7 @@ def generate_missing_program_certificates(
             - ineligible (int): enrollments that did not pass _has_earned_program_cert
             - failed (int): enrollments skipped due to an unexpected exception
     """
-    stats = {
-        "processed": 0,
-        "created": 0,
-        "ineligible": 0,
-        "failed": 0,
-    }
-
+    stats = Counter()
     candidate_qs = get_eligible_program_certificate_candidates()
     last_id = 0
     while True:
@@ -1310,12 +1304,7 @@ def generate_missing_program_certificates(
         if not batch:
             break
 
-        batch_stats = {
-            "created": 0,
-            "ineligible": 0,
-            "failed": 0,
-        }
-
+        batch_stats = Counter()
         for enrollment in batch:
             last_id = enrollment.id
             stats["processed"] += 1

--- a/courses/api.py
+++ b/courses/api.py
@@ -17,7 +17,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Prefetch, Q
 from django_countries import countries
 from mitol.common.utils import now_in_utc
 from mitol.common.utils.collections import (
@@ -1250,8 +1250,6 @@ def get_eligible_program_certificate_candidates():
     Returns:
         QuerySet[ProgramEnrollment]
     """
-    from django.db.models import Exists, OuterRef, Prefetch  # noqa: PLC0415
-
     existing_cert = ProgramCertificate.all_objects.filter(
         user_id=OuterRef("user_id"),
         program_id=OuterRef("program_id"),
@@ -1312,7 +1310,6 @@ def generate_missing_program_certificates(
 
     candidate_qs = get_eligible_program_certificate_candidates()
     last_id = 0
-
     while True:
         batch = list(candidate_qs.filter(id__gt=last_id)[:batch_size])
         if not batch:

--- a/courses/api.py
+++ b/courses/api.py
@@ -1278,7 +1278,6 @@ def get_eligible_program_certificate_candidates():
 
 
 def generate_missing_program_certificates(
-    dry_run=True,  # noqa: FBT002
     batch_size=500,
 ):
     """
@@ -1290,36 +1289,26 @@ def generate_missing_program_certificates(
     a single bad record does not abort the entire run.
 
     Args:
-        dry_run (bool): When True (default) no certificates are written to the
-            database; counters reflect what *would* happen.
         batch_size (int): Number of enrollments to process per iteration.
 
     Returns:
         dict: Summary counters:
             - processed (int): total enrollments evaluated
-            - would_create (int): eligible enrollments in dry-run mode
-            - created (int): certificates actually written (write mode only)
+            - created (int): certificates actually written
             - ineligible (int): enrollments that did not pass _has_earned_program_cert
             - failed (int): enrollments skipped due to an unexpected exception
     """
     stats = {
         "processed": 0,
-        "would_create": 0,
         "created": 0,
         "ineligible": 0,
         "failed": 0,
     }
 
-    if dry_run:
-        log.info(
-            "generate_missing_program_certificates starting in DRY-RUN mode "
-            "(no certificates will be written)."
-        )
-    else:
-        log.info(
-            "generate_missing_program_certificates starting in WRITE mode "
-            "(missing certificates will be created)."
-        )
+    log.info(
+        "generate_missing_program_certificates starting in WRITE mode "
+        "(missing certificates will be created)."
+    )
 
     candidate_qs = get_eligible_program_certificate_candidates()
     last_id = 0
@@ -1330,7 +1319,6 @@ def generate_missing_program_certificates(
             break
 
         batch_stats = {
-            "would_create": 0,
             "created": 0,
             "ineligible": 0,
             "failed": 0,
@@ -1341,33 +1329,17 @@ def generate_missing_program_certificates(
             stats["processed"] += 1
 
             try:
-                if dry_run:
-                    eligible = _has_earned_program_cert(
-                        enrollment.user, enrollment.program
-                    )
-                    if eligible:
-                        stats["would_create"] += 1
-                        batch_stats["would_create"] += 1
-                        log.debug(
-                            "DRY-RUN would create program certificate: user=%s program=%s",
-                            enrollment.user.edx_username,
-                            enrollment.program.readable_id,
-                        )
-                    else:
-                        stats["ineligible"] += 1
-                        batch_stats["ineligible"] += 1
+                _, created = generate_program_certificate(
+                    user=enrollment.user,
+                    program=enrollment.program,
+                    force_create=False,
+                )
+                if created:
+                    stats["created"] += 1
+                    batch_stats["created"] += 1
                 else:
-                    _, created = generate_program_certificate(
-                        user=enrollment.user,
-                        program=enrollment.program,
-                        force_create=False,
-                    )
-                    if created:
-                        stats["created"] += 1
-                        batch_stats["created"] += 1
-                    else:
-                        stats["ineligible"] += 1
-                        batch_stats["ineligible"] += 1
+                    stats["ineligible"] += 1
+                    batch_stats["ineligible"] += 1
 
             except Exception:
                 stats["failed"] += 1
@@ -1378,26 +1350,20 @@ def generate_missing_program_certificates(
                     enrollment.program_id,
                 )
 
-        would_create_msg = (
-            f"would_create={batch_stats['would_create']}" if dry_run else ""
-        )
         log.info(
             "generate_missing_program_certificates batch finished: "
-            "last_id=%d batch_size=%d %s created=%d ineligible=%d failed=%d",
+            "last_id=%d batch_size=%d created=%d ineligible=%d failed=%d",
             last_id,
             len(batch),
-            would_create_msg,
             batch_stats["created"],
             batch_stats["ineligible"],
             batch_stats["failed"],
         )
 
     log.info(
-        "generate_missing_program_certificates complete: dry_run=%s processed=%d "
-        "would_create=%d created=%d ineligible=%d failed=%d",
-        dry_run,
+        "generate_missing_program_certificates complete: processed=%d "
+        "created=%d ineligible=%d failed=%d",
         stats["processed"],
-        stats["would_create"],
         stats["created"],
         stats["ineligible"],
         stats["failed"],

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -3463,12 +3463,11 @@ def test_get_eligible_program_certificate_candidates_excludes_non_live_program()
 
 
 @patch("courses.signals.upsert_custom_properties")
-def test_generate_missing_program_certificates_dry_run_no_writes(
+def test_generate_missing_program_certificates_creates_cert(
     mock_upsert, mocker, user, default_mode_records
 ):
     """
-    In dry-run mode would_create is populated correctly and no
-    ProgramCertificate records are written.
+    The missing certificate is created and the created counter reflects that.
     """
     mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
 
@@ -3489,41 +3488,7 @@ def test_generate_missing_program_certificates_dry_run_no_writes(
     )
     CourseRunCertificateFactory.create(user=user, course_run=course_run)
 
-    stats = generate_missing_program_certificates(dry_run=True)
-
-    assert stats["would_create"] >= 1
-    assert stats["created"] == 0
-    assert ProgramCertificate.objects.filter(user=user, program=program).count() == 0
-
-
-@patch("courses.signals.upsert_custom_properties")
-def test_generate_missing_program_certificates_write_mode_creates_cert(
-    mock_upsert, mocker, user, default_mode_records
-):
-    """
-    In write mode the missing certificate is created and the created counter
-    reflects that.
-    """
-    mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
-
-    program = ProgramFactory.create(live=True)
-    program.requirements_root.add_child(
-        node_type=ProgramRequirementNodeType.OPERATOR,
-        operator=ProgramRequirement.Operator.ALL_OF,
-        title="Required Courses",
-    )
-    course = CourseFactory.create()
-    program.add_requirement(course)
-    course_run = CourseRunFactory.create(course=course)
-    course_run.enrollment_modes.set(default_mode_records)
-    course_run.save()
-
-    ProgramEnrollment.objects.create(
-        user=user, program=program, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
-    )
-    CourseRunCertificateFactory.create(user=user, course_run=course_run)
-
-    stats = generate_missing_program_certificates(dry_run=False)
+    stats = generate_missing_program_certificates()
 
     assert stats["created"] >= 1
     assert ProgramCertificate.objects.filter(user=user, program=program).count() == 1
@@ -3555,8 +3520,8 @@ def test_generate_missing_program_certificates_idempotent(
     )
     CourseRunCertificateFactory.create(user=user, course_run=course_run)
 
-    first = generate_missing_program_certificates(dry_run=False)
-    second = generate_missing_program_certificates(dry_run=False)
+    first = generate_missing_program_certificates()
+    second = generate_missing_program_certificates()
 
     assert first["created"] >= 1
     assert second["created"] == 0
@@ -3589,7 +3554,7 @@ def test_generate_missing_program_certificates_failure_isolation(mock_upsert, mo
 
     mocker.patch("courses.api.generate_program_certificate", side_effect=_side_effect)
 
-    stats = generate_missing_program_certificates(dry_run=False)
+    stats = generate_missing_program_certificates()
 
     assert stats["failed"] == 1
     assert stats["processed"] >= 1

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -3537,6 +3537,11 @@ def test_generate_missing_program_certificates_failure_isolation(mock_upsert, mo
         active=True,
         program=ProgramFactory.create(live=True),
     )
+    ProgramEnrollmentFactory.create(
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+        active=True,
+        program=ProgramFactory.create(live=True),
+    )
 
     call_count = 0
 
@@ -3548,9 +3553,12 @@ def test_generate_missing_program_certificates_failure_isolation(mock_upsert, mo
             raise RuntimeError(msg)
         return None, False
 
-    mocker.patch("courses.api.generate_program_certificate", side_effect=_side_effect)
+    mock_generate = mocker.patch(
+        "courses.api.generate_program_certificate", side_effect=_side_effect
+    )
 
     stats = generate_missing_program_certificates()
 
     assert stats["failed"] == 1
-    assert stats["processed"] >= 1
+    assert stats["processed"] == 2
+    assert mock_generate.call_count == 2

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -3402,3 +3402,194 @@ def test_upgrade_program_enrollment_if_eligible_returns_false_when_electives_mis
     program_enrollment.refresh_from_db()
     assert upgraded is False
     assert program_enrollment.enrollment_mode == EDX_ENROLLMENT_AUDIT_MODE
+
+
+# ---------------------------------------------------------------------------
+# generate_missing_program_certificates tests
+# ---------------------------------------------------------------------------
+from courses.api import (  # noqa: E402
+    generate_missing_program_certificates,
+    get_eligible_program_certificate_candidates,
+)
+
+
+@pytest.mark.django_db
+def test_get_eligible_program_certificate_candidates_verified_only():
+    """Audit enrollments must not appear in the candidate queryset."""
+    verified_enrollment = ProgramEnrollmentFactory.create(
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+        active=True,
+        program=ProgramFactory.create(live=True),
+    )
+    ProgramEnrollmentFactory.create(
+        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+        active=True,
+        program=ProgramFactory.create(live=True),
+    )
+
+    qs = get_eligible_program_certificate_candidates()
+    ids = list(qs.values_list("id", flat=True))
+    assert verified_enrollment.id in ids
+
+
+@pytest.mark.django_db
+def test_get_eligible_program_certificate_candidates_excludes_existing_cert():
+    """Enrollments that already have a program certificate must be excluded."""
+    program = ProgramFactory.create(live=True)
+    enrollment = ProgramEnrollmentFactory.create(
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+        active=True,
+        program=program,
+    )
+    ProgramCertificateFactory.create(user=enrollment.user, program=program)
+
+    qs = get_eligible_program_certificate_candidates()
+    ids = list(qs.values_list("id", flat=True))
+    assert enrollment.id not in ids
+
+
+@pytest.mark.django_db
+def test_get_eligible_program_certificate_candidates_excludes_non_live_program():
+    """Enrollments in non-live programs must not appear."""
+    enrollment = ProgramEnrollmentFactory.create(
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+        active=True,
+        program=ProgramFactory.create(live=False),
+    )
+
+    qs = get_eligible_program_certificate_candidates()
+    ids = list(qs.values_list("id", flat=True))
+    assert enrollment.id not in ids
+
+
+@patch("courses.signals.upsert_custom_properties")
+def test_generate_missing_program_certificates_dry_run_no_writes(
+    mock_upsert, mocker, user, default_mode_records
+):
+    """
+    In dry-run mode would_create is populated correctly and no
+    ProgramCertificate records are written.
+    """
+    mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
+
+    program = ProgramFactory.create(live=True)
+    program.requirements_root.add_child(
+        node_type=ProgramRequirementNodeType.OPERATOR,
+        operator=ProgramRequirement.Operator.ALL_OF,
+        title="Required Courses",
+    )
+    course = CourseFactory.create()
+    program.add_requirement(course)
+    course_run = CourseRunFactory.create(course=course)
+    course_run.enrollment_modes.set(default_mode_records)
+    course_run.save()
+
+    ProgramEnrollment.objects.create(
+        user=user, program=program, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
+    CourseRunCertificateFactory.create(user=user, course_run=course_run)
+
+    stats = generate_missing_program_certificates(dry_run=True)
+
+    assert stats["would_create"] >= 1
+    assert stats["created"] == 0
+    assert ProgramCertificate.objects.filter(user=user, program=program).count() == 0
+
+
+@patch("courses.signals.upsert_custom_properties")
+def test_generate_missing_program_certificates_write_mode_creates_cert(
+    mock_upsert, mocker, user, default_mode_records
+):
+    """
+    In write mode the missing certificate is created and the created counter
+    reflects that.
+    """
+    mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
+
+    program = ProgramFactory.create(live=True)
+    program.requirements_root.add_child(
+        node_type=ProgramRequirementNodeType.OPERATOR,
+        operator=ProgramRequirement.Operator.ALL_OF,
+        title="Required Courses",
+    )
+    course = CourseFactory.create()
+    program.add_requirement(course)
+    course_run = CourseRunFactory.create(course=course)
+    course_run.enrollment_modes.set(default_mode_records)
+    course_run.save()
+
+    ProgramEnrollment.objects.create(
+        user=user, program=program, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
+    CourseRunCertificateFactory.create(user=user, course_run=course_run)
+
+    stats = generate_missing_program_certificates(dry_run=False)
+
+    assert stats["created"] >= 1
+    assert ProgramCertificate.objects.filter(user=user, program=program).count() == 1
+
+
+@patch("courses.signals.upsert_custom_properties")
+def test_generate_missing_program_certificates_idempotent(
+    mock_upsert, mocker, user, default_mode_records
+):
+    """
+    Running the task twice must not create duplicate certificates.
+    """
+    mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
+
+    program = ProgramFactory.create(live=True)
+    program.requirements_root.add_child(
+        node_type=ProgramRequirementNodeType.OPERATOR,
+        operator=ProgramRequirement.Operator.ALL_OF,
+        title="Required Courses",
+    )
+    course = CourseFactory.create()
+    program.add_requirement(course)
+    course_run = CourseRunFactory.create(course=course)
+    course_run.enrollment_modes.set(default_mode_records)
+    course_run.save()
+
+    ProgramEnrollment.objects.create(
+        user=user, program=program, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
+    CourseRunCertificateFactory.create(user=user, course_run=course_run)
+
+    first = generate_missing_program_certificates(dry_run=False)
+    second = generate_missing_program_certificates(dry_run=False)
+
+    assert first["created"] >= 1
+    assert second["created"] == 0
+    assert ProgramCertificate.objects.filter(user=user, program=program).count() == 1
+
+
+@patch("courses.signals.upsert_custom_properties")
+def test_generate_missing_program_certificates_failure_isolation(mock_upsert, mocker):
+    """
+    An exception raised for one enrollment must not prevent the others from
+    being processed.
+    """
+    mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
+
+    ProgramEnrollmentFactory.create(
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+        active=True,
+        program=ProgramFactory.create(live=True),
+    )
+
+    call_count = 0
+
+    def _side_effect(user, program, force_create=False):  # noqa: FBT002
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            msg = "simulated transient error"
+            raise RuntimeError(msg)
+        return None, False
+
+    mocker.patch("courses.api.generate_program_certificate", side_effect=_side_effect)
+
+    stats = generate_missing_program_certificates(dry_run=False)
+
+    assert stats["failed"] == 1
+    assert stats["processed"] >= 1

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -43,9 +43,11 @@ from courses.api import (
     deactivate_run_enrollment,
     defer_enrollment,
     generate_course_run_certificates,
+    generate_missing_program_certificates,
     generate_openedx_course_url,
     generate_program_certificate,
     get_certificate_grade_eligible_runs,
+    get_eligible_program_certificate_candidates,
     get_verifiable_credentials_payload,
     import_courserun_from_edx,
     manage_course_run_certificate_access,
@@ -3404,62 +3406,56 @@ def test_upgrade_program_enrollment_if_eligible_returns_false_when_electives_mis
     assert program_enrollment.enrollment_mode == EDX_ENROLLMENT_AUDIT_MODE
 
 
-# ---------------------------------------------------------------------------
-# generate_missing_program_certificates tests
-# ---------------------------------------------------------------------------
-from courses.api import (  # noqa: E402
-    generate_missing_program_certificates,
-    get_eligible_program_certificate_candidates,
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("scenario", "should_include"),
+    [
+        ("verified_only", True),
+        ("audit_mode", False),
+        ("has_certificate", False),
+        ("non_live_program", False),
+    ],
 )
-
-
-@pytest.mark.django_db
-def test_get_eligible_program_certificate_candidates_verified_only():
-    """Audit enrollments must not appear in the candidate queryset."""
-    verified_enrollment = ProgramEnrollmentFactory.create(
-        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
-        active=True,
-        program=ProgramFactory.create(live=True),
-    )
-    ProgramEnrollmentFactory.create(
-        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
-        active=True,
-        program=ProgramFactory.create(live=True),
-    )
-
+def test_get_eligible_program_certificate_candidates(scenario, should_include):
+    """Test various filter scenarios for eligible program certificate candidates."""
     qs = get_eligible_program_certificate_candidates()
+
+    if scenario == "verified_only":
+        # Verified enrollment should be included
+        enrollment = ProgramEnrollmentFactory.create(
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+            active=True,
+            program=ProgramFactory.create(live=True),
+        )
+    elif scenario == "audit_mode":
+        # Audit enrollments must not appear
+        enrollment = ProgramEnrollmentFactory.create(
+            enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+            active=True,
+            program=ProgramFactory.create(live=True),
+        )
+    elif scenario == "has_certificate":
+        # Enrollments with existing certificate must be excluded
+        program = ProgramFactory.create(live=True)
+        enrollment = ProgramEnrollmentFactory.create(
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+            active=True,
+            program=program,
+        )
+        ProgramCertificateFactory.create(user=enrollment.user, program=program)
+    elif scenario == "non_live_program":
+        # Enrollments in non-live programs must not appear
+        enrollment = ProgramEnrollmentFactory.create(
+            enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+            active=True,
+            program=ProgramFactory.create(live=False),
+        )
+
     ids = list(qs.values_list("id", flat=True))
-    assert verified_enrollment.id in ids
-
-
-@pytest.mark.django_db
-def test_get_eligible_program_certificate_candidates_excludes_existing_cert():
-    """Enrollments that already have a program certificate must be excluded."""
-    program = ProgramFactory.create(live=True)
-    enrollment = ProgramEnrollmentFactory.create(
-        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
-        active=True,
-        program=program,
-    )
-    ProgramCertificateFactory.create(user=enrollment.user, program=program)
-
-    qs = get_eligible_program_certificate_candidates()
-    ids = list(qs.values_list("id", flat=True))
-    assert enrollment.id not in ids
-
-
-@pytest.mark.django_db
-def test_get_eligible_program_certificate_candidates_excludes_non_live_program():
-    """Enrollments in non-live programs must not appear."""
-    enrollment = ProgramEnrollmentFactory.create(
-        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
-        active=True,
-        program=ProgramFactory.create(live=False),
-    )
-
-    qs = get_eligible_program_certificate_candidates()
-    ids = list(qs.values_list("id", flat=True))
-    assert enrollment.id not in ids
+    if should_include:
+        assert enrollment.id in ids
+    else:
+        assert enrollment.id not in ids
 
 
 @patch("courses.signals.upsert_custom_properties")

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -78,6 +78,28 @@ def send_partner_school_email(record_uuid):
 
 
 @app.task
+def generate_missing_program_certificates(dry_run=True, batch_size=500):  # noqa: FBT002
+    """
+    Task to create missing program certificates for verified enrollments that have
+    earned them but were not issued a certificate (e.g. due to a missed signal).
+
+    Args:
+        dry_run (bool): When True (default) log what would be created without
+            writing to the database.  Set to False to enable writes.
+        batch_size (int): Number of enrollments to process per pk-windowed batch.
+    """
+    from courses.api import (
+        generate_missing_program_certificates as _api_fn,
+    )
+
+    results = _api_fn(dry_run=dry_run, batch_size=batch_size)
+    log.info(
+        "generate_missing_program_certificates task finished: %s",
+        results,
+    )
+
+
+@app.task
 def upgrade_eligible_program_enrollments():
     """Upgrade eligible learners for all audit-mode program enrollments."""
     from courses.api import upgrade_program_enrollment_if_eligible

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -78,21 +78,19 @@ def send_partner_school_email(record_uuid):
 
 
 @app.task
-def generate_missing_program_certificates(dry_run=True, batch_size=500):  # noqa: FBT002
+def generate_missing_program_certificates(batch_size=500):
     """
     Task to create missing program certificates for verified enrollments that have
     earned them but were not issued a certificate (e.g. due to a missed signal).
 
     Args:
-        dry_run (bool): When True (default) log what would be created without
-            writing to the database.  Set to False to enable writes.
         batch_size (int): Number of enrollments to process per pk-windowed batch.
     """
     from courses.api import (
         generate_missing_program_certificates as _api_fn,
     )
 
-    results = _api_fn(dry_run=dry_run, batch_size=batch_size)
+    results = _api_fn(batch_size=batch_size)
     log.info(
         "generate_missing_program_certificates task finished: %s",
         results,

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -78,9 +78,9 @@ def send_partner_school_email(record_uuid):
 
 
 @app.task
-def generate_missing_program_certificates(batch_size=500):
+def generate_program_certificates(batch_size=500):
     """
-    Task to create missing program certificates for verified enrollments that have
+    Task to create program certificates for verified enrollments that have
     earned them but were not issued a certificate (e.g. due to a missed signal).
 
     Args:
@@ -92,7 +92,7 @@ def generate_missing_program_certificates(batch_size=500):
 
     results = _api_fn(batch_size=batch_size)
     log.info(
-        "generate_missing_program_certificates task finished: %s",
+        "generate_program_certificates task finished: %s",
         results,
     )
 

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -8,6 +8,7 @@ from courses.factories import (
 )
 from courses.tasks import (
     generate_course_certificates,
+    generate_missing_program_certificates,
     send_partner_school_email,
     subscribe_edx_course_emails,
 )
@@ -50,3 +51,35 @@ def test_send_partner_school_email(mocker):
     )
     send_partner_school_email.delay(record.share_uuid)
     send_partner_school_sharing_message.assert_called_once()
+
+
+def test_generate_missing_program_certificates_task_dry_run(mocker):
+    """Task delegates to the API function with dry_run=True by default."""
+    mock_api = mocker.patch(
+        "courses.api.generate_missing_program_certificates",
+        return_value={
+            "processed": 0,
+            "would_create": 0,
+            "created": 0,
+            "ineligible": 0,
+            "failed": 0,
+        },
+    )
+    generate_missing_program_certificates.delay()
+    mock_api.assert_called_once_with(dry_run=True, batch_size=500)
+
+
+def test_generate_missing_program_certificates_task_write_mode(mocker):
+    """Task delegates to the API function with dry_run=False when requested."""
+    mock_api = mocker.patch(
+        "courses.api.generate_missing_program_certificates",
+        return_value={
+            "processed": 1,
+            "would_create": 0,
+            "created": 1,
+            "ineligible": 0,
+            "failed": 0,
+        },
+    )
+    generate_missing_program_certificates.delay(dry_run=False)
+    mock_api.assert_called_once_with(dry_run=False, batch_size=500)

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -53,33 +53,16 @@ def test_send_partner_school_email(mocker):
     send_partner_school_sharing_message.assert_called_once()
 
 
-def test_generate_missing_program_certificates_task_dry_run(mocker):
-    """Task delegates to the API function with dry_run=True by default."""
-    mock_api = mocker.patch(
-        "courses.api.generate_missing_program_certificates",
-        return_value={
-            "processed": 0,
-            "would_create": 0,
-            "created": 0,
-            "ineligible": 0,
-            "failed": 0,
-        },
-    )
-    generate_missing_program_certificates.delay()
-    mock_api.assert_called_once_with(dry_run=True, batch_size=500)
-
-
-def test_generate_missing_program_certificates_task_write_mode(mocker):
-    """Task delegates to the API function with dry_run=False when requested."""
+def test_generate_missing_program_certificates_task(mocker):
+    """Task delegates to the API function."""
     mock_api = mocker.patch(
         "courses.api.generate_missing_program_certificates",
         return_value={
             "processed": 1,
-            "would_create": 0,
             "created": 1,
             "ineligible": 0,
             "failed": 0,
         },
     )
-    generate_missing_program_certificates.delay(dry_run=False)
-    mock_api.assert_called_once_with(dry_run=False, batch_size=500)
+    generate_missing_program_certificates.delay()
+    mock_api.assert_called_once_with(batch_size=500)

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -56,7 +56,7 @@ def test_send_partner_school_email(mocker):
 def test_generate_program_certificates_task(mocker):
     """Task delegates to the API function."""
     mock_api = mocker.patch(
-        "courses.api.generate_missing_program_certificate",
+        "courses.api.generate_program_certificates",
         return_value={
             "processed": 1,
             "created": 1,

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -56,7 +56,7 @@ def test_send_partner_school_email(mocker):
 def test_generate_program_certificates_task(mocker):
     """Task delegates to the API function."""
     mock_api = mocker.patch(
-        "courses.api.generate_program_certificates",
+        "courses.api.generate_missing_program_certificates",
         return_value={
             "processed": 1,
             "created": 1,

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -8,7 +8,7 @@ from courses.factories import (
 )
 from courses.tasks import (
     generate_course_certificates,
-    generate_missing_program_certificates,
+    generate_program_certificates,
     send_partner_school_email,
     subscribe_edx_course_emails,
 )
@@ -53,10 +53,10 @@ def test_send_partner_school_email(mocker):
     send_partner_school_sharing_message.assert_called_once()
 
 
-def test_generate_missing_program_certificates_task(mocker):
+def test_generate_program_certificates_task(mocker):
     """Task delegates to the API function."""
     mock_api = mocker.patch(
-        "courses.api.generate_missing_program_certificates",
+        "courses.api.generate_missing_program_certificate",
         return_value={
             "processed": 1,
             "created": 1,
@@ -64,5 +64,5 @@ def test_generate_missing_program_certificates_task(mocker):
             "failed": 0,
         },
     )
-    generate_missing_program_certificates.delay()
+    generate_program_certificates.delay()
     mock_api.assert_called_once_with(batch_size=500)

--- a/main/settings.py
+++ b/main/settings.py
@@ -912,6 +912,16 @@ CRON_UPGRADE_PROGRAM_ENROLLMENTS_DAYS = get_string(
     default="*",
     description="'day_of_week' value for 'upgrade-eligible-program-enrollments' scheduled task (default runs daily).",
 )
+CRON_MISSING_PROGRAM_CERTIFICATES_HOURS = get_string(
+    name="CRON_MISSING_PROGRAM_CERTIFICATES_HOURS",
+    default="2",
+    description="'hours' value for the 'generate-missing-program-certificates' scheduled task (default runs at 2 AM).",
+)
+CRON_MISSING_PROGRAM_CERTIFICATES_DAYS = get_string(
+    name="CRON_MISSING_PROGRAM_CERTIFICATES_DAYS",
+    default="*",
+    description="'day_of_week' value for 'generate-missing-program-certificates' scheduled task (default runs daily).",
+)
 CRON_ORPHAN_CHECK_HOURS = get_string(
     name="CRON_ORPHAN_CHECK_HOURS",
     default="3",
@@ -1040,6 +1050,19 @@ CELERY_BEAT_SCHEDULE = {
             day_of_month="*",
             month_of_year="*",
         ),
+    },
+    "generate-missing-program-certificates": {
+        "task": "courses.tasks.generate_missing_program_certificates",
+        "schedule": crontab(
+            minute=0,
+            hour=CRON_MISSING_PROGRAM_CERTIFICATES_HOURS,
+            day_of_week=CRON_MISSING_PROGRAM_CERTIFICATES_DAYS,
+            day_of_month="*",
+            month_of_year="*",
+        ),
+        # Runs in dry-run mode by default.  Set dry_run=False in kwargs after
+        # validating output in production logs.
+        "kwargs": {"dry_run": True},
     },
     "update-b2b-enrollment-code-sheets": {
         "task": "b2b.tasks.queue_update_all_contract_enrollment_sheets",

--- a/main/settings.py
+++ b/main/settings.py
@@ -1052,7 +1052,7 @@ CELERY_BEAT_SCHEDULE = {
         ),
     },
     "generate-missing-program-certificates": {
-        "task": "courses.tasks.generate_missing_program_certificates",
+        "task": "courses.tasks.generate_program_certificates",
         "schedule": crontab(
             minute=0,
             hour=CRON_MISSING_PROGRAM_CERTIFICATES_HOURS,

--- a/main/settings.py
+++ b/main/settings.py
@@ -1060,9 +1060,6 @@ CELERY_BEAT_SCHEDULE = {
             day_of_month="*",
             month_of_year="*",
         ),
-        # Runs in dry-run mode by default.  Set dry_run=False in kwargs after
-        # validating output in production logs.
-        "kwargs": {"dry_run": True},
     },
     "update-b2b-enrollment-code-sheets": {
         "task": "b2b.tasks.queue_update_all_contract_enrollment_sheets",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11185


### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a task to generate missing certificates, if any. It is configured to run daily, but can be changed according to our needs.
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Create program with some courses and program as requirements.
- Create enrollments, course grades, and certificates for the required courses and programs.
- Also, create data where user should not be eligible for a program certificate. it could be:
  - Missing passing grades in courses
  - missing certificates for the courses
  - missing certificate for the required programs
- Run the task and verify that it create the legit program certificates.