### PR TITLE
fix: sort users by id in faulty openedx user repair test assertions

### DIFF
--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -1111,9 +1111,9 @@ def test_repair_all_faulty_openedx_users(mocker):
     repair_all_faulty_openedx_users()
 
     assert patched_repair_users.call_count == 1
-    assert sorted(
-        patched_repair_users.call_args.args[0], key=lambda u: u.id
-    ) == sorted(users, key=lambda u: u.id)
+    assert sorted(patched_repair_users.call_args.args[0], key=lambda u: u.id) == sorted(
+        users, key=lambda u: u.id
+    )
 
 
 @pytest.mark.parametrize("exception_raised", [MockHttpError, Exception, None])
@@ -1162,9 +1162,9 @@ def test_retry_users_grace_period(mocker):
 
     assert patched_repair_users.call_count == 1
 
-    assert sorted(
-        patched_repair_users.call_args.args[0], key=lambda u: u.id
-    ) == sorted(users_to_repair, key=lambda u: u.id)
+    assert sorted(patched_repair_users.call_args.args[0], key=lambda u: u.id) == sorted(
+        users_to_repair, key=lambda u: u.id
+    )
 
 
 def test_unenroll_edx_course_run(mocker):

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -1111,7 +1111,9 @@ def test_repair_all_faulty_openedx_users(mocker):
     repair_all_faulty_openedx_users()
 
     assert patched_repair_users.call_count == 1
-    assert list(patched_repair_users.call_args.args[0]) == users
+    assert sorted(
+        patched_repair_users.call_args.args[0], key=lambda u: u.id
+    ) == sorted(users, key=lambda u: u.id)
 
 
 @pytest.mark.parametrize("exception_raised", [MockHttpError, Exception, None])
@@ -1160,7 +1162,9 @@ def test_retry_users_grace_period(mocker):
 
     assert patched_repair_users.call_count == 1
 
-    assert list(patched_repair_users.call_args.args[0]) == users_to_repair
+    assert sorted(
+        patched_repair_users.call_args.args[0], key=lambda u: u.id
+    ) == sorted(users_to_repair, key=lambda u: u.id)
 
 
 def test_unenroll_edx_course_run(mocker):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10550

### Description (What does it do?)

`test_retry_users_grace_period` and `test_repair_all_faulty_openedx_users` were intermittently failing due to index mismatch errors caused by inconsistent ordering.

This PR fixes the flaky ordering issue in these two tests in `openedx/api_test.py`.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
