### PR TITLE
fix: add created and failed statuses to align with xpro statuses in hubspot deal sync task

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -123,6 +123,18 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                         "displayOrder": 7,
                         "hidden": False,
                     },
+                    {
+                        "value": "created",
+                        "label": "created",
+                        "displayOrder": 8,
+                        "hidden": False,
+                    },
+                    {
+                        "value": "failed",
+                        "label": "failed",
+                        "displayOrder": 9,
+                        "hidden": False,
+                    },
                 ],
             },
             {
@@ -579,6 +591,18 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                         "value": models.OrderStatus.REVIEW,
                         "label": models.OrderStatus.REVIEW,
                         "displayOrder": 7,
+                        "hidden": False,
+                    },
+                    {
+                        "value": "created",
+                        "label": "created",
+                        "displayOrder": 8,
+                        "hidden": False,
+                    },
+                    {
+                        "value": "failed",
+                        "label": "failed",
+                        "displayOrder": 9,
                         "hidden": False,
                     },
                 ],


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11149

### Description (What does it do?)
This PR fixes a HubSpot property conflict that caused xPRO's `hubspot_xpro.tasks.sync_deal_with_hubspot` task to fail after mitxonline pushed its custom property definitions to a shared HubSpot portal.

## Problem

mitxonline defines a custom `status` enumeration property on HubSpot deals and line items via `CUSTOM_ECOMMERCE_PROPERTIES`. When `_ensure_target_hubspot_custom_properties()` is called (e.g. during UAI cart-add tracking), it updates the `status` property definition in the target portal with mitxonline's 8 options:

```
fulfilled, canceled, errored, declined, pending, refunded, partially_refunded, review
```

This overwrites xPRO's property definition, which includes two additional values not in mitxonline's set:

```
created, failed
```

After the overwrite, any xPRO order sync that sends `status="created"` or `status="failed"` is rejected by HubSpot with a `VALIDATION_ERROR`, causing the task to fail.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
### How can this be tested?

1. **Unit tests** — Run the existing hubspot_sync test suite to confirm no regressions:
   ```bash
   docker compose exec web pytest hubspot_sync/ -x -q
   ```

2. **Verify the property definition** — After running `configure_hubspot_properties` (or `upsert_custom_properties()`), confirm the `status` property on deals and line items includes `created` and `failed` alongside mitxonline's native statuses:
   ```bash
   docker compose exec web python manage.py shell -c "
   from mitol.hubspot_api.api import HubspotApi
   client = HubspotApi()
   for obj_type in ['deals', 'line_items']:
       prop = client.crm.properties.core_api.get_by_name(obj_type, 'status')
       values = [o.value for o in prop.options]
       assert 'created' in values and 'failed' in values, f'Missing options in {obj_type}'
       print(f'{obj_type} status options: {values}')
   "
   ```

3. **Cross-app sync** — In xPRO, trigger `hubspot_xpro.tasks.sync_deal_with_hubspot` against an order with `status='created'` or `status='failed'` and confirm it no longer raises a HubSpot `VALIDATION_ERROR`:
   ```bash
   docker compose -f ~/Desktop/mitxpro/docker-compose.yml exec web python manage.py shell -c "
   from ecommerce.factories import OrderFactory
   from hubspot_xpro.api import sync_deal_with_hubspot
   order = OrderFactory.create(status='created')
   result = sync_deal_with_hubspot(order.id)
   print('SUCCESS:', result.id)
   "
   ```

4. **Deployment step** — After deploying to any environment where xPRO and mitxonline share a HubSpot portal, run mitxonline's `configure_hubspot_properties` management command to push the expanded property definition:
   ```bash
   docker compose exec web python manage.py configure_hubspot_properties
   ```


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
