### PR TITLE
Skip certificate validation if page revision missing

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -1685,6 +1685,10 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
     def clean(self):
         from cms.models import CertificatePage, CoursePage  # noqa: PLC0415
 
+        # Skip validation if certificate_page_revision is not set (e.g., when revoking)
+        if self.certificate_page_revision is None:
+            return
+
         certpage = CertificatePage.objects.filter(
             pk=int(self.certificate_page_revision.object_id),
         )
@@ -1777,6 +1781,10 @@ class ProgramCertificate(TimestampedModel, BaseCertificate):
 
     def clean(self):
         from cms.models import CertificatePage, ProgramPage  # noqa: PLC0415
+
+        # Skip validation if certificate_page_revision is not set (e.g., when revoking)
+        if self.certificate_page_revision is None:
+            return
 
         certpage = CertificatePage.objects.filter(
             pk=int(self.certificate_page_revision.object_id),

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -521,6 +521,20 @@ def test_course_run_certificate_start_end_dates_and_page_revision(mocker):
     )
 
 
+def test_course_run_certificate_clean_allows_missing_page_revision(mocker):
+    """Revoking a certificate can clear certificate_page_revision before save."""
+    mocker.patch(
+        "hubspot_sync.api.upsert_custom_properties",
+    )
+    certificate = CourseRunCertificateFactory.create(
+        course_run__course__page__certificate_page__product_name="product_name"
+    )
+    certificate.certificate_page_revision = None
+
+    # Should not raise when revision is intentionally unset.
+    certificate.clean()
+
+
 def test_program_certificate_start_end_dates_and_page_revision(user, mocker):
     """
     Test that the ProgramCertificate start_end_dates property works properly.


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11150

### Description (What does it do?)
Return early from CourseRunCertificate.clean and ProgramCertificate.clean when certificate_page_revision is None to avoid validation errors during revocation flows that clear the revision. Added a unit test to ensure CourseRunCertificate.clean does not raise when certificate_page_revision is intentionally unset.


### How can this be tested?

1. Open a course run certificate in Django Admin
2. Clear the "Certificate page revision" field (or check a "revoke" checkbox if one exists)
3. Save the form
4. Verify it saves without the AttributeError
