### PR TITLE
Filter out certificates which have future values for their issue_date

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -1144,10 +1144,7 @@ def _has_earned_program_cert(user, program):
         elif node.is_program:
             # has earned certificate for the required sub-program
             return ProgramCertificate.all_objects.filter(
-                user=user,
-                program=node.required_program,
-                is_revoked=False,
-                is_active=True,
+                user=user, program=node.required_program, is_revoked=False
             ).exists()
         return False
 

--- a/courses/api.py
+++ b/courses/api.py
@@ -1143,8 +1143,11 @@ def _has_earned_program_cert(user, program):
             return node.course in [*cert_courses, *grade_courses]
         elif node.is_program:
             # has earned certificate for the required sub-program
-            return ProgramCertificate.objects.filter(
-                user=user, program=node.required_program, is_revoked=False
+            return ProgramCertificate.all_objects.filter(
+                user=user,
+                program=node.required_program,
+                is_revoked=False,
+                is_active=True,
             ).exists()
         return False
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -63,7 +63,7 @@ class ActiveCertificates(models.Manager):
         return (
             super()
             .get_queryset()
-            .filter(is_revoked=False, issued_date__lte=now_in_utc())
+            .filter(is_revoked=False, issue_date__lte=now_in_utc())
         )
 
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -60,7 +60,11 @@ class ActiveCertificates(models.Manager):
         Returns:
             QuerySet: queryset for un-revoked certificates
         """
-        return super().get_queryset().filter(is_revoked=False)
+        return (
+            super()
+            .get_queryset()
+            .filter(is_revoked=False, issued_date__lte=now_in_utc())
+        )
 
 
 class ProgramQuerySet(models.QuerySet):  # pylint: disable=missing-docstring

--- a/courses/views/v1/views_test.py
+++ b/courses/views/v1/views_test.py
@@ -4,7 +4,7 @@ Tests for course views
 
 # pylint: disable=unused-argument, redefined-outer-name, too-many-arguments
 import operator as op
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 from urllib.parse import quote
 
@@ -14,6 +14,7 @@ from anys import ANY_STR
 from django.db.models import Count, Q
 from django.test import Client, RequestFactory
 from django.urls import reverse
+from mitol.common.utils import now_in_utc
 from requests import ConnectionError as RequestsConnectionError
 from requests import HTTPError
 from rest_framework import status
@@ -21,13 +22,16 @@ from rest_framework.test import APIClient
 from reversion.models import Version
 
 from b2b.factories import ContractPageFactory
+from cms.factories import ProgramPageFactory
 from cms.serializers import CoursePageSerializer, ProgramPageSerializer
 from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
 from courses.factories import (
     BlockedCountryFactory,
     CourseFactory,
+    CourseRunCertificateFactory,
     CourseRunEnrollmentFactory,
     CourseRunFactory,
+    ProgramCertificateFactory,
     ProgramEnrollmentFactory,
     ProgramFactory,
 )
@@ -895,6 +899,47 @@ def test_program_enrollments(user_drf_client, user_with_enrollments_and_certific
         }
         for program_enrollment in program_enrollments
     ]
+
+
+def test_program_enrollments_future_program_cert(user_drf_client, user):
+    """
+    Test that v1 program enrollments returns null for a ProgramCertificate with a
+    future issue_date, treating it as though no certificate exists.
+    """
+    program_page = ProgramPageFactory.create()
+    program = program_page.program
+    ProgramEnrollmentFactory.create(user=user, program=program)
+    ProgramCertificateFactory.create(
+        user=user,
+        program=program,
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+
+    resp = user_drf_client.get(reverse("v1:user_program_enrollments_api-list"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    enrollment_data = next(e for e in resp.json() if e["program"]["id"] == program.id)
+    assert enrollment_data["certificate"] is None
+
+
+def test_user_enrollments_future_course_cert(user_drf_client, user):
+    """
+    Test that v1 user enrollments returns null for a CourseRunCertificate with a
+    future issue_date, treating it as though no certificate exists.
+    """
+    run = CourseRunFactory.create()
+    enrollment = CourseRunEnrollmentFactory.create(user=user, run=run)
+    CourseRunCertificateFactory.create(
+        user=user,
+        course_run=run,
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+
+    resp = user_drf_client.get(reverse("v1:user-enrollments-api-list"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    enrollment_data = next(e for e in resp.json() if e["id"] == enrollment.id)
+    assert enrollment_data["certificate"] is None
 
 
 @pytest.mark.parametrize("fulfilled_order_exists", [True, False])

--- a/courses/views/v1/views_test.py
+++ b/courses/views/v1/views_test.py
@@ -922,6 +922,7 @@ def test_program_enrollments_future_program_cert(user_drf_client, user):
     assert enrollment_data["certificate"] is None
 
 
+@pytest.mark.skip_nplusone_check
 def test_user_enrollments_future_course_cert(user_drf_client, user):
     """
     Test that v1 user enrollments returns null for a CourseRunCertificate with a

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -1236,6 +1236,20 @@ def test_get_course_certificate():
     assert resp400.status_code == status.HTTP_400_BAD_REQUEST
 
 
+def test_get_course_certificate_future_issue_date():
+    """Test that get_course_certificate returns 404 for certificates with a future issue_date."""
+    courseware_page = CoursePageFactory.create()
+    cert_page = courseware_page.certificate_page
+    cert_page.save_revision()
+    certificate = CourseRunCertificateFactory.create(
+        certificate_page_revision=cert_page.revisions.last(),
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+    client = APIClient()
+    resp = client.get(reverse("v2:get_course_certificate", args=[certificate.uuid]))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_get_program_certificate():
     """
     Test that the get_course_certificate handles valid, invalid, and not-found
@@ -1257,6 +1271,70 @@ def test_get_program_certificate():
 
     resp400 = client.get(reverse("v2:get_program_certificate", args=["not-uuid"]))
     assert resp400.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_get_program_certificate_future_issue_date():
+    """Test that get_program_certificate returns 404 for certificates with a future issue_date."""
+    courseware_page = ProgramPageFactory.create()
+    cert_page = courseware_page.certificate_page
+    cert_page.save_revision()
+    certificate = ProgramCertificateFactory.create(
+        certificate_page_revision=cert_page.revisions.last(),
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+    client = APIClient()
+    resp = client.get(reverse("v2:get_program_certificate", args=[certificate.uuid]))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_program_enrollments_future_program_cert(user_drf_client, user):
+    """
+    Test that v2 program enrollments returns null for a ProgramCertificate with a
+    future issue_date, treating it as though no certificate exists.
+    """
+    program_page = ProgramPageFactory.create()
+    program = program_page.program
+    ProgramEnrollmentFactory.create(user=user, program=program)
+    ProgramCertificateFactory.create(
+        user=user,
+        program=program,
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+
+    resp = user_drf_client.get(reverse("v2:user_program_enrollments_api-list"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    enrollment_data = next(e for e in resp.json() if e["program"]["id"] == program.id)
+    assert enrollment_data["certificate"] is None
+
+
+def test_program_enrollments_future_course_cert(user_drf_client, user):
+    """
+    Test that v2 program enrollments returns null for a CourseRunCertificate with a
+    future issue_date in the nested course run enrollment, treating it as though no
+    certificate exists.
+    """
+    program = ProgramFactory.create()
+    course = CourseFactory.create()
+    run = CourseRunFactory.create(course=course)
+    program.add_requirement(course)
+
+    ProgramEnrollmentFactory.create(user=user, program=program)
+    run_enrollment = CourseRunEnrollmentFactory.create(user=user, run=run)
+    CourseRunCertificateFactory.create(
+        user=user,
+        course_run=run,
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+
+    resp = user_drf_client.get(reverse("v2:user_program_enrollments_api-list"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    enrollment_data = next(e for e in resp.json() if e["program"]["id"] == program.id)
+    run_enrollment_data = next(
+        e for e in enrollment_data["enrollments"] if e["id"] == run_enrollment.id
+    )
+    assert run_enrollment_data["certificate"] is None
 
 
 @pytest.mark.django_db

--- a/courses/views/v3/views_test.py
+++ b/courses/views/v3/views_test.py
@@ -2,15 +2,25 @@
 Tests for courses api views v3
 """
 
+from datetime import timedelta
+
 import pytest
 from django.db.models import Q
 from django.urls import reverse
+from mitol.common.utils import now_in_utc
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from courses.conftest import B2BCourses, UserWithEnrollmentsAndCerts
 from courses.constants import ENROLL_CHANGE_STATUS_UNENROLLED
-from courses.factories import ProgramEnrollmentFactory, ProgramFactory
+from courses.factories import (
+    CourseRunCertificateFactory,
+    CourseRunEnrollmentFactory,
+    CourseRunFactory,
+    ProgramCertificateFactory,
+    ProgramEnrollmentFactory,
+    ProgramFactory,
+)
 from courses.models import (
     PaidProgram,
     ProgramEnrollment,
@@ -481,6 +491,51 @@ def test_program_enrollments(
         }
         for program_enrollment in program_enrollments
     ]
+
+
+def test_program_enrollments_future_program_cert(user_drf_client, user):
+    """
+    Test that v3 program enrollments returns null for a ProgramCertificate with a
+    future issue_date, treating it as though no certificate exists.
+    """
+    program = ProgramFactory.create(live=True)
+    ProgramEnrollmentFactory.create(user=user, program=program)
+    ProgramCertificateFactory.create(
+        user=user,
+        program=program,
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+
+    resp = user_drf_client.get(reverse("v3:user_program_enrollments_api-list"))
+    assert resp.status_code == status.HTTP_200_OK
+
+    enrollment_data = next(e for e in resp.json() if e["program"]["id"] == program.id)
+    assert enrollment_data["certificate"] is None
+
+
+def test_user_enrollments_future_course_cert(user_drf_client, user):
+    """
+    Test that v3 course enrollments returns null for a CourseRunCertificate with a
+    future issue_date, treating it as though no certificate exists.
+    """
+    run = CourseRunFactory.create()
+    enrollment = CourseRunEnrollmentFactory.create(user=user, run=run)
+    CourseRunCertificateFactory.create(
+        user=user,
+        course_run=run,
+        issue_date=now_in_utc() + timedelta(days=1),
+    )
+
+    resp = user_drf_client.get(
+        reverse("v3:user_enrollments_api-detail", kwargs={"pk": enrollment.id})
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["certificate"] is None
+
+    list_resp = user_drf_client.get(reverse("v3:user_enrollments_api-list"))
+    assert list_resp.status_code == status.HTTP_200_OK
+    enrollment_data = next(e for e in list_resp.json() if e["id"] == enrollment.id)
+    assert enrollment_data["certificate"] is None
 
 
 def test_create_program_enrollment(user_drf_client, user):


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/11235
### Description (What does it do?)
Hooks into the ActiveCertificates manager to additionally filter out certificates which have an issue_date in the future. This does not touch admin pages, which use the unfiltered certificate model managers instead.

### How can this be tested?
Tests should continue passing.

Manual testing:
- Provision a program or courseruncertificate. You should be able to observe it both via the API endpoint (http://mitxonline.odl.local:9080/api/v2/program_certificates/<UUID>/) as well as the wagtail serve page (http://mitxonline.odl.local:9080/certificate/program/<UUID>/)
- In the admin, set the issue_date to a time in the future.
- Observe that those URLs now return 404s.

### Additional Context
- @annagav pointed out that we check CourseRunCertificates in a signal to see if we should issue a new ProgramCertificate - filtering out things in the future would affect that process, but luckily we already use the unfiltered `all_objects` manager in that context. Additionally, when checking course requirements we rely on raw joins between the Course and CourseRunCertificates, so we should bypass the manager in that context too.
<img width="638" height="144" alt="Screenshot 2026-05-12 at 11 42 02 AM" src="https://github.com/user-attachments/assets/763be977-a3ba-42cf-ae8c-85a07dce5375" />
<img width="662" height="146" alt="Screenshot 2026-05-12 at 11 44 44 AM" src="https://github.com/user-attachments/assets/799274a4-178f-43b8-95e8-c15b6205c511" />


