### PR TITLE
Set cart-add dealstage to checkout_abandoned

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -61,6 +61,9 @@ from users.models import (
 
 log = logging.getLogger(__name__)
 
+# HubSpot internal option value for the "Checkout Abandoned" deal stage.
+CART_ADD_DEAL_STAGE = "checkout_abandoned"
+
 CUSTOM_ECOMMERCE_PROPERTIES = {
     # defines which hubspot properties are mapped with which local properties when objects are synced.
     # See https://developers.hubspot.com/docs/methods/ecomm-bridge/ecomm-bridge-overview for more details
@@ -2217,6 +2220,8 @@ def _sync_cart_add_deal_with_hubspot(
 ) -> SimplePublicObject:
     """Create or update cart-add deal and line-item objects and associate them in target account."""
     deal_input = _build_target_deal_message(order, hubspot_client)
+    # Cart-add events should always be tracked as "Checkout Abandoned".
+    deal_input.properties["dealstage"] = CART_ADD_DEAL_STAGE
 
     # Extract unique_app_id from deal input to check for existing deals
     unique_app_id = deal_input.properties.get("unique_app_id")

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -893,6 +893,44 @@ def test_track_cart_add_with_hubspot_uai_fallback_to_primary_account(
     mock_sync_deal.assert_called_once()
 
 
+def test_sync_cart_add_deal_with_hubspot_sets_checkout_abandoned_stage(
+    mocker, hubspot_order
+):
+    """Cart-add deals should always use the checkout_abandoned deal stage."""
+    mock_client = mocker.Mock()
+    mock_client.crm.objects.basic_api.create.return_value = SimpleNamespace(id="obj-id")
+
+    mocker.patch(
+        "hubspot_sync.api._build_target_deal_message",
+        return_value=SimplePublicObjectInput(
+            properties={
+                "dealname": "MITXONLINE-ORDER-1",
+                "dealstage": "checkout_pending",
+                "unique_app_id": "test-app-id",
+            }
+        ),
+    )
+    mocker.patch(
+        "hubspot_sync.api._build_target_line_item_message",
+        return_value=SimplePublicObjectInput(properties={"name": "line-item"}),
+    )
+    mocker.patch("hubspot_sync.api._find_target_deal_id_by_dealname", return_value=None)
+    mocker.patch(
+        "hubspot_sync.api._find_target_deal_id_by_unique_app_id", return_value=None
+    )
+    mocker.patch("hubspot_sync.api.wait_for_hubspot_rate_limit")
+
+    api._sync_cart_add_deal_with_hubspot(hubspot_order, "contact-id", mock_client)  # noqa: SLF001
+
+    deal_create_call = mock_client.crm.objects.basic_api.create.call_args_list[0]
+    assert (
+        deal_create_call.kwargs["simple_public_object_input_for_create"].properties[
+            "dealstage"
+        ]
+        == api.CART_ADD_DEAL_STAGE
+    )
+
+
 def test_normalize_deal_properties_for_target_account_pipeline_stage_mismatch(mocker):
     """Dealstage should be normalized to one allowed by the selected pipeline."""
     mock_client = mocker.Mock()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11228

### Description (What does it do?)
Introduce CART_ADD_DEAL_STAGE constant and force the dealstage on cart-add deals to that value in _sync_cart_add_deal_with_hubspot. This ensures cart-add events are always tracked as the HubSpot "checkout_abandoned" stage. Added a unit test that mocks HubSpot client and verifies the created deal's dealstage matches the new constant.


### How can this be tested?

- Add any course to your cart and verify that a hubspot deal is created with the deal stage of "checkout abandoned"
- Pay for the course and verify that the same hubspot deal is updated so the deal stage is "processed".