### PR TITLE
Remove unique app id from the line items

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -611,16 +611,6 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                 ],
             },
             {
-                "name": "unique_app_id",
-                "label": "Unique App ID",
-                "description": "The unique app ID for the lineitem",
-                "groupName": "lineiteminformation",
-                "type": "string",
-                "fieldType": "text",
-                "hasUniqueValue": True,
-                "hidden": True,
-            },
-            {
                 "name": "enrollment_mode",
                 "label": "Enrollment Mode",
                 "description": "The enrollment mode the user is currently enrolled into the product as.",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11277

### Description (What does it do?)
The root of the issue linked above is that course run certificates and program certificates are represented as an enumeration property on a Contact. Attempting to specify a value that Hubspot doesn't know about for that property [throws an error](https://mit-office-of-digital-learning.sentry.io/issues/7450672110/?project=5864687).

In production, we found that we only have about 300 "valid" values that Hubspot knows about - in production we have about 3000 possible values. That's strange, as we attempt to upsert all valid values for custom properties via `upsert_custom_properties` before dispatching a task to do the sync - in theory, if these two things were working together, we'd expect to see the valid values match what we could generate on database state. 

When I dug into this I found that there was a different [sentry error](https://mit-office-of-digital-learning.sentry.io/issues/7090144228/?project=5864687&query=is%3Aunresolved%20Error%20syncing%20Hubspot%20user&referrer=issue-stream) coming out of `upsert_custom_properties`, because attempting to reconcile the property `unique_app_id` fails due to it being marked as read only on `LineItem` objects. If this was not happening, there could still be other issues, but this prevents the process of fixing the certificate properties from occurring, so it's a good place to start.

The [code](https://github.com/mitodl/mitxonline/commit/6ddb7eee74cb98fc812b59e3c7df95ff16690991#diff-03cd5759b29faa6d42e22697ed1bb7797ac6613840a2ebe63b1174b83dabb071R56-R733) where we try and perform this update and the matching static property configuration is not new, so either it has always been broken or something changed about that specific property definition at some point to make it read only.

This leaves us with a few options:
- Option 1: Ensure that the definition for unique_app_id is not read_only. In theory, this should allow `upsert_custom_properties` to continue, and let us attempt to backfill all the missing certificate values. I'd prefer this if possible since it requires no behavioral changes to be made. However, I've been unable to find this property via the UI with my current access level, so this may require more investigation.
- Option 2: Remove the offending `unique_app_id` and just upsert everything else. *That's what this PR does*, but I'm not sure if the process of upserting that actually _does_ work in some other account, so I'm a bit leery about it. 


### Additional Context
- It is worth noting that this may still not fix the issue. By my rough math, we've got north of 500k worth of characters in the payload we'd try and upsert for course run certificates, and enumerations are limited to a maximum size of 512000 bytes. It's entirely possible that this lets us progress a bit further so we can hit a different error, but we won't know until we try