### PR TITLE
Prefer UAI HubSpot pipeline ID in sync

### DIFF
--- a/docs/source/configuration/hubspot.rst
+++ b/docs/source/configuration/hubspot.rst
@@ -6,4 +6,5 @@ In order to connect your local instance of MITx Online with HubSpot, you will ne
 MITOL_HUBSPOT_API_PRIVATE_TOKEN=<ask a developer to add you to the hubspot account>
 MITOL_HUBSPOT_API_ID_PREFIX=<your_initials>-mitxonline-dev
 HUBSPOT_PIPELINE_ID=19817792
+UAI_HUBSPOT_PIPELINE_ID=75e28846-ad0d-4be2-a027-5e1da6590b98
 ```

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1730,7 +1730,11 @@ def _normalize_deal_properties_for_target_account(  # noqa: C901
         if current_pipeline not in pipeline_stage_map:
             resolved_pipeline = _pick_preferred_option(
                 list(pipeline_stage_map.keys()),
-                [str(getattr(settings, "HUBSPOT_PIPELINE_ID", "")), "default"],
+                [
+                    str(getattr(settings, "UAI_HUBSPOT_PIPELINE_ID", "")),
+                    str(getattr(settings, "HUBSPOT_PIPELINE_ID", "")),
+                    "default",
+                ],
             )
             if resolved_pipeline:
                 deal_properties["pipeline"] = resolved_pipeline

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -960,6 +960,39 @@ def test_normalize_deal_properties_for_target_account_pipeline_stage_mismatch(mo
     assert deal_input.properties["dealstage"] == "created"
 
 
+def test_normalize_deal_properties_for_target_account_prefers_ecommerce_pipeline(
+    mocker, settings
+):
+    """UAI deals should fall back to UAI_HUBSPOT_PIPELINE_ID when the source pipeline is not in the target account."""
+    settings.UAI_HUBSPOT_PIPELINE_ID = "uai-ecommerce-pipeline-id"
+    mock_client = mocker.Mock()
+    mocker.patch(
+        "hubspot_sync.api._get_target_pipeline_stage_map",
+        return_value={
+            "sales-pipeline-id": ["closedwon", "closedlost"],
+            "default": ["checkout_pending"],
+            "uai-ecommerce-pipeline-id": ["created", "processed"],
+        },
+    )
+    mocker.patch(
+        "hubspot_sync.api._get_target_property_options",
+        return_value=["created", "fulfilled", "failed", "refunded"],
+    )
+
+    deal_input = SimplePublicObjectInput(
+        properties={
+            "pipeline": "missing-pipeline-id",
+            "dealstage": "checkout_pending",
+            "status": "pending",
+        }
+    )
+
+    api._normalize_deal_properties_for_target_account(mock_client, deal_input)  # noqa: SLF001
+
+    assert deal_input.properties["pipeline"] == "uai-ecommerce-pipeline-id"
+    assert deal_input.properties["dealstage"] == "created"
+
+
 def test_build_target_line_item_message_uses_target_product_id_from_search(
     mocker, hubspot_order
 ):

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -993,6 +993,73 @@ def test_normalize_deal_properties_for_target_account_prefers_ecommerce_pipeline
     assert deal_input.properties["dealstage"] == "created"
 
 
+def test_normalize_deal_properties_for_target_account_falls_back_to_hubspot_pipeline_id(
+    mocker, settings
+):
+    """If UAI_HUBSPOT_PIPELINE_ID is unavailable, HUBSPOT_PIPELINE_ID should be used."""
+    settings.UAI_HUBSPOT_PIPELINE_ID = "missing-uai-pipeline-id"
+    settings.HUBSPOT_PIPELINE_ID = "mitx-pipeline-id"
+    mock_client = mocker.Mock()
+    mocker.patch(
+        "hubspot_sync.api._get_target_pipeline_stage_map",
+        return_value={
+            "sales-pipeline-id": ["closedwon", "closedlost"],
+            "mitx-pipeline-id": ["created", "processed"],
+            "default": ["checkout_pending"],
+        },
+    )
+    mocker.patch(
+        "hubspot_sync.api._get_target_property_options",
+        return_value=["created", "fulfilled", "failed", "refunded"],
+    )
+
+    deal_input = SimplePublicObjectInput(
+        properties={
+            "pipeline": "missing-source-pipeline-id",
+            "dealstage": "checkout_pending",
+            "status": "pending",
+        }
+    )
+
+    api._normalize_deal_properties_for_target_account(mock_client, deal_input)  # noqa: SLF001
+
+    assert deal_input.properties["pipeline"] == "mitx-pipeline-id"
+    assert deal_input.properties["dealstage"] == "created"
+
+
+def test_normalize_deal_properties_for_target_account_falls_back_to_default_pipeline(
+    mocker, settings
+):
+    """If configured pipeline ids are unavailable, the default pipeline should be used."""
+    settings.UAI_HUBSPOT_PIPELINE_ID = "missing-uai-pipeline-id"
+    settings.HUBSPOT_PIPELINE_ID = "missing-mitx-pipeline-id"
+    mock_client = mocker.Mock()
+    mocker.patch(
+        "hubspot_sync.api._get_target_pipeline_stage_map",
+        return_value={
+            "sales-pipeline-id": ["closedwon", "closedlost"],
+            "default": ["checkout_pending"],
+        },
+    )
+    mocker.patch(
+        "hubspot_sync.api._get_target_property_options",
+        return_value=["created", "fulfilled", "failed", "refunded"],
+    )
+
+    deal_input = SimplePublicObjectInput(
+        properties={
+            "pipeline": "missing-source-pipeline-id",
+            "dealstage": "checkout_pending",
+            "status": "pending",
+        }
+    )
+
+    api._normalize_deal_properties_for_target_account(mock_client, deal_input)  # noqa: SLF001
+
+    assert deal_input.properties["pipeline"] == "default"
+    assert deal_input.properties["dealstage"] == "checkout_pending"
+
+
 def test_build_target_line_item_message_uses_target_product_id_from_search(
     mocker, hubspot_order
 ):

--- a/main/settings.py
+++ b/main/settings.py
@@ -1411,6 +1411,11 @@ UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN = get_string(
     default=None,
     description="Hubspot private token for UAI/Learn account",
 )
+UAI_HUBSPOT_PIPELINE_ID = get_string(
+    name="UAI_HUBSPOT_PIPELINE_ID",
+    default="75e28846-ad0d-4be2-a027-5e1da6590b98",
+    description="Hubspot ecommerce pipeline ID for the UAI/xPro account",
+)
 
 # Unified Ecommerce integration
 


### PR DESCRIPTION
Add support for a UAI-specific HubSpot pipeline ID and prefer it when normalizing deal properties. Updates main/settings.py to introduce UAI_HUBSPOT_PIPELINE_ID with a default value, adds the env var to the docs (docs/source/configuration/hubspot.rst), and changes hubspot_sync/api.py to check UAI_HUBSPOT_PIPELINE_ID before HUBSPOT_PIPELINE_ID. Adds a unit test (test_normalize_deal_properties_for_target_account_prefers_ecommerce_pipeline) to verify the preference and mapping behavior.

### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11287

### Description (What does it do?)
Add support for a UAI-specific HubSpot pipeline ID and prefer it when normalizing deal properties. Updates main/settings.py to introduce UAI_HUBSPOT_PIPELINE_ID with a default value, adds the env var to the docs (docs/source/configuration/hubspot.rst), and changes hubspot_sync/api.py to check UAI_HUBSPOT_PIPELINE_ID before HUBSPOT_PIPELINE_ID. Adds a unit test (test_normalize_deal_properties_for_target_account_prefers_ecommerce_pipeline) to verify the preference and mapping behavior.

### How can this be tested?

- Add a UAI course to your cart.
- Verify that a deal is created in Hubspot.  Click on the deal and verify that the "Pipeline" shows "Ecommerce Pipeline".

