### PR TITLE
Normalize cart-add deal stage for target account

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -2224,8 +2224,10 @@ def _sync_cart_add_deal_with_hubspot(
 ) -> SimplePublicObject:
     """Create or update cart-add deal and line-item objects and associate them in target account."""
     deal_input = _build_target_deal_message(order, hubspot_client)
-    # Cart-add events should always be tracked as "Checkout Abandoned".
+    # Prefer "Checkout Abandoned" for cart-add events, then normalize so the
+    # payload still matches the selected target-account pipeline configuration.
     deal_input.properties["dealstage"] = CART_ADD_DEAL_STAGE
+    _normalize_deal_properties_for_target_account(hubspot_client, deal_input)
 
     # Extract unique_app_id from deal input to check for existing deals
     unique_app_id = deal_input.properties.get("unique_app_id")

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -918,6 +918,58 @@ def test_sync_cart_add_deal_with_hubspot_sets_checkout_abandoned_stage(
     mocker.patch(
         "hubspot_sync.api._find_target_deal_id_by_unique_app_id", return_value=None
     )
+    mock_normalize = mocker.patch(
+        "hubspot_sync.api._normalize_deal_properties_for_target_account"
+    )
+    mocker.patch("hubspot_sync.api.wait_for_hubspot_rate_limit")
+
+    api._sync_cart_add_deal_with_hubspot(hubspot_order, "contact-id", mock_client)  # noqa: SLF001
+
+    mock_normalize.assert_called_once()
+
+    deal_create_call = mock_client.crm.objects.basic_api.create.call_args_list[0]
+    assert (
+        deal_create_call.kwargs["simple_public_object_input_for_create"].properties[
+            "dealstage"
+        ]
+        == api.CART_ADD_DEAL_STAGE
+    )
+
+
+def test_sync_cart_add_deal_with_hubspot_normalizes_stage_after_override(
+    mocker, hubspot_order
+):
+    """Cart-add stage should be normalized if checkout_abandoned is invalid in target account."""
+    mock_client = mocker.Mock()
+    mock_client.crm.objects.basic_api.create.return_value = SimpleNamespace(id="obj-id")
+
+    mocker.patch(
+        "hubspot_sync.api._build_target_deal_message",
+        return_value=SimplePublicObjectInput(
+            properties={
+                "dealname": "MITXONLINE-ORDER-1",
+                "pipeline": "19817792",
+                "dealstage": "checkout_pending",
+                "unique_app_id": "test-app-id",
+            }
+        ),
+    )
+    mocker.patch(
+        "hubspot_sync.api._build_target_line_item_message",
+        return_value=SimplePublicObjectInput(properties={"name": "line-item"}),
+    )
+    mocker.patch("hubspot_sync.api._find_target_deal_id_by_dealname", return_value=None)
+    mocker.patch(
+        "hubspot_sync.api._find_target_deal_id_by_unique_app_id", return_value=None
+    )
+
+    def _normalize_to_created(_client, deal_input):
+        deal_input.properties["dealstage"] = "created"
+
+    mocker.patch(
+        "hubspot_sync.api._normalize_deal_properties_for_target_account",
+        side_effect=_normalize_to_created,
+    )
     mocker.patch("hubspot_sync.api.wait_for_hubspot_rate_limit")
 
     api._sync_cart_add_deal_with_hubspot(hubspot_order, "contact-id", mock_client)  # noqa: SLF001
@@ -927,7 +979,7 @@ def test_sync_cart_add_deal_with_hubspot_sets_checkout_abandoned_stage(
         deal_create_call.kwargs["simple_public_object_input_for_create"].properties[
             "dealstage"
         ]
-        == api.CART_ADD_DEAL_STAGE
+        == "created"
     )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11287

```

HTTP response headers: HTTPHeaderDict({'date': 'Fri, 15 May 2026 19:34:51 GMT', 'content-type': 'application/json;charset=utf-8', 'content-length': '443', 'cf-ray': '9fc49517deb83e97-IAD', 'cf-cache-status': 'DYNAMIC', 'strict-transport-security': 'max-age=31536000; includeSubDomains; preload', 'vary': 'origin, Accept-Encoding', 'access-control-allow-credentials': 'false', 'server-timing': 'hcid;desc="019e2d22-6b1d-7e74-8930-5eda1ad0f1f8", cfr;desc="9fc4951811813e97-IAD"', 'x-hubspot-correlation-id': '019e2d22-6b1d-7e74-8930-5eda1ad0f1f8', 'x-hubspot-ratelimit-daily': '1000000', 'x-hubspot-ratelimit-daily-remaining': '999799', 'x-hubspot-ratelimit-interval-milliseconds': '10000', 'x-hubspot-ratelimit-max': '190', 'x-hubspot-ratelimit-remaining': '189', 'x-hubspot-ratelimit-secondly': '19', 'x-hubspot-ratelimit-secondly-remaining': '18', 'set-cookie': '__cf_bm=Pn876c_0HarBil_UOm0p_.uYnUSUIVqUsbfYgDAD__c-1778873691-1.0.1.1-NunXx6IuQYEe16_0j8xTm6u6A2.02Rq2MOqbvzkUnQOWsf4uPuSgGa8AO7llBdQG.7AXih4E4v6Z3wOncwvPDO_nQNaASToJCfyLQQzVdXY; path=/; expires=Fri, 15-May-26 20:04:51 GMT; domain=.hubapi.com; HttpOnly; Secure; SameSite=None', 'report-to': '{"endpoints":[{"url":"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=v8Os4P46cJ3%2B0bbB9sT%2FZlzgaf3R8oZz6%2FIdZSpOGE4kU4GLGtHMoXtrlD1rCISIEYXGt%2ByHxYpMpNdCQ%2Fx3JdsopxjXlkZsjjU9d0ZCyG%2BZQa7KKslrY%2Fj22QlxH%2FWS"}],"group":"cf-nel","max_age":604800}', 'nel': '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}', 'server': 'cloudflare'}) 

2026-05-15 15:34:51.061 
 
hubspot.crm.objects.exceptions.ApiException: (400) 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/rest.py", line 190, in request 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/rest.py", line 207, in POST 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/api_client.py", line 428, in request 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/api_client.py", line 185, in __call_api 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/api_client.py", line 190, in __call_api 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/api_client.py", line 378, in call_api 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/api/basic_api.py", line 284, in create_with_http_info 

2026-05-15 15:34:51.061 
 
  File "/opt/venv/lib/python3.11/site-packages/hubspot/crm/objects/api/basic_api.py", line 196, in create 

2026-05-15 15:34:51.061 
 
    deal = hubspot_client.crm.objects.basic_api.create( 

2026-05-15 15:34:51.061 
 
  File "/src/hubspot_sync/api.py", line 2248, in _sync_cart_add_deal_with_hubspot 

2026-05-15 15:34:51.061 
 
    deal = _sync_cart_add_deal_with_hubspot(order, contact_id, hubspot_client) 

2026-05-15 15:34:51.061 
 
  File "/src/hubspot_sync/api.py", line 2346, in track_cart_add_with_hubspot 

2026-05-15 15:34:51.061 
 
[2026-05-15 19:34:51,060: ERROR/ForkPoolWorker-3] Failed to sync HubSpot cart-add deal for user 292 product 262 (is_uai=True) 

2026-05-15 15:34:50.339 
 
[2026-05-15 19:34:50,339: INFO/ForkPoolWorker-3] Found existing HubSpot contact in target account for user_id=292 email=collinp@mit.edu contact_id=216973050904
```

### Description (What does it do?)
Call _normalize_deal_properties_for_target_account after forcing the cart-add dealstage so the outgoing deal payload conforms to the target account's pipeline configuration. Update tests to mock and assert the normalization is invoked, and add a new test to verify that an invalid/overridden cart-add stage is normalized (e.g. to "created") before the create call.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Adding any course to your cart should set the deal stage to "checkout abandoned" in the "ecommerce" pipeline.  UAI courses added to the cart should result in this functionality occurring in the Xpro hubspot account.

