### PR TITLE
Add workflow file for zizmor

### DIFF
--- a/.github/workflows/actions-static-analysis.yml
+++ b/.github/workflows/actions-static-analysis.yml
@@ -1,0 +1,29 @@
+name: GitHub Actions Static Analysis
+
+on:
+  push:
+    branches: ["main", "jkachel/11326-add-zizmor-ci-step"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+            inputs: ".github/workflows/"
+            min-severity: high
+            min-confiednce: medium

--- a/.github/workflows/actions-static-analysis.yml
+++ b/.github/workflows/actions-static-analysis.yml
@@ -2,9 +2,11 @@ name: GitHub Actions Static Analysis
 
 on:
   push:
-    branches: ["main", "jkachel/11326-add-zizmor-ci-step"]
+    paths:
+      - ".github/workflows/**"
   pull_request:
-    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
 
 permissions: {}
 

--- a/.github/workflows/actions-static-analysis.yml
+++ b/.github/workflows/actions-static-analysis.yml
@@ -27,3 +27,4 @@ jobs:
             inputs: ".github/workflows/"
             min-severity: high
             min-confidence: medium
+            advanced-security: false

--- a/.github/workflows/actions-static-analysis.yml
+++ b/.github/workflows/actions-static-analysis.yml
@@ -26,4 +26,4 @@ jobs:
         with:
             inputs: ".github/workflows/"
             min-severity: high
-            min-confiednce: medium
+            min-confidence: medium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20.18"
 

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   add-to-hq:
-    uses: mitodl/ol-github-workflows/.github/workflows/add-to-ol-hq.yaml@main
+    uses: mitodl/ol-github-workflows/.github/workflows/add-to-ol-hq.yaml@edd566dec1edd920d35ab1fb60b589cddc44afad # latest main 5/17/2026
     secrets: inherit


### PR DESCRIPTION
### What are the relevant tickets?

mitodl/hq#11326

### Description (What does it do?)

Adds a CI step to run zizmor if the PR contains changes to the GitHub workflows. Fix the couple of simple things that it tagged as issues.

### How can this be tested?

- Check out this branch, then create a new branch from it.
- Make a change to the workflows in some sort of manner. There's a Hello World one that would be fine for this here: https://gist.github.com/weibeld/f136048d0a82aacc063f42e684e3c494 but you may want to add a `uses` block that checks out the repo or something (and maybe pin it to a tag so zizmor complains about it).
- Commit the change and push. This should trigger the workflow to run.
- Clean up your branch.

You can also check out the prior workflow runs in this PR because I added the workflow before fixing issues - you should see what issues were there that are fixed in the PR.

In addition, this updates the pin for the `setup-node` action to the latest v6.4.0 (from v2-beta) and pins the new issues action to the latest commit (since that uses a home-grown one and we don't have releases/tags for it). This should have no effect on these workflows - the JavaScript tests should still complete successfully, and new issues put in this repo should copy into mitodl/hq as before.

### Additional Context

This is configured to only output high severity issues with a medium amount of confidence, so we shouldn't get test failures for things that aren't really problematic. (For instance, the defaults flag the pins that Renovate puts in, because it doesn't list the full version number of the action that it's pinning.)