### PR TITLE
fix: add audit trail on first enrollment as well

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -159,6 +159,8 @@ def create_local_enrollment(user, run, *, mode=EDX_DEFAULT_ENROLLMENT_MODE):
             "enrollment_mode": mode,
         },
     )
+    if created:
+        enrollment.save_and_log(None)
     if not created and not enrollment.active:
         enrollment.reactivate_and_save()
     if not enrollment.edx_enrolled:
@@ -249,6 +251,9 @@ def create_run_enrollments(  # noqa: C901
                 ),
             )
 
+            if created:
+                enrollment.save_and_log(None)
+
             # If the run is associated with a B2B contract, add the contract
             # to the user's contract list and update their org memberships
             if run.b2b_contract:
@@ -323,6 +328,9 @@ def create_program_enrollments(
                     "enrollment_mode": enrollment_mode,
                 },
             )
+            if created:
+                enrollment.save_and_log(None)
+
             if not created and enrollment.change_status is not None:
                 enrollment.reactivate_and_save()
 

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -561,7 +561,11 @@ def test_create_program_enrollments_creation_fail(mocker, user):
     creation of local enrollment records
     """
     programs = ProgramFactory.create_batch(2)
-    enrollment = ProgramEnrollmentFactory.build(program=programs[1])
+    # Use .create() (not .build()) so the enrollment has a primary key.
+    # `create_program_enrollments` now calls `enrollment.save_and_log(None)`
+    # when get_or_create reports created=True, which writes an audit row
+    # via a ForeignKey to the enrollment and therefore requires a saved PK.
+    enrollment = ProgramEnrollmentFactory.create(user=user, program=programs[1])
     mocker.patch(
         "courses.api.ProgramEnrollment.all_objects.get_or_create",
         side_effect=[Exception(), (enrollment, True)],

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -84,10 +84,12 @@ from courses.factories import (
 from courses.models import (
     CourseRunCertificate,
     CourseRunEnrollment,
+    CourseRunEnrollmentAudit,
     EnrollmentMode,
     PaidCourseRun,
     ProgramCertificate,
     ProgramEnrollment,
+    ProgramEnrollmentAudit,
     ProgramRequirement,
     ProgramRequirementNodeType,
 )
@@ -243,6 +245,26 @@ def test_create_local_enrollment_existing_enrollment(
     assert enrollment.edx_enrolled is True
 
 
+def test_create_local_enrollment_writes_audit_on_creation(user):
+    """
+    create_local_enrollment should write a CourseRunEnrollmentAudit row when a
+    brand-new enrollment is created. Without this, the very first event in an
+    enrollment's lifecycle would be missing from the audit table.
+    """
+    run = CourseRunFactory.create()
+
+    enrollment, created = create_local_enrollment(user, run)
+
+    assert created is True
+    audit_rows = CourseRunEnrollmentAudit.objects.filter(enrollment=enrollment)
+    assert audit_rows.count() == 1
+    audit_row = audit_rows.first()
+    assert audit_row.acting_user is None
+    assert audit_row.data_after["id"] == enrollment.id
+    assert audit_row.data_after["active"] is True
+    assert audit_row.data_after["edx_enrolled"] is True
+
+
 @pytest.mark.parametrize(
     "enrollment_mode", [EDX_DEFAULT_ENROLLMENT_MODE, EDX_ENROLLMENT_VERIFIED_MODE]
 )
@@ -293,6 +315,32 @@ def test_create_run_enrollments(
             assert enrollment.run == run
             assert enrollment.enrollment_mode == enrollment_mode
             patched_send_enrollment_email.assert_any_call(enrollment)
+
+
+def test_create_run_enrollments_writes_audit_on_creation(mocker, user):
+    """
+    create_run_enrollments should write a CourseRunEnrollmentAudit row for every
+    newly-created enrollment.
+    """
+    runs = CourseRunFactory.create_batch(2)
+    mocker.patch("courses.api.enroll_in_edx_course_runs")
+    mocker.patch("courses.api.mail_api.send_course_run_enrollment_email")
+    mocker.patch("courses.tasks.subscribe_edx_course_emails.delay")
+
+    successful_enrollments, edx_request_success = create_run_enrollments(user, runs)
+
+    assert edx_request_success is True
+    assert len(successful_enrollments) == len(runs)
+    for enrollment in successful_enrollments:
+        audit_rows = CourseRunEnrollmentAudit.objects.filter(enrollment=enrollment)
+        assert audit_rows.count() == 1, (
+            f"expected exactly one audit row for the newly-created enrollment {enrollment.id}, "
+            f"found {audit_rows.count()}"
+        )
+        audit_row = audit_rows.first()
+        assert audit_row.acting_user is None
+        assert audit_row.data_after["id"] == enrollment.id
+        assert audit_row.data_after["active"] is True
 
 
 @pytest.mark.parametrize("is_active", [True, False])
@@ -524,6 +572,28 @@ def test_create_program_enrollments_creation(user, mode):
         assert enrollment.active is True
         assert enrollment.program == program
         assert enrollment.enrollment_mode == mode
+
+
+def test_create_program_enrollments_writes_audit_on_creation(user):
+    """
+    create_program_enrollments should write a ProgramEnrollmentAudit row for
+    every newly-created enrollment.
+    """
+    programs = ProgramFactory.create_batch(2)
+
+    successful_enrollments = create_program_enrollments(user, programs)
+
+    assert len(successful_enrollments) == len(programs)
+    for enrollment in successful_enrollments:
+        audit_rows = ProgramEnrollmentAudit.objects.filter(enrollment=enrollment)
+        assert audit_rows.count() == 1, (
+            f"expected exactly one audit row for the newly-created enrollment {enrollment.id}, "
+            f"found {audit_rows.count()}"
+        )
+        audit_row = audit_rows.first()
+        assert audit_row.acting_user is None
+        assert audit_row.data_after["id"] == enrollment.id
+        assert audit_row.data_after["active"] is True
 
 
 @pytest.mark.parametrize("active", [True, False])

--- a/courses/management/commands/create_local_enrollments.py
+++ b/courses/management/commands/create_local_enrollments.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
                     user = User.objects.filter(username=edx_enrollment.user).first()
                     if user:
                         (
-                            _,
+                            enrollment,
                             created,
                         ) = CourseRunEnrollment.all_objects.get_or_create(
                             user=user,
@@ -68,6 +68,11 @@ class Command(BaseCommand):
                             ),
                         )
                         if created:
+                            # `get_or_create` bypasses `save_and_log`, so the
+                            # initial creation is not audited by default.
+                            # Re-save through `save_and_log` to record the
+                            # create event in CourseRunEnrollmentAudit.
+                            enrollment.save_and_log(None)
                             created_count[courseware_id] += 1
 
                 except:  # noqa: PERF203, E722

--- a/courses/management/commands/create_local_enrollments.py
+++ b/courses/management/commands/create_local_enrollments.py
@@ -68,10 +68,6 @@ class Command(BaseCommand):
                             ),
                         )
                         if created:
-                            # `get_or_create` bypasses `save_and_log`, so the
-                            # initial creation is not audited by default.
-                            # Re-save through `save_and_log` to record the
-                            # create event in CourseRunEnrollmentAudit.
                             enrollment.save_and_log(None)
                             created_count[courseware_id] += 1
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11151

### Description (What does it do?)
This pull request ensures that all newly created enrollment records are properly audited by calling `save_and_log(None)` immediately after creation via `get_or_create`. This change affects both course and program enrollments, and updates tests and management commands to accommodate the new behavior.

**Enrollment Auditing Improvements:**

* Calls `save_and_log(None)` on new `CourseRunEnrollment` and `ProgramEnrollment` objects right after creation in `create_local_enrollment`, `send_enrollment_emails`, and `create_program_enrollments` to ensure audit logs are created for these events. [[1]](diffhunk://#diff-986b261128afc6d6a2b8fd5a0211077aec62e49e82ceeb65ad8fdec1298cde0dR162-R163) [[2]](diffhunk://#diff-986b261128afc6d6a2b8fd5a0211077aec62e49e82ceeb65ad8fdec1298cde0dR254-R256) [[3]](diffhunk://#diff-986b261128afc6d6a2b8fd5a0211077aec62e49e82ceeb65ad8fdec1298cde0dR331-R333)
* Updates the management command `create_local_enrollments.py` to call `save_and_log(None)` after creating enrollments, ensuring that enrollments created through scripts are also audited. [[1]](diffhunk://#diff-d8d565dda57c52ed69eab8d8f6fe77e6ae1c7573c847c3d01d16feef797eef90L57-R57) [[2]](diffhunk://#diff-d8d565dda57c52ed69eab8d8f6fe77e6ae1c7573c847c3d01d16feef797eef90R71-R75)

**Testing Updates:**

* Modifies `test_create_program_enrollments_creation_fail` to use `.create()` instead of `.build()` for `ProgramEnrollmentFactory`, ensuring that the test works correctly since the audit log now requires a saved primary key.

### How can this be tested?
1. Checkout to this branch.
2. Enroll in any course from mitxonline and check the audit trail from admin.
3. For Course enrollment check `/admin/courses/courserunenrollmentaudit/`
4. For Program enrollment check `/admin/courses/programenrollmentaudit/`
5. Entries should exist on course/program enrollment


### Screenshots

<img width="1330" height="789" alt="image" src="https://github.com/user-attachments/assets/7a271a4d-3c36-42ea-8bbe-d707fc2a847b" />

