### PR TITLE
Fix consideration for program certificate generation

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -1115,18 +1115,25 @@ def _has_earned_program_cert(user, program):
         bool: True if a user has earned all the course certificates required
               for a given program else False
     """
-    program_course_ids = [course[0].id for course in program.courses]
+
+    user_courseruns = CourseRun.objects.filter(
+        enrollments__user=user,
+        enrollments__active=True,
+        enrollments__change_status__isnull=True,
+    ).filter(course__in=program.courses_qset)
 
     cert_courses = Course.objects.filter(
-        id__in=program_course_ids,
+        courseruns__in=user_courseruns,
         courseruns__courseruncertificates__user=user,
         courseruns__courseruncertificates__is_revoked=False,
     )
     grade_courses = Course.objects.filter(
-        id__in=program_course_ids,
+        courseruns__in=user_courseruns.exclude(
+            enrollment_modes__mode_slug=EDX_ENROLLMENT_VERIFIED_MODE
+        ),
         courseruns__grades__user=user,
         courseruns__grades__passed=True,
-    ).exclude(courseruns__enrollment_modes__mode_slug=EDX_ENROLLMENT_VERIFIED_MODE)
+    )
     root = ProgramRequirement.get_root_nodes().get(program=program)
 
     def _has_earned(node):

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -2122,6 +2122,14 @@ def test_generate_program_certificate_audit_courses(user, default_mode_records):
     program.add_requirement(cert_course)
     program.add_requirement(audit_course)
 
+    # Add some additional course runs for the audit course.
+    # This test missed a case - if the course had a mix of runs that were both
+    # audit-only and not, the certificates wouldn't be generated.
+
+    audit_verified_course_run = CourseRunFactory.create(course=audit_course)
+    audit_verified_course_run.enrollment_modes.set(default_mode_records)
+    audit_verified_course_run.save()
+
     ProgramEnrollment.objects.create(
         user=user,
         program=program,

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1641,6 +1641,9 @@ def test_generate_program_certificate_success_single_requirement_course(
     course_run = CourseRunFactory.create(course=course)
     course_run.enrollment_modes.set(default_mode_records)
     course_run.save()
+    CourseRunEnrollmentFactory.create(
+        run=course_run, user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
     CourseRunGradeFactory.create(course_run=course_run, user=user, passed=True, grade=1)
 
     CourseRunCertificateFactory.create(user=user, course_run=course_run)
@@ -1686,6 +1689,12 @@ def test_generate_program_certificate_success_multiple_required_courses(
         run.enrollment_modes.set(default_mode_records)
         run.save()
 
+    CourseRunEnrollmentFactory.create_batch(
+        3,
+        run=factory.Iterator(course_runs),
+        user=user,
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+    )
     CourseRunCertificateFactory.create_batch(
         3, user=user, course_run=factory.Iterator(course_runs)
     )
@@ -1995,6 +2004,9 @@ def test_generate_program_certificate_with_subprogram_requirement(  # noqa: PLR0
     sub_course_run = CourseRunFactory.create(course=sub_course)
     sub_course_run.enrollment_modes.set(default_mode_records)
     sub_course_run.save()
+    CourseRunEnrollmentFactory.create(
+        run=sub_course_run, user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
     CourseRunGradeFactory.create(
         course_run=sub_course_run, user=user, passed=True, grade=1
     )
@@ -2065,6 +2077,9 @@ def test_generate_program_certificate_with_revoked_subprogram_certificate(
 
     # User completes the sub-program and gets a certificate, but it gets revoked
     sub_course_run = CourseRunFactory.create(course=sub_course)
+    CourseRunEnrollmentFactory.create(
+        run=sub_course_run, user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
     CourseRunGradeFactory.create(
         course_run=sub_course_run, user=user, passed=True, grade=1
     )
@@ -3486,6 +3501,9 @@ def test_generate_missing_program_certificates_creates_cert(
     course_run = CourseRunFactory.create(course=course)
     course_run.enrollment_modes.set(default_mode_records)
     course_run.save()
+    CourseRunEnrollmentFactory.create(
+        run=course_run, user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
 
     ProgramEnrollment.objects.create(
         user=user, program=program, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
@@ -3518,6 +3536,9 @@ def test_generate_missing_program_certificates_idempotent(
     course_run = CourseRunFactory.create(course=course)
     course_run.enrollment_modes.set(default_mode_records)
     course_run.save()
+    CourseRunEnrollmentFactory.create(
+        run=course_run, user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
 
     ProgramEnrollment.objects.create(
         user=user, program=program, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE

--- a/courses/management/tests/manage_program_certificate_test.py
+++ b/courses/management/tests/manage_program_certificate_test.py
@@ -125,10 +125,18 @@ def test_program_certificate_management_revoke_unrevoke_success(user, revoke, un
     assert certificate.is_revoked is (False if unrevoke else True)  # noqa: SIM211
 
 
+@pytest.mark.parametrize(
+    "force_cert",
+    [
+        True,
+        False,
+    ],
+)
 def test_program_certificate_management_create(
     user,
     program_with_empty_requirements,  # noqa: F811
     mocker,
+    force_cert,
 ):
     """
     Test that create operation for program certificate management command
@@ -162,13 +170,14 @@ def test_program_certificate_management_create(
         create=True,
         program=program_with_empty_requirements.readable_id,
         user=user.edx_username,
+        force=force_cert,
     )
 
     generated_certificates = ProgramCertificate.objects.filter(
         user=user, program=program_with_empty_requirements
     )
 
-    assert generated_certificates.count() == 1
+    assert generated_certificates.count() == (1 if force_cert else 0)
 
 
 def test_program_certificate_management_force_create(


### PR DESCRIPTION

### What are the relevant tickets?

Closes mitodl/hq#11403

### Description (What does it do?)

Fixes an issue with program certificate generation - if the user is enrolled in a course run that's audit-only, but the course has runs that have a verified mode, the user wouldn't get a program certificate.

### How can this be tested?

Automated tests should pass and the test for this specifically should be updated to account for this case.

To test manually, create a program with courses and audit-only course runs. Ensure at least one course has a separate, verified run. Enroll the user in the program with a verified enrollment and enroll them in the audit-only runs. Enter passing grades for the course runs, then attempt to generate the program certificate. It should work - you should get a program certificate for the program and no course run certificates.

This should also work if some of the course run enrollments are verified enrollments too. The rule is that we should generate you a program certificate if you have a verified enrollment in the program, a passing grade in the course runs that are audit-only, and a certificate in the course runs that have verified modes. So, any permutation of this should work. The problematic case is when the course has some runs that are audit-only and some that have verified modes.