### PR TITLE
Upgrade django_health_checks

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -253,6 +253,7 @@ INSTALLED_APPS = (
     "reversion",
     # django-treebeard
     "treebeard",
+    "health_check",
     # Put our apps after this point
     "main",
     "authentication",
@@ -290,50 +291,11 @@ INSTALLED_APPS = (
     "drf_spectacular",
     "mitol.apigateway.apps.ApigatewayApp",
     "b2b",
-    "health_check",
-    "health_check.cache",
-    "health_check.contrib.migrations",
-    "health_check.contrib.celery_ping",
-    "health_check.contrib.redis",
-    "health_check.contrib.db_heartbeat",
     "rest_framework_api_key",
 )
 # Only include the seed data app if this isn't running in prod
 # if ENVIRONMENT not in ("production", "prod"):
 #     INSTALLED_APPS += ("localdev.seed",)  # noqa: ERA001
-
-HEALTH_CHECK = {
-    "SUBSETS": {
-        # The 'startup' subset includes checks that must pass before the application can
-        # start.
-        "startup": [
-            "MigrationsHealthCheck",  # Ensures database migrations are applied.
-            "CacheBackend",  # Verifies the cache backend is operational.
-            "RedisHealthCheck",  # Confirms Redis is reachable and functional.
-            "DatabaseHeartBeatCheck",  # Checks the database connection is alive.
-        ],
-        # The 'liveness' subset includes checks to determine if the application is
-        # running.
-        "liveness": ["DatabaseHeartBeatCheck"],  # Minimal check to ensure the app is
-        # alive.
-        # The 'readiness' subset includes checks to determine if the application is
-        # ready to serve requests.
-        "readiness": [
-            "CacheBackend",  # Ensures the cache is ready for use.
-            "RedisHealthCheck",  # Confirms Redis is ready for use.
-            "DatabaseHeartBeatCheck",  # Verifies the database is ready for queries.
-        ],
-        # The 'full' subset includes all available health checks for a comprehensive
-        # status report.
-        "full": [
-            "MigrationsHealthCheck",  # Ensures database migrations are applied.
-            "CacheBackend",  # Verifies the cache backend is operational.
-            "RedisHealthCheck",  # Confirms Redis is reachable and functional.
-            "DatabaseHeartBeatCheck",  # Checks the database connection is alive.
-            "CeleryPingHealthCheck",  # Verifies Celery workers are responsive.
-        ],
-    }
-}
 
 MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",

--- a/main/urls.py
+++ b/main/urls.py
@@ -52,6 +52,7 @@ urlpatterns = [
         SpectacularSwaggerView.as_view(url_name="schema"),
         name="swagger",
     ),
+    path("", include("main.urls_healthcheck")),
     path("", include("authentication.urls")),
     path("", include("openedx.urls")),
     path("", include("mail.urls")),
@@ -90,7 +91,6 @@ urlpatterns = [
     re_path(r"^records/.*", index, {"noindex": True}, name="learner-records"),
     re_path(r"^catalog/", index, name="catalog"),
     path("api/instructor/<int:pk>/", instructor_page, name="cms_instructor_page"),
-    re_path(r"^health/", include("health_check.urls")),
     # Wagtail
     re_path(
         r"^cms/login", cms_signin_redirect_to_site_signin, name="wagtailadmin_login"

--- a/main/urls_healthcheck.py
+++ b/main/urls_healthcheck.py
@@ -1,0 +1,59 @@
+"""Healthcheck urls"""
+
+from django.conf import settings
+from django.urls import include, path, re_path
+from health_check.views import HealthCheckView
+from redis.asyncio import Redis as RedisClient
+
+BASE_CHECKS = [
+    "health_check.Cache",
+    "health_check.Database",
+    (
+        "health_check.contrib.redis.Redis",
+        {"client_factory": lambda: RedisClient.from_url(settings.REDIS_URL)},
+    ),
+]
+
+
+urlpatterns = [
+    path(
+        "health/",
+        include(
+            [
+                re_path(
+                    r"startup\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                        ]
+                    ),
+                ),
+                re_path(
+                    r"liveness\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            "health_check.Database",
+                        ]
+                    ),
+                ),
+                re_path(
+                    r"readiness\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                        ]
+                    ),
+                ),
+                re_path(
+                    r"full\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                            "health_check.contrib.celery.Ping",
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ),
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "django-cors-headers>=4.0.0,<5",
     "django-countries>=7.2.1,<8",
     "django-filter>=24.3,<25",
-    "django-health-check",
+    "django-health-check[celery,redis]>=4.0.0",
     "django-hijack>=3.6.0,<4",
     "django-ipware>=7.0.0,<8",
     "django-redis>=6.0.0,<7",
@@ -118,9 +118,6 @@ dev = [
 [tool.uv]
 package = false
 default-groups = "all"
-
-[tool.uv.sources]
-django-health-check = { git = "https://github.com/revsys/django-health-check", rev = "53f9bdc3a7acc8a577319987fef0bd3040eef4b4" } # pragma: allowlist secret
 
 [tool.uv.build-backend]
 module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -681,10 +681,23 @@ wheels = [
 
 [[package]]
 name = "django-health-check"
-version = "3.20.1.dev10+g53f9bdc3a"
-source = { git = "https://github.com/revsys/django-health-check?rev=53f9bdc3a7acc8a577319987fef0bd3040eef4b4#53f9bdc3a7acc8a577319987fef0bd3040eef4b4" }
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/c3/99dbf858f939cbf709bf82648daa63632a81484d59b888e92ec687601091/django_health_check-4.4.1.tar.gz", hash = "sha256:2658c21710c09632f75318bb66b5865ff0721f82bab812193d479680773e4c0b", size = 21751, upload-time = "2026-05-15T16:08:37.517Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/df/697390fe7bdfefd1e48e29c190ebe255c45db4c1819d58b76fbc826bc5a8/django_health_check-4.4.1-py3-none-any.whl", hash = "sha256:363d94e839c90a75e822694f260ca31bd42978d948ad77ea1df18c7f68ff9021", size = 26877, upload-time = "2026-05-15T16:08:36.192Z" },
+]
+
+[package.optional-dependencies]
+celery = [
+    { name = "celery" },
+]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]
@@ -1990,7 +2003,7 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "django-countries" },
     { name = "django-filter" },
-    { name = "django-health-check" },
+    { name = "django-health-check", extra = ["celery", "redis"] },
     { name = "django-hijack" },
     { name = "django-ipware" },
     { name = "django-oauth-toolkit" },
@@ -2100,7 +2113,7 @@ requires-dist = [
     { name = "django-cors-headers", specifier = ">=4.0.0,<5" },
     { name = "django-countries", specifier = ">=7.2.1,<8" },
     { name = "django-filter", specifier = ">=24.3,<25" },
-    { name = "django-health-check", git = "https://github.com/revsys/django-health-check?rev=53f9bdc3a7acc8a577319987fef0bd3040eef4b4" },
+    { name = "django-health-check", extras = ["celery", "redis"], specifier = ">=4.0.0" },
     { name = "django-hijack", specifier = ">=3.6.0,<4" },
     { name = "django-ipware", specifier = ">=7.0.0,<8" },
     { name = "django-oauth-toolkit", specifier = "==3.1" },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Upgrade django-health-checks to the latest version. This included breaking changes to the setup so that's addressed here. The migration check did not carry over as they dropped that because the django check framework is supposed to be used to check that.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the app, you should then be able to access the health check urls:

http://mitxonline.odl.local/health/startup/?format=json
http://mitxonline.odl.local/health/liveness/?format=json
http://mitxonline.odl.local/health/readiness/?format=json
http://mitxonline.odl.local/health/full/?format=json