### PR TITLE
fix: handle missing signature image in CertificatePage signatory_items

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -450,7 +450,9 @@ class CertificatePage(CourseProgramChildPage):
                 "title_2": page.title_2,
                 "title_3": page.title_3,
                 "organization": page.organization,
-                "signature_image": page.signature_image.file.url,
+                "signature_image": page.signature_image.file.url
+                if page.signature_image
+                else None,
             }
             for page in self.signatory_pages
         ]

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -619,6 +619,23 @@ def test_certificate_for_program_page():
         assert signatory.value.signature_image.title == "Image"
 
 
+def test_signatory_items_with_no_signature_image():
+    """
+    signatory_items should return None for signature_image when none is set,
+    rather than raising AttributeError.
+    """
+    course_page = CoursePageFactory.create(certificate_page=None)
+    certificate_page = CertificatePageFactory.create(
+        parent=course_page,
+        signatories__0__signatory__page__name="Name",
+        signatories__0__signatory__page__signature_image=None,
+    )
+    items = certificate_page.signatory_items
+    assert len(items) == 1
+    assert items[0]["name"] == "Name"
+    assert items[0]["signature_image"] is None
+
+
 @pytest.mark.parametrize("test_course", [True, False])
 def test_courseware_title_synced_with_product_page_title(test_course):
     """Tests that Courseware title is synced with the Course Page title from CMS"""


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11458#issuecomment-4544706989

Sentry error https://mit-office-of-digital-learning.sentry.io/issues/7292013765/?query=is%3Aunresolved&referrer=issue-stream
```
Got AttributeError when attempting to get a value for field `signatory_items` on serializer `CertificatePageModelSerializer`.
The serializer field might be named incorrectly and not match any attribute or key on the `CertificatePage` instance.
Original exception text was: 'NoneType' object has no attribute 'file'.
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes a 500 error when a signatory on a Certificate Page has no signature image. signatory_items now returns null for signature_image instead of raising an AttributeError in API `/api/v2/program_certificates/{UUID}/`




### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Automatic test should pass

Manual test: In the CMS, create a Certificate Page with at least one signatory that has no signature image set. Then call GET `/api/v2/program_certificates/{UUID}/`  — it should return 200 with "signature_image": null instead of a 500 error.

```
---e.g. api/v2/program_certificates/{UUID}/`

   "signatory_items": [
      {
        "name": "XXX",
        "title_1": null,
        "title_2": null,
        "title_3": null,
        "organization": null,
        "signature_image": null
      }
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
