### PR TITLE
Add language handling flags for b2b_courserun

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -279,6 +279,8 @@ def _get_source_runs_for_course(
     course: Course,
     *,
     require_designated: bool = True,
+    ignore_langs: bool = True,
+    only_lang: str | None = None,
 ) -> list[CourseRun]:
     """
     Return the set of source runs for a course.
@@ -289,6 +291,10 @@ def _get_source_runs_for_course(
         course: The course to inspect.
         require_designated: If True, raise SourceCourseIncompleteError when no
             source run exists. If False, fall back to the newest non-B2B run.
+        ignore_langs: If True, only pull the source run that has `is_primary_language`
+            set or has the language code set to empty string.
+        only_lang: If set, only add the specified additional language (plus the
+            default)
     Returns:
         List of distinct source CourseRun objects, one per language (or one
         for the "no language" legacy case).
@@ -324,12 +330,20 @@ def _get_source_runs_for_course(
         msg = f"No source run found for {course}."
         raise SourceCourseIncompleteError(msg)
 
+    if ignore_langs:
+        return [primary_source_run]
+
     # Pull all the other source runs for the course and run tag combo
     source_runs = (
         CourseRun.all_objects.filter(course=course)
         .filter(is_source_run=True, run_tag=primary_source_run.run_tag)
         .all()
     )
+
+    if only_lang:
+        source_runs = source_runs.filter(
+            Q(language=only_lang) | (Q(language="") | Q(is_primary_language=True))
+        )
 
     seen_languages: list = []
     filtered_run_list = {}
@@ -358,6 +372,8 @@ def create_contract_run(  # noqa: PLR0913
     org_prefix: str | None = UAI_COURSEWARE_ID_PREFIX,
     no_reruns: bool = False,
     queue_codes: bool = False,
+    ignore_langs: bool = False,
+    only_lang: str | None = None,
 ) -> list[tuple[CourseRun, Product]]:
     """
     Create run(s) for the specified contract.
@@ -405,13 +421,18 @@ def create_contract_run(  # noqa: PLR0913
         org_prefix (str): Organization prefix. For UAI courses, this should be "UAI_".
         no_reruns (bool): Don't rerun the course - raise an exception instead.
         queue_codes (bool): Queue enrollment code generation after saving.
+        ignore_langs (bool): Only create a run for the primary language.
+        only_lang (str|None): Only create a run for the primary language and the specified one.
     Returns:
         list[tuple[CourseRun, Product]]: One (CourseRun, Product) pair per
         source language run. Legacy single-language courses produce a one-element
         list.
     """
     source_runs = _get_source_runs_for_course(
-        course, require_designated=require_designated_source_run
+        course,
+        require_designated=require_designated_source_run,
+        ignore_langs=ignore_langs,
+        only_lang=only_lang,
     )
 
     content_type = ContentType.objects.filter(

--- a/b2b/management/commands/b2b_courseware.py
+++ b/b2b/management/commands/b2b_courseware.py
@@ -60,7 +60,7 @@ Specifying a course will unlink any of the course's runs that are attached to th
 Specifying a program will only unlink the program from the contract, unless "--remove-program-runs" is set. If it is, then all the runs that belong to both the contract and the program's courses will be removed from the contract. Note that doing this and then re-adding the program will *not* re-attach the existing runs to the contract - you will need to do that manually.
     """
 
-    def create_run(
+    def create_run(  # noqa: PLR0913
         self,
         contract,
         courseware,
@@ -68,6 +68,8 @@ Specifying a program will only unlink the program from the contract, unless "--r
         skip_edx=False,
         org_prefix=None,
         no_reruns=False,
+        ignore_langs=False,
+        only_lang=None,
     ):
         """Create a run for the specified contract."""
         try:
@@ -77,6 +79,8 @@ Specifying a program will only unlink the program from the contract, unless "--r
                 skip_edx=skip_edx,
                 org_prefix=org_prefix,
                 no_reruns=no_reruns,
+                ignore_langs=ignore_langs,
+                only_lang=only_lang,
             )
         except InvalidKeyError:
             self.stderr.write(
@@ -168,6 +172,16 @@ Specifying a program will only unlink the program from the contract, unless "--r
             action="store_true",
             help="Create enrollment codes after adding course(s) to the contract. (Skips this by default; run b2b_codes validate afterward if the contract requires codes.)",
         )
+        add_subparser.add_argument(
+            "--no-lang",
+            action="store_true",
+            help="Ignore languages - only create runs for the primary language (or the blank language)",
+        )
+        add_subparser.add_argument(
+            "--lang",
+            type=str,
+            help="Include the default and the specified language code only.",
+        )
 
         remove_subparser = subparsers.add_parser(
             "remove",
@@ -182,7 +196,7 @@ Specifying a program will only unlink the program from the contract, unless "--r
 
         return super().add_arguments(parser)
 
-    def handle_add(self, contract, coursewares, **kwargs):  # noqa: C901
+    def handle_add(self, contract, coursewares, **kwargs):  # noqa: C901, PLR0915
         """Handle the add subcommand."""
 
         skip_edx = kwargs.pop("no_create_runs", False)
@@ -191,6 +205,8 @@ Specifying a program will only unlink the program from the contract, unless "--r
         org_prefix = kwargs.pop("prefix")
         make_codes = kwargs.pop("make_codes", False)
         no_reruns = not kwargs.pop("allow_reruns", True)
+        ignore_langs = kwargs.pop("no_lang", False)
+        only_lang = kwargs.pop("lang", None)
 
         managed = 0
 
@@ -250,7 +266,11 @@ Specifying a program will only unlink the program from the contract, unless "--r
                 )
 
                 prog_add, prog_no_source = contract.add_program_courses(
-                    courseware, skip_edx=skip_edx, no_reruns=no_reruns
+                    courseware,
+                    skip_edx=skip_edx,
+                    no_reruns=no_reruns,
+                    ignore_langs=ignore_langs,
+                    only_lang=only_lang,
                 )
                 if prog_no_source > 0:
                     self.stdout.write(
@@ -300,6 +320,8 @@ Specifying a program will only unlink the program from the contract, unless "--r
                 skip_edx=skip_edx,
                 org_prefix=org_prefix,
                 no_reruns=no_reruns,
+                ignore_langs=ignore_langs,
+                only_lang=only_lang,
             ):
                 # This is a course, so create a run (unless we've been told not to).
 

--- a/b2b/management/tests/b2b_courseware_test.py
+++ b/b2b/management/tests/b2b_courseware_test.py
@@ -262,3 +262,191 @@ def test_add_courserun_existing_contract(force):
 
     run.refresh_from_db()
     assert run.b2b_contract == (contract if force else existing_contract)
+
+
+@pytest.mark.parametrize(
+    "explicit_primary",
+    [
+        True,
+        False,
+    ],
+)
+def test_add_course_ignore_langs(mock_clone_courserun, explicit_primary):
+    """Test that adding a single course with translations works still if we ignore the translations."""
+
+    primary_opts = {
+        "language": "en" if explicit_primary else "",
+        "is_primary_language": explicit_primary,
+    }
+
+    contract = ContractPageFactory.create()
+    run = CourseRunFactory.create(
+        is_source_run=True,
+        **primary_opts,
+    )
+    _add_run_languages(run)
+
+    command = b2b_courseware.Command()
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(run.course.readable_id),
+        allow_reruns=True,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+        no_lang=True,
+    )
+
+    assert contract.get_course_runs().count() == 1
+
+
+@pytest.mark.parametrize(
+    "explicit_primary",
+    [
+        True,
+        False,
+    ],
+)
+def test_add_program_ignore_langs(mock_clone_courserun, explicit_primary):
+    """Test that adding a program with translations works still if we ignore the translations."""
+
+    primary_opts = {
+        "language": "en" if explicit_primary else "",
+        "is_primary_language": explicit_primary,
+    }
+
+    contract = ContractPageFactory.create()
+    run = CourseRunFactory.create(
+        is_source_run=True,
+        **primary_opts,
+    )
+    _add_run_languages(run)
+
+    run2 = CourseRunFactory.create(
+        is_source_run=True,
+        **primary_opts,
+    )
+    _add_run_languages(run2)
+
+    program = ProgramFactory.create()
+    program.add_requirement(run.course)
+    program.add_requirement(run2.course)
+
+    command = b2b_courseware.Command()
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(program.readable_id),
+        allow_reruns=True,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+        no_lang=True,
+    )
+
+    assert contract.get_course_runs().count() == 2
+    assert contract.get_course_runs().filter(course=run.course).count() == 1
+    assert contract.get_course_runs().filter(course=run2.course).count() == 1
+
+
+@pytest.mark.parametrize(
+    "explicit_primary",
+    [
+        True,
+        False,
+    ],
+)
+def test_add_course_specific_lang(mock_clone_courserun, explicit_primary):
+    """Test that adding a single course with translations works still if we ignore the translations."""
+
+    primary_opts = {
+        "language": "en" if explicit_primary else "",
+        "is_primary_language": explicit_primary,
+    }
+
+    contract = ContractPageFactory.create()
+    run = CourseRunFactory.create(
+        is_source_run=True,
+        **primary_opts,
+    )
+    _add_run_languages(run)
+
+    command = b2b_courseware.Command()
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(run.course.readable_id),
+        allow_reruns=True,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+        lang="sw",
+    )
+
+    assert contract.get_course_runs().count() == 2
+    assert contract.get_course_runs().filter(language="sw").exists()
+
+
+@pytest.mark.parametrize(
+    "explicit_primary",
+    [
+        True,
+        False,
+    ],
+)
+def test_add_program_specific_lang(mock_clone_courserun, explicit_primary):
+    """Test that adding a program with translations works still if we ignore the translations."""
+
+    primary_opts = {
+        "language": "en" if explicit_primary else "",
+        "is_primary_language": explicit_primary,
+    }
+
+    contract = ContractPageFactory.create()
+    run = CourseRunFactory.create(
+        is_source_run=True,
+        **primary_opts,
+    )
+    _add_run_languages(run)
+
+    run2 = CourseRunFactory.create(
+        is_source_run=True,
+        **primary_opts,
+    )
+    _add_run_languages(run2)
+
+    program = ProgramFactory.create()
+    program.add_requirement(run.course)
+    program.add_requirement(run2.course)
+
+    command = b2b_courseware.Command()
+
+    command.handle(
+        subcommand="add",
+        contract=str(contract.id),
+        courseware=str(program.readable_id),
+        allow_reruns=True,
+        force=False,
+        can_import="",
+        prefix="",
+        make_code=False,
+        lang="sw",
+    )
+
+    assert contract.get_course_runs().count() == 4
+    assert contract.get_course_runs().filter(course=run.course).count() == 2
+    assert (
+        contract.get_course_runs().filter(course=run.course, language="sw").count() == 1
+    )
+    assert contract.get_course_runs().filter(course=run2.course).count() == 2
+    assert (
+        contract.get_course_runs().filter(course=run2.course, language="sw").count()
+        == 1
+    )

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -529,8 +529,15 @@ class ContractPage(Page, ClusterableModel):
             .all()
         )
 
-    def add_program_courses(
-        self, program, order=None, *, skip_edx=False, no_reruns=True
+    def add_program_courses(  # noqa: PLR0913
+        self,
+        program,
+        order=None,
+        *,
+        skip_edx=False,
+        no_reruns=True,
+        ignore_langs=False,
+        only_lang=None,
     ):
         """
         Add a program, and then queue adding all its courses.
@@ -563,7 +570,12 @@ class ContractPage(Page, ClusterableModel):
             | models.Q(courseruns__run_tag="SOURCE")
         ).all():
             created_runs = create_contract_run(
-                self, course, no_reruns=no_reruns, skip_edx=skip_edx
+                self,
+                course,
+                no_reruns=no_reruns,
+                skip_edx=skip_edx,
+                ignore_langs=ignore_langs,
+                only_lang=only_lang,
             )
             managed += len(created_runs)
 


### PR DESCRIPTION
### What are the relevant tickets?

n/a (but technically part of mitodl/hq#11401 et al)

### Description (What does it do?)

Adds a `no-lang` flag to the `b2b_courseware add` command, which will instruct it to not create runs for _any_ translations for the course. This works when adding a course or a program - not importing a course, nor assigning an existing run to a contract. You will get the primary language only - either the source run for the course that has `is_primary_language` set, or has `language` set to empty string.

Adds a `lang` flag to the `b2b_courseware add` command that allows _one_ translation for runs, along with the primary language. (So, `--no-lang` but with a pinhole for one set of translation.)

### How can this be tested?

Automated tests should pass; there are tests specifically for this.

Create a course with a handful of course runs. One should be primary (with the flag set) and all should be source runs. Then, add those courses to the contract with `b2b_courseware add --no-lang`. It should only re-run the primary run (the one with the flag set).

Create another course with a handful of runs, with one set to primary (using the flag). Then, add both this course and the first course to a program as requirements. Add the program to a contract with `b2b_courseware add --no-lang`. You should end up with two runs in the contract - one each for the primary language runs.

Optionally, repeat these tests but have one run set with the language field blank, and `is_primary_language` unset. That run should still be selected as the primary language run.

Do these tests one more time, except use `--lang <lang>` instead of `--no-lang`. (It would be best to make sure you have at least 3 runs per course.) You should then end up with 2 runs for each course - one that is the primary, and one that is the language you specified.
