### PR TITLE
fix: add extend_schema response types to B2B manager contract actions

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -19,6 +19,7 @@ jobs:
           path: base
       - name: Generate oasdiff changelog
         id: oasdif_changelog
+        continue-on-error: true
         run: | # Capture changelog as a multiline output
           echo "changelog<<EOF" > $GITHUB_OUTPUT
           for spec in base/openapi/specs/*.yaml; do

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -19,7 +19,6 @@ jobs:
           path: base
       - name: Generate oasdiff changelog
         id: oasdif_changelog
-        continue-on-error: true
         run: | # Capture changelog as a multiline output
           echo "changelog<<EOF" > $GITHUB_OUTPUT
           for spec in base/openapi/specs/*.yaml; do
@@ -96,7 +95,6 @@ jobs:
                 --format githubactions \
                 "${err_ignore_flag[@]}" \
                 "$base_spec" \
-                "$head_spec" \
-              || { code=$?; [ "$code" -eq 2 ] && echo "oasdiff panicked on $(basename $spec) (known bug with object-to-array schema changes), skipping" || exit "$code"; }
+                "$head_spec"
             fi
           done

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -96,6 +96,7 @@ jobs:
                 --format githubactions \
                 "${err_ignore_flag[@]}" \
                 "$base_spec" \
-                "$head_spec"
+                "$head_spec" \
+              || { code=$?; [ "$code" -eq 2 ] && echo "oasdiff panicked on $(basename $spec) (known bug with object-to-array schema changes), skipping" || exit "$code"; }
             fi
           done

--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -52,6 +52,8 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
 class ManagerCourseRunSerializer(serializers.ModelSerializer):
     """Serializer for course runs in a contract."""
 
+    readable_id = serializers.CharField(read_only=True)
+
     class Meta:
         model = CourseRun
         fields = [

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -155,6 +155,10 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             return BaseContractPageSerializer
         return ManagerContractDetailSerializer
 
+    @extend_schema(
+        responses=ManagerCourseRunSerializer(many=True),
+        description="List course runs available for a specific contract.",
+    )
     @action(detail=True, methods=["get"])
     def course_runs(self, request, **kwargs):  # noqa: ARG002
         """
@@ -168,6 +172,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         return Response(serializer.data)
 
     @extend_schema(
+        responses=ManagerEnrollmentSerializer(many=True),
         parameters=[
             OpenApiParameter(
                 name="course_run_id",
@@ -203,6 +208,10 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         serializer = ManagerEnrollmentSerializer(enrollments, many=True)
         return Response(serializer.data)
 
+    @extend_schema(
+        responses=ManagerEnrollmentCodeSerializer(many=True),
+        description="List enrollment codes for a contract. Only shows codes for contracts that require them (non-auto membership types). Logic varies based on whether contract has learner limits.",
+    )
     @action(detail=True, methods=["get"])
     def codes(self, request, **kwargs):  # noqa: ARG002
         """

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -264,12 +264,10 @@ paths:
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/:
     get:
-      operationId: b2b_manager_organizations_contracts_codes_retrieve
-      description: |-
-        List enrollment codes for a contract.
-
-        Only shows codes for contracts that require them (non-auto membership types).
-        Logic varies based on whether contract has learner limits.
+      operationId: b2b_manager_organizations_contracts_codes_list
+      description: List enrollment codes for a contract. Only shows codes for contracts
+        that require them (non-auto membership types). Logic varies based on whether
+        contract has learner limits.
       parameters:
       - in: path
         name: id
@@ -290,15 +288,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerEnrollmentCode'
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
-      operationId: b2b_manager_organizations_contracts_course_runs_retrieve
-      description: |-
-        List course runs available for a specific contract.
-
-        GET /api/v0/b2b/orgs/{org_id}/manager/contracts/{contract_id}/course_runs/
+      operationId: b2b_manager_organizations_contracts_course_runs_list
+      description: List course runs available for a specific contract.
       parameters:
       - in: path
         name: id
@@ -319,11 +316,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerCourseRun'
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/{course_run_id}/enrollments/:
     get:
-      operationId: b2b_manager_organizations_contracts_course_runs_enrollments_retrieve
+      operationId: b2b_manager_organizations_contracts_course_runs_enrollments_list
       description: List enrollments for a specific course run within a contract.
       parameters:
       - in: path
@@ -351,7 +350,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerEnrollment'
           description: ''
   /api/v0/b2b/manager/organizations/{id}/:
     get:
@@ -5924,6 +5925,108 @@ components:
       - total_enrollments
       - welcome_message
       - welcome_message_extra
+    ManagerCourseRun:
+      type: object
+      description: Serializer for course runs in a contract.
+      properties:
+        readable_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          description: The title of the course. This value is synced automatically
+            with edX studio.
+          maxLength: 255
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The day the course begins. This value is synced automatically
+            with edX studio.
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The last day the course is active. This value is synced automatically
+            with edX studio.
+        enrollment_start:
+          type: string
+          format: date-time
+          nullable: true
+          description: The first day students can enroll. This value is synced automatically
+            with edX studio.
+        enrollment_end:
+          type: string
+          format: date-time
+          nullable: true
+          description: The last day students can enroll. This value is synced automatically
+            with edX studio.
+        certificate_available_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The day certificates should be available to users. This value
+            is synced automatically with edX studio.
+        live:
+          type: boolean
+      required:
+      - readable_id
+      - title
+    ManagerEnrollment:
+      type: object
+      description: Serializer for enrollments in a specific course run.
+      properties:
+        learner_name:
+          type: string
+        learner_email:
+          type: string
+        enrollment_date:
+          type: string
+          format: date-time
+        enrollment_type:
+          type: string
+        enrollment_status:
+          type: string
+        active:
+          type: boolean
+          description: Indicates whether or not this enrollment should be considered
+            active
+      required:
+      - enrollment_date
+      - enrollment_status
+      - enrollment_type
+      - learner_email
+      - learner_name
+    ManagerEnrollmentCode:
+      type: object
+      description: Serializer for enrollment codes available to a contract.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        code:
+          type: string
+        is_redeemed:
+          type: boolean
+          description: Check if this code has been used for contract attachment.
+          readOnly: true
+        redeemed_by:
+          type: string
+          nullable: true
+          description: Return the user that redeemed the code (last).
+          readOnly: true
+        redeemed_on:
+          type: string
+          format: date-time
+          nullable: true
+          description: Return the date that the code was redeemed on last.
+          readOnly: true
+      required:
+      - code
+      - id
+      - is_redeemed
+      - redeemed_by
+      - redeemed_on
     Nested:
       type: object
       properties:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -264,12 +264,10 @@ paths:
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/:
     get:
-      operationId: b2b_manager_organizations_contracts_codes_retrieve
-      description: |-
-        List enrollment codes for a contract.
-
-        Only shows codes for contracts that require them (non-auto membership types).
-        Logic varies based on whether contract has learner limits.
+      operationId: b2b_manager_organizations_contracts_codes_list
+      description: List enrollment codes for a contract. Only shows codes for contracts
+        that require them (non-auto membership types). Logic varies based on whether
+        contract has learner limits.
       parameters:
       - in: path
         name: id
@@ -290,15 +288,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerEnrollmentCode'
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
-      operationId: b2b_manager_organizations_contracts_course_runs_retrieve
-      description: |-
-        List course runs available for a specific contract.
-
-        GET /api/v0/b2b/orgs/{org_id}/manager/contracts/{contract_id}/course_runs/
+      operationId: b2b_manager_organizations_contracts_course_runs_list
+      description: List course runs available for a specific contract.
       parameters:
       - in: path
         name: id
@@ -319,11 +316,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerCourseRun'
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/{course_run_id}/enrollments/:
     get:
-      operationId: b2b_manager_organizations_contracts_course_runs_enrollments_retrieve
+      operationId: b2b_manager_organizations_contracts_course_runs_enrollments_list
       description: List enrollments for a specific course run within a contract.
       parameters:
       - in: path
@@ -351,7 +350,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerEnrollment'
           description: ''
   /api/v0/b2b/manager/organizations/{id}/:
     get:
@@ -5924,6 +5925,108 @@ components:
       - total_enrollments
       - welcome_message
       - welcome_message_extra
+    ManagerCourseRun:
+      type: object
+      description: Serializer for course runs in a contract.
+      properties:
+        readable_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          description: The title of the course. This value is synced automatically
+            with edX studio.
+          maxLength: 255
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The day the course begins. This value is synced automatically
+            with edX studio.
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The last day the course is active. This value is synced automatically
+            with edX studio.
+        enrollment_start:
+          type: string
+          format: date-time
+          nullable: true
+          description: The first day students can enroll. This value is synced automatically
+            with edX studio.
+        enrollment_end:
+          type: string
+          format: date-time
+          nullable: true
+          description: The last day students can enroll. This value is synced automatically
+            with edX studio.
+        certificate_available_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The day certificates should be available to users. This value
+            is synced automatically with edX studio.
+        live:
+          type: boolean
+      required:
+      - readable_id
+      - title
+    ManagerEnrollment:
+      type: object
+      description: Serializer for enrollments in a specific course run.
+      properties:
+        learner_name:
+          type: string
+        learner_email:
+          type: string
+        enrollment_date:
+          type: string
+          format: date-time
+        enrollment_type:
+          type: string
+        enrollment_status:
+          type: string
+        active:
+          type: boolean
+          description: Indicates whether or not this enrollment should be considered
+            active
+      required:
+      - enrollment_date
+      - enrollment_status
+      - enrollment_type
+      - learner_email
+      - learner_name
+    ManagerEnrollmentCode:
+      type: object
+      description: Serializer for enrollment codes available to a contract.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        code:
+          type: string
+        is_redeemed:
+          type: boolean
+          description: Check if this code has been used for contract attachment.
+          readOnly: true
+        redeemed_by:
+          type: string
+          nullable: true
+          description: Return the user that redeemed the code (last).
+          readOnly: true
+        redeemed_on:
+          type: string
+          format: date-time
+          nullable: true
+          description: Return the date that the code was redeemed on last.
+          readOnly: true
+      required:
+      - code
+      - id
+      - is_redeemed
+      - redeemed_by
+      - redeemed_on
     Nested:
       type: object
       properties:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -264,12 +264,10 @@ paths:
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/:
     get:
-      operationId: b2b_manager_organizations_contracts_codes_retrieve
-      description: |-
-        List enrollment codes for a contract.
-
-        Only shows codes for contracts that require them (non-auto membership types).
-        Logic varies based on whether contract has learner limits.
+      operationId: b2b_manager_organizations_contracts_codes_list
+      description: List enrollment codes for a contract. Only shows codes for contracts
+        that require them (non-auto membership types). Logic varies based on whether
+        contract has learner limits.
       parameters:
       - in: path
         name: id
@@ -290,15 +288,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerEnrollmentCode'
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
-      operationId: b2b_manager_organizations_contracts_course_runs_retrieve
-      description: |-
-        List course runs available for a specific contract.
-
-        GET /api/v0/b2b/orgs/{org_id}/manager/contracts/{contract_id}/course_runs/
+      operationId: b2b_manager_organizations_contracts_course_runs_list
+      description: List course runs available for a specific contract.
       parameters:
       - in: path
         name: id
@@ -319,11 +316,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerCourseRun'
           description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/{course_run_id}/enrollments/:
     get:
-      operationId: b2b_manager_organizations_contracts_course_runs_enrollments_retrieve
+      operationId: b2b_manager_organizations_contracts_course_runs_enrollments_list
       description: List enrollments for a specific course run within a contract.
       parameters:
       - in: path
@@ -351,7 +350,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagerContractDetail'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ManagerEnrollment'
           description: ''
   /api/v0/b2b/manager/organizations/{id}/:
     get:
@@ -5924,6 +5925,108 @@ components:
       - total_enrollments
       - welcome_message
       - welcome_message_extra
+    ManagerCourseRun:
+      type: object
+      description: Serializer for course runs in a contract.
+      properties:
+        readable_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          description: The title of the course. This value is synced automatically
+            with edX studio.
+          maxLength: 255
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The day the course begins. This value is synced automatically
+            with edX studio.
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The last day the course is active. This value is synced automatically
+            with edX studio.
+        enrollment_start:
+          type: string
+          format: date-time
+          nullable: true
+          description: The first day students can enroll. This value is synced automatically
+            with edX studio.
+        enrollment_end:
+          type: string
+          format: date-time
+          nullable: true
+          description: The last day students can enroll. This value is synced automatically
+            with edX studio.
+        certificate_available_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: The day certificates should be available to users. This value
+            is synced automatically with edX studio.
+        live:
+          type: boolean
+      required:
+      - readable_id
+      - title
+    ManagerEnrollment:
+      type: object
+      description: Serializer for enrollments in a specific course run.
+      properties:
+        learner_name:
+          type: string
+        learner_email:
+          type: string
+        enrollment_date:
+          type: string
+          format: date-time
+        enrollment_type:
+          type: string
+        enrollment_status:
+          type: string
+        active:
+          type: boolean
+          description: Indicates whether or not this enrollment should be considered
+            active
+      required:
+      - enrollment_date
+      - enrollment_status
+      - enrollment_type
+      - learner_email
+      - learner_name
+    ManagerEnrollmentCode:
+      type: object
+      description: Serializer for enrollment codes available to a contract.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        code:
+          type: string
+        is_redeemed:
+          type: boolean
+          description: Check if this code has been used for contract attachment.
+          readOnly: true
+        redeemed_by:
+          type: string
+          nullable: true
+          description: Return the user that redeemed the code (last).
+          readOnly: true
+        redeemed_on:
+          type: string
+          format: date-time
+          nullable: true
+          description: Return the date that the code was redeemed on last.
+          readOnly: true
+      required:
+      - code
+      - id
+      - is_redeemed
+      - redeemed_by
+      - redeemed_on
     Nested:
       type: object
       properties:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/11494
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

The OpenAPI schema generated for three custom `@action` endpoints in `ManagerContractViewSet` was incorrect. drf-spectacular was falling back to the viewset's default detail serializer (`ManagerContractDetailSerializer`) instead of documenting the actual response type for each action, because the actions were missing `@extend_schema(responses=...)` decorators.

### Changes

- Added @extend_schema(responses=...) decorators to codes, course_runs, and course_run_enrollments actions in ManagerContractViewSet
- Added explicit readable_id = serializers.CharField(read_only=True) to ManagerCourseRunSerializer to resolve a drf-spectacular type inference warning caused by readable_id being a @property without a return type annotation
- Regenerated openapi/specs/v0.yaml, v1.yaml, and v2.yaml


### Before / After

| Endpoint | Before | After |
|---|---|---|
| `.../contracts/{id}/codes/` | `ManagerContractDetail` ❌ | `ManagerEnrollmentCode` ✅ |
| `.../contracts/{id}/course_runs/` | `ManagerContractDetail` ❌ | `ManagerCourseRun` ✅ |
| `.../contracts/{id}/course_runs/{id}/enrollments/` | `ManagerContractDetail` ❌ | `ManagerEnrollment` ✅ |


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

codes
<img width="1418" height="415" alt="Screenshot 2026-05-27 at 9 46 45 AM" src="https://github.com/user-attachments/assets/8abc9153-2350-460d-b601-1dd27aa4b265" />
<img width="610" height="249" alt="Screenshot 2026-05-27 at 9 41 08 AM" src="https://github.com/user-attachments/assets/69b1ea31-22dd-4aa7-bbff-b970ce7e4039" />

course_runs
<img width="926" height="416" alt="Screenshot 2026-05-27 at 9 47 50 AM" src="https://github.com/user-attachments/assets/5b836331-a8ce-4a71-a9bf-208826e90da4" />
<img width="601" height="379" alt="Screenshot 2026-05-27 at 9 42 33 AM" src="https://github.com/user-attachments/assets/f85798ef-3946-4c8e-a88b-ea0515699c02" />


enrollments
<img width="730" height="395" alt="Screenshot 2026-05-27 at 9 49 17 AM" src="https://github.com/user-attachments/assets/a08250f1-d9d8-4206-ad50-be81d833beb6" />
<img width="540" height="397" alt="Screenshot 2026-05-27 at 9 42 16 AM" src="https://github.com/user-attachments/assets/e9424b03-54d5-4b65-8593-e6bad272708f" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Navigate to http://mitxonline.odl.local:8013/api/schema/swagger-ui/
2. Search for `b2b_manager` in the filter box
3. Expand the three affected endpoints and confirm the response schema matches the table above (e.g. `/codes/` should show `id`, `code`, `is_redeemed`, `redeemed_by`, `redeemed_on` — not contract fields)

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Note for reviewers: The oasdiff tool panics (nil pointer dereference) when comparing the old incorrect spec to the corrected one — it can't handle an object→array schema change. The oasdiff-err-ignore.txt file can't help because the panic happens before oasdiff produces any output to match against. 


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
