### PR TITLE
feat: purge Fastly cache on course/program changes

### DIFF
--- a/cms/signals.py
+++ b/cms/signals.py
@@ -1,8 +1,9 @@
 import logging
 
+from django.db import transaction
 from wagtail.signals import page_published
 
-from cms.models import FlexiblePricingRequestForm
+from cms.models import CoursePage, FlexiblePricingRequestForm, ProgramPage
 from flexiblepricing.utils import ensure_flexprice_form_fields
 
 logger = logging.getLogger("cms.signalreceiver")
@@ -32,4 +33,31 @@ def flex_pricing_field_check(sender, **kwargs):  # noqa: ARG001
             logger.info("Form changed (or needs changes)")
 
 
+def purge_fastly_cache_on_publish(sender, **kwargs):  # noqa: ARG001
+    """
+    Receives the Wagtail page_published signal and purges the corresponding
+    Fastly surrogate key so that MIT Learn product pages are invalidated.
+
+    Key format:
+        CoursePage   -> mitxonline:course:<readable_id>
+        ProgramPage  -> mitxonline:program:<readable_id>
+    """
+    from cms.tasks import queue_fastly_surrogate_key_purge  # noqa: PLC0415
+
+    instance = kwargs["instance"]
+
+    if isinstance(instance, CoursePage):
+        surrogate_key = f"mitxonline:course:{instance.course.readable_id}"
+    elif isinstance(instance, ProgramPage):
+        surrogate_key = f"mitxonline:program:{instance.program.readable_id}"
+    else:
+        return
+
+    logger.info(
+        "Scheduling Fastly surrogate key purge on page publish: %s", surrogate_key
+    )
+    transaction.on_commit(lambda: queue_fastly_surrogate_key_purge.delay(surrogate_key))
+
+
 page_published.connect(flex_pricing_field_check)
+page_published.connect(purge_fastly_cache_on_publish)

--- a/cms/tasks.py
+++ b/cms/tasks.py
@@ -9,6 +9,7 @@ from cms.models import Page
 from main.celery import app
 from main.settings import (
     MITX_ONLINE_FASTLY_AUTH_TOKEN,
+    MITX_ONLINE_FASTLY_SERVICE_ID,
     MITX_ONLINE_FASTLY_URL,
     SITE_BASE_URL,
 )
@@ -94,6 +95,67 @@ def queue_fastly_full_purge():
 
     logger.error("Purge request failed.")
     return False
+
+
+@app.task
+def queue_fastly_surrogate_key_purge(surrogate_key):
+    """
+    Purges all Fastly cached responses tagged with the given surrogate key.
+
+    Uses the Fastly purge-by-tag API:
+    POST /service/{service_id}/purge/{surrogate_key}
+
+    This allows MIT Learn pages to declare which MITxOnline surrogate keys they
+    subscribe to (via the Surrogate-Key response header), and MITxOnline to
+    invalidate those pages when course/program data changes.
+
+    Key format: mitxonline:course:<readable_id> or mitxonline:program:<readable_id>
+
+    Args:
+        surrogate_key (str): The surrogate key to purge, e.g.
+            "mitxonline:course:course-v1:MITx+6.00.1x"
+    """
+    logger = logging.getLogger("fastly_purge")
+
+    if not MITX_ONLINE_FASTLY_SERVICE_ID:
+        logger.warning(
+            "FASTLY_SERVICE_ID is not set; skipping surrogate key purge for %s",
+            surrogate_key,
+        )
+        return False
+
+    if not MITX_ONLINE_FASTLY_AUTH_TOKEN:
+        logger.warning(
+            "FASTLY_AUTH_TOKEN is not set; skipping surrogate key purge for %s",
+            surrogate_key,
+        )
+        return False
+
+    logger.info("Purging Fastly surrogate key: %s", surrogate_key)
+
+    api_url = urljoin(
+        MITX_ONLINE_FASTLY_URL,
+        f"/service/{MITX_ONLINE_FASTLY_SERVICE_ID}/purge/{surrogate_key}",
+    )
+    headers = {
+        "Fastly-Key": MITX_ONLINE_FASTLY_AUTH_TOKEN,
+        "fastly-soft-purge": "1",
+    }
+
+    resp = requests.post(api_url, headers=headers, timeout=10)
+
+    if resp.status_code >= 400:  # noqa: PLR2004
+        logger.error(
+            "Fastly surrogate key purge failed for %s: %s %s",
+            surrogate_key,
+            resp.status_code,
+            resp.reason,
+        )
+        logger.error("Fastly returned: %s", resp.text)
+        return False
+
+    logger.info("Fastly surrogate key purge OK for %s: %s", surrogate_key, resp.text)
+    return True
 
 
 @app.task

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -84,8 +84,8 @@ def purge_fastly_cache_on_course_save(
     **kwargs,  # noqa: ARG001
 ):
     """
-    Purges the Fastly surrogate key for a Course when it is saved via Django
-    admin, so that MIT Learn product pages reflecting this course are invalidated.
+    Purges the Fastly surrogate key for a Course when it is saved,
+    so that MIT Learn product pages reflecting this course are invalidated.
     """
     from cms.tasks import queue_fastly_surrogate_key_purge  # noqa: PLC0415
 
@@ -101,7 +101,7 @@ def purge_fastly_cache_on_course_run_save(
 ):
     """
     Purges the Fastly surrogate key for the parent Course when a CourseRun is
-    saved via Django admin (e.g. enrollment mode changes), so that MIT Learn
+    saved (e.g. enrollment mode changes), so that MIT Learn
     product pages are invalidated.
     """
     from cms.tasks import queue_fastly_surrogate_key_purge  # noqa: PLC0415
@@ -117,9 +117,9 @@ def purge_fastly_cache_on_program_save(
     **kwargs,  # noqa: ARG001
 ):
     """
-    Purges the Fastly surrogate key for a Program when it is saved via Django
-    admin (e.g. program requirements, enrollment modes), so that MIT Learn
-    product pages are invalidated.
+    Purges the Fastly surrogate key for a Program when it is
+    saved (e.g. program requirements, enrollment modes),
+    so that MIT Learn product pages are invalidated.
     """
     from cms.tasks import queue_fastly_surrogate_key_purge  # noqa: PLC0415
 

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -8,6 +8,8 @@ from django.dispatch import receiver
 
 from courses.api import generate_multiple_programs_certificate
 from courses.models import (
+    Course,
+    CourseRun,
     CourseRunCertificate,
     Program,
     ProgramCertificate,
@@ -73,3 +75,53 @@ def handle_create_program_certificate(
     transaction.on_commit(
         lambda: hubspot_tasks.sync_program_certificate_with_hubspot.delay(instance.id)
     )
+
+
+@receiver(post_save, sender=Course, dispatch_uid="course_post_save_fastly_purge")
+def purge_fastly_cache_on_course_save(
+    sender,  # noqa: ARG001
+    instance,
+    **kwargs,  # noqa: ARG001
+):
+    """
+    Purges the Fastly surrogate key for a Course when it is saved via Django
+    admin, so that MIT Learn product pages reflecting this course are invalidated.
+    """
+    from cms.tasks import queue_fastly_surrogate_key_purge  # noqa: PLC0415
+
+    surrogate_key = f"mitxonline:course:{instance.readable_id}"
+    transaction.on_commit(lambda: queue_fastly_surrogate_key_purge.delay(surrogate_key))
+
+
+@receiver(post_save, sender=CourseRun, dispatch_uid="courserun_post_save_fastly_purge")
+def purge_fastly_cache_on_course_run_save(
+    sender,  # noqa: ARG001
+    instance,
+    **kwargs,  # noqa: ARG001
+):
+    """
+    Purges the Fastly surrogate key for the parent Course when a CourseRun is
+    saved via Django admin (e.g. enrollment mode changes), so that MIT Learn
+    product pages are invalidated.
+    """
+    from cms.tasks import queue_fastly_surrogate_key_purge  # noqa: PLC0415
+
+    surrogate_key = f"mitxonline:course:{instance.course.readable_id}"
+    transaction.on_commit(lambda: queue_fastly_surrogate_key_purge.delay(surrogate_key))
+
+
+@receiver(post_save, sender=Program, dispatch_uid="program_post_save_fastly_purge")
+def purge_fastly_cache_on_program_save(
+    sender,  # noqa: ARG001
+    instance,
+    **kwargs,  # noqa: ARG001
+):
+    """
+    Purges the Fastly surrogate key for a Program when it is saved via Django
+    admin (e.g. program requirements, enrollment modes), so that MIT Learn
+    product pages are invalidated.
+    """
+    from cms.tasks import queue_fastly_surrogate_key_purge  # noqa: PLC0415
+
+    surrogate_key = f"mitxonline:program:{instance.readable_id}"
+    transaction.on_commit(lambda: queue_fastly_surrogate_key_purge.delay(surrogate_key))

--- a/courses/signals_test.py
+++ b/courses/signals_test.py
@@ -117,3 +117,47 @@ def test_sync_program_certificate_with_hubspot_on_save(
 
     assert sync_program_cert_mock.call_count == 2
     sync_program_cert_mock.assert_called_with(cert.id)
+
+
+# ---------------------------------------------------------------------------
+# Fastly surrogate-key purge signal tests
+# ---------------------------------------------------------------------------
+
+
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("cms.tasks.queue_fastly_surrogate_key_purge.delay")
+def test_purge_fastly_cache_on_course_save_update(mock_purge_delay, mock_on_commit):
+    """
+    Updating (re-saving) a Course enqueues a fresh purge each time.
+    """
+    course = CourseFactory.create()
+    mock_purge_delay.assert_called_with(f"mitxonline:course:{course.readable_id}")
+
+    course.title = "Updated Title"
+    course.save()
+
+    mock_purge_delay.assert_called_with(f"mitxonline:course:{course.readable_id}")
+
+
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("cms.tasks.queue_fastly_surrogate_key_purge.delay")
+def test_purge_fastly_cache_on_course_run_save(mock_purge_delay, mock_on_commit):
+    """
+    Saving a CourseRun enqueues a Fastly surrogate-key purge for the parent
+    course: mitxonline:course:<readable_id>.
+    """
+    course_run = CourseRunFactory.create()
+    mock_purge_delay.assert_called_with(
+        f"mitxonline:course:{course_run.course.readable_id}"
+    )
+
+
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("cms.tasks.queue_fastly_surrogate_key_purge.delay")
+def test_purge_fastly_cache_on_program_save(mock_purge_delay, mock_on_commit):
+    """
+    Saving a Program enqueues a Fastly surrogate-key purge for
+    mitxonline:program:<readable_id>.
+    """
+    program = ProgramFactory.create()
+    mock_purge_delay.assert_called_with(f"mitxonline:program:{program.readable_id}")

--- a/main/settings.py
+++ b/main/settings.py
@@ -1316,6 +1316,12 @@ MITX_ONLINE_FASTLY_URL = get_string(
     description="The URL to the Fastly API.",
 )
 
+MITX_ONLINE_FASTLY_SERVICE_ID = get_string(
+    name="FASTLY_SERVICE_ID",
+    default=None,
+    description="Fastly service ID used for surrogate key (tag) purging.",
+)
+
 # Hubspot sync settings
 MITOL_HUBSPOT_API_PRIVATE_TOKEN = get_string(
     name="MITOL_HUBSPOT_API_PRIVATE_TOKEN",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11195

### Description (What does it do?)
This pull request adds automated Fastly cache purging for course and program content updates to ensure that MIT Learn product pages reflect the latest changes. The main changes introduce new signal handlers and a background task to purge Fastly surrogate keys whenever relevant models are published or updated, both via Wagtail and Django admin.

**Fastly Cache Purging Integration:**

* Added a new Celery task `queue_fastly_surrogate_key_purge` in `cms/tasks.py` to purge Fastly cached responses by surrogate key using Fastly's API. This allows for targeted cache invalidation when course or program data changes.
* Introduced a new setting `MITX_ONLINE_FASTLY_SERVICE_ID` in `main/settings.py` to support Fastly surrogate key purging.

**Signal Handlers for Cache Purging:**

* Added Wagtail `page_published` signal handler `purge_fastly_cache_on_publish` in `cms/signals.py` to purge the relevant Fastly surrogate key when a `CoursePage` or `ProgramPage` is published.
* Registered Django `post_save` signal handlers in `courses/signals.py` to purge the Fastly surrogate key when a `Course`, `CourseRun`, or `Program` is updated via the Django admin.

**Supporting Changes:**

* Updated imports in `cms/signals.py` and `courses/signals.py` to include required models and modules for the new cache purging logic. [[1]](diffhunk://#diff-a1b337bbb6b74af507e8b4343b278ae70e87d57c042b7ae97ef55e7eb236f4f0R3-R6) [[2]](diffhunk://#diff-a4506e21256ca44e4eefea56d3c223eefd91704ebef1faab8b41287c55aea8fdR13-R14)
* Added import for the new Fastly service ID setting in `cms/tasks.py`.


### How can this be tested?
I couldn't test end-to-end locally due to mitxonline and mit-learn integration issues but I was able to verify the task being triggered in the celery

End-to-end testing steps:
1. Checkout the `mit-learn` from this PR: https://github.com/mitodl/mit-learn/pull/3393
2. Follow the instructions from that PR -- Open any course or program page from mitxonline
3. Make changes to that course/program here
4. Refresh that detail page in learn and see that its not fetching from cache and showing the latest content from mitxonline