### PR TITLE
Move where variant options are set during import_courserun

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -1503,6 +1503,10 @@ def import_courserun_from_edx(  # noqa: C901, PLR0913
     - include_in_learn_catalog (bool): Set the "include_in_learn_catalog" flag on the new page.
     - ingest_content_files_for_ai (bool): Set the "ingest_content_files_for_ai" flag on the new page.
     - is_source_run (bool): Set the "is_source_run" flag on the course run to designate it as a B2B source course.
+    - language (str): The language to set the imported run to. Defaults to "en".
+    - is_primary_language (bool): Whether or not this is the primary run for this language. Defaults False.
+    - variant_length (str): One of the length codes. Defaults to empty string (Full).
+    - variant_industry (str): One of the industry focus codes. Defaults to empty string (Original).
     Returns:
     tuple of (CourseRun, CoursePage|None, Product|None) - relevant objects for the imported run
     """

--- a/courses/api.py
+++ b/courses/api.py
@@ -1457,6 +1457,10 @@ def import_courserun_from_edx(  # noqa: C901, PLR0913
     include_in_learn_catalog: bool = False,
     ingest_content_files_for_ai: bool = False,
     is_source_run: bool = False,
+    language: str = "en",
+    is_primary_language: bool = False,
+    variant_length: str = "",
+    variant_industry: str = "",
 ):
     """
     Import a course run from edX.
@@ -1558,6 +1562,10 @@ def import_courserun_from_edx(  # noqa: C901, PLR0913
         live=live,
         is_self_paced=edx_course_run.is_self_paced(),
         is_source_run=is_source_run,
+        language=language,
+        is_primary_language=is_primary_language,
+        variant_industry=variant_industry,
+        variant_length=variant_length,
     )
 
     course_page = None

--- a/courses/management/commands/import_courserun.py
+++ b/courses/management/commands/import_courserun.py
@@ -219,7 +219,7 @@ class Command(BaseCommand):
 
         return None
 
-    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument  # noqa: C901, PLR0915, ARG002
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument  # noqa: C901, PLR0911, PLR0915, ARG002
         if kwargs.get("publish_cms_page") and kwargs.get("draft_cms_page"):
             self.stderr.write(
                 self.style.ERROR(
@@ -319,22 +319,51 @@ class Command(BaseCommand):
         success_count = 0
 
         for edx_course in edx_courses:
-            run_data = import_courserun_from_edx(
-                course_key=edx_course.course_id,
-                live=kwargs.get("live", False),
-                use_specific_course=kwargs.get("use_specific_course"),
-                price=price,
-                block_countries=kwargs.get("block_countries"),
-                departments=kwargs.get("depts"),
-                create_depts=kwargs.get("create_depts", False),
-                create_cms_page=kwargs.get("create_cms_page", False),
-                publish_cms_page=publish_cms_page,
-                include_in_learn_catalog=kwargs.get("include_in_learn_catalog", False),
-                ingest_content_files_for_ai=kwargs.get(
-                    "ingest_content_files_for_ai", False
-                ),
-                is_source_run=kwargs.get("source_course", False),
-            )
+            try:
+                run_data = import_courserun_from_edx(
+                    course_key=edx_course.course_id,
+                    live=kwargs.get("live", False),
+                    use_specific_course=kwargs.get("use_specific_course"),
+                    price=price,
+                    block_countries=kwargs.get("block_countries"),
+                    departments=kwargs.get("depts"),
+                    create_depts=kwargs.get("create_depts", False),
+                    create_cms_page=kwargs.get("create_cms_page", False),
+                    publish_cms_page=publish_cms_page,
+                    include_in_learn_catalog=kwargs.get(
+                        "include_in_learn_catalog", False
+                    ),
+                    ingest_content_files_for_ai=kwargs.get(
+                        "ingest_content_files_for_ai", False
+                    ),
+                    is_source_run=kwargs.get("source_course", False),
+                    variant_industry=kwargs.get("industry", ""),
+                    variant_length=kwargs.get("length", ""),
+                    language=kwargs.get("language", "en"),
+                    is_primary_language=kwargs.get("primary_lang", False),
+                )
+            except ValidationError:
+                log.exception(
+                    "import_courserun couldn't import %s - validation error",
+                    edx_course.course_id,
+                )
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Validation error importing {edx_course.course_id}."
+                    )
+                )
+                return f"Validation error importing {edx_course.course_id}."
+            except LookupError:
+                log.exception(
+                    "import_courserun: couldn't import %s - lookup error (probably bad language code?)",
+                    edx_course.course_id,
+                )
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Lookup error importing {edx_course.course_id}. (This is likely a bad language code or variant option.)"
+                    )
+                )
+                return f"Lookup error importing {edx_course.course_id}. (This is likely a bad language code or variant option.)"
 
             if not isinstance(run_data, tuple) or len(run_data) != 3:  # noqa: PLR2004
                 continue
@@ -349,11 +378,6 @@ class Command(BaseCommand):
                     self.style.SUCCESS(f"\t --> Created product {product}")
                 )
 
-            run.variant_industry = kwargs.get("industry", "")
-            run.variant_length = kwargs.get("length", "")
-            run.language = kwargs.get("language")
-            run.is_primary_language = kwargs.get("primary_lang", False)
-
             if kwargs.get("run_tag", False):
                 run.run_tag = kwargs.get("run_tag")
             else:
@@ -362,16 +386,6 @@ class Command(BaseCommand):
                         f"WARNING: No specific run tag specified for {run.courseware_id} in language {run.language}, so using the default {run.run_tag}. This is probably not what you want."
                     )
                 )
-
-            try:
-                run.clean_language()
-            except ValidationError:
-                self.stderr.write(
-                    self.style.ERROR(
-                        f"ERROR: Language code {run.language} specified is invalid, cannot set."
-                    )
-                )
-                continue
 
             try:
                 run.save()

--- a/courses/management/tests/import_courserun_test.py
+++ b/courses/management/tests/import_courserun_test.py
@@ -203,14 +203,10 @@ class TestImportCourserunCommand:
             industry="E",
         )
 
-        courserun_qs = CourseRun.objects.filter(
-            courseware_id=mock_edx_course_detail.course_id
-        )
-
         assert len(std_err.getvalue()) > 0
-        assert courserun_qs.exists()
-        courserun = courserun_qs.get()
-        assert courserun.language != "qq"
+        assert not CourseRun.objects.filter(
+            courseware_id=mock_edx_course_detail.course_id
+        ).exists()
 
     @pytest.mark.parametrize(
         "valid_variant",

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -535,7 +535,7 @@ def test_filter_with_org_id_inactive_contract_excluded(
 ):
     """Test that courses from inactive contracts are not returned"""
     org = OrganizationPageFactory(name="Test Org")
-    contract = ContractPageFactory(organization=org, active=False)
+    contract = ContractPageFactory(organization=org)
     user = UserFactory()
     user.b2b_organizations.add(org)
     user.b2b_contracts.add(contract)
@@ -543,6 +543,9 @@ def test_filter_with_org_id_inactive_contract_excluded(
 
     (course, _) = contract_ready_course
     create_contract_run(contract, course)
+
+    contract.active = False
+    contract.save()
 
     client = APIClient()
     client.force_authenticate(user=user)


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

This was in #3621 but is now separated out so it can be reviewed more quickly. 

`import_courserun` will try to set language, industry, and length options on the imported run. However, it was doing this after the run was imported, and the underlying `import_courserun_from_edx` call just sets these fields to the default which causes a collision when importing the variants. So, instead, the variant options are now set in `import_courserun_from_edx`.

### How can this be tested?

Testing requires a working edX installation. This doesn't affect B2B contracts, so those don't need to be set up.

_Example starting course run: `course-v1:UAI+UAI.99+1T2026`_

In edX Studio:

1. Create a new course run. Using the example run, the org would be `UAI`, the course number would be `UAI.99`, and the run tag would be `1T2026`.
2. Re-run the course run. Change the run tag to indicate that it's a variant. For example, this would indicate an English/healthcare/short variant: `1T2026_en_HC_S`.

In MITx Online:

1. Import the initial run: `import_courserun --courserun course-v1:UAI+UAI.99+1T2026 --source-course --lang en --primary-lang -d Testing --create-depts`
2. Ensure that there's a default variant set for the course: `check_courseware_variant course-v1:UAI+UAI.99 --fix-default`.
3. Create a new variant for the course in the Django Admin that matches the settings of the re-run. (Using the example, this means adding a variant option for English, Healthcare, and Short.)
4. Import the variant run: `import_courserun --courserun course-v1:UAI+UAI.99+1T2026_en_HC_S --source-course --lang en --industry HC --length S --use-specific-course course-v1:UAI+UAI.99 --run-tag 1T2026`

This should work successfully. You should see the variant run in the Course Runs listed in the Course in Django Admin, and you should see the option if you run `check_courseware_variant course-v1:UAI+UAI.99`. 

### Additional Context

This came up when trying to import a run that matched the language, so the example also has a matching language. However, this would likely have caused an issue regardless because the CourseRun object was being created with defaults, and the default for the language field changed to `en` (from empty string).