### PR TITLE
Fix run tag generation and re-run check issues when re-running a variant

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -151,6 +151,8 @@ def create_contract_run_key(
             courseware_id__startswith=new_course_key,
             run_tag__endswith=mostly_run_tag,
             language=source_course.language,
+            variant_industry=source_course.variant_industry,
+            variant_length=source_course.variant_length,
         )
         .select_for_update()
         .order_by("-courseware_id")
@@ -482,23 +484,40 @@ def create_contract_run(  # noqa: PLR0913
         )
         new_readable_id = str(new_course_key)
 
-        # If there's a language, we want to change the courseware ID (which is
-        # sent to edX) but not the run tag, because we group translated course
-        # runs by run tag.
-        if clone_course_run.language:
-            new_readable_id = f"{new_readable_id}_{clone_course_run.language}"
+        # We group runs by the run tag that gets stored in the run_tag field. edX
+        # has a run tag too, though, but not any of the other extra fields so
+        # we need to throw some additional data into the run tag so we're not
+        # colliding with the other runs in this tag.
+
+        lang_tag = f"_{clone_course_run.language}" if clone_course_run.language else ""
+        industry_tag = (
+            f"_{clone_course_run.variant_industry}"
+            if clone_course_run.variant_industry
+            else ""
+        )
+        length_tag = (
+            f"_{clone_course_run.variant_length}"
+            if clone_course_run.variant_length
+            else ""
+        )
+
+        new_readable_id = f"{new_readable_id}{lang_tag}{industry_tag}{length_tag}"
 
         new_run_tag = new_course_key.run
 
         if (
             CourseRun.objects.filter(
-                course=course, b2b_contract=contract, language=clone_course_run.language
+                course=course,
+                b2b_contract=contract,
+                language=clone_course_run.language,
+                variant_industry=clone_course_run.variant_industry,
+                variant_length=clone_course_run.variant_length,
             ).exists()
             and no_reruns
         ):
             msg = (
                 f"Can't create a run for {course} and contract {contract}: "
-                f"courseware ID {new_readable_id} already exists."
+                f"courseware ID {new_readable_id} already exists and we're not rerunning it."
             )
             log.warning(msg)
             continue
@@ -518,6 +537,8 @@ def create_contract_run(  # noqa: PLR0913
             b2b_contract=contract,
             language=clone_course_run.language,
             is_primary_language=clone_course_run.is_primary_language,
+            variant_length=clone_course_run.variant_length,
+            variant_industry=clone_course_run.variant_industry,
         )
         course_run.save()
 
@@ -538,7 +559,9 @@ def create_contract_run(  # noqa: PLR0913
             clone_course_run,
         )
 
-        lang_suffix = f" [{course_run.language}]" if course_run.language else ""
+        lang_suffix = (
+            f" [{lang_tag}{industry_tag}{length_tag}]" if course_run.language else ""
+        )
         with reversion.create_revision():
             course_run_product = Product(
                 price=(

--- a/b2b/api_test.py
+++ b/b2b/api_test.py
@@ -609,6 +609,149 @@ def test_create_contract_run(mocker, source_run_exists, run_exists):
     mocked_clone_run.assert_called()
 
 
+def test_create_contract_run_variants(mocker):
+    """
+    Test creating runs for a contract when there are variant runs.
+
+    Variants should be created successfully, even if some of the variant options
+    overlap (i.e. same language, same industry, etc.)
+    """
+
+    mocked_clone_run = mocker.patch("openedx.tasks.clone_courserun.delay")
+    extra_variants = (
+        (
+            "en",
+            "HC",
+            "S",
+        ),
+        (
+            "fr",
+            "F",
+            "S",
+        ),
+        (
+            "fr",
+            "HC",
+            "S",
+        ),
+        (
+            "fr",
+            "",
+            "",
+        ),
+    )
+
+    contract = factories.ContractPageFactory.create()
+    course = CourseFactory.create()
+
+    source_course_run_key = CourseKey.from_string(f"{course.readable_id}+SOURCE")
+    default_source_run = CourseRunFactory.create(
+        course=course,
+        courseware_id=str(source_course_run_key),
+        run_tag="SOURCE",
+        is_source_run=True,
+        language="en",
+        is_primary_language=True,
+    )
+    variant_source_runs = []
+    for language, variant_industry, variant_length in extra_variants:
+        SupportedVariant.objects.create(
+            variant_object=course,
+            language=language,
+            variant_industry=variant_industry,
+            variant_length=variant_length,
+        )
+
+        # Technically we'll format the created runs without dunders if there's a
+        # blank but it's fine for the source run.
+        variant_source_runs.append(
+            CourseRunFactory.create(
+                course=course,
+                courseware_id=f"{source_course_run_key!s}_{language}_{variant_industry}_{variant_length}",
+                run_tag="SOURCE",
+                is_source_run=True,
+                language=language,
+                variant_industry=variant_industry,
+                variant_length=variant_length,
+            )
+        )
+
+    target_course_id = create_contract_run_key(default_source_run, contract)
+
+    assert not course.courseruns.filter(
+        courseware_id__startswith=target_course_id
+    ).exists()
+
+    create_contract_run(contract, course)
+    mocked_clone_run.assert_called()
+
+    assert (
+        course.courseruns.filter(courseware_id__startswith=target_course_id).count()
+        == 5
+    )
+    run_check_qs = course.courseruns.filter(b2b_contract=contract)
+
+    found_count = 0
+    for language, variant_industry, variant_length in [
+        (
+            "en",
+            "",
+            "",
+        ),
+        *extra_variants,
+    ]:
+        found_it = False
+        if run_check_qs.filter(
+            language=language,
+            variant_industry=variant_industry,
+            variant_length=variant_length,
+        ).exists():
+            found_it = True
+            found_count += 1
+
+        assert found_it
+
+    assert found_count == 5
+
+    # Test reruns now - if we re-run create_contract_run, we should get a new
+    # source of runs, but with a new starting run tag.
+
+    # Side effect! Test the create_contract_run_key for this scenario too.
+    target_course_id = create_contract_run_key(default_source_run, contract)
+    target_course_id_key = CourseKey.from_string(target_course_id)
+    assert target_course_id_key.run[0] == "2"
+
+    create_contract_run(contract, course, no_reruns=False)
+    mocked_clone_run.assert_called()
+
+    assert course.courseruns.filter(b2b_contract=contract).count() == 10
+    run_check_qs = course.courseruns.filter(
+        b2b_contract=contract, courseware_id__startswith=target_course_id
+    )
+
+    found_count = 0
+    for language, variant_industry, variant_length in [
+        (
+            "en",
+            "",
+            "",
+        ),
+        *extra_variants,
+    ]:
+        found_it = False
+        if run_check_qs.filter(
+            language=language,
+            variant_industry=variant_industry,
+            variant_length=variant_length,
+        ).exists():
+            found_it = True
+            found_count += 1
+
+        assert found_it
+
+    assert found_count == 5
+
+
 def test_b2b_reconcile_user_orgs():  # noqa: PLR0915
     """Test that we can get a list of B2B orgs from somewhere and fix a user's associations."""
 


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#11579

### Description (What does it do?)

The `create_contract_run` and `create_contract_run_key` APIs did not use the industry and length options when determining whether or not a source run had already been run or not. This means it worked OK when the variants were all different languages, but not when they weren't, which was the exact use case that we hit in 11579. It will now use the language, length, and industry options from the source course to determine if the source run has been run or not.

This also updates the course run key generation code to include the flags for variants in the key, so that they're unique in edX. (So far the course numbers have all been different - but this is just how this has worked out so far.)

### How can this be tested?

The automated tests are updated for this so they should pass.

Test locally by starting with the same setup from https://github.com/mitodl/mitxonline/pull/3626. If that PR hasn't been merged, you can skip importing and just create the course and the variant source runs manually. It is important that your variants overlap in some way - the easiest is to make the languages all `en`.

Then, create a contract with matching variants, and add the course to it using `b2b_courseware add`. You should get course runs for all the variants.

Add the course again using `b2b_courseware add --allow-reruns`. You should get new course runs with the run index incremented (so, 2T versus 1T). 

### Additional Context

The additional stuff that I noted in the issue was sort of nothing - the course key generation code did need a bit of revising, though, but the behavior that it was exhibiting for the default variant was fine.