### PR TITLE
Force color terminal output under GH actions

### DIFF
--- a/main/env_test.py
+++ b/main/env_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from main.env import EnvironmentVariableParseException, get_float
+from main.test_utils import assert_drf_json_equal
 
 FAKE_ENVIRONS = {
     "true": "True",
@@ -17,6 +18,10 @@ FAKE_ENVIRONS = {
     "list_of_int": "[3,4,5]",
     "list_of_str": '["x", "y", \'z\']',
 }
+
+
+def test_fail():
+    assert_drf_json_equal([], [1, 2, 3])
 
 
 def test_get_float(mocker):

--- a/main/env_test.py
+++ b/main/env_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from main.env import EnvironmentVariableParseException, get_float
-from main.test_utils import assert_drf_json_equal
 
 FAKE_ENVIRONS = {
     "true": "True",
@@ -18,10 +17,6 @@ FAKE_ENVIRONS = {
     "list_of_int": "[3,4,5]",
     "list_of_str": '["x", "y", \'z\']',
 }
-
-
-def test_fail():
-    assert_drf_json_equal([], [1, 2, 3])
 
 
 def test_get_float(mocker):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ fixture-parentheses = false
 
 
 [tool.pytest.ini_options]
-addopts = "--cov . --cov-report xml --cov-report term --cov-report html --ds=main.settings --reuse-db"
+addopts = "--cov . --cov-report xml --cov-report term --cov-report html --ds=main.settings --reuse-db --color=yes"
 norecursedirs = [
   "node_modules",
   ".git",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This forces pytest to render color output so that we can see failures in diffs easier.
 / at all
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
See the github action test output in the first commit which failed, it should render the diff from `assert_drf_json_equal` w/ color plus all of the pytest output generally: https://github.com/mitodl/mitxonline/actions/runs/26830041042/job/79108417304