### PR TITLE
Fix migration conflict in the cms app

### DIFF
--- a/cms/migrations/0064_alter_signatorypage_signature_image.py
+++ b/cms/migrations/0064_alter_signatorypage_signature_image.py
@@ -36,7 +36,7 @@ def backfill_missing_signatory_images(apps, _schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("cms", "0062_alter_certificatepage_signatories"),
+        ("cms", "0063_alter_coursepage_max_price_alter_coursepage_min_price_and_more"),
         ("wagtailimages", "0027_image_description"),
     ]
 


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

We ended up with two `0063` migrations in `cms`; this renames one to `0064`.

### How can this be tested?

Migrations should succeed. The two `0063`s weren't interdependent so I just renamed the most recent one.