### PR TITLE
Removes ORM warning in the program serializer

### DIFF
--- a/drf_lint_baseline.json
+++ b/drf_lint_baseline.json
@@ -23,8 +23,6 @@
   "courses/serializers/v2/courses.py:398:18:ORM001",
   "courses/serializers/v2/departments.py:35:40:ORM002",
   "courses/serializers/v2/departments.py:49:42:ORM002",
-  "courses/serializers/v2/programs.py:197:48:ORM002",
-  "courses/serializers/v2/programs.py:203:30:ORM001",
   "courses/serializers/v2/programs.py:324:36:ORM002",
   "courses/serializers/v2/programs.py:344:20:ORM002",
   "courses/serializers/v2/programs.py:476:53:ORM002",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
It removes the ORM002 warning on that serializer path.



### How can this be tested?
Tests should pass
