### PR TITLE
feat: implement future enrollments migration from edX to MITx Online

### DIFF
--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -721,7 +721,7 @@ class Command(BaseCommand):
         current mode differs. Scoped only to verified rows to avoid downgrading
         enrollments not covered by this migration.
         """
-        upgrade_user_ids, upgrade_run_ids = set(), set()
+        upgrade_q = Q()
         for row in verified_rows:
             existing_mode = existing_enrollments.get(
                 (row["user_mitxonline_id"], row["courserun_id"])
@@ -730,13 +730,12 @@ class Command(BaseCommand):
                 existing_mode is not None
                 and existing_mode != EDX_ENROLLMENT_VERIFIED_MODE
             ):
-                upgrade_user_ids.add(row["user_mitxonline_id"])
-                upgrade_run_ids.add(row["courserun_id"])
-        if upgrade_user_ids:
-            CourseRunEnrollment.all_objects.filter(
-                user_id__in=upgrade_user_ids,
-                run_id__in=upgrade_run_ids,
-            ).exclude(enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE).update(
+                upgrade_q |= Q(
+                    user_id=row["user_mitxonline_id"],
+                    run_id=row["courserun_id"],
+                )
+        if upgrade_q:
+            CourseRunEnrollment.all_objects.filter(upgrade_q).update(
                 enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
             )
 

--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -1,10 +1,7 @@
-import uuid
-
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models import Q
-from mitol.common.utils.datetime import now_in_utc
 from reversion.models import Version
 from trino.auth import BasicAuthentication
 from trino.dbapi import connect
@@ -18,23 +15,13 @@ from courses.models import (
     CourseRunEnrollment,
     CourseRunGrade,
     Department,
-    PaidCourseRun,
     Program,
     ProgramCertificate,
     ProgramEnrollment,
 )
 from ecommerce.api import fulfill_completed_order
 from ecommerce.constants import ZERO_PAYMENT_DATA
-from ecommerce.models import (
-    Discount,
-    DiscountRedemption,
-    Line,
-    Order,
-    OrderStatus,
-    PendingOrder,
-    Product,
-    Transaction,
-)
+from ecommerce.models import Discount, PendingOrder, Product
 from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
 from users.models import GENDER_CHOICES, LegalAddress, User, UserProfile
 
@@ -461,7 +448,7 @@ class Command(BaseCommand):
 
         query = (
             "SELECT * FROM edxorg_to_mitxonline_enrollments "
-            "WHERE user_mitxonline_id IS NOT NULL AND courserun_id IS NOT NULL"
+            "WHERE user_mitxonline_id IS NOT NULL AND courserun_id IS NOT NULL "
             "AND courseruncertificate_created_on IS NOT NULL"
         )
         if courserun_readable_ids:
@@ -727,46 +714,6 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Created {created_orders} Orders"))
 
-    @staticmethod
-    def _create_verified_enrollment_order(
-        user, product, product_version, discount, courserun_id
-    ):
-        """
-        Directly create a fulfilled order for a verified enrollment without triggering
-        enrollment hooks (which would send notification emails).
-        """
-        order = Order.objects.create(
-            state=OrderStatus.FULFILLED,
-            purchaser=user,
-            total_price_paid=0,
-        )
-        Line.objects.create(
-            order=order,
-            product_version=product_version,
-            quantity=1,
-            purchased_content_type_id=product.content_type_id,
-            purchased_object_id=product.object_id,
-        )
-        Transaction.objects.create(
-            order=order,
-            transaction_id=uuid.uuid1(),
-            amount=0,
-            data=ZERO_PAYMENT_DATA,
-        )
-        if discount:
-            DiscountRedemption.objects.create(
-                redeemed_discount=discount,
-                redeemed_by=user,
-                redeemed_order=order,
-                redemption_date=now_in_utc(),
-            )
-        PaidCourseRun.objects.get_or_create(
-            user=user,
-            course_run_id=courserun_id,
-            defaults={"order": order},
-        )
-        return order
-
     def _migrate_enrollments(self, conn, options):
         """
         Migrate the edX future enrollments from edX to MITx Online. Create Orders for the verified enrollments.
@@ -868,12 +815,13 @@ class Command(BaseCommand):
                         continue
 
                     with transaction.atomic():
-                        self._create_verified_enrollment_order(
-                            user,
-                            product,
-                            product_version,
-                            discount,
-                            row["courserun_id"],
+                        order = PendingOrder.create_from_product(
+                            product, user, discount=discount
+                        )
+                        fulfill_completed_order(
+                            order,
+                            payment_data=ZERO_PAYMENT_DATA,
+                            already_enrolled=True,
                         )
                         total_orders += 1
 
@@ -923,9 +871,10 @@ class Command(BaseCommand):
                 "course_certificates",
                 "program_certificates",
                 "entitlements",
+                "future_enrollments",
             ],
             default="course_runs",
-            help="Choose which migration to run: course_runs, users, course_certificates, program_certificates, entitlements (default: course_runs)",
+            help="Choose which migration to run: course_runs, users, course_certificates, program_certificates, entitlements, future_enrollments (default: course_runs)",
         )
         parser.add_argument("--dry-run", action="store_true")
         parser.add_argument(

--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -714,6 +714,32 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Created {created_orders} Orders"))
 
+    @staticmethod
+    def _upgrade_enrollment_modes(verified_rows, existing_enrollments):
+        """
+        Upgrade enrollment mode to verified for any existing enrollments whose
+        current mode differs. Scoped only to verified rows to avoid downgrading
+        enrollments not covered by this migration.
+        """
+        upgrade_user_ids, upgrade_run_ids = set(), set()
+        for row in verified_rows:
+            existing_mode = existing_enrollments.get(
+                (row["user_mitxonline_id"], row["courserun_id"])
+            )
+            if (
+                existing_mode is not None
+                and existing_mode != EDX_ENROLLMENT_VERIFIED_MODE
+            ):
+                upgrade_user_ids.add(row["user_mitxonline_id"])
+                upgrade_run_ids.add(row["courserun_id"])
+        if upgrade_user_ids:
+            CourseRunEnrollment.all_objects.filter(
+                user_id__in=upgrade_user_ids,
+                run_id__in=upgrade_run_ids,
+            ).exclude(enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE).update(
+                enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+            )
+
     def _migrate_enrollments(self, conn, options):
         """
         Migrate the edX future enrollments from edX to MITx Online. Create Orders for the verified enrollments.
@@ -764,9 +790,18 @@ class Command(BaseCommand):
                 )
                 continue
 
+            user_ids = {row["user_mitxonline_id"] for row in verified_rows}
+            existing_enrollments = {
+                (uid, rid): mode
+                for uid, rid, mode in CourseRunEnrollment.all_objects.filter(
+                    user_id__in=user_ids,
+                    run_id__in={row["courserun_id"] for row in verified_rows},
+                ).values_list("user_id", "run_id", "enrollment_mode")
+            }
+
+            self._upgrade_enrollment_modes(verified_rows, existing_enrollments)
             total_enrollments += self._bulk_create_enrollments(rows, batch_size)
 
-            user_ids = {row["user_mitxonline_id"] for row in verified_rows}
             product_version_ids = {
                 row["product_version_id"]
                 for row in verified_rows
@@ -784,6 +819,14 @@ class Command(BaseCommand):
 
             for row in verified_rows:
                 try:
+                    if (
+                        existing_enrollments.get(
+                            (row["user_mitxonline_id"], row["courserun_id"])
+                        )
+                        == EDX_ENROLLMENT_VERIFIED_MODE
+                    ):
+                        continue
+
                     user = users.get(row["user_mitxonline_id"])
                     product_version = product_versions.get(
                         row.get("product_version_id")
@@ -831,13 +874,6 @@ class Command(BaseCommand):
                             f"Failed to create order for enrollment row: {row} error: {e}"
                         )
                     )
-
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f"{total_enrollments} enrollments created, "
-                    f"{total_orders} verified orders created"
-                )
-            )
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -1,7 +1,10 @@
+import uuid
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models import Q
+from mitol.common.utils.datetime import now_in_utc
 from reversion.models import Version
 from trino.auth import BasicAuthentication
 from trino.dbapi import connect
@@ -15,13 +18,23 @@ from courses.models import (
     CourseRunEnrollment,
     CourseRunGrade,
     Department,
+    PaidCourseRun,
     Program,
     ProgramCertificate,
     ProgramEnrollment,
 )
 from ecommerce.api import fulfill_completed_order
 from ecommerce.constants import ZERO_PAYMENT_DATA
-from ecommerce.models import PendingOrder, Product
+from ecommerce.models import (
+    Discount,
+    DiscountRedemption,
+    Line,
+    Order,
+    OrderStatus,
+    PendingOrder,
+    Product,
+    Transaction,
+)
 from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
 from users.models import GENDER_CHOICES, LegalAddress, User, UserProfile
 
@@ -449,6 +462,7 @@ class Command(BaseCommand):
         query = (
             "SELECT * FROM edxorg_to_mitxonline_enrollments "
             "WHERE user_mitxonline_id IS NOT NULL AND courserun_id IS NOT NULL"
+            "AND courseruncertificate_created_on IS NOT NULL"
         )
         if courserun_readable_ids:
             placeholders = [
@@ -571,7 +585,8 @@ class Command(BaseCommand):
 
         query = (
             "SELECT * FROM edxorg_to_mitxonline_program_certificates "
-            "WHERE user_mitxonline_id IS NOT NULL AND program_id IS NOT NULL"
+            "WHERE user_mitxonline_id IS NOT NULL AND program_id IS NOT NULL "
+            "AND certificate_page_revision_id IS NOT NULL "
         )
 
         if limit is not None:
@@ -712,6 +727,177 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Created {created_orders} Orders"))
 
+    @staticmethod
+    def _create_verified_enrollment_order(
+        user, product, product_version, discount, courserun_id
+    ):
+        """
+        Directly create a fulfilled order for a verified enrollment without triggering
+        enrollment hooks (which would send notification emails).
+        """
+        order = Order.objects.create(
+            state=OrderStatus.FULFILLED,
+            purchaser=user,
+            total_price_paid=0,
+        )
+        Line.objects.create(
+            order=order,
+            product_version=product_version,
+            quantity=1,
+            purchased_content_type_id=product.content_type_id,
+            purchased_object_id=product.object_id,
+        )
+        Transaction.objects.create(
+            order=order,
+            transaction_id=uuid.uuid1(),
+            amount=0,
+            data=ZERO_PAYMENT_DATA,
+        )
+        if discount:
+            DiscountRedemption.objects.create(
+                redeemed_discount=discount,
+                redeemed_by=user,
+                redeemed_order=order,
+                redemption_date=now_in_utc(),
+            )
+        PaidCourseRun.objects.get_or_create(
+            user=user,
+            course_run_id=courserun_id,
+            defaults={"order": order},
+        )
+        return order
+
+    def _migrate_enrollments(self, conn, options):
+        """
+        Migrate the edX future enrollments from edX to MITx Online. Create Orders for the verified enrollments.
+        """
+        limit = options.get("limit")
+        batch_size = options.get("batch_size", 1000)
+        dry_run = options.get("dry_run")
+
+        cur = conn.cursor()
+
+        query = (
+            "SELECT * FROM edxorg_to_mitxonline_enrollments "
+            "WHERE user_mitxonline_id IS NOT NULL AND courserun_id IS NOT NULL "
+            "AND courseruncertificate_created_on IS NULL"
+        )
+        if limit is not None:
+            query += f" LIMIT {int(limit)}"
+
+        cur.execute(query)
+        columns = [desc[0] for desc in cur.description]
+
+        total_enrollments = 0
+        total_orders = 0
+
+        while True:
+            results = cur.fetchmany(batch_size)
+            if not results:
+                break
+
+            rows = [dict(zip(columns, r)) for r in results]
+
+            verified_rows = [
+                row
+                for row in rows
+                if row.get("courserunenrollment_enrollment_mode")
+                == EDX_ENROLLMENT_VERIFIED_MODE
+            ]
+
+            if dry_run:
+                total_enrollments += len(rows)
+                total_orders += len(verified_rows)
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"[DRY RUN] Would create "
+                        f"{total_enrollments} enrollments, "
+                        f"{total_orders} verified orders"
+                    )
+                )
+                continue
+
+            total_enrollments += self._bulk_create_enrollments(rows, batch_size)
+
+            user_ids = {row["user_mitxonline_id"] for row in verified_rows}
+            product_version_ids = {
+                row["product_version_id"]
+                for row in verified_rows
+                if row.get("product_version_id")
+            }
+            discount_ids = {
+                row["discount_id"] for row in verified_rows if row.get("discount_id")
+            }
+
+            users = {u.id: u for u in User.objects.filter(id__in=user_ids)}
+            product_versions = {
+                v.id: v for v in Version.objects.filter(id__in=product_version_ids)
+            }
+            discounts = {d.id: d for d in Discount.objects.filter(id__in=discount_ids)}
+
+            for row in verified_rows:
+                try:
+                    user = users.get(row["user_mitxonline_id"])
+                    product_version = product_versions.get(
+                        row.get("product_version_id")
+                    )
+                    product = (
+                        Product.all_objects.filter(
+                            id=product_version.field_dict.get("id")
+                        ).first()
+                        if product_version
+                        else None
+                    )
+                    discount = discounts.get(row.get("discount_id"))
+
+                    if not all([user, product_version, product]):
+                        missing = [
+                            name
+                            for name, val in [
+                                ("user", user),
+                                ("product_version", product_version),
+                                ("product", product),
+                            ]
+                            if not val
+                        ]
+                        self.stdout.write(
+                            self.style.ERROR(
+                                f"Missing objects {missing} for row: {row}"
+                            )
+                        )
+                        continue
+
+                    with transaction.atomic():
+                        self._create_verified_enrollment_order(
+                            user,
+                            product,
+                            product_version,
+                            discount,
+                            row["courserun_id"],
+                        )
+                        total_orders += 1
+
+                except Exception as e:  # noqa: BLE001
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Failed to create order for enrollment row: {row} error: {e}"
+                        )
+                    )
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"{total_enrollments} enrollments created, "
+                    f"{total_orders} verified orders created"
+                )
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Enrollment migration complete: "
+                f"{total_enrollments} enrollments, {total_orders} orders"
+            )
+        )
+
     def add_arguments(self, parser) -> None:
         parser.add_argument(
             "--use-default-signatory",
@@ -778,3 +964,7 @@ class Command(BaseCommand):
                 "Migrating the edX entitlements to program orders and enrollments ..."
             )
             self._migrate_entitlements(conn, options)
+
+        if migrate_type == "future_enrollments":
+            self.stdout.write("Migrating the edX future enrollments  ...")
+            self._migrate_enrollments(conn, options)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11545

### Description (What does it do?)
<!--- Describe your changes in detail -->
implements future enrollments migration functionality in `migrate_edx_data` management command. It creates enrollments and fulfilled orders for verified enrollments


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Same setup as https://github.com/mitodl/mitxonline/pull/2922 for Trino and env 

Ensure you setup some course runs, products, and discount code

For local testing, modify the query to be something like:

```
  query = (
       "SELECT user_mitxonline_id, courserun_id, courserunenrollment_enrollment_mode, "
       " product_version_id, discount_id "
       "FROM ("
       "  VALUES "
       "    (1, 2, 'verified', 3, 4),"
       "    (1, 3, 'audit', NULL, NULL)"
       ") AS t(user_mitxonline_id, courserun_id, courserunenrollment_enrollment_mode, "
       "product_version_id, discount_id)"
   )

```
Replace 1,2,3,4 with real IDs from your local. 

- `user_mitxonline_id` is your user ID
- `product_version_id` — The revision ID of the course run product

To find out product_version_id, run this query in dbshell.
```
---courserun product ID can be found at admin/ecommerce/product/
postgres=# select id from reversion_version where object_id ='<product ID>' limit 1;
```
-  discount_id - the discount ID for 100% unlimited discount created in admin/ecommerce/discount/


Run `manage.py migrate_edx_data --type future_enrollments`

Verify

fulfilled orders (0 total price paid) created at http://mitxonline.odl.local:8013/admin/ecommerce/fulfilledorder/
enrollments created at http://mitxonline.odl.local:8013/admin/courses/
paid course runs created at http://mitxonline.odl.local:8013/admin/courses/paidcourserun/


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
