### PR TITLE
fix: create program enrollment when B2B user enrolls in a course run

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -1292,7 +1292,7 @@ def _apply_available_discount(request, product: Product, basket: Basket) -> None
     basket_discount.save()
 
 
-def create_b2b_enrollment(request, product: Product):
+def create_b2b_enrollment(request, product: Product, program_id: str | None = None):
     """
     Create a B2B enrollment for the given product for the current user.
 
@@ -1316,6 +1316,7 @@ def create_b2b_enrollment(request, product: Product):
     Args:
     - request: The HTTP request object containing the user and basket data.
     - product: The Product object representing the B2B product to enroll in.
+    - program_id: Optional readable_id of the program to enroll the user in.
     Returns: a dict containing
     - "result": the result of the attempt; one of the USER_MSG_TYPE_B2B constants.
     - "order": the order ID if the enrollment was successful and no checkout is needed.
@@ -1343,6 +1344,10 @@ def create_b2b_enrollment(request, product: Product):
         response = generate_checkout_payload(request)
 
         if "no_checkout" in response:
+            # Course run enrollment succeeded - now handle program enrollment
+            if program_id:
+                _enroll_in_program_for_b2b(request.user, product, program_id)
+
             return {
                 "result": main_constants.USER_MSG_TYPE_B2B_ENROLL_SUCCESS,
                 "order": response["order_id"],
@@ -1358,6 +1363,55 @@ def create_b2b_enrollment(request, product: Product):
         "result": main_constants.USER_MSG_TYPE_B2B_ERROR_REQUIRES_CHECKOUT,
         "price": basket_price,
     }
+
+
+def _enroll_in_program_for_b2b(user, product: Product, program_id: str):
+    """
+    Enroll the user in the specified program as part of a B2B course enrollment.
+
+    Validates that the program belongs to the same contract as the course run
+    being enrolled in, then creates a ProgramEnrollment if one doesn't exist.
+
+    Args:
+    - user: The user to enroll.
+    - product: The Product for the course run being enrolled in.
+    - program_id: The readable_id of the program to enroll in.
+    """
+    from courses.api import create_program_enrollments  # noqa: PLC0415
+    from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE  # noqa: PLC0415
+
+    purchasable_object = product.purchasable_object
+    contract = purchasable_object.b2b_contract
+
+    try:
+        program = Program.objects.get(readable_id=program_id)
+    except Program.DoesNotExist:
+        log.warning(
+            "B2B enroll: program %s not found, skipping program enrollment",
+            program_id,
+        )
+        return
+
+    # Validate the program belongs to the same contract as the course run
+    if not ContractProgramItem.objects.filter(
+        contract=contract, program=program
+    ).exists():
+        log.warning(
+            "B2B enroll: program %s is not in contract %s, skipping program enrollment",
+            program_id,
+            contract,
+        )
+        return
+
+    create_program_enrollments(
+        user, [program], enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
+
+    log.info(
+        "B2B enroll: created program enrollment for user %s in program %s",
+        user,
+        program_id,
+    )
 
 
 def reconcile_user_orgs(user, organizations):

--- a/b2b/api_test.py
+++ b/b2b/api_test.py
@@ -19,6 +19,7 @@ from opaque_keys.edx.keys import CourseKey
 from b2b import factories
 from b2b.api import (
     _apply_available_discount,
+    _enroll_in_program_for_b2b,
     _get_source_runs_for_course,
     _handle_extra_enrollment_codes,
     _validate_b2b_enrollment_prerequisites,
@@ -46,15 +47,21 @@ from b2b.constants import (
 )
 from b2b.exceptions import SourceCourseIncompleteError
 from b2b.factories import ContractPageFactory, OrganizationPageFactory
-from b2b.models import OrganizationIndexPage, OrganizationPage, UserOrganization
+from b2b.models import (
+    ContractProgramItem,
+    OrganizationIndexPage,
+    OrganizationPage,
+    UserOrganization,
+)
 from courses.constants import UAI_COURSEWARE_ID_PREFIX
 from courses.factories import (
     CourseFactory,
     CourseRunEnrollmentFactory,
     CourseRunFactory,
     DepartmentFactory,
+    ProgramFactory,
 )
-from courses.models import CourseRunEnrollment
+from courses.models import CourseRunEnrollment, ProgramEnrollment
 from ecommerce.api_test import create_basket
 from ecommerce.constants import REDEMPTION_TYPE_ONE_TIME, REDEMPTION_TYPE_UNLIMITED
 from ecommerce.factories import (
@@ -530,6 +537,47 @@ def test_create_b2b_enrollment(  # noqa: PLR0913, C901, PLR0915
         assert my_run.enrollment_mode == EDX_ENROLLMENT_VERIFIED_MODE
     else:
         assert result["result"] == USER_MSG_TYPE_B2B_DISALLOWED
+
+
+@pytest.mark.parametrize(
+    ("program_in_contract", "program_exists"),
+    [
+        (True, True),
+        (False, True),
+        (True, False),
+    ],
+)
+def test_enroll_in_program_for_b2b(program_in_contract, program_exists):
+    """
+    Test _enroll_in_program_for_b2b creates a ProgramEnrollment when valid.
+
+    Should create a ProgramEnrollment only when the program exists and belongs
+    to the same contract as the course run. Should skip gracefully otherwise.
+    """
+    contract = factories.ContractPageFactory.create(
+        integration_type=CONTRACT_MEMBERSHIP_SSO,
+        membership_type=CONTRACT_MEMBERSHIP_SSO,
+    )
+    program = ProgramFactory.create() if program_exists else None
+    program_id = program.readable_id if program else "nonexistent-program"
+
+    if program_in_contract and program_exists:
+        ContractProgramItem.objects.create(
+            contract=contract, program=program, sort_order=0
+        )
+
+    user = UserFactory.create()
+    course = CourseFactory.create()
+    run = CourseRunFactory.create(course=course, b2b_contract=contract)
+
+    product = ProductFactory.create(purchasable_object=run)
+
+    _enroll_in_program_for_b2b(user, product, program_id)
+
+    if program_in_contract and program_exists:
+        assert ProgramEnrollment.objects.filter(user=user, program=program).exists()
+    else:
+        assert ProgramEnrollment.objects.filter(user=user).count() == 0
 
 
 @pytest.mark.parametrize(

--- a/b2b/serializers/v0/__init__.py
+++ b/b2b/serializers/v0/__init__.py
@@ -140,6 +140,21 @@ class GenerateCheckoutPayloadSerializer(serializers.Serializer):
     )
 
 
+class B2BEnrollRequestSerializer(serializers.Serializer):
+    """
+    Serializer for the B2B enrollment request body.
+
+    Accepts an optional program_id so the user can be enrolled in the
+    appropriate program alongside the course run enrollment.
+    """
+
+    program_id = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="The readable_id of the program to enroll the user in.",
+    )
+
+
 class CreateB2BEnrollmentSerializer(serializers.Serializer):
     """
     Serializer for the result from create_b2b_enrollment.

--- a/b2b/views/v0/__init__.py
+++ b/b2b/views/v0/__init__.py
@@ -27,6 +27,7 @@ from b2b.models import (
     OrganizationPage,
 )
 from b2b.serializers.v0 import (
+    B2BEnrollRequestSerializer,
     ContractPageSerializer,
     CreateB2BEnrollmentSerializer,
     OrganizationPageSerializer,
@@ -147,7 +148,7 @@ class Enroll(APIView):
     permission_classes = [IsAuthenticated]
 
     @extend_schema(
-        request=None,
+        request=B2BEnrollRequestSerializer,
         responses=CreateB2BEnrollmentSerializer,
     )
     @csrf_exempt
@@ -162,7 +163,12 @@ class Enroll(APIView):
             content_type=course_run_content_type, object_id=courserun.id
         ).get()
 
-        response = create_b2b_enrollment(request, product)
+        # Parse optional program_id from request body
+        request_serializer = B2BEnrollRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        program_id = request_serializer.validated_data.get("program_id")
+
+        response = create_b2b_enrollment(request, product, program_id=program_id)
 
         return Response(
             CreateB2BEnrollmentSerializer(response).data,

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -221,6 +221,17 @@ paths:
         required: true
       tags:
       - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
       responses:
         '200':
           content:
@@ -3882,6 +3893,17 @@ components:
       x-enum-descriptions:
       - anytime
       - dated
+    B2BEnrollRequestRequest:
+      type: object
+      description: |-
+        Serializer for the B2B enrollment request body.
+
+        Accepts an optional program_id so the user can be enrolled in the
+        appropriate program alongside the course run enrollment.
+      properties:
+        program_id:
+          type: string
+          description: The readable_id of the program to enroll the user in.
     BaseContractPage:
       type: object
       description: Simplified serializer for the ContractPage model.

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -221,6 +221,17 @@ paths:
         required: true
       tags:
       - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
       responses:
         '200':
           content:
@@ -3882,6 +3893,17 @@ components:
       x-enum-descriptions:
       - anytime
       - dated
+    B2BEnrollRequestRequest:
+      type: object
+      description: |-
+        Serializer for the B2B enrollment request body.
+
+        Accepts an optional program_id so the user can be enrolled in the
+        appropriate program alongside the course run enrollment.
+      properties:
+        program_id:
+          type: string
+          description: The readable_id of the program to enroll the user in.
     BaseContractPage:
       type: object
       description: Simplified serializer for the ContractPage model.

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -221,6 +221,17 @@ paths:
         required: true
       tags:
       - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/B2BEnrollRequestRequest'
       responses:
         '200':
           content:
@@ -3882,6 +3893,17 @@ components:
       x-enum-descriptions:
       - anytime
       - dated
+    B2BEnrollRequestRequest:
+      type: object
+      description: |-
+        Serializer for the B2B enrollment request body.
+
+        Accepts an optional program_id so the user can be enrolled in the
+        appropriate program alongside the course run enrollment.
+      properties:
+        program_id:
+          type: string
+          description: The readable_id of the program to enroll the user in.
     BaseContractPage:
       type: object
       description: Simplified serializer for the ContractPage model.


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11541

### Description (What does it do?)
When a learner enrolled in a B2B course run that was part of a contract program,
no ProgramEnrollment record was created — only the CourseRunEnrollment. This meant
the program dashboard wouldn't reflect their enrollment correctly. To fix this, the
B2B enroll endpoint now accepts an optional `program_id` in the request body. When
provided, it validates the program belongs to the same contract as the course run,
then creates a verified ProgramEnrollment if one doesn't already exist.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- See testing instructions in https://github.com/mitodl/mit-learn/pull/3439


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
