### PR TITLE
Add assigned name to serializer

### DIFF
--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -96,6 +96,7 @@ class ManagerEnrollmentCodeSerializer(serializers.ModelSerializer):
     redemption_status = serializers.SerializerMethodField()
     assigned_to = serializers.SerializerMethodField()
     assigned_on = serializers.SerializerMethodField()
+    assigned_name = serializers.SerializerMethodField()
     redeemed_on = serializers.SerializerMethodField()
     redeemed_by = serializers.SerializerMethodField()
     last_sent = serializers.SerializerMethodField()
@@ -108,6 +109,7 @@ class ManagerEnrollmentCodeSerializer(serializers.ModelSerializer):
             "redemption_status",
             "assigned_to",
             "assigned_on",
+            "assigned_name",
             "redeemed_on",
             "redeemed_by",
             "last_sent",
@@ -155,6 +157,13 @@ class ManagerEnrollmentCodeSerializer(serializers.ModelSerializer):
         if not redemption or not redemption.user:
             return None
         return redemption.user.email
+
+    def get_assigned_name(self, obj) -> str | None:
+        """Return the name of the user this code is assigned to."""
+        redemption = self._get_redemption(obj)
+        if not redemption:
+            return None
+        return redemption.assigned_email
 
     def get_last_sent(self, obj) -> datetime | None:
         """Return when the last reminder email was sent."""

--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -163,7 +163,7 @@ class ManagerEnrollmentCodeSerializer(serializers.ModelSerializer):
         redemption = self._get_redemption(obj)
         if not redemption:
             return None
-        return redemption.assigned_email
+        return redemption.assigned_name
 
     def get_last_sent(self, obj) -> datetime | None:
         """Return when the last reminder email was sent."""

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -6908,6 +6908,11 @@ components:
           nullable: true
           description: Return when the invite/assignment was created.
           readOnly: true
+        assigned_name:
+          type: string
+          nullable: true
+          description: Return the name of the user this code is assigned to.
+          readOnly: true
         redeemed_on:
           type: string
           format: date-time
@@ -6926,6 +6931,7 @@ components:
           description: Return when the last reminder email was sent.
           readOnly: true
       required:
+      - assigned_name
       - assigned_on
       - assigned_to
       - code

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -6908,6 +6908,11 @@ components:
           nullable: true
           description: Return when the invite/assignment was created.
           readOnly: true
+        assigned_name:
+          type: string
+          nullable: true
+          description: Return the name of the user this code is assigned to.
+          readOnly: true
         redeemed_on:
           type: string
           format: date-time
@@ -6926,6 +6931,7 @@ components:
           description: Return when the last reminder email was sent.
           readOnly: true
       required:
+      - assigned_name
       - assigned_on
       - assigned_to
       - code

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -6908,6 +6908,11 @@ components:
           nullable: true
           description: Return when the invite/assignment was created.
           readOnly: true
+        assigned_name:
+          type: string
+          nullable: true
+          description: Return the name of the user this code is assigned to.
+          readOnly: true
         redeemed_on:
           type: string
           format: date-time
@@ -6926,6 +6931,7 @@ components:
           description: Return when the last reminder email was sent.
           readOnly: true
       required:
+      - assigned_name
       - assigned_on
       - assigned_to
       - code


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11375

### Description (What does it do?)
Adds assigned_name to serializer. It doesn't do much yet since there's no preassignment endpoints yet, but there is some backpopulated data for older records, so this is a step towards the finalized API structure.

### How can this be tested?
With a test contract and organization set up, visit the /codes endpoint. You should observe that there's a new field.
`http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/codes/`. 

Have redeemed an enrollment code and set `DiscountContractAttachmentRedemption.assigned_name` field on the corresponding record you should see that reflected in the API response

<img width="1150" height="893" alt="Screenshot 2026-06-08 at 3 08 28 PM" src="https://github.com/user-attachments/assets/e02caf8d-6a88-4225-bc1c-1922953d907e" />


### Additional Context
At the moment there isn't a way to set the assigned name - it depends on forthcoming endpoints which will allow building out the "preassignment" functionality (https://github.com/mitodl/mitxonline/pull/3646). That said, you may have some entries in your database which has the field populated [via migration](https://github.com/mitodl/mitxonline/pull/3625/changes#diff-bd4eb877fef2809a34b7f5b507d081041d1d1d38d4faec49e7fce7c414e93d53R8-R25) if you had any redeemed codes prior to that migration running.
