### PR TITLE
Increase QoL for some B2B things

### DIFF
--- a/b2b/admin.py
+++ b/b2b/admin.py
@@ -96,33 +96,31 @@ class ContractPageProgramInline(DisplayOnlyAdminMixin, admin.TabularInline):
     readonly_fields = ["program", "sort_order"]
 
 
-class ContractPageCourseRunInline(admin.TabularInline):
+class ContractPageCourseRunInline(DisplayOnlyAdminMixin, admin.TabularInline):
     """Inline to display course runs for contract pages."""
 
     model = CourseRun
     fk_name = "b2b_contract"
     extra = 0
     fields = [
-        "courseware_id",
+        "title_linked",
         "title",
+        "run_tag",
+        "language",
+        "variant_length",
+        "variant_industry",
     ]
+    readonly_fields = [
+        "title_linked",
+        "title",
+        "run_tag",
+        "language",
+        "variant_length",
+        "variant_industry",
+    ]
+
     verbose_name = "Contract Course Run"
     verbose_name_plural = "Contract Course Runs"
-
-    def has_add_permission(self, request, obj):  # noqa: ARG002
-        """Turn off add permission. These admins are supposed to be read-only."""
-
-        return False
-
-    def has_delete_permission(self, request, obj):  # noqa: ARG002
-        """Turn off delete permission. These admins are supposed to be read-only."""
-
-        return False
-
-    def has_change_permission(self, request, obj):  # noqa: ARG002
-        """Turn off change permission. These admins are supposed to be read-only."""
-
-        return False
 
 
 @admin.register(DiscountContractAttachmentRedemption)

--- a/b2b/admin.py
+++ b/b2b/admin.py
@@ -1,9 +1,8 @@
 """B2B model admin. Only for convenience; you should use the Wagtail interface instead."""
 
-from collections.abc import Sequence
-
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
+from django.db.models import Count
 
 from b2b.models import (
     ContractPage,
@@ -13,9 +12,10 @@ from b2b.models import (
     UserOrganization,
 )
 from courses.models import CourseRun
+from main.admin import DisplayOnlyAdminMixin, ReadOnlyModelAdmin
 
 
-class UserOrganizationAdminInline(admin.TabularInline):
+class UserOrganizationAdminInline(DisplayOnlyAdminMixin, admin.TabularInline):
     """Inline that filters to just show organization admins"""
 
     model = UserOrganization
@@ -42,21 +42,6 @@ class UserOrganizationAdminInline(admin.TabularInline):
             .filter(is_manager=True)
         )
 
-    def has_add_permission(self, request, obj):  # noqa: ARG002
-        """Determine if the user can add new ones from here (no, they cannot)"""
-
-        return False
-
-    def has_change_permission(self, request, obj=None):  # noqa: ARG002
-        """Determine if the user can add new ones from here (no, they cannot)"""
-
-        return False
-
-    def has_delete_permission(self, request, obj=None):  # noqa: ARG002
-        """Determine if the user can add new ones from here (no, they cannot)"""
-
-        return False
-
     @admin.display(description="User Email")
     def user_email(self, obj):
         """Return the user's email address."""
@@ -73,27 +58,69 @@ class ContractPagePossibleVariantInline(GenericTabularInline):
     extra = 0
 
 
-class ReadOnlyModelAdmin(admin.ModelAdmin):
-    """Read-only admin for models."""
+class OrganizationContractsInline(DisplayOnlyAdminMixin, admin.TabularInline):
+    """Inline to display the contracts for the selected org"""
 
-    fields: Sequence[str] = []
+    model = ContractPage
+    extra = 0
+    fk_name = "organization"
 
-    def __init__(self, *args, **kwargs):
-        """Set the readonly_fields to the fields if we can."""
+    fields = [
+        "title_linked",
+        "slug",
+        "membership_type",
+        "max_learners",
+        "active",
+        "contract_start",
+        "contract_end",
+    ]
+    readonly_fields = [
+        "title_linked",
+        "slug",
+        "membership_type",
+        "max_learners",
+        "active",
+        "contract_start",
+        "contract_end",
+    ]
 
-        self.readonly_fields = self.fields or [
-            field.name
-            for field in self.model._meta.fields  # noqa: SLF001
-        ]
-        super().__init__(*args, **kwargs)
 
-    def has_add_permission(self, request):  # noqa: ARG002
-        """Disable create."""
+class ContractPageProgramInline(DisplayOnlyAdminMixin, admin.TabularInline):
+    """Inline to display programs for contract pages."""
+
+    model = ContractProgramItem
+    extra = 0
+    verbose_name = "Contract Program"
+    verbose_name_plural = "Contract Programs"
+    fields = ["program", "sort_order"]
+    readonly_fields = ["program", "sort_order"]
+
+
+class ContractPageCourseRunInline(admin.TabularInline):
+    """Inline to display course runs for contract pages."""
+
+    model = CourseRun
+    fk_name = "b2b_contract"
+    extra = 0
+    fields = [
+        "courseware_id",
+        "title",
+    ]
+    verbose_name = "Contract Course Run"
+    verbose_name_plural = "Contract Course Runs"
+
+    def has_add_permission(self, request, obj):  # noqa: ARG002
+        """Turn off add permission. These admins are supposed to be read-only."""
 
         return False
 
-    def has_delete_permission(self, request, obj=None):  # noqa: ARG002
-        """Disable deletions."""
+    def has_delete_permission(self, request, obj):  # noqa: ARG002
+        """Turn off delete permission. These admins are supposed to be read-only."""
+
+        return False
+
+    def has_change_permission(self, request, obj):  # noqa: ARG002
+        """Turn off change permission. These admins are supposed to be read-only."""
 
         return False
 
@@ -128,61 +155,6 @@ class DiscountContractAttachmentRedemptionAdmin(ReadOnlyModelAdmin):
     ]
 
 
-class ContractPageProgramInline(admin.TabularInline):
-    """Inline to display programs for contract pages."""
-
-    model = ContractProgramItem
-    extra = 0
-    verbose_name = "Contract Program"
-    verbose_name_plural = "Contract Programs"
-    fields = ["program", "sort_order"]
-    readonly_fields = ["program", "sort_order"]
-
-    def has_add_permission(self, request, obj):  # noqa: ARG002
-        """Turn off add permission. These admins are supposed to be read-only."""
-
-        return False
-
-    def has_delete_permission(self, request, obj):  # noqa: ARG002
-        """Turn off delete permission. These admins are supposed to be read-only."""
-
-        return False
-
-    def has_change_permission(self, request, obj):  # noqa: ARG002
-        """Turn off change permission. These admins are supposed to be read-only."""
-
-        return False
-
-
-class ContractPageCourseRunInline(admin.TabularInline):
-    """Inline to display course runs for contract pages."""
-
-    model = CourseRun
-    fk_name = "b2b_contract"
-    extra = 0
-    fields = [
-        "courseware_id",
-        "title",
-    ]
-    verbose_name = "Contract Course Run"
-    verbose_name_plural = "Contract Course Runs"
-
-    def has_add_permission(self, request, obj):  # noqa: ARG002
-        """Turn off add permission. These admins are supposed to be read-only."""
-
-        return False
-
-    def has_delete_permission(self, request, obj):  # noqa: ARG002
-        """Turn off delete permission. These admins are supposed to be read-only."""
-
-        return False
-
-    def has_change_permission(self, request, obj):  # noqa: ARG002
-        """Turn off change permission. These admins are supposed to be read-only."""
-
-        return False
-
-
 @admin.register(ContractPage)
 class ContractPageAdmin(ReadOnlyModelAdmin):
     """Admin for contract pages."""
@@ -193,6 +165,7 @@ class ContractPageAdmin(ReadOnlyModelAdmin):
         "title",
         "organization",
         "integration_type",
+        "max_learners",
         "contract_start",
         "contract_end",
     ]
@@ -229,6 +202,7 @@ class OrganizationPageAdmin(ReadOnlyModelAdmin):
         "name",
         "org_key",
         "sso_organization_id",
+        "contract_count",
     ]
     fields = [
         "id",
@@ -242,7 +216,18 @@ class OrganizationPageAdmin(ReadOnlyModelAdmin):
 
     inlines = [
         UserOrganizationAdminInline,
+        OrganizationContractsInline,
     ]
+
+    def contract_count(self, obj):
+        """Pull the contract count for the org."""
+
+        return obj.contract_count if hasattr(obj, "contract_count") else "-"
+
+    def get_queryset(self, request):
+        """Add an annotation so we can have contract counts."""
+
+        return super().get_queryset(request).annotate(contract_count=Count("contracts"))
 
 
 @admin.register(UserOrganization)

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -4,6 +4,7 @@ import logging
 from decimal import Decimal
 
 from django.conf import settings
+from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -213,6 +214,7 @@ class OrganizationPage(Page):
         )
 
     @property
+    @admin.display(description="Title")
     def title_linked(self):
         """Return the title with a link to the page"""
 
@@ -705,6 +707,7 @@ class ContractPage(Page, ClusterableModel):
         return (managed, no_source)
 
     @property
+    @admin.display(description="Title")
     def title_linked(self):
         """Return the title with a link to the page"""
 

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -9,7 +9,9 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.http import Http404
+from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django.utils.text import slugify
 from mitol.common.models import TimestampedModel
 from mitol.common.utils import now_in_utc
@@ -208,6 +210,22 @@ class OrganizationPage(Page):
             self._active_contracts
             if hasattr(self, "_active_contracts")
             else self.contracts.filter(active=True).all()
+        )
+
+    @property
+    def title_linked(self):
+        """Return the title with a link to the page"""
+
+        dj_change_url = reverse("admin:b2b_organizationpage_change", args=(self.id,))
+        wagtail_url = reverse(
+            "wagtailadmin_explore",
+            kwargs={
+                "parent_page_id": self.id,
+            },
+        )
+
+        return format_html(
+            f'{self.title} <a href="{dj_change_url}">Admin</a> | <a href="{wagtail_url}">Wagtail</a>'
         )
 
     class Meta:
@@ -685,6 +703,22 @@ class ContractPage(Page, ClusterableModel):
             item.save(skip_run_creation=True)
 
         return (managed, no_source)
+
+    @property
+    def title_linked(self):
+        """Return the title with a link to the page"""
+
+        dj_change_url = reverse("admin:b2b_contractpage_change", args=(self.id,))
+        wagtail_url = reverse(
+            "wagtailadmin_explore",
+            kwargs={
+                "parent_page_id": self.id,
+            },
+        )
+
+        return format_html(
+            f'{self.title} <a href="{dj_change_url}">Admin</a> | <a href="{wagtail_url}">Wagtail</a>'
+        )
 
     class Meta:
         """Meta options for the ContractPage."""

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -37,7 +37,11 @@ from courses.models import (
     RelatedProgram,
     VerifiableCredential,
 )
-from main.admin import AuditableModelAdmin, ModelAdminRunActionsForAllMixin
+from main.admin import (
+    AuditableModelAdmin,
+    DisplayOnlyAdminMixin,
+    ModelAdminRunActionsForAllMixin,
+)
 from main.utils import get_field_names
 from openedx.tasks import retry_failed_edx_enrollments
 
@@ -81,7 +85,7 @@ class CoursePossibleVariantInline(GenericTabularInline):
     extra = 0
 
 
-class CourseRunInline(admin.TabularInline):
+class CourseRunInline(DisplayOnlyAdminMixin, admin.TabularInline):
     """Inline for course runs for a given course"""
 
     model = CourseRun
@@ -89,7 +93,7 @@ class CourseRunInline(admin.TabularInline):
     fields = (
         "id",
         "title",
-        "courseware_id",
+        "title_linked",
         "run_tag",
         "language",
         "is_primary_language",
@@ -100,16 +104,20 @@ class CourseRunInline(admin.TabularInline):
         "enrollment_start",
         "upgrade_deadline",
     )
-    show_change_link = True
-
-    def has_add_permission(self, *args, **kwargs):  # noqa: ARG002
-        return False
-
-    def has_change_permission(self, *args, **kwargs):  # noqa: ARG002
-        return False
-
-    def has_delete_permission(self, *args, **kwargs):  # noqa: ARG002
-        return False
+    readonly_fields = (
+        "id",
+        "title",
+        "title_linked",
+        "run_tag",
+        "language",
+        "is_primary_language",
+        "is_source_run",
+        "b2b_contract",
+        "start_date",
+        "end_date",
+        "enrollment_start",
+        "upgrade_deadline",
+    )
 
 
 @admin.register(Program)

--- a/courses/models.py
+++ b/courses/models.py
@@ -7,6 +7,7 @@ import logging
 import uuid
 from decimal import ROUND_HALF_EVEN, Decimal
 
+from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -15,8 +16,10 @@ from django.core.validators import MaxValueValidator, MinValueValidator, RegexVa
 from django.db import models
 from django.db.models import Exists, OuterRef, Prefetch, Q
 from django.db.models.constraints import CheckConstraint, UniqueConstraint
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django.utils.text import slugify
 from django_countries.fields import CountryField
 from lru_method_cache import lru_method_cache
@@ -1384,6 +1387,15 @@ class CourseRun(TimestampedModel, VariantOptionsModel):
             "run by creation date is treated as primary."
         ),
     )
+
+    @property
+    @admin.display(description="Courseware ID")
+    def title_linked(self):
+        """Return the title with a link to the page"""
+
+        dj_change_url = reverse("admin:courses_courserun_change", args=(self.id,))
+
+        return format_html(f'{self.courseware_id} <a href="{dj_change_url}">Admin</a>')
 
     class Meta:
         unique_together = ("course", "courseware_id", "run_tag")

--- a/main/admin.py
+++ b/main/admin.py
@@ -1,5 +1,7 @@
 """Django admin functionality that is relevant to the entire app"""
 
+from collections.abc import Sequence
+
 from django.contrib import admin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 
@@ -62,3 +64,49 @@ class ModelAdminRunActionsForAllMixin:
             request._set_post(post)  # noqa: SLF001
 
         return super().changelist_view(request, extra_context)
+
+
+class DisplayOnlyAdminMixin:
+    """Admin that doesn't allow for editing."""
+
+    extra = 0
+
+    def has_add_permission(self, request, obj):  # noqa: ARG002
+        """Determine if the user can add new ones from here (no, they cannot)"""
+
+        return False
+
+    def has_change_permission(self, request, obj=None):  # noqa: ARG002
+        """Determine if the user can add new ones from here (no, they cannot)"""
+
+        return False
+
+    def has_delete_permission(self, request, obj=None):  # noqa: ARG002
+        """Determine if the user can add new ones from here (no, they cannot)"""
+
+        return False
+
+
+class ReadOnlyModelAdmin(admin.ModelAdmin):
+    """Read-only admin for models."""
+
+    fields: Sequence[str] = []
+
+    def __init__(self, *args, **kwargs):
+        """Set the readonly_fields to the fields if we can."""
+
+        self.readonly_fields = self.fields or [
+            field.name
+            for field in self.model._meta.fields  # noqa: SLF001
+        ]
+        super().__init__(*args, **kwargs)
+
+    def has_add_permission(self, request):  # noqa: ARG002
+        """Disable create."""
+
+        return False
+
+    def has_delete_permission(self, request, obj=None):  # noqa: ARG002
+        """Disable deletions."""
+
+        return False


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

This PR just contains a few things that I wanted to make using the system a bit easier:

- OrganizationPage admin list: show contract count for the org
- OrganizationPage admin change: add links to contract inline to navigate to the contract admin pages (both Django Admin and Wagtail); add more fields to the inline
- ContractPage admin: add links to course runs to link to the Django Admin page for the run; add more fields to the course run admin (run tag, variant opts)
- Course admin: add links to the course run in the admin
- General: added a mixin for read-only admin inlines (just disables add/delete/change)

Sort of generally this also introduces a `title_linked` prop that is in a handful of models; this generates a title with a link to the relevant Django Admin and/or Wagtail admin page. It's sort of model-dependent though.

### How can this be tested?

Test the admin: specifically, the Contract, Organization, and Course admins. You should see the new fields and be able to navigate between things successfully.

### Additional Context

This will probably not be the last of this sort of thing; this was a handful of things that I thought would be nice to have and were easy wins so I went ahead with it.