### PR TITLE
Exclude variant runs from course and program certificate considerations

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -931,12 +931,18 @@ def get_certificate_grade_eligible_runs(now):
     # Get all the course runs eligible for certificates generation
     # For a valid run it would be live, certificate_available_date would be in future or within a month of passing
     # the certificate_available_date.
+    # Changes for variants: if the run is a variant for anything _other_ than a
+    # language, make it ineligible for a certificate.
 
-    course_runs = CourseRun.objects.live(include_b2b=True).filter(
-        Q(certificate_available_date__isnull=True)
-        | Q(
-            certificate_available_date__gt=now
-            - timedelta(days=settings.CERTIFICATE_CREATION_WINDOW_IN_DAYS)
+    course_runs = (
+        CourseRun.objects.live(include_b2b=True)
+        .nonvariant()
+        .filter(
+            Q(certificate_available_date__isnull=True)
+            | Q(
+                certificate_available_date__gt=now
+                - timedelta(days=settings.CERTIFICATE_CREATION_WINDOW_IN_DAYS)
+            )
         )
     )
     return course_runs  # noqa: RET504
@@ -1128,11 +1134,15 @@ def _has_earned_program_cert(user, program):
               for a given program else False
     """
 
-    user_courseruns = CourseRun.objects.filter(
-        enrollments__user=user,
-        enrollments__active=True,
-        enrollments__change_status__isnull=True,
-    ).filter(course__in=program.courses_qset)
+    user_courseruns = (
+        CourseRun.objects.filter(
+            enrollments__user=user,
+            enrollments__active=True,
+            enrollments__change_status__isnull=True,
+        )
+        .nonvariant()
+        .filter(course__in=program.courses_qset)
+    )
 
     cert_courses = Course.objects.filter(
         courseruns__in=user_courseruns,

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -61,6 +61,8 @@ from courses.api import (
 )
 from courses.constants import (
     ALL_ENROLL_CHANGE_STATUSES,
+    COURSE_VARIANT_INDUSTRY,
+    COURSE_VARIANT_LENGTH,
     ENROLL_CHANGE_STATUS_DEFERRED,
     ENROLL_CHANGE_STATUS_REFUNDED,
     ENROLL_CHANGE_STATUS_UNENROLLED,
@@ -1219,6 +1221,15 @@ def test_generate_course_certificates_no_valid_course_run(settings, courses_api_
         certificate_available_date=now_in_utc()
         - timedelta(days=settings.CERTIFICATE_CREATION_WINDOW_IN_DAYS + 1),
     )
+    # Expand the batch to include variants - expecting this to fail, so variants
+    # are industry/length variants. (These would be OK for certs otherwise.)
+    CourseRunFactory.create_batch(
+        2,
+        completed=True,
+        certificate_available_date=now_in_utc(),
+        variant_industry=FAKE.random_element(COURSE_VARIANT_INDUSTRY[1:])[0],
+        variant_length=FAKE.random_element(COURSE_VARIANT_LENGTH[1:])[0],
+    )
     generate_course_run_certificates()
     assert (
         "No course runs matched the certificates generation criteria"
@@ -1305,17 +1316,27 @@ def test_course_certificates_with_course_end_date_self_paced_combination(  # noq
     )
 
 
+@pytest.mark.parametrize(
+    "is_translation",
+    [
+        True,
+        False,
+    ],
+)
 @patch("courses.signals.upsert_custom_properties")
-def test_generate_course_certificates_with_course_end_date(
+def test_generate_course_certificates_with_course_end_date(  # noqa: PLR0913
     mock_upsert_custom_properties,
     mocker,
     courses_api_logs,
     passed_grade_with_enrollment,
     settings,
+    is_translation,
 ):
     """Test that certificates are generated for passed grades when there are valid course runs for certificates"""
     course_run = passed_grade_with_enrollment.course_run
     course_run.certificate_available_date = now_in_utc()
+    course_run.language = "fr" if is_translation else "en"
+    course_run.is_primary_language = not is_translation
     course_run.save()
 
     user = passed_grade_with_enrollment.user

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -217,6 +217,32 @@ class CourseRunFactory(DjangoModelFactory):
             start_date=factory.Faker("future_datetime", tzinfo=ZoneInfo("UTC")),
             end_date=None,
         )
+        completed = factory.Trait(
+            start_date=factory.Faker(
+                "date_time_between",
+                start_date="-3m",
+                end_date="-2m",
+                tzinfo=ZoneInfo("UTC"),
+            ),
+            end_date=factory.Faker(
+                "date_time_between",
+                start_date="-1m",
+                end_date="now",
+                tzinfo=ZoneInfo("UTC"),
+            ),
+            enrollment_start=factory.Faker(
+                "date_time_between",
+                start_date="-4m",
+                end_date="-3m",
+                tzinfo=ZoneInfo("UTC"),
+            ),
+            enrollment_end=factory.Faker(
+                "date_time_between",
+                start_date="-1m",
+                end_date="-10d",
+                tzinfo=ZoneInfo("UTC"),
+            ),
+        )
 
 
 NODE_TYPES = [x[0] for x in ProgramRequirementNodeType.choices]

--- a/courses/factories_test.py
+++ b/courses/factories_test.py
@@ -1,0 +1,17 @@
+"""Test for factories."""
+
+import pytest
+
+from courses.factories import CourseRunFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_courserun_completed_trait():
+    """Test that the completed trait on CourseRunFactory generates dates properly."""
+
+    for run in CourseRunFactory.create_batch(10, completed=True):
+        assert run.start_date <= run.end_date
+        assert run.enrollment_start <= run.enrollment_end
+        assert run.enrollment_end <= run.end_date
+        assert run.enrollment_start <= run.start_date

--- a/courses/models.py
+++ b/courses/models.py
@@ -179,6 +179,10 @@ class CourseRunQuerySet(models.QuerySet):  # pylint: disable=missing-docstring
         """Filter for source runs"""
         return self.filter(Q(is_source_run=True) | Q(run_tag="SOURCE"))
 
+    def nonvariant(self):
+        """Filter for non-variant - languages OK, industry/length not OK"""
+        return self.filter(variant_industry="", variant_length="")
+
 
 class UsableCourseRunManager(models.Manager):
     """Simple manager to filter out source runs."""

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -1664,3 +1664,18 @@ def test_run_language_constraints_regular_languages(set_language_field, set_prim
             ).count()
             == 4
         )
+
+
+def test_nonvariant_filter():
+    """Test that the nonvariant filter in CourseRunQuerySet works as expected."""
+
+    cr1 = CourseRunFactory.create()
+    CourseRunFactory.create(course=cr1.course, variant_industry="HC")
+    CourseRunFactory.create(course=cr1.course, variant_length="S")
+    CourseRunFactory.create(course=cr1.course, language="fr")
+    CourseRunFactory.create(course=cr1.course, language="pt", variant_industry="HC")
+
+    assert CourseRun.objects.filter(course=cr1.course).count() == 5
+    assert CourseRun.objects.filter(course=cr1.course).nonvariant().count() == 2
+    assert CourseRun.all_objects.filter(course=cr1.course).count() == 5
+    assert CourseRun.all_objects.filter(course=cr1.course).nonvariant().count() == 2


### PR DESCRIPTION

### What are the relevant tickets?

Closes mitodl/hq#11586

### Description (What does it do?)

Excludes variant course runs from certificate considerations. This means runs that have either industry or length options set - languages are OK.

### How can this be tested?

For these tests: Make sure the program and the runs that you create are set up so that they're otherwise OK for certificates - they need the `verified` enrollment mode, appropriate start/end dates (or self-paced flag set), and a certificate available date in the past. The program and run enrollments should be verified mode as well.

Make sure everything has product pages and certificates available in Wagtail too. It won't make certificates if there's no certificate to assign.

_Course run cert generation_

Course run generation is relatively easy to test; it pulls a list of eligible runs and you can just evaluate that. Create:

- Course
   - Regular run
   - Translated run
   - Variant run - `variant_length` and/or `variant_industry` set

Test course run eligibility by dropping into a Django shell and running `courses.api.get_certificate_grade_eligible_runs`. You should see the regular and the translated run in the list but not the variant run.

If you want to test certificate generation, you will need to ensure your runs have corresponding runs in edX, and that you have users that are enrolled and have passing grades. (Or, you should also be able to create the grades in mitxonline with the `set_by_admin` flag set.) Then, you should be able to trigger certificate generation using `manage_certificates` or triggering the task directly. (Note that using the override options _also_ disables the certificate eligibility checks too.)

_Program cert generation_

The best data structure for this is:

- Program
   - Required Course
      - Regular Run w/ verified enrollment
   - Required Course
      - Regular Run w/ audit enrollment
- Program
   - Required Course
      - Translated Run w/ verified enrollment
   - Required Course
      - Translated Run w/ audit enrollment
- Program
   - Required Course
      - Variant Run w/ verified enrollment
   - Required Course
      - Variant Run w/ audit enrollment

You'll need enrollments and grades in all of these runs and matching data in edX, and a verified enrollment in the program(s). Then, trigger program certificate generation. The variant runs shouldn't get a certificate and the program they're in shouldn't generate one either, assuming the above buildout.

### Additional Context

This uses a `nonvariant` filter that was added to the `CourseRunQuerySet` - if we need to adjust the logic, we should be able to fairly easily.

I did not add the "certificate eligible" flag as I had suggested; at least for now it seems like the variants that we have (other than language) are generally more "stripped down" versions of the content so it didn't seem particularly useful. This can be revisited later. 