### PR TITLE
Change filtering behavior for b2b manager org endpoint

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -45,26 +45,25 @@ class ManagerOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         """Filter to organizations where the user is a manager."""
 
-        org_qset = OrganizationPage.objects.prefetch_related(
-            Prefetch(
-                "contracts",
-                queryset=ContractPage.objects.prefetch_related(
-                    Prefetch(
-                        "contract_programs",
-                        queryset=ContractProgramItem.objects.order_by("sort_order"),
-                        to_attr="contract_program_ids",
-                    )
-                ).filter(active=True),
-                to_attr="_active_contracts",
-            ),
-        )
         return (
-            org_qset.distinct()
-            if self.request.user and self.request.user.is_superuser
-            else org_qset.filter(
+            OrganizationPage.objects.prefetch_related(
+                Prefetch(
+                    "contracts",
+                    queryset=ContractPage.objects.prefetch_related(
+                        Prefetch(
+                            "contract_programs",
+                            queryset=ContractProgramItem.objects.order_by("sort_order"),
+                            to_attr="contract_program_ids",
+                        )
+                    ).filter(active=True),
+                    to_attr="_active_contracts",
+                ),
+            )
+            .filter(
                 organization_users__user=self.request.user,
                 organization_users__is_manager=True,
-            ).distinct()
+            )
+            .distinct()
         )
 
     @extend_schema(


### PR DESCRIPTION
### Description (What does it do?)
Superusers currently get an unfiltered list of orgs back, which resulted in [some confusion](https://mitodl.slack.com/archives/C03K5HYGPT9/p1781187704270539?thread_ts=1781127311.093989&cid=C03K5HYGPT9). This changes that behavior so that they only get organizations that they're actually managers for, letting us check it to conditionalize display elements on the response.

### How can this be tested?
- Set up a superuser as a manager of a b2b organization.
- Observe that `/api/v0/b2b/manager/organizations/` endpoint returns that b2b organization
- In admin, change the corresponding `UserOrganization` record so that the user is no longer a manager of the org.
- Observe that `/api/v0/b2b/manager/organizations/` endpoint no longer returns that b2b organization
