### PR TITLE
Fix rogue serializer call that isn't prefetching

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -21,6 +21,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import slugify
+from mitol.common.serializers import THIS_IS_NOT_AN_API
 from mitol.common.utils.datetime import now_in_utc
 from mitol.olposthog.features import is_enabled
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
@@ -1544,7 +1545,10 @@ class CoursePage(ProductPage):
     def course_details(self):
         from courses.serializers.v2.courses import CourseSerializer  # noqa: PLC0415
 
-        return CourseSerializer(self.course).data
+        # Note: this IS an API, but it's untested so hacking this in for now
+        return CourseSerializer(
+            self.course, context={"skip_prefetch_checks": THIS_IS_NOT_AN_API}
+        ).data
 
 
 class ProgramPage(ProductPage):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This sets the flag that skips the prefetch checks for the CMS APIs.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
TBD