### PR TITLE
Reassign endpoint, without fully deleting row

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -698,7 +698,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             )
 
         assignment_record.assigned_email = email
-        assignment_record.name = name
+        assignment_record.assigned_name = name
         assignment_record.assigned_by = request.user
         assignment_record.last_reminder_sent_on = now_in_utc()
         assignment_record.save()

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -421,6 +421,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         responses={
             200: ManagerEnrollmentCodeSerializer,
             404: DetailErrorSerializer,
+            409: DetailErrorSerializer,
         },
         parameters=[
             OpenApiParameter(
@@ -635,5 +636,76 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 ).data,
                 "errors": errors,
             },
+            status=http_status.HTTP_200_OK,
+        )
+
+    @extend_schema(
+        description="Reassign the assignment for a specific enrollment code",
+        request=AssignRevokeCodeRequestSerializer,
+        responses={
+            200: ManagerEnrollmentCodeSerializer,
+            400: DetailErrorSerializer,
+            404: DetailErrorSerializer,
+        },
+        parameters=[
+            OpenApiParameter(
+                name="code",
+                type=str,
+                location=OpenApiParameter.PATH,
+                description="The discount code to reassign.",
+                required=True,
+            ),
+        ],
+    )
+    @action(
+        detail=True,
+        methods=["put"],
+        url_path="codes/(?P<code>[^/.]+)/reassign",
+    )
+    def reassign_code(self, request, **kwargs):
+        """
+        Reassign specific enrollment code to a new email address.
+
+        PUT /api/v0/b2b/orgs/{org_id}/manager/contracts/{contract_id}/codes/{code}/reassign/
+
+        Removes the DiscountContractAttachmentRedemption record for the specified code and reassigns it to a new email address.
+        """
+
+        contract = self.get_object()
+        code = kwargs.get("code")
+        serializer = AssignRevokeCodeRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"detail": "Invalid request data."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        email = serializer.validated_data["email"]
+        name = serializer.validated_data.get("name", "")
+
+        discount = contract.get_discounts().filter(discount_code=code).first()
+        if not discount:
+            return Response(
+                {"detail": "Code not found for this contract."},
+                status=http_status.HTTP_404_NOT_FOUND,
+            )
+        assignment_record = discount.contract_redemptions.first()
+        if not assignment_record:
+            # May not be worth throwing out this error - we could just create the record and move on with our lives
+            return Response(
+                {"detail": "No assignment exists for this code."},
+                status=http_status.HTTP_404_NOT_FOUND,
+            )
+
+        assignment_record.assigned_email = email
+        assignment_record.name = name
+        assignment_record.assigned_by = request.user
+        assignment_record.last_reminder_sent_on = now_in_utc()
+        assignment_record.save()
+        queue_send_enrollment_code_assignment_email.delay([assignment_record.id])
+        discount.prefetched_redemptions = [assignment_record]
+
+        return Response(
+            ManagerEnrollmentCodeSerializer(discount).data,
             status=http_status.HTTP_200_OK,
         )

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -646,6 +646,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             200: ManagerEnrollmentCodeSerializer,
             400: DetailErrorSerializer,
             404: DetailErrorSerializer,
+            409: DetailErrorSerializer,
         },
         parameters=[
             OpenApiParameter(
@@ -695,6 +696,11 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             return Response(
                 {"detail": "No assignment exists for this code."},
                 status=http_status.HTTP_404_NOT_FOUND,
+            )
+        if assignment_record.user or assignment_record.redeemed_on:
+            return Response(
+                {"detail": "Cannot reassign a code that has already been redeemed."},
+                status=http_status.HTTP_409_CONFLICT,
             )
 
         assignment_record.assigned_email = email

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -1375,6 +1375,36 @@ def test_reassign_code_no_assignment(org_setup, manager_drf_client):
     assert "detail" in resp.json()
 
 
+def test_reassign_code_already_redeemed(org_setup, manager_drf_client):
+    """reassign_code returns 409 when the code has already been redeemed by a user."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    redeemer = UserFactory.create()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email="assignee@example.com",
+        user=redeemer,
+    )
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.put(
+        reassign_url, data={"email": "new@example.com"}, format="json"
+    )
+
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert "detail" in resp.json()
+
+
 def test_reassign_code_forbidden(org_setup, manager_drf_client):
     """A manager cannot reassign codes for a contract belonging to an org they don't manage."""
     _, _, *_, (contract_3, *_) = org_setup

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -1192,3 +1192,211 @@ def test_bulk_assign_internal_error(org_setup, manager_drf_client, mocker):
 
     assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert "detail" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# reassign_code tests
+# ---------------------------------------------------------------------------
+
+
+def test_reassign_code(org_setup, manager_drf_client, mocker):
+    """A manager can reassign an assigned code to a new email address."""
+    mock_task = mocker.patch(
+        "b2b.views.v0.manager.queue_send_enrollment_code_assignment_email"
+    )
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    redemption = DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email="original@example.com",
+        assigned_name="Original Name",
+    )
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.put(
+        reassign_url,
+        data={"email": "new@example.com", "name": "New Name"},
+        format="json",
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+
+    redemption.refresh_from_db()
+    assert redemption.assigned_email == "new@example.com"
+    mock_task.delay.assert_called_once_with([redemption.id])
+
+    resp_data = resp.json()
+    assert resp_data["code"] == discount.discount_code
+    assert resp_data["redemption_status"] == REDEMPTION_STATUS_ASSIGNED
+    assert resp_data["assigned_to"] == "new@example.com"
+
+
+def test_reassign_code_updates_assigned_by(org_setup, manager_drf_client, mocker):
+    """reassign_code stamps the requesting manager as assigned_by."""
+    mocker.patch("b2b.views.v0.manager.queue_send_enrollment_code_assignment_email")
+    manager_user, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    redemption = DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email="original@example.com",
+    )
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    manager_drf_client.put(
+        reassign_url,
+        data={"email": "new@example.com"},
+        format="json",
+    )
+
+    redemption.refresh_from_db()
+    assert redemption.assigned_by == manager_user
+
+
+def test_reassign_code_name_defaults_to_empty(org_setup, manager_drf_client, mocker):
+    """Reassigning a code without a name stores an empty string for assigned_name."""
+    mocker.patch("b2b.views.v0.manager.queue_send_enrollment_code_assignment_email")
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email="original@example.com",
+        assigned_name="Old Name",
+    )
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.put(
+        reassign_url,
+        data={"email": "new@example.com"},
+        format="json",
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["assigned_name"] == ""
+
+
+def test_reassign_code_invalid_request(org_setup, manager_drf_client):
+    """reassign_code returns 400 when the request body is missing the required email field."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email="original@example.com",
+    )
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.put(
+        reassign_url, data={"name": "No Email"}, format="json"
+    )
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_reassign_code_not_found(org_setup, manager_drf_client):
+    """reassign_code returns 404 when the code does not belong to the contract."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": "nonexistent-code",
+        },
+    )
+
+    resp = manager_drf_client.put(
+        reassign_url, data={"email": "new@example.com"}, format="json"
+    )
+
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert "detail" in resp.json()
+
+
+def test_reassign_code_no_assignment(org_setup, manager_drf_client):
+    """reassign_code returns 404 when no assignment exists for the code."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.put(
+        reassign_url, data={"email": "new@example.com"}, format="json"
+    )
+
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert "detail" in resp.json()
+
+
+def test_reassign_code_forbidden(org_setup, manager_drf_client):
+    """A manager cannot reassign codes for a contract belonging to an org they don't manage."""
+    _, _, *_, (contract_3, *_) = org_setup
+
+    discount = contract_3.get_discounts().order_by("id").first()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_3,
+        assigned_email="original@example.com",
+    )
+
+    reassign_url = reverse(
+        "b2b:b2b-manager-org-contract-reassign-code",
+        kwargs={
+            "parent_lookup_organization": contract_3.organization.id,
+            "pk": contract_3.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.put(
+        reassign_url, data={"email": "new@example.com"}, format="json"
+    )
+
+    assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -457,6 +457,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/:
     post:
       operationId: b2b_manager_organizations_contracts_codes_remind_create

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -401,6 +401,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+  /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/reassign/:
+    put:
+      operationId: b2b_manager_organizations_contracts_codes_reassign_update
+      description: Reassign the assignment for a specific enrollment code
+      parameters:
+      - in: path
+        name: code
+        schema:
+          type: string
+        description: The discount code to reassign.
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: ID of the contract
+        required: true
+      - in: path
+        name: parent_lookup_organization
+        schema:
+          type: integer
+        description: ID of the parent organization
+        required: true
+      tags:
+      - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagerEnrollmentCode'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/:
     post:
       operationId: b2b_manager_organizations_contracts_codes_remind_create
@@ -474,6 +530,12 @@ paths:
                 $ref: '#/components/schemas/ManagerEnrollmentCode'
           description: ''
         '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
+        '409':
           content:
             application/json:
               schema:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -457,6 +457,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/:
     post:
       operationId: b2b_manager_organizations_contracts_codes_remind_create

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -401,6 +401,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+  /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/reassign/:
+    put:
+      operationId: b2b_manager_organizations_contracts_codes_reassign_update
+      description: Reassign the assignment for a specific enrollment code
+      parameters:
+      - in: path
+        name: code
+        schema:
+          type: string
+        description: The discount code to reassign.
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: ID of the contract
+        required: true
+      - in: path
+        name: parent_lookup_organization
+        schema:
+          type: integer
+        description: ID of the parent organization
+        required: true
+      tags:
+      - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagerEnrollmentCode'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/:
     post:
       operationId: b2b_manager_organizations_contracts_codes_remind_create
@@ -474,6 +530,12 @@ paths:
                 $ref: '#/components/schemas/ManagerEnrollmentCode'
           description: ''
         '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
+        '409':
           content:
             application/json:
               schema:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -457,6 +457,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/:
     post:
       operationId: b2b_manager_organizations_contracts_codes_remind_create

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -401,6 +401,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+  /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/reassign/:
+    put:
+      operationId: b2b_manager_organizations_contracts_codes_reassign_update
+      description: Reassign the assignment for a specific enrollment code
+      parameters:
+      - in: path
+        name: code
+        schema:
+          type: string
+        description: The discount code to reassign.
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: ID of the contract
+        required: true
+      - in: path
+        name: parent_lookup_organization
+        schema:
+          type: integer
+        description: ID of the parent organization
+        required: true
+      tags:
+      - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssignRevokeCodeRequestRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagerEnrollmentCode'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/:
     post:
       operationId: b2b_manager_organizations_contracts_codes_remind_create
@@ -474,6 +530,12 @@ paths:
                 $ref: '#/components/schemas/ManagerEnrollmentCode'
           description: ''
         '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
+        '409':
           content:
             application/json:
               schema:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11375

### Description (What does it do?)
Adds a reassign endpoint, which is functionally similar to an atomic revoke + assign. 

I put together a more extensive PR [here](https://github.com/mitodl/mitxonline/pull/3674) which implemented this by fully deleting the row and recreating it, which necessitated a larger refactor. This is a slightly thinner attempt which works by swapping out individual values on the row. 

The only practical difference here is that the created_on timestamp will reflect the old values instead of the time of reassignment. It's probably up for debate as to whether or not we'd like to overwrite that as well, but it can be overwritten with this approach if needed.

### How can this be tested?

#### Manual Testing
- With a b2b contract set up, assign at least one code to yourself via /assign. You can get the list of codes by visiting `http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/codes/`, and it's easiest to assign the codes using the [swagger UI for /assign](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_assign_create)
- Once executed, you should see at /codes that reflects that the code you assigned has values for `assigned_email`, `assigned_name`, `assigned_by` and `last_sent`. It should also have a `redemption_status` of `assigned`.
- Using the swagger UI for [the new reassign endpoint](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_reassign_update), attempt to reassign the code you've selected.
- The response should reflect the updated email, name, and last_sent values you specified. If you have mailpit set up, you should've received an email invitation with the values specified.

API tests should also continue to pass.