### PR TITLE
Add the prefetch to the CMS course_detail object

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -21,7 +21,6 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import slugify
-from mitol.common.serializers import THIS_IS_NOT_AN_API
 from mitol.common.utils.datetime import now_in_utc
 from mitol.olposthog.features import is_enabled
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
@@ -1545,10 +1544,13 @@ class CoursePage(ProductPage):
     def course_details(self):
         from courses.serializers.v2.courses import CourseSerializer  # noqa: PLC0415
 
-        # Note: this IS an API, but it's untested so hacking this in for now
-        return CourseSerializer(
-            self.course, context={"skip_prefetch_checks": THIS_IS_NOT_AN_API}
-        ).data
+        # check on course_id so we don't fetch
+        if self.course_id is None:
+            return None
+
+        course = Course.objects.prefetch("programs").get(id=self.course_id)
+
+        return CourseSerializer(course).data
 
 
 class ProgramPage(ProductPage):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This is a follow up to https://github.com/mitodl/mitxonline/pull/3669 that adds in the correct prefetch and removes the temporary hack. Note: there is still technically an N+1 here if you're logged in and fetch course pages via the list API - but that is a lot messier to fix becuse of how wagtail pages are polymorphic. The long-term fix is to provide page-type specific endpoints so that the wagtail API view types the queryset to the actual course page model instead of the generic `Page` type and we can then do prefetches on that API.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass and you should be able to hit http://mitxonline.odl.local/api/v2/pages/?type=cms.coursepage&fields=* and it not error and have `course_details` populated.
