### PR TITLE
Change UUID if revoking or reassigning code

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -1,6 +1,7 @@
 """B2B manager dashboard views."""
 
 import logging
+import uuid
 from dataclasses import dataclass
 
 from django.contrib.contenttypes.models import ContentType
@@ -472,6 +473,8 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 status=http_status.HTTP_409_CONFLICT,
             )
         assignment_record.delete()
+        discount.discount_code = str(uuid.uuid4())
+        discount.save()
 
         return Response(
             ManagerEnrollmentCodeSerializer(discount).data,
@@ -702,7 +705,8 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 {"detail": "Cannot reassign a code that has already been redeemed."},
                 status=http_status.HTTP_409_CONFLICT,
             )
-
+        discount.discount_code = str(uuid.uuid4())
+        discount.save()
         assignment_record.assigned_email = email
         assignment_record.assigned_name = name
         assignment_record.assigned_by = request.user

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -719,6 +719,7 @@ def test_revoke_code(org_setup, manager_drf_client):
     _, _, (contract_1, *_), *_ = org_setup
 
     discount = contract_1.get_discounts().order_by("id").first()
+    original_code = discount.discount_code
     DiscountContractAttachmentRedemption.objects.create(
         discount=discount,
         contract=contract_1,
@@ -743,7 +744,7 @@ def test_revoke_code(org_setup, manager_drf_client):
     ).exists()
 
     resp_data = resp.json()
-    assert resp_data["code"] == discount.discount_code
+    assert resp_data["code"] != original_code
     assert resp_data["redemption_status"] == REDEMPTION_STATUS_UNASSIGNED
 
 
@@ -1207,6 +1208,7 @@ def test_reassign_code(org_setup, manager_drf_client, mocker):
     _, _, (contract_1, *_), *_ = org_setup
 
     discount = contract_1.get_discounts().order_by("id").first()
+    original_code = discount.discount_code
     redemption = DiscountContractAttachmentRedemption.objects.create(
         discount=discount,
         contract=contract_1,
@@ -1236,7 +1238,7 @@ def test_reassign_code(org_setup, manager_drf_client, mocker):
     mock_task.delay.assert_called_once_with([redemption.id])
 
     resp_data = resp.json()
-    assert resp_data["code"] == discount.discount_code
+    assert resp_data["code"] != original_code
     assert resp_data["redemption_status"] == REDEMPTION_STATUS_ASSIGNED
     assert resp_data["assigned_to"] == "new@example.com"
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11375

### Description (What does it do?)
After some discussion w/ James/Linda/Peter/Bon, it sounds like the revoke behavior we agree upon is to swap the code out when revoking/reassigning an assigned but unredeemed code. This PR just implements that.

There will probably be subsequent work to iron out what other use cases need to be implemented, but it sounds like that needs a bit more investigation and thought before we're ready to write code.

### How can this be tested?

#### Reassign:
- With a b2b contract set up, assign at least one code to yourself via /assign. You can get the list of codes by visiting http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/codes/, and it's easiest to assign the codes using the [swagger UI for /assign](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_assign_create)
- Once executed, you should see at /codes that reflects that the code you assigned has values for assigned_email, assigned_name, assigned_by and last_sent. It should also have a redemption_status of assigned. Note the uuid.
- Using the swagger UI for [the reassign endpoint](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_reassign_update), attempt to reassign the code you've selected.
- The response should reflect the updated email, name, and last_sent values you specified. If you have mailpit set up, you should've received an email invitation with the values specified. You should also see that the UUID has changed



#### Revoke:
- With a b2b contract set up, assign at least one code to yourself via /assign. You can get the list of codes by visiting http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/codes/, and it's easiest to assign the codes using the [swagger UI for /assign](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_assign_create)
- Once executed, you should see at /codes that reflects that the code you assigned has values for assigned_email, assigned_name, assigned_by and last_sent. It should also have a redemption_status of assigned. Note the uuid.
- Using the swagger UI for [the revoke endpoint](https://rc.mitxonline.mit.edu/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_revoke_destroy), attempt to revoke the code you've selected.
- The response should reflect that there is no longer an assigned name or email. You should also see that the UUID has changed