### PR TITLE
Use CSRFExemptSessionAuthentication for ManagerContractViewSet

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -100,9 +100,6 @@ class ManagerOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
 
     permission_classes = [IsAuthenticated]
     serializer_class = OrganizationPageSerializer
-    authentication_classes = [
-        CsrfExemptSessionAuthentication,
-    ]
 
     def get_queryset(self):
         """Filter to organizations where the user is a manager."""
@@ -178,6 +175,9 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """List an organization's contracts."""
 
     permission_classes = [IsAuthenticated, IsOrganizationManager]
+    authentication_classes = [
+        CsrfExemptSessionAuthentication,
+    ]
 
     def get_queryset(self):
         """Get the queryset; add some annotations/etc for computed fields"""

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -43,6 +43,7 @@ from b2b.serializers.v0.manager import (
 from b2b.tasks import queue_send_enrollment_code_assignment_email
 from courses.models import CourseRun, CourseRunEnrollment
 from ecommerce.models import Discount
+from main.authentication import CsrfExemptSessionAuthentication
 
 log = logging.getLogger(__name__)
 
@@ -99,6 +100,9 @@ class ManagerOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
 
     permission_classes = [IsAuthenticated]
     serializer_class = OrganizationPageSerializer
+    authentication_classes = [
+        CsrfExemptSessionAuthentication,
+    ]
 
     def get_queryset(self):
         """Filter to organizations where the user is a manager."""


### PR DESCRIPTION
### Description (What does it do?)
Danielle found that most of the mutative endpoints fail w/ CSRF errors (we didn't catch it because /codes is a GET which doesn't enforce CSRF checks, and my testing has been through the DRF and Swagger endpoints, which handle CSRF tokens correctly)

This takes a page from the `attach` endpoint and uses the same authenticator to skip the check for CSRF. It still enforces that you're an authenticated manager.


### How can this be tested?
It's a bit of a pain because you still need to be authenticated as a manager, but the easiest way is going to be by testing the `/remind` endpoint and modifying a request from within the browser.
- Ensure you have a b2b contract w/ at least one assigned code
- Login as a manager for the contract. Open your network tab
- For that assigned code go to `http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_remind_create` and execute the request. This should return a 200.
- Modify the request to drop the `X-CSRFTOKEN` header and resend. The specifics of this step will vary browser to browser. You should observe that the request continues to succeed.

If those steps are taken on a branch without this change, the second request will result in a 403.


### Additional Info
- Chris' comment [here](https://github.com/mitodl/mitxonline/pull/3684#issuecomment-4735838488) suggests that we really ought to be enforcing CSRF. If that's the case, this PR is definitely not the right way to go, and I'll circle back with Danielle to try and figure out what the intended behavior ought to be and we'll chuck this code!