### PR TITLE
Add check for redeemed code or assignments without assigned email and indicate errors if either case is detected in remind endpoint

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -57,6 +57,12 @@ class CodeAssignment:
     code: str
 
 
+def is_redeemed_attachment_record(
+    assignment_record: DiscountContractAttachmentRedemption,
+) -> bool:
+    return assignment_record.user or assignment_record.redeemed_on
+
+
 def assign_codes_and_send_emails(
     assignments: list[CodeAssignment], assigning_user
 ) -> bool:
@@ -467,7 +473,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 status=http_status.HTTP_404_NOT_FOUND,
             )
 
-        if assignment_record.user or assignment_record.redeemed_on:
+        if is_redeemed_attachment_record(assignment_record):
             return Response(
                 {"detail": "Cannot revoke a code that has already been redeemed."},
                 status=http_status.HTTP_409_CONFLICT,
@@ -487,6 +493,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         responses={
             200: ManagerEnrollmentCodeSerializer,
             404: DetailErrorSerializer,
+            409: DetailErrorSerializer,
         },
         parameters=[
             OpenApiParameter(
@@ -524,6 +531,22 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             return Response(
                 {"detail": "Assignment for email does not exist"},
                 status=http_status.HTTP_404_NOT_FOUND,
+            )
+
+        if is_redeemed_attachment_record(assignment_record):
+            return Response(
+                {
+                    "detail": "Cannot send a reminder email to an already claimed assignment."
+                },
+                status=http_status.HTTP_409_CONFLICT,
+            )
+
+        if not assignment_record.assigned_email:
+            return Response(
+                {
+                    "detail": "Cannot send a reminder email for an assignment with no assigned email."
+                },
+                status=http_status.HTTP_409_CONFLICT,
             )
 
         # Just send the email reminder and update the last sent timestamp
@@ -700,7 +723,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 {"detail": "No assignment exists for this code."},
                 status=http_status.HTTP_404_NOT_FOUND,
             )
-        if assignment_record.user or assignment_record.redeemed_on:
+        if is_redeemed_attachment_record(assignment_record):
             return Response(
                 {"detail": "Cannot reassign a code that has already been redeemed."},
                 status=http_status.HTTP_409_CONFLICT,

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -3,6 +3,7 @@
 import pytest
 import reversion
 from django.urls import reverse
+from mitol.common.utils.datetime import now_in_utc
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -937,6 +938,88 @@ def test_send_reminder_forbidden(org_setup, manager_drf_client):
     )
 
     assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_send_reminder_already_redeemed(org_setup, manager_drf_client):
+    """send_reminder returns 409 when the assignment has already been redeemed."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    user = UserFactory.create()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email=user.email,
+        user=user,
+    )
+
+    remind_url = reverse(
+        "b2b:b2b-manager-org-contract-send-reminder-for-code-assignment",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.post(remind_url, format="json")
+
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert "already claimed" in resp.json()["detail"]
+
+
+def test_send_reminder_redeemed_on_set(org_setup, manager_drf_client):
+    """send_reminder returns 409 when redeemed_on is set even without a linked user."""
+
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email="assignee@example.com",
+        redeemed_on=now_in_utc(),
+    )
+
+    remind_url = reverse(
+        "b2b:b2b-manager-org-contract-send-reminder-for-code-assignment",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.post(remind_url, format="json")
+
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert "already claimed" in resp.json()["detail"]
+
+
+def test_send_reminder_no_assigned_email(org_setup, manager_drf_client):
+    """send_reminder returns 409 when the assignment record has no assigned email."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discount = contract_1.get_discounts().order_by("id").first()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract_1,
+        assigned_email="",
+    )
+
+    remind_url = reverse(
+        "b2b:b2b-manager-org-contract-send-reminder-for-code-assignment",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+            "code": discount.discount_code,
+        },
+    )
+
+    resp = manager_drf_client.post(remind_url, format="json")
+
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert "no assigned email" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -502,6 +502,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/revoke/:
     delete:
       operationId: b2b_manager_organizations_contracts_codes_revoke_destroy

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -502,6 +502,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/revoke/:
     delete:
       operationId: b2b_manager_organizations_contracts_codes_revoke_destroy

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -502,6 +502,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/revoke/:
     delete:
       operationId: b2b_manager_organizations_contracts_codes_revoke_destroy


### PR DESCRIPTION
### Description (What does it do?)
Danielle and I realized we had a gap in what we should prevent in the /remind endpoint. This implements the following two checks:
- We didn't check for codes which were redeemed. The result is that you could send reminder emails to folks with codes that have already been used. Obviously pointless, so attempting to do so now results in a 409.
- We didn't check for assignments which don't have assigned_to emails. This is a bit of belt and suspenders as the only case where these records shouldn't have an assigned_to value is if they were directly redeemed without preassignment (in which case they'd now get caught by the previous check) but it is cheap to add and understand.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

API requests will be easiest to verify with the [Swagger UI](http://mitxonline.odl.local:9080/api/schema/swagger-ui/)

#### Redeemed code guard:
- With a b2b contract set up, redeem at least one code by visiting `/api/v0/b2b/attach/{enrollment_code}/` with an unredeemed code.
- Attempt to hit `/api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/` with the code you just redeemed. You should get a 409 with an error informing you that you cannot send a reminder to an already claimed assignment.

#### No email guard:
- With a b2b contract set up, assign at least one code by visiting `/api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/assign/` with an unredeemed code.
- In the database, update the resulting `DiscountContractAttachmentRedemption` record and set `assigned_email` to an empty string.
- Attempt to hit `/api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/{code}/remind/` with the code you just redeemed. You should get a 409 with an error informing you that you cannot send a reminder to an assignment without an email.
