### PR TITLE
Update b2b_codes to work better with assignments; minor QoL fixes

### DIFF
--- a/b2b/admin.py
+++ b/b2b/admin.py
@@ -3,6 +3,7 @@
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.db.models import Count
+from django.utils.html import format_html
 
 from b2b.models import (
     ContractPage,
@@ -124,10 +125,19 @@ class ContractPageCourseRunInline(DisplayOnlyAdminMixin, admin.TabularInline):
 
 
 @admin.register(DiscountContractAttachmentRedemption)
-class DiscountContractAttachmentRedemptionAdmin(ReadOnlyModelAdmin):
+class DiscountContractAttachmentRedemptionAdmin(admin.ModelAdmin):
     """Admin for discount attachments."""
 
-    list_display = ["user", "contract", "discount", "created_on"]
+    list_display = [
+        "discount_code",
+        "status",
+        "user",
+        "assignee",
+        "contract",
+        "created_on",
+        "redeemed_on",
+        "last_reminder_sent_on",
+    ]
     list_filter = [
         (
             "user",
@@ -141,16 +151,66 @@ class DiscountContractAttachmentRedemptionAdmin(ReadOnlyModelAdmin):
             "user__user_organizations__organization",
             admin.RelatedOnlyFieldListFilter,
         ),
+        "assigned_email",
+        "assigned_name",
     ]
     date_hierarchy = "created_on"
-    fields = ["user", "contract", "discount", "created_on"]
-    readonly_fields = ["user", "contract", "discount", "created_on"]
+    fields = [
+        "user",
+        "assigned_name",
+        "assigned_email",
+        "assigned_by",
+        "contract",
+        "discount",
+        "created_on",
+        "redeemed_on",
+        "last_reminder_sent_on",
+    ]
+    readonly_fields = [
+        "user",
+        "contract",
+        "discount",
+        "assigned_by",
+        "created_on",
+        "redeemed_on",
+        "last_reminder_sent_on",
+    ]
     search_fields = [
         "user__email",
         "user__global_id",
         "contract__slug",
         "discount__discount_code",
+        "assigned_email",
+        "assigned_name",
     ]
+
+    @admin.display(description="Discount Code")
+    def discount_code(self, instance):
+        """Return the discount code"""
+
+        return instance.discount.discount_code
+
+    def status(self, instance):
+        """Return the current state of the instance."""
+
+        if not instance.user and not instance.assigned_email:
+            return "-"
+
+        states = []
+
+        if instance.user:
+            states.append("Redeemed")
+        if instance.assigned_email:
+            states.append("Assigned")
+
+        return format_html("<br />".join(states))
+
+    @admin.display(description="Assignee")
+    def assignee(self, instance):
+        """Return the assignee information, if available."""
+
+        namestr = f"<br />{instance.assigned_name}" if instance.assigned_name else ""
+        return format_html(f"{instance.assigned_email}{namestr}")
 
 
 @admin.register(ContractPage)

--- a/b2b/management/commands/b2b_codes.py
+++ b/b2b/management/commands/b2b_codes.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import BaseCommand, CommandError
-from django.db.models import Count, Q
+from django.db import transaction
+from django.db.models import Count, Prefetch, Q
 from rich.console import Console
 from rich.table import Table
 
@@ -164,6 +165,7 @@ class Command(BaseCommand):
             "Seat Limit": str(contract.max_learners)
             if contract.max_learners
             else "Unlim",
+            "Assignments": str(contract.get_assignments().count()),
             "Attachments": str(contract.get_learners().count()),
             "Run Count": str(contract.get_course_runs().count()),
             "Enrollments": str(contract.get_enrollments().count()),
@@ -203,17 +205,25 @@ class Command(BaseCommand):
         contract_products = contract.get_products()
 
         for discount in discounts:
+            assignment = getattr(discount, "contract_assignments", [])
+            assignment = assignment[0] if len(assignment) > 0 else None
+
             code = {
                 "Contract": str(contract),
                 "Course Run": "",
                 "Enrollment Code": discount.discount_code,
+                "Assigned To": f"{assignment.assigned_name} <{assignment.assigned_email}>"
+                if assignment
+                else "",
                 "Attach Redemption": "",
                 "Enroll Redemption": "",
                 "Attach Link": f"{settings.MIT_LEARN_ATTACH_URL}{discount.discount_code}/",
             }
 
             if include_redemption_info:
-                attach_qs = discount.contract_redemptions.filter(contract=contract)
+                attach_qs = discount.contract_redemptions.filter(
+                    contract=contract, user__isnull=False
+                )
                 if attach_qs.count():
                     code["Attach Redemption"] = ",".join(
                         [dcr.user.email for dcr in attach_qs.all()]
@@ -253,6 +263,34 @@ class Command(BaseCommand):
 
             return
 
+        if kwargs.pop("assignments", False):
+            # Display just assignments, in a manner similar to --usage.
+
+            code_assignments = []
+
+            for contract in contracts:
+                code_assignments.extend(
+                    [
+                        {
+                            "Contract": str(contract),
+                            "Code": str(dcar.discount.discount_code),
+                            "Assigned To": str(dcar.assigned_name),
+                            "Assigned Email": str(dcar.assigned_email),
+                            "Assignment Date": str(dcar.created_on),
+                        }
+                        for dcar in contract.get_assignments().all()
+                    ]
+                )
+
+            self._output_code_data(
+                kwargs.pop("output_format", "fancy"),
+                code_assignments,
+                filename=kwargs.pop("filename", None),
+                table_name="Code Assignments",
+            )
+
+            return
+
         if kwargs.pop("usage", False):
             # Display just code redemptions per contract.
             # This will be one big table with a flag specifying if the code is
@@ -273,7 +311,7 @@ class Command(BaseCommand):
                     for dcar in DiscountContractAttachmentRedemption.objects.prefetch_related(
                         "discount", "user"
                     )
-                    .filter(contract=contract)
+                    .filter(contract=contract, user__isnull=False)
                     .all()
                 ]
                 enrollments = [
@@ -317,9 +355,17 @@ class Command(BaseCommand):
 
         if kwargs.pop("all", False):
             for contract in contracts:
-                codes.extend(
-                    self._format_enrollment_codes(contract, contract.get_discounts())
+                discounts = contract.get_discounts().prefetch_related(
+                    Prefetch(
+                        "contract_redemptions",
+                        queryset=DiscountContractAttachmentRedemption.objects.exclude(
+                            assigned_email=""
+                        ),
+                        to_attr="contract_assignments",
+                    )
                 )
+
+                codes.extend(self._format_enrollment_codes(contract, discounts))
 
             self._output_code_data(
                 kwargs.pop("output_format", "fancy"),
@@ -339,8 +385,22 @@ class Command(BaseCommand):
 
             annotated_discounts = (
                 contract.get_discounts()
-                .annotate(Count("contract_redemptions"))
-                .filter(contract_redemptions__count=0)
+                .prefetch_related(
+                    Prefetch(
+                        "contract_redemptions",
+                        queryset=DiscountContractAttachmentRedemption.objects.exclude(
+                            assigned_email=""
+                        ),
+                        to_attr="contract_assignments",
+                    )
+                )
+                .annotate(
+                    actual_redemption_count=Count(
+                        "contract_redemptions",
+                        filter=Q(contract_redemptions__user__isnull=False),
+                    )
+                )
+                .filter(actual_redemption_count=0)
                 .all()[:remaining_discounts]
             )
 
@@ -541,6 +601,108 @@ class Command(BaseCommand):
 
         [self.stdout.write(",".join(code)) for code in removed_codes]
 
+    def handle_assign(self, **kwargs):
+        """Handle assignments for the specified contract."""
+
+        if kwargs.get("all", False):
+            self.stderr.write("Sorry, can't assign codes for all contracts.")
+            return
+
+        contracts = self._get_contract_list(**kwargs, allow_everything=False)
+        dry_run = not kwargs.pop("commit", False)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING("Commit flag not set - no changes will be written.")
+            )
+
+        file = kwargs.pop("input_file", None)
+
+        assignees = []
+
+        if file:
+            with Path.open(file) as csvfile:
+                email, name, *_ = csv.reader(csvfile)
+                assignees.append([email, name])
+        else:
+            assignees.append(
+                [kwargs.pop("assigned_email", False), kwargs.pop("assigned_name", "")]
+            )
+
+            if not assignees[0][0]:
+                self.stderr.write(
+                    "No input file specified, and no email supplied either. Can't continue."
+                )
+                return
+
+        if len(assignees) == 0:
+            self.stderr.write("Nothing to work with.")
+            return
+
+        if kwargs.pop("revoke", False):
+            # We're revoking these, not assigning them, so find the applicable
+            # redemption records, clear the assignment, and regen the code.
+
+            revocatables = []
+
+            for contract in contracts:
+                self.stdout.write(
+                    f"Getting assignments for revocation for {contract.title}..."
+                )
+
+                revocatables.extend(
+                    contract.code_redemptions.filter(
+                        user__isnull=True, assigned_email__in=[a[0] for a in assignees]
+                    ).all()
+                )
+
+            self.stdout.write(f"Revoking {len(revocatables)} assignments...")
+
+            with transaction.atomic():
+                for revocatable in revocatables:
+                    revocatable.assigned_email = ""
+                    revocatable.assigned_name = ""
+                    revocatable.discount_code = uuid.uuid4()
+
+                if not dry_run:
+                    updated_count = (
+                        DiscountContractAttachmentRedemption.objects.bulk_update(
+                            revocatables,
+                            ["assigned_email", "assigned_name", "discount_code"],
+                        )
+                    )
+
+                    self.stdout.write(
+                        self.style.SUCCESS(f"Cleared {updated_count} assignments.")
+                    )
+
+            return
+
+        assignables = []
+
+        for contract in contracts:
+            self.stdout.write(f"Processing assignments for {contract.title}...")
+
+            if (
+                contract.membership_type in CONTRACT_MEMBERSHIP_AUTOS
+                or contract.max_learners == ""
+                or contract.max_learners < 1
+            ):
+                self.stderr.write(
+                    f"Contract {contract.title} doesn't use per-seat codes, skipping"
+                )
+                continue
+
+            if len(assignees) > contract.max_learners:
+                self.stderr.write(
+                    f"Too many assignees ({len(assignees)}) for the number of seats in the contract ({contract.max_learners}), skipping"
+                )
+                continue
+
+            assigned_codes = contract.discounts_qs.filter()
+
+            # if len(assignees) >
+
     def add_arguments(self, parser):
         """Add arguments to the command."""
 
@@ -566,10 +728,14 @@ class Command(BaseCommand):
             "expire",
             help="Expire enrollment codes for a contract or organization, optionally creating new ones.",
         )
+        assign_parser = subparser.add_parser(
+            "assign", help="Assign codes to people, or clear existing assignments."
+        )
 
         self._add_b2b_obj_args(output_parser)
         self._add_b2b_obj_args(validate_parser)
         self._add_b2b_obj_args(expire_parser)
+        self._add_b2b_obj_args(assign_parser)
 
         output_parser.add_argument(
             "--format",
@@ -591,6 +757,11 @@ class Command(BaseCommand):
             "--usage",
             action="store_true",
             help="Output redemptions/usage for codes.",
+        )
+        output_parser.add_argument(
+            "--assignments",
+            action="store_true",
+            help="Output assignments for codes.",
         )
         output_parser.add_argument(
             "--all",
@@ -618,6 +789,36 @@ class Command(BaseCommand):
             default=True,
         )
 
+        assign_parser.add_argument(
+            "--name",
+            type=str,
+            dest="assigned_name",
+            help="The name of the assignee. Valid only with --email.",
+        )
+        assign_parser.add_argument(
+            "--email",
+            type=str,
+            dest="assigned_email",
+            help="The email address of the assignee. Required if only assigning a single code or revoking an assignment.",
+        )
+        assign_parser.add_argument(
+            "--file",
+            "--csv",
+            type=str,
+            dest="input_file",
+            help="The file to read for assignments (CSV in 'email,name' format).",
+        )
+        assign_parser.add_argument(
+            "--revoke",
+            type="store_true",
+            help="Revoke the user(s). This will regenerate the code as well.",
+        )
+        assign_parser.add_argument(
+            "--commit",
+            type="store_true",
+            help="Commit the requested changes. Otherwise, this will be a dry run.",
+        )
+
     def handle(self, *args, **kwargs):
         """Dispatch the requested subcommand."""
 
@@ -629,6 +830,8 @@ class Command(BaseCommand):
             self.handle_validate(*args, **kwargs)
         elif op == "expire":
             self.handle_expire(*args, **kwargs)
+        elif op == "assign":
+            self.handle_assign(*args, **kwargs)
         else:
             msg = f"Invalid subcommand {op}"
             raise CommandError(msg)

--- a/b2b/management/commands/b2b_codes.py
+++ b/b2b/management/commands/b2b_codes.py
@@ -623,8 +623,10 @@ class Command(BaseCommand):
 
         if file:
             with Path.open(file) as csvfile:
-                email, name, *_ = csv.reader(csvfile)
-                assignees.append([email, name])
+                csvreader = csv.reader(csvfile)
+                for email, name, *_ in csvreader:
+                    self.stdout.write(f"Found {email} - {name}")
+                    assignees.append([email, name])
         else:
             assignees.append(
                 [kwargs.pop("assigned_email", False), kwargs.pop("assigned_name", "")]
@@ -663,19 +665,14 @@ class Command(BaseCommand):
                 for revocatable in revocatables:
                     revocatable.assigned_email = ""
                     revocatable.assigned_name = ""
-                    revocatable.discount_code = uuid.uuid4()
+                    revocatable.discount.discount_code = uuid.uuid4()
 
-                if not dry_run:
-                    updated_count = (
-                        DiscountContractAttachmentRedemption.objects.bulk_update(
-                            revocatables,
-                            ["assigned_email", "assigned_name", "discount_code"],
-                        )
-                    )
+                    if not dry_run:
+                        revocatable.save()
 
-                    self.stdout.write(
-                        self.style.SUCCESS(f"Cleared {updated_count} assignments.")
-                    )
+                self.stdout.write(
+                    self.style.SUCCESS(f"Cleared {len(revocatables)} assignments.")
+                )
 
             return
 
@@ -722,6 +719,8 @@ class Command(BaseCommand):
                 )
                 continue
 
+            unused_codes = list(unused_codes)
+
             now = now_in_utc()
 
             code_assignments = [
@@ -730,6 +729,7 @@ class Command(BaseCommand):
                     assigned_name=a[1],
                     assigned_email=a[0],
                     created_on=now,
+                    discount=unused_codes.pop(),
                 )
                 for a in assignees
                 if a[0] not in already_assigned
@@ -743,6 +743,12 @@ class Command(BaseCommand):
                     DiscountContractAttachmentRedemption.objects.bulk_create(
                         code_assignments
                     )
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Processed {len(code_assignments)} assignments for {contract}."
+                )
+            )
 
     def add_arguments(self, parser):
         """Add arguments to the command."""

--- a/b2b/management/commands/b2b_codes.py
+++ b/b2b/management/commands/b2b_codes.py
@@ -11,6 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management import BaseCommand, CommandError
 from django.db import transaction
 from django.db.models import Count, Prefetch, Q
+from mitol.common.utils import now_in_utc
 from rich.console import Console
 from rich.table import Table
 
@@ -247,7 +248,7 @@ class Command(BaseCommand):
 
         return codes
 
-    def handle_output(self, **kwargs):
+    def handle_output(self, **kwargs):  # noqa: C901
         """Output code information."""
 
         contracts = self._get_contract_list(allow_everything=True, **kwargs)
@@ -601,7 +602,7 @@ class Command(BaseCommand):
 
         [self.stdout.write(",".join(code)) for code in removed_codes]
 
-    def handle_assign(self, **kwargs):
+    def handle_assign(self, **kwargs):  # noqa: C901, PLR0915
         """Handle assignments for the specified contract."""
 
         if kwargs.get("all", False):
@@ -678,8 +679,6 @@ class Command(BaseCommand):
 
             return
 
-        assignables = []
-
         for contract in contracts:
             self.stdout.write(f"Processing assignments for {contract.title}...")
 
@@ -699,9 +698,51 @@ class Command(BaseCommand):
                 )
                 continue
 
-            assigned_codes = contract.discounts_qs.filter()
+            already_assigned = list(
+                contract.discounts_qs.filter(
+                    contract_redemptions__assigned_email__in=[a[0] for a in assignees]
+                ).values_list("contract_redemptions__assigned_email", flat=True)
+            )
 
-            # if len(assignees) >
+            if len(already_assigned) > 0:
+                already_done = " ".join(already_assigned)
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"{len(already_assigned)} codes already assigned to these users: {already_done}"
+                    )
+                )
+
+            unused_codes = contract.get_unused_discounts().exclude(
+                pk__in=contract.get_assignments().values_list("discount_id", flat=True)
+            )
+
+            if unused_codes.count() < len(assignees) - len(already_assigned):
+                self.stderr.write(
+                    f"Not enough free codes for {len(assignees)} new assignee(s) in contract {contract.title} ({unused_codes.count()}), skipping"
+                )
+                continue
+
+            now = now_in_utc()
+
+            code_assignments = [
+                DiscountContractAttachmentRedemption(
+                    contract=contract,
+                    assigned_name=a[1],
+                    assigned_email=a[0],
+                    created_on=now,
+                )
+                for a in assignees
+                if a[0] not in already_assigned
+            ]
+
+            if not dry_run:
+                with transaction.atomic():
+                    self.stdout.write(
+                        f"Committing {len(code_assignments)} new assignments for {contract.title}"
+                    )
+                    DiscountContractAttachmentRedemption.objects.bulk_create(
+                        code_assignments
+                    )
 
     def add_arguments(self, parser):
         """Add arguments to the command."""
@@ -810,12 +851,12 @@ class Command(BaseCommand):
         )
         assign_parser.add_argument(
             "--revoke",
-            type="store_true",
+            action="store_true",
             help="Revoke the user(s). This will regenerate the code as well.",
         )
         assign_parser.add_argument(
             "--commit",
-            type="store_true",
+            action="store_true",
             help="Commit the requested changes. Otherwise, this will be a dry run.",
         )
 

--- a/b2b/models.py
+++ b/b2b/models.py
@@ -587,6 +587,13 @@ class ContractPage(Page, ClusterableModel):
 
         return run_qs.filter(run_qs_filter).all()
 
+    def get_assignments(self):
+        """Get assignments for the contract."""
+
+        return self.code_redemptions.filter(user__isnull=True).exclude(
+            assigned_email=""
+        )
+
     def get_enrollments(self):
         """Get the enrollments for the contract's runs"""
 

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -96,12 +96,14 @@ class CourseRunInline(DisplayOnlyAdminMixin, admin.TabularInline):
         "title_linked",
         "run_tag",
         "language",
-        "is_primary_language",
-        "is_source_run",
+        "variant_length",
+        "variant_industry",
         "b2b_contract",
+        "live",
         "start_date",
         "end_date",
         "enrollment_start",
+        "enrollment_end",
         "upgrade_deadline",
     )
     readonly_fields = (
@@ -110,14 +112,41 @@ class CourseRunInline(DisplayOnlyAdminMixin, admin.TabularInline):
         "title_linked",
         "run_tag",
         "language",
-        "is_primary_language",
-        "is_source_run",
+        "variant_length",
+        "variant_industry",
         "b2b_contract",
+        "live",
         "start_date",
         "end_date",
         "enrollment_start",
+        "enrollment_end",
         "upgrade_deadline",
     )
+
+    def get_queryset(self, request):  # noqa: ARG002
+        """Use the all_objects manager."""
+
+        return self.model.all_objects
+
+
+class SourceCourseRunInline(CourseRunInline):
+    """CourseRunInline, but just source runs."""
+
+    verbose_name = "Source Course Run"
+
+    def get_queryset(self, request):  # noqa: ARG002
+        """Filter the course runs to just include source course runs."""
+
+        return self.model.all_objects.filter(is_source_run=True)
+
+
+class EnrollableCourseRunInline(CourseRunInline):
+    """CourseRunInline, but just enrollable runs."""
+
+    def get_queryset(self, request):  # noqa: ARG002
+        """Filter the course runs to exclude source courses."""
+
+        return self.model.all_objects.filter(is_source_run=False)
 
 
 @admin.register(Program)
@@ -178,7 +207,11 @@ class CourseAdmin(admin.ModelAdmin):
         "readable_id",
     )
     list_filter = ["live", "departments"]
-    inlines = [CourseRunInline, CoursePossibleVariantInline]
+    inlines = [
+        SourceCourseRunInline,
+        EnrollableCourseRunInline,
+        CoursePossibleVariantInline,
+    ]
 
     formfield_overrides = {
         models.CharField: {"widget": TextInput(attrs={"size": "80"})}


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

Updates the `b2b_codes` management command so that it works better with code assignments:
- Where this filters on attachment redemptions, don't consider redemption records that are assignments
- Add assignments to the `b2b_codes output` output
- Add assignments to the `b2b_codes output --stats` output
- Add new `--assignments` flag to `b2b_codes output` that just shows current assignments
- Add `b2b_codes assign` subcommand
   - Can take a single name/email, or a CSV-format list (same as the frontend), to assign codes to a specified contract
   - Has a `--revoke` flag, which will clear the assignments for the specified user(s)
 
Also, this splits out the course run inlines in the Course change page in Django Admin into two - one that shows just source courses, and one that shows enrollable courses. This also adds the variant length and industry fields, the live flag, and the enrollment end date and removes the primary language toggle.

Late addition: this also updates the contract attach redemption admin to add more information to both the list view and the change view, and allows for the assigned user/email to be updated.

### How can this be tested?

Django Admin changes: load a course with source course runs and regular runs. You should see them in their appropriate sections, and you should see the field changes as well.

Output updates: Create a contract that uses codes and create some assignments (easiest way is to use the admin dashboard in the Learn frontend). Then, use `b2b_codes output --contract <contract>`: the default should include the assignment (if there is one) and should show the proper number of records; adding the `--stats` or `--usage` flags should show you correct assignment data. Use `b2b_codes output --assignments` to list just the assignments for the contract.

Assignment command: Create a contract that uses codes. Then, use `b2b_codes assign`:
- Specify the email and name for a single assignment: `--email <email> --name <name>`. This should work, and the assignment email should be sent.
- Specify a list of users in a CSV file. The format is the same as the frontend - email,name.
   - If any specified users are _already_ assigned to codes, it should list out those users.
   - If there are too many users for the number of seats in the contract, it will skip the contract.
   - If there are too many users for the number of _free_ seats in the contract, it will skip the contract.
   - Otherwise, it will create the appropriate assignments, which you should be able to verify with `b2b_codes output`.
- _For either of these,_ specifying an organization will apply assignments to all applicable contracts in the org.
   - Only seat-limited code contracts count.
   - However, the `--all` flag is invalid - it will not allow you to assign users to all contracts.
- _For either of these,_ changes will _not_ be made unless the `--commit` flag is specified. It should tell you this.

Revocation: Same tests as `b2b_codes assign`, but add the `--revoke` flag. (Again, no changes unless `--commit` is specified.)
