### PR TITLE
Finalize Email Template for Code assignment

### DIFF
--- a/b2b/mail.py
+++ b/b2b/mail.py
@@ -48,6 +48,7 @@ def send_enrollment_code_assignment_email(assignment_record_ids):
                         "code": code,
                         "code_url": code_url,
                         "organization_name": organization_name,
+                        "contract_name": assignment.contract.name,
                     },
                 )
         except:  # pylint: disable=bare-except  # noqa: E722

--- a/b2b/templates/mail/enrollment_code_assignment/body.html
+++ b/b2b/templates/mail/enrollment_code_assignment/body.html
@@ -5,10 +5,14 @@
   <tr>
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-              <tr>You've been invited to learn with MIT</tr>
+              <tr>
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 20px; line-height: 24px; color: #000000; font-weight: bold;">
+                      You've been invited to learn with MIT.
+                  </td>
+              </tr>
               <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
-                      <p style="margin: 0 0 10px;">{{ organization_name }} has provided you with access to {{ contract_name }} on MIT Learn.</p>
+                      <p style="margin: 0 0 10px;"><strong>{{ organization_name }}</strong> has provided you with access to <strong>{{ contract_name }}</strong> on MIT Learn.</p>
                       <p style="margin: 0 0 10px;">Claim your seat to view your available courses and begin learning.</p>
                   </td>
               </tr>
@@ -46,7 +50,7 @@
               <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p>Welcome to MIT Learn,</p>
-                      <p style="font-weight: bold;">MIT Learn Team</p>
+                      <p><strong>MIT Learn Team</strong></p>
                   </td>
               </tr>
 

--- a/b2b/templates/mail/enrollment_code_assignment/body.html
+++ b/b2b/templates/mail/enrollment_code_assignment/body.html
@@ -46,7 +46,7 @@
               <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p>Welcome to MIT Learn,</p>
-                      <p>MIT Learn Team</p>
+                      <p style="font-weight: bold;">MIT Learn Team</p>
                   </td>
               </tr>
 

--- a/b2b/templates/mail/enrollment_code_assignment/body.html
+++ b/b2b/templates/mail/enrollment_code_assignment/body.html
@@ -42,7 +42,7 @@
                   </td>
               </tr>
               <tr>
-                <td style="padding: 0 20px 20px;">
+                <td style="padding: 0 20px 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                     <p>If you're unable to use the button above, copy and paste this link into your browser:</p>
                     {{code_url}}
                 </td>

--- a/b2b/templates/mail/enrollment_code_assignment/body.html
+++ b/b2b/templates/mail/enrollment_code_assignment/body.html
@@ -1,14 +1,15 @@
-{% extends "email_base.html" %}
+{% extends "learn_email_base.html" %}
 
 {% block content %}
 <!-- 1 Column Text + Button : BEGIN -->
   <tr>
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+              <tr>You've been invited to learn with MIT</tr>
               <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
-                      <p style="margin: 0 0 10px;">Dear {{ assignment.assigned_name }},</p>
-                      <p style="margin: 0 0 10px;">You have been invited to join {{ organization_name }}. Please click the button below to accept.</p>
+                      <p style="margin: 0 0 10px;">{{ organization_name }} has provided you with access to {{ contract_name }} on MIT Learn.</p>
+                      <p style="margin: 0 0 10px;">Claim your seat to view your available courses and begin learning.</p>
                   </td>
               </tr>
               <tr>
@@ -17,7 +18,19 @@
                       <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
                           <tr>
                               <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
-                                   <a class="button-a button-a-primary" href="{{code_url}}" style="background: #ffffff; border: 1px solid #a31f34; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 17px; color: #a31f34; display: block; border-radius: 4px;">Join Organization</a>
+                                   <a class="button-a button-a-primary" href="{{code_url}}" style="
+              background: #a31f34;
+              border: 1px solid #a31f34;
+              font-family: 'Source Sans Pro', sans-serif;
+              font-weight: 500;
+              font-size: 14px;
+              line-height: 14px;
+              text-decoration: none;
+              text-align: center;
+              padding: 16px;
+              color: #fff;
+              display: block;
+              border-radius: 4px;">Claim Your Seat</a>
                               </td>
                           </tr>
                       </table>
@@ -26,10 +39,16 @@
               </tr>
               <tr>
                 <td style="padding: 0 20px 20px;">
-                    <p>If the button doesn't work, copy and paste this link into your web browser:</p>
+                    <p>If you're unable to use the button above, copy and paste this link into your browser:</p>
                     {{code_url}}
                 </td>
-            </tr>
+              </tr>
+              <tr>
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                      <p>Welcome to MIT Learn,</p>
+                      <p>MIT Learn Team</p>
+                  </td>
+              </tr>
 
           </table>
       </td>

--- a/b2b/templates/mail/enrollment_code_assignment/body.html
+++ b/b2b/templates/mail/enrollment_code_assignment/body.html
@@ -13,7 +13,7 @@
               <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px;"><strong>{{ organization_name }}</strong> has provided you with access to <strong>{{ contract_name }}</strong> on MIT Learn.</p>
-                      <p style="margin: 0 0 10px;">Claim your seat to view your available courses and begin learning.</p>
+                      <p style="margin: 20px 0 10px;">Claim your seat to view your available courses and begin learning.</p>
                   </td>
               </tr>
               <tr>

--- a/b2b/templates/mail/enrollment_code_assignment/subject.txt
+++ b/b2b/templates/mail/enrollment_code_assignment/subject.txt
@@ -1,1 +1,1 @@
-Organization Invitation
+You've been invited to MIT Learn

--- a/mail/templates/learn_email_base.html
+++ b/mail/templates/learn_email_base.html
@@ -356,14 +356,6 @@
               "
             >
               {% block footer %}
-
-              If you don't want to receive these emails in the future, you can
-              <a
-                href="{{ APP_BASE_URL }}/dashboard/settings/"
-                style="text-decoration: underline"
-                >unsubscribe</a
-              >. <br /><br />
-
               {% endblock %}
               {% block footer-address %}
               <b>MIT Learn</b>&nbsp;&bull;&nbsp;77 Massachusetts

--- a/mail/templates/learn_email_base.html
+++ b/mail/templates/learn_email_base.html
@@ -241,7 +241,7 @@
     <![endif]-->
 
       <div
-        style="max-width: 680px; background: #fff; margin: 30px auto 0 auto"
+        style="max-width: 680px; background: #fff; margin: 30px auto 0 auto; padding: 16px;"
         class="email-container"
       >
         <!--[if mso]>

--- a/mail/templates/learn_email_base.html
+++ b/mail/templates/learn_email_base.html
@@ -1,0 +1,390 @@
+{% load i18n static %}
+<!doctype html>
+<html
+  lang="en"
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:o="urn:schemas-microsoft-com:office:office"
+>
+  <head>
+    <meta charset="utf-8" />
+    <!-- utf-8 works for most cases -->
+    <meta name="viewport" content="width=device-width" />
+    <!-- Forcing initial-scale shouldn't be necessary -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!-- Use the latest (edge) version of IE rendering engine -->
+    <meta name="x-apple-disable-message-reformatting" />
+    <!-- Disable auto-scale in iOS 10 Mail entirely -->
+    <title>{{ subject }}</title>
+    <!-- The title tag shows in email notifications, like Android 4.4. -->
+
+    <!-- Web Font / @font-face : BEGIN -->
+    <!-- NOTE: If web fonts are not required, lines 10 - 27 can be safely removed. -->
+
+    <!-- Desktop Outlook chokes on web font references and defaults to Times New Roman, so we force a safe fallback font. -->
+    <!--[if mso]>
+      <style>
+        * {
+          font-family: sans-serif !important;
+        }
+      </style>
+    <![endif]-->
+
+    <!-- All other clients get the webfont reference; some will render the font and others will silently fail to the fallbacks. More on that here: http://stylecampaign.com/blog/2015/02/webfont-support-in-email/ -->
+    <!--[if !mso]><!-->
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700"
+    />
+    <!--<![endif]-->
+
+    <!-- Web Font / @font-face : END -->
+
+    <!-- CSS Reset : BEGIN -->
+    <style>
+      /* What it does: Remove spaces around the email design added by some email clients. */
+      /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
+      html,
+      body {
+        margin: 0 auto !important;
+        padding: 0 !important;
+        height: 100% !important;
+        width: 100% !important;
+      }
+
+      /* What it does: Stops email clients resizing small text. */
+      * {
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%;
+      }
+
+      /* What it does: Centers email on Android 4.4 */
+      div[style*='margin: 16px 0'] {
+        margin: 0 !important;
+      }
+
+      /* What it does: Stops Outlook from adding extra spacing to tables. */
+      table,
+      td {
+        mso-table-lspace: 0pt !important;
+        mso-table-rspace: 0pt !important;
+      }
+
+      /* What it does: Fixes webkit padding issue. Fix for Yahoo mail table alignment bug. Applies table-layout to the first 2 tables then removes for anything nested deeper. */
+      table {
+        border-spacing: 0 !important;
+        border-collapse: collapse !important;
+        table-layout: fixed !important;
+        margin: 0 auto !important;
+      }
+      table table table {
+        table-layout: auto;
+      }
+
+      /* What it does: Uses a better rendering method when resizing images in IE. */
+      img {
+        -ms-interpolation-mode: bicubic;
+      }
+
+      /* What it does: Prevents Windows 10 Mail from underlining links despite inline CSS. Styles for underlined links should be inline. */
+      a {
+        text-decoration: none;
+      }
+
+      /* What it does: A work-around for email clients meddling in triggered links. */
+      *[x-apple-data-detectors],  /* iOS */
+        .unstyle-auto-detected-links *,
+        .aBn {
+        border-bottom: 0 !important;
+        cursor: default !important;
+        color: inherit !important;
+        text-decoration: none !important;
+        font-size: inherit !important;
+        font-family: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+      }
+
+      /* What it does: Prevents Gmail from displaying a download button on large, non-linked images. */
+      .a6S {
+        display: none !important;
+        opacity: 0.01 !important;
+      }
+      /* If the above doesn't work, add a .g-img class to any image in question. */
+      img.g-img + div {
+        display: none !important;
+      }
+
+      /* What it does: Removes right gutter in Gmail iOS app: https://github.com/TedGoas/Cerberus/issues/89  */
+      /* Create one of these media queries for each additional viewport size you'd like to fix */
+
+      /* iPhone 4, 4S, 5, 5S, 5C, and 5SE */
+      @media only screen and (min-device-width: 320px) and (max-device-width: 374px) {
+        .email-container {
+          min-width: 320px !important;
+        }
+      }
+      /* iPhone 6, 6S, 7, 8, and X */
+      @media only screen and (min-device-width: 375px) and (max-device-width: 413px) {
+        .email-container {
+          min-width: 375px !important;
+        }
+      }
+      /* iPhone 6+, 7+, and 8+ */
+      @media only screen and (min-device-width: 414px) {
+        .email-container {
+          min-width: 414px !important;
+        }
+      }
+    </style>
+    <!-- CSS Reset : END -->
+    <!-- Reset list spacing because Outlook ignores much of our inline CSS. -->
+    <!--[if mso]>
+      <style type="text/css">
+        ul,
+        ol {
+          margin: 0 !important;
+        }
+        li {
+          margin-left: 30px !important;
+        }
+        li.list-item-first {
+          margin-top: 0 !important;
+        }
+        li.list-item-last {
+          margin-bottom: 10px !important;
+        }
+      </style>
+    <![endif]-->
+
+    <!-- Progressive Enhancements : BEGIN -->
+    <style>
+      /* What it does: Hover styles for buttons */
+      .button-td,
+      .button-a {
+        transition: all 100ms ease-in;
+      }
+      .button-td-primary:hover,
+      .button-a-primary:hover {
+        border-color: #a31f34 !important;
+      }
+
+      /* Media Queries */
+      @media screen and (max-width: 480px) {
+        /* What it does: Forces elements to resize to the full width of their container. Useful for resizing images beyond their max-width. */
+        .fluid {
+          width: 100% !important;
+          max-width: 100% !important;
+          height: auto !important;
+          margin-left: auto !important;
+          margin-right: auto !important;
+        }
+
+        /* What it does: Forces table cells into full-width rows. */
+        .stack-column,
+        .stack-column-center {
+          display: block !important;
+          width: 100% !important;
+          max-width: 100% !important;
+          direction: ltr !important;
+        }
+        /* And center justify these ones. */
+        .stack-column-center {
+          text-align: center !important;
+        }
+
+        /* What it does: Generic utility class for centering. Useful for images, buttons, and nested tables. */
+        .center-on-narrow {
+          text-align: center !important;
+          display: block !important;
+          margin-left: auto !important;
+          margin-right: auto !important;
+          float: none !important;
+        }
+        table.center-on-narrow {
+          display: inline-block !important;
+        }
+
+        /* What it does: Adjust typography on small screens to improve readability */
+        .email-container p {
+          font-size: 17px !important;
+        }
+      }
+    </style>
+    <!-- Progressive Enhancements : END -->
+
+    <!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
+    <!--[if gte mso 9]>
+      <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG />
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+      </xml>
+    <![endif]-->
+  </head>
+  <body
+    width="100%"
+    style="
+      margin: 0;
+      padding: 0 !important;
+      mso-line-height-rule: exactly;
+      background-color: #f3f4f8;
+    "
+  >
+    <center style="background-color: #f3f4f8">
+      <!--[if mso | IE]>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #ffffff;">
+    <tr>
+    <td>
+    <![endif]-->
+
+      <div
+        style="max-width: 680px; background: #fff; margin: 0 auto"
+        class="email-container"
+      >
+        <!--[if mso]>
+            <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="680">
+            <tr>
+            <td>
+            <![endif]-->
+        <!-- Email Header : BEGIN -->
+        <table
+          role="presentation"
+          cellspacing="0"
+          cellpadding="0"
+          border="0"
+          width="100%"
+          style="font-size: 12px"
+        >
+          <tr style="margin-top: 32px; margin-bottom: 32px">
+            <td style="text-align: left; padding: 20px">
+              <img
+                src="{{ base_url }}/static/images/mit-learn.png"
+                width="113"
+                height="32"
+                alt="MIT-Learn"
+                style="
+                  height: 24px;
+                  width: 134px;
+                  background: #ffffff;
+                  font-family: sans-serif;
+                  font-size: 15px;
+                  line-height: 15px;
+                  display: block;
+                  color: #a31f34;
+                "
+              />
+            </td>
+            <td></td>
+            <td style="text-align: right; padding: 20px">
+              <img
+                src="{{ base_url }}/static/images/mit-black-logo.png"
+                width="113"
+                height="32"
+                alt="MIT-Learn"
+                style="
+                  height: 24px;
+                  width: 45px;
+                  background: #ffffff;
+                  font-family: sans-serif;
+                  font-size: 15px;
+                  line-height: 15px;
+                  display: block;
+                  color: #a31f34;
+                  float: right;
+                "
+              />
+            </td>
+          </tr>
+        </table>
+        <!-- Email Header : END -->
+        <!--[if mso]>
+            <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="680">
+            <tr>
+            <td>
+            <![endif]-->
+        <!-- Email Body : BEGIN -->
+        <table
+          role="presentation"
+          cellspacing="0"
+          cellpadding="0"
+          border="0"
+          width="100%"
+          style="margin: 0 auto"
+        >
+          <tr>
+            <td>
+              <p style="border-top: 1px solid #f3f4f8"></p>
+            </td>
+          </tr>
+
+          {% block content %}{% endblock %}
+
+          <!-- Clear Spacer : BEGIN -->
+          <tr>
+            <td
+              aria-hidden="true"
+              height="40"
+              style="font-size: 0px; line-height: 0px"
+            >
+              &nbsp;
+            </td>
+          </tr>
+          <!-- Clear Spacer : END -->
+        </table>
+        <!-- Email Body : END -->
+        <!-- Email Footer : BEGIN -->
+        <table
+          role="presentation"
+          cellspacing="0"
+          cellpadding="0"
+          border="0"
+          width="100%"
+          style="font-size: 12px"
+        >
+          <tr>
+            <td
+              style="
+                padding: 20px;
+                font-family: sans-serif;
+                font-size: 12px;
+                line-height: 15px;
+                color: #000;
+                text-align: center;
+              "
+            >
+              {% block footer %}
+
+              If you don't want to receive these emails in the future, you can
+              <a
+                href="{{ APP_BASE_URL }}/dashboard/settings/"
+                style="text-decoration: underline"
+                >unsubscribe</a
+              >. <br /><br />
+
+              {% endblock %}
+              {% block footer-address %}
+              <b>MIT Learn</b>&nbsp;&bull;&nbsp;77 Massachusetts
+              Avenue&nbsp;&bull;&nbsp;Cambridge, MA 02139&nbsp;&bull;&nbsp;USA
+              {% endblock %}
+            </td>
+          </tr>
+        </table>
+        <!-- Email Footer : END -->
+        <!--[if mso]>
+        </td>
+        </tr>
+        </table>
+        <![endif]-->
+      </div>
+
+      <!--[if mso | IE]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+    </center>
+  </body>
+</html>

--- a/mail/templates/learn_email_base.html
+++ b/mail/templates/learn_email_base.html
@@ -241,7 +241,7 @@
     <![endif]-->
 
       <div
-        style="max-width: 680px; background: #fff; margin: 0 auto"
+        style="max-width: 680px; background: #fff; margin: 30 auto 0 auto"
         class="email-container"
       >
         <!--[if mso]>
@@ -312,14 +312,8 @@
           cellpadding="0"
           border="0"
           width="100%"
-          style="margin: 0 auto"
+          style="margin: 0 auto; border-top: 1px solid #f3f4f8"
         >
-          <tr>
-            <td>
-              <p style="border-top: 1px solid #f3f4f8"></p>
-            </td>
-          </tr>
-
           {% block content %}{% endblock %}
 
         </table>

--- a/mail/templates/learn_email_base.html
+++ b/mail/templates/learn_email_base.html
@@ -322,17 +322,6 @@
 
           {% block content %}{% endblock %}
 
-          <!-- Clear Spacer : BEGIN -->
-          <tr>
-            <td
-              aria-hidden="true"
-              height="40"
-              style="font-size: 0px; line-height: 0px"
-            >
-              &nbsp;
-            </td>
-          </tr>
-          <!-- Clear Spacer : END -->
         </table>
         <!-- Email Body : END -->
         <!-- Email Footer : BEGIN -->
@@ -344,6 +333,13 @@
           width="100%"
           style="font-size: 12px"
         >
+            <tr>
+
+            <td style="mso-table-lspace:0; mso-table-rspace:0">
+              <p style="border-top: 1px solid #f3f4f8"></p>
+            </td>
+
+            </tr>
           <tr>
             <td
               style="

--- a/mail/templates/learn_email_base.html
+++ b/mail/templates/learn_email_base.html
@@ -241,7 +241,7 @@
     <![endif]-->
 
       <div
-        style="max-width: 680px; background: #fff; margin: 30 auto 0 auto"
+        style="max-width: 680px; background: #fff; margin: 30px auto 0 auto"
         class="email-container"
       >
         <!--[if mso]>

--- a/main/settings.py
+++ b/main/settings.py
@@ -1129,7 +1129,7 @@ MITOL_COMMON_USER_FACTORY = "users.factories.UserFactory"
 # mitol-django-mail
 MITOL_MAIL_FROM_EMAIL = MAILGUN_FROM_EMAIL
 MITOL_MAIL_REPLY_TO_ADDRESS = MITX_ONLINE_REPLY_TO_ADDRESS
-MITOL_MAIL_MESSAGE_CLASSES = []
+MITOL_MAIL_MESSAGE_CLASSES = ["b2b.mail.EnrollmentCodeAssignmentMessage"]
 MITOL_MAIL_RECIPIENT_OVERRIDE = MAILGUN_RECIPIENT_OVERRIDE
 MITOL_MAIL_FORMAT_RECIPIENT_FUNC = "users.utils.format_recipient"
 MITOL_MAIL_ENABLE_EMAIL_DEBUGGER = get_bool(  # NOTE: this will override the legacy mail debugger defined in this project


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11375

### Description (What does it do?)
Cleans up the email template we were using for code assignment. I stole as much as possible from Learn, but it still needed some tweaks to look right  - this may well be subject to further revision but it's MUCH closer to the [Figma](https://www.figma.com/proto/mSDdN8giMcncBwNgwcVJL9/UX-Wireframes?node-id=18549-24117&viewport=673%2C-9752%2C0.26&t=wvmNJCpIBgu2GnaF-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=15893%3A8706&page-id=15728%3A419899) than the placeholder was.

### Screenshots (if appropriate):
Email as shown in Mailpit
<img width="1261" height="802" alt="Screenshot 2026-06-24 at 11 28 35 AM" src="https://github.com/user-attachments/assets/0c53eb93-c758-4352-ac4d-641841fba805" />

The from and reply to emails in RC and Production are mitlearn-support@mit.edu (as defined by the settings values MIT_LEARN_FROM_EMAIL and MIT_LEARN_REPLY_TO_EMAIL)
<img width="490" height="157" alt="Screenshot 2026-06-24 at 1 34 55 PM" src="https://github.com/user-attachments/assets/6524afa8-8b44-43e8-881f-5a8ca6a08363" />




### How can this be tested?
- Set up mailpit and set MITOL_MAIL_CONNECTION_BACKEND='django.core.mail.backends.smtp.EmailBackend'
- Set `MITX_ONLINE_EMAIL_HOST` and `MITX_ONLINE_EMAIL_PORT` to wherever mailpit is running.
- For any assigned code, use http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_remind_create to resend a reminder. 
- You should get an email in mailpit for the code specified.
