### PR TITLE
Add backfill_program_certificate_titles management command

### DIFF
--- a/courses/management/commands/backfill_program_certificate_titles.py
+++ b/courses/management/commands/backfill_program_certificate_titles.py
@@ -115,12 +115,8 @@ class Command(BaseCommand):
 
         Returns ``(changed, revisions_changed, certs_affected)``.
         """
-        # Build the whole report block in memory and decide which revisions to
-        # rewrite, but do NOT print anything yet. The writes happen first, inside
-        # transaction.atomic(); only once they commit do we flush the block. That
-        # way a rollback (e.g. a save() error on a later revision) can never leave
-        # behind output claiming a change that was undone — on failure the
-        # exception propagates before any line is written.
+        # Build the block in memory and flush it only after the writes commit, so
+        # a rollback never leaves behind output claiming a change that was undone.
         lines = [
             "",
             readable_id,
@@ -153,9 +149,8 @@ class Command(BaseCommand):
         if commit and to_change:
             with transaction.atomic():
                 for revision in to_change:
-                    # Reassign rather than mutate in place so the change is
-                    # always picked up regardless of save()/update_fields or
-                    # any dirty-tracking behavior on the model.
+                    # Reassign (don't mutate in place) so save(update_fields=...)
+                    # reliably detects the JSONField change.
                     content = revision.content
                     content["product_name"] = title
                     revision.content = content

--- a/courses/management/commands/backfill_program_certificate_titles.py
+++ b/courses/management/commands/backfill_program_certificate_titles.py
@@ -1,0 +1,152 @@
+"""Backfill the frozen "Certificate Title" on already-issued program certificates."""
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from courses.models import Program, ProgramCertificate
+
+
+class Command(BaseCommand):
+    """Rewrite issued program certificates' frozen product_name to the live title."""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        """Add the command's program-selection and --commit arguments."""
+        parser.add_argument("--program", action="append", dest="programs")
+        parser.add_argument("--all-programs", action="store_true", dest="all_programs")
+        parser.add_argument("--commit", action="store_true")
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Backfill frozen program-certificate titles from the live CMS page."""
+        programs = options["programs"]
+        all_programs = options["all_programs"]
+        if bool(programs) == bool(all_programs):
+            msg = (
+                "Provide exactly one of --program <readable_id> (repeatable) "
+                "or --all-programs."
+            )
+            raise CommandError(msg)
+
+        commit = options["commit"]
+        banner = "COMMIT" if commit else "DRY RUN"
+        self.stdout.write(self.style.WARNING(f"=== {banner} ==="))
+
+        programs_processed = 0
+        programs_skipped = 0
+        revisions_changed = 0
+        certs_affected = 0
+
+        for readable_id, program in self._target_programs(programs, all_programs):
+            if program is None:
+                programs_skipped += 1
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"{readable_id}: skipping — no program with that readable_id."
+                    )
+                )
+                continue
+
+            certificate_page = self._certificate_page(program)
+            if certificate_page is None:
+                programs_skipped += 1
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"{readable_id}: skipping — no certificate page."
+                    )
+                )
+                continue
+
+            title = certificate_page.product_name
+
+            if not title or title.startswith("PLACEHOLDER - "):
+                programs_skipped += 1
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"{readable_id}: skipping — live Certificate Title is "
+                        f'empty or a placeholder ("{title}"). Fix the CMS page first.'
+                    )
+                )
+                continue
+
+            programs_processed += 1
+            self.stdout.write(f'{readable_id}: target Certificate Title "{title}"')
+
+            with transaction.atomic():
+                for revision, certs in self._distinct_revisions(program):
+                    old = revision.content.get("product_name")
+                    if old == title:
+                        self.stdout.write(
+                            f'  {revision.id}  ({len(certs)} certs)  "{old}"  [skipped]'
+                        )
+                        continue
+                    if commit:
+                        revision.content["product_name"] = title
+                        revision.save()
+                        status = "changed"
+                    else:
+                        status = "would-change"
+                    revisions_changed += 1
+                    certs_affected += len(certs)
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"  {revision.id}  ({len(certs)} certs)  "
+                            f'"{old}" -> "{title}"  [{status}]'
+                        )
+                    )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Summary: {programs_processed} program(s) processed, "
+                f"{programs_skipped} skipped, "
+                f"{revisions_changed} revision(s) changed, "
+                f"{certs_affected} cert(s) affected."
+            )
+        )
+
+    @staticmethod
+    def _target_programs(programs, all_programs):
+        """Yield ``(readable_id, program_or_None)`` for each targeted program.
+
+        For ``--program`` a missing readable_id yields ``(readable_id, None)`` so
+        the caller can report and skip it. For ``--all-programs`` every program is
+        yielded (with its own readable_id).
+        """
+        if all_programs:
+            for program in Program.objects.all():
+                yield program.readable_id, program
+            return
+        by_readable_id = {
+            program.readable_id: program
+            for program in Program.objects.filter(readable_id__in=programs)
+        }
+        for readable_id in programs:
+            yield readable_id, by_readable_id.get(readable_id)
+
+    @staticmethod
+    def _certificate_page(program):
+        """Return the program's live ``CertificatePage``, or ``None`` if the
+        program has no CMS page or no certificate page.
+        """
+        try:
+            page = program.page
+        except ObjectDoesNotExist:
+            return None
+        if page is None:
+            return None
+        return page.certificate_page
+
+    @staticmethod
+    def _distinct_revisions(program):
+        """Yield ``(revision, certs)`` for each distinct non-null revision shared
+        by the program's active certificates.
+        """
+        grouped = {}
+        for cert in ProgramCertificate.objects.filter(program=program):
+            revision = cert.certificate_page_revision
+            if revision is None:
+                continue
+            grouped.setdefault(revision.id, (revision, []))[1].append(cert)
+        return list(grouped.values())

--- a/courses/management/commands/backfill_program_certificate_titles.py
+++ b/courses/management/commands/backfill_program_certificate_titles.py
@@ -1,10 +1,29 @@
-"""Backfill the frozen "Certificate Title" on already-issued program certificates."""
+"""Backfill the frozen "Certificate Title" on issued program certificates."""
+
+from collections import Counter
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from courses.models import Program, ProgramCertificate
+
+# A live Certificate Title still carrying this prefix has never been filled in.
+PLACEHOLDER_PREFIX = "PLACEHOLDER - "
+
+# Report field labels. Kept as constants so the command and its tests stay in
+# sync and the columns line up (the label column is padded to LABEL_WIDTH).
+LABEL_WIDTH = 17
+LABEL_PROGRAM_TITLE = "Program Title"
+LABEL_CERT_OLD = "Cert Title (old)"
+LABEL_CERT_NEW = "Cert Title (new)"
+LABEL_CHANGE_DRY = "Will change"
+LABEL_CHANGE_COMMIT = "Changed"
+
+
+def format_field(label, value):
+    """Format one aligned ``  <label> : <value>`` report line."""
+    return f"  {label:<{LABEL_WIDTH}}: {value}"
 
 
 class Command(BaseCommand):
@@ -23,28 +42,26 @@ class Command(BaseCommand):
         """Backfill frozen program-certificate titles from the live CMS page."""
         programs = options["programs"]
         all_programs = options["all_programs"]
-        if bool(programs) == bool(all_programs):
-            msg = (
-                "Provide exactly one of --program <readable_id> (repeatable) "
-                "or --all-programs."
-            )
+        if not programs and not all_programs:
+            msg = "Provide --program <readable_id> or --all-programs."
+            raise CommandError(msg)
+        if programs and all_programs:
+            msg = "--program and --all-programs are mutually exclusive."
             raise CommandError(msg)
 
         commit = options["commit"]
+        change_label = LABEL_CHANGE_COMMIT if commit else LABEL_CHANGE_DRY
         banner = "COMMIT" if commit else "DRY RUN"
         self.stdout.write(self.style.WARNING(f"=== {banner} ==="))
 
-        programs_will_change = 0
-        programs_already_correct = 0
-        programs_skipped = 0
-        revisions_changed = 0
-        certs_affected = 0
+        tally = Counter()
 
         for readable_id, program in self._target_programs(programs, all_programs):
             if program is None:
-                programs_skipped += 1
+                tally["skipped"] += 1
                 self._write_block(
                     readable_id,
+                    change_label=change_label,
                     program_title="—",
                     new_title="—",
                     reason="no program with that readable_id",
@@ -53,9 +70,10 @@ class Command(BaseCommand):
 
             certificate_page = self._certificate_page(program)
             if certificate_page is None:
-                programs_skipped += 1
+                tally["skipped"] += 1
                 self._write_block(
                     readable_id,
+                    change_label=change_label,
                     program_title=program.title,
                     new_title="—",
                     reason="no certificate page",
@@ -64,10 +82,11 @@ class Command(BaseCommand):
 
             title = certificate_page.product_name
 
-            if not title or title.startswith("PLACEHOLDER - "):
-                programs_skipped += 1
+            if not title or title.startswith(PLACEHOLDER_PREFIX):
+                tally["skipped"] += 1
                 self._write_block(
                     readable_id,
+                    change_label=change_label,
                     program_title=program.title,
                     new_title=title or "—",
                     reason=(
@@ -78,39 +97,40 @@ class Command(BaseCommand):
                 continue
 
             changed, n_revisions, n_certs = self._process_program(
-                readable_id, program, title, commit=commit
+                readable_id, program, title, commit=commit, change_label=change_label
             )
-            revisions_changed += n_revisions
-            certs_affected += n_certs
-            if changed:
-                programs_will_change += 1
-            else:
-                programs_already_correct += 1
+            tally["revisions"] += n_revisions
+            tally["certs"] += n_certs
+            tally["will_change" if changed else "already_correct"] += 1
 
-        total = programs_will_change + programs_already_correct + programs_skipped
+        total = tally["will_change"] + tally["already_correct"] + tally["skipped"]
+        change_word = "changed" if commit else "will change"
         self.stdout.write("")
         self.stdout.write(
             self.style.SUCCESS(
                 f"Summary: {total} program(s), "
-                f"{programs_will_change} will change, "
-                f"{programs_already_correct} already correct, "
-                f"{programs_skipped} skipped "
-                f"({revisions_changed} revision(s), {certs_affected} cert(s) affected)."
+                f"{tally['will_change']} {change_word}, "
+                f"{tally['already_correct']} already correct, "
+                f"{tally['skipped']} skipped "
+                f"({tally['revisions']} revision(s), "
+                f"{tally['certs']} cert(s) affected)."
             )
         )
 
-    def _write_block(self, readable_id, *, program_title, new_title, reason):
+    def _write_block(
+        self, readable_id, *, change_label, program_title, new_title, reason
+    ):
         """Print a full per-program block for a program that is being skipped."""
         self.stdout.write("")
         self.stdout.write(readable_id)
-        self.stdout.write(f"  Program Title    : {program_title}")
-        self.stdout.write("  Cert Title (now) : —")
-        self.stdout.write(f"  Cert Title (new) : {new_title}")
+        self.stdout.write(format_field(LABEL_PROGRAM_TITLE, program_title))
+        self.stdout.write(format_field(LABEL_CERT_OLD, "—"))
+        self.stdout.write(format_field(LABEL_CERT_NEW, new_title))
         self.stdout.write(
-            self.style.WARNING(f"  Will change      : SKIPPED — {reason}")
+            self.style.WARNING(format_field(change_label, f"SKIPPED — {reason}"))
         )
 
-    def _process_program(self, readable_id, program, title, *, commit):
+    def _process_program(self, readable_id, program, title, *, commit, change_label):
         """Print a valid program's block and (when committing) rewrite revisions.
 
         Returns ``(changed, revisions_changed, certs_affected)``.
@@ -120,14 +140,14 @@ class Command(BaseCommand):
         lines = [
             "",
             readable_id,
-            f"  Program Title    : {program.title}",
-            f"  Cert Title (new) : {title}",
+            format_field(LABEL_PROGRAM_TITLE, program.title),
+            format_field(LABEL_CERT_NEW, title),
         ]
 
         revisions = self._distinct_revisions(program)
         if not revisions:
-            lines.append("  Cert Title (now) : —  (no issued certificates)")
-            lines.append("  Will change      : NO")
+            lines.append(format_field(LABEL_CERT_OLD, "—  (no issued certificates)"))
+            lines.append(format_field(change_label, "NO"))
             self._flush(lines)
             return False, 0, 0
 
@@ -136,15 +156,15 @@ class Command(BaseCommand):
         certs_affected = 0
         for revision, certs in revisions:
             old = revision.content.get("product_name")
-            label = f"{len(certs)} cert(s), revision {revision.id}"
-            lines.append(f"  Cert Title (now) : {old}  ({label})")
+            count = f"{len(certs)} cert(s), revision {revision.id}"
+            lines.append(format_field(LABEL_CERT_OLD, f"{old}  ({count})"))
             if old == title:
-                lines.append("  Will change      : NO")
+                lines.append(format_field(change_label, "NO"))
                 continue
             to_change.append(revision)
             revisions_changed += 1
             certs_affected += len(certs)
-            lines.append(self.style.SUCCESS("  Will change      : YES"))
+            lines.append(self.style.SUCCESS(format_field(change_label, "YES")))
 
         if commit and to_change:
             with transaction.atomic():
@@ -196,11 +216,14 @@ class Command(BaseCommand):
 
     @staticmethod
     def _distinct_revisions(program):
-        """Yield ``(revision, certs)`` for each distinct non-null revision shared
-        by the program's active certificates.
+        """Return ``[(revision, certs), ...]`` for each distinct non-null revision
+        shared by the program's certificates.
+
+        Uses ``all_objects`` so revoked (and any future-dated) certificates are
+        included — their frozen titles need backfilling too.
         """
         grouped = {}
-        certs = ProgramCertificate.objects.filter(program=program).select_related(
+        certs = ProgramCertificate.all_objects.filter(program=program).select_related(
             "certificate_page_revision"
         )
         for cert in certs:

--- a/courses/management/commands/backfill_program_certificate_titles.py
+++ b/courses/management/commands/backfill_program_certificate_titles.py
@@ -34,7 +34,8 @@ class Command(BaseCommand):
         banner = "COMMIT" if commit else "DRY RUN"
         self.stdout.write(self.style.WARNING(f"=== {banner} ==="))
 
-        programs_processed = 0
+        programs_will_change = 0
+        programs_already_correct = 0
         programs_skipped = 0
         revisions_changed = 0
         certs_affected = 0
@@ -42,20 +43,22 @@ class Command(BaseCommand):
         for readable_id, program in self._target_programs(programs, all_programs):
             if program is None:
                 programs_skipped += 1
-                self.stdout.write(
-                    self.style.ERROR(
-                        f"{readable_id}: skipping — no program with that readable_id."
-                    )
+                self._write_block(
+                    readable_id,
+                    program_title="—",
+                    new_title="—",
+                    reason="no program with that readable_id",
                 )
                 continue
 
             certificate_page = self._certificate_page(program)
             if certificate_page is None:
                 programs_skipped += 1
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"{readable_id}: skipping — no certificate page."
-                    )
+                self._write_block(
+                    readable_id,
+                    program_title=program.title,
+                    new_title="—",
+                    reason="no certificate page",
                 )
                 continue
 
@@ -63,53 +66,93 @@ class Command(BaseCommand):
 
             if not title or title.startswith("PLACEHOLDER - "):
                 programs_skipped += 1
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"{readable_id}: skipping — live Certificate Title is "
-                        f'empty or a placeholder ("{title}"). Fix the CMS page first.'
-                    )
+                self._write_block(
+                    readable_id,
+                    program_title=program.title,
+                    new_title=title or "—",
+                    reason=(
+                        f"live Certificate Title is empty or a placeholder "
+                        f'("{title}") — fix the CMS page first'
+                    ),
                 )
                 continue
 
-            programs_processed += 1
-            self.stdout.write(f'{readable_id}: target Certificate Title "{title}"')
+            changed, n_revisions, n_certs = self._process_program(
+                readable_id, program, title, commit=commit
+            )
+            revisions_changed += n_revisions
+            certs_affected += n_certs
+            if changed:
+                programs_will_change += 1
+            else:
+                programs_already_correct += 1
 
-            with transaction.atomic():
-                for revision, certs in self._distinct_revisions(program):
-                    old = revision.content.get("product_name")
-                    if old == title:
-                        self.stdout.write(
-                            f'  {revision.id}  ({len(certs)} certs)  "{old}"  [skipped]'
-                        )
-                        continue
-                    if commit:
-                        # Reassign rather than mutate in place so the change is
-                        # always picked up regardless of save()/update_fields or
-                        # any dirty-tracking behavior on the model.
-                        content = revision.content
-                        content["product_name"] = title
-                        revision.content = content
-                        revision.save(update_fields=["content"])
-                        status = "changed"
-                    else:
-                        status = "would-change"
-                    revisions_changed += 1
-                    certs_affected += len(certs)
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f"  {revision.id}  ({len(certs)} certs)  "
-                            f'"{old}" -> "{title}"  [{status}]'
-                        )
-                    )
-
+        total = programs_will_change + programs_already_correct + programs_skipped
+        self.stdout.write("")
         self.stdout.write(
             self.style.SUCCESS(
-                f"Summary: {programs_processed} program(s) processed, "
-                f"{programs_skipped} skipped, "
-                f"{revisions_changed} revision(s) changed, "
-                f"{certs_affected} cert(s) affected."
+                f"Summary: {total} program(s), "
+                f"{programs_will_change} will change, "
+                f"{programs_already_correct} already correct, "
+                f"{programs_skipped} skipped "
+                f"({revisions_changed} revision(s), {certs_affected} cert(s) affected)."
             )
         )
+
+    def _write_block(self, readable_id, *, program_title, new_title, reason):
+        """Print a full per-program block for a program that is being skipped."""
+        self.stdout.write("")
+        self.stdout.write(readable_id)
+        self.stdout.write(f"  Program Title    : {program_title}")
+        self.stdout.write("  Cert Title (now) : —")
+        self.stdout.write(f"  Cert Title (new) : {new_title}")
+        self.stdout.write(
+            self.style.WARNING(f"  Will change      : SKIPPED — {reason}")
+        )
+
+    def _process_program(self, readable_id, program, title, *, commit):
+        """Print a valid program's block and (when committing) rewrite revisions.
+
+        Returns ``(changed, revisions_changed, certs_affected)``.
+        """
+        # Print the header (program title + target title) once, then a
+        # (now / will change) pairing for each distinct frozen revision.
+        self.stdout.write("")
+        self.stdout.write(readable_id)
+        self.stdout.write(f"  Program Title    : {program.title}")
+        self.stdout.write(f"  Cert Title (new) : {title}")
+
+        revisions = self._distinct_revisions(program)
+        if not revisions:
+            self.stdout.write("  Cert Title (now) : —  (no issued certificates)")
+            self.stdout.write("  Will change      : NO")
+            return False, 0, 0
+
+        changed = False
+        revisions_changed = 0
+        certs_affected = 0
+        with transaction.atomic():
+            for revision, certs in revisions:
+                old = revision.content.get("product_name")
+                label = f"{len(certs)} cert(s), revision {revision.id}"
+                self.stdout.write(f"  Cert Title (now) : {old}  ({label})")
+                if old == title:
+                    self.stdout.write("  Will change      : NO")
+                    continue
+                if commit:
+                    # Reassign rather than mutate in place so the change is
+                    # always picked up regardless of save()/update_fields or
+                    # any dirty-tracking behavior on the model.
+                    content = revision.content
+                    content["product_name"] = title
+                    revision.content = content
+                    revision.save(update_fields=["content"])
+                changed = True
+                revisions_changed += 1
+                certs_affected += len(certs)
+                self.stdout.write(self.style.SUCCESS("  Will change      : YES"))
+
+        return changed, revisions_changed, certs_affected
 
     @staticmethod
     def _target_programs(programs, all_programs):

--- a/courses/management/commands/backfill_program_certificate_titles.py
+++ b/courses/management/commands/backfill_program_certificate_titles.py
@@ -115,31 +115,44 @@ class Command(BaseCommand):
 
         Returns ``(changed, revisions_changed, certs_affected)``.
         """
-        # Print the header (program title + target title) once, then a
-        # (now / will change) pairing for each distinct frozen revision.
-        self.stdout.write("")
-        self.stdout.write(readable_id)
-        self.stdout.write(f"  Program Title    : {program.title}")
-        self.stdout.write(f"  Cert Title (new) : {title}")
+        # Build the whole report block in memory and decide which revisions to
+        # rewrite, but do NOT print anything yet. The writes happen first, inside
+        # transaction.atomic(); only once they commit do we flush the block. That
+        # way a rollback (e.g. a save() error on a later revision) can never leave
+        # behind output claiming a change that was undone — on failure the
+        # exception propagates before any line is written.
+        lines = [
+            "",
+            readable_id,
+            f"  Program Title    : {program.title}",
+            f"  Cert Title (new) : {title}",
+        ]
 
         revisions = self._distinct_revisions(program)
         if not revisions:
-            self.stdout.write("  Cert Title (now) : —  (no issued certificates)")
-            self.stdout.write("  Will change      : NO")
+            lines.append("  Cert Title (now) : —  (no issued certificates)")
+            lines.append("  Will change      : NO")
+            self._flush(lines)
             return False, 0, 0
 
-        changed = False
+        to_change = []
         revisions_changed = 0
         certs_affected = 0
-        with transaction.atomic():
-            for revision, certs in revisions:
-                old = revision.content.get("product_name")
-                label = f"{len(certs)} cert(s), revision {revision.id}"
-                self.stdout.write(f"  Cert Title (now) : {old}  ({label})")
-                if old == title:
-                    self.stdout.write("  Will change      : NO")
-                    continue
-                if commit:
+        for revision, certs in revisions:
+            old = revision.content.get("product_name")
+            label = f"{len(certs)} cert(s), revision {revision.id}"
+            lines.append(f"  Cert Title (now) : {old}  ({label})")
+            if old == title:
+                lines.append("  Will change      : NO")
+                continue
+            to_change.append(revision)
+            revisions_changed += 1
+            certs_affected += len(certs)
+            lines.append(self.style.SUCCESS("  Will change      : YES"))
+
+        if commit and to_change:
+            with transaction.atomic():
+                for revision in to_change:
                     # Reassign rather than mutate in place so the change is
                     # always picked up regardless of save()/update_fields or
                     # any dirty-tracking behavior on the model.
@@ -147,12 +160,14 @@ class Command(BaseCommand):
                     content["product_name"] = title
                     revision.content = content
                     revision.save(update_fields=["content"])
-                changed = True
-                revisions_changed += 1
-                certs_affected += len(certs)
-                self.stdout.write(self.style.SUCCESS("  Will change      : YES"))
 
-        return changed, revisions_changed, certs_affected
+        self._flush(lines)
+        return bool(to_change), revisions_changed, certs_affected
+
+    def _flush(self, lines):
+        """Write the collected report lines for one program to stdout."""
+        for line in lines:
+            self.stdout.write(line)
 
     @staticmethod
     def _target_programs(programs, all_programs):

--- a/courses/management/commands/backfill_program_certificate_titles.py
+++ b/courses/management/commands/backfill_program_certificate_titles.py
@@ -83,8 +83,13 @@ class Command(BaseCommand):
                         )
                         continue
                     if commit:
-                        revision.content["product_name"] = title
-                        revision.save()
+                        # Reassign rather than mutate in place so the change is
+                        # always picked up regardless of save()/update_fields or
+                        # any dirty-tracking behavior on the model.
+                        content = revision.content
+                        content["product_name"] = title
+                        revision.content = content
+                        revision.save(update_fields=["content"])
                         status = "changed"
                     else:
                         status = "would-change"

--- a/courses/management/commands/backfill_program_certificate_titles.py
+++ b/courses/management/commands/backfill_program_certificate_titles.py
@@ -149,11 +149,9 @@ class Command(BaseCommand):
         if commit and to_change:
             with transaction.atomic():
                 for revision in to_change:
-                    # Reassign (don't mutate in place) so save(update_fields=...)
-                    # reliably detects the JSONField change.
-                    content = revision.content
-                    content["product_name"] = title
-                    revision.content = content
+                    # Build a fresh dict rather than mutating revision.content in
+                    # place, so the stored JSONField is replaced cleanly.
+                    revision.content = {**revision.content, "product_name": title}
                     revision.save(update_fields=["content"])
 
         self._flush(lines)
@@ -173,7 +171,7 @@ class Command(BaseCommand):
         yielded (with its own readable_id).
         """
         if all_programs:
-            for program in Program.objects.all():
+            for program in Program.objects.all().order_by("readable_id"):
                 yield program.readable_id, program
             return
         by_readable_id = {
@@ -202,7 +200,10 @@ class Command(BaseCommand):
         by the program's active certificates.
         """
         grouped = {}
-        for cert in ProgramCertificate.objects.filter(program=program):
+        certs = ProgramCertificate.objects.filter(program=program).select_related(
+            "certificate_page_revision"
+        )
+        for cert in certs:
             revision = cert.certificate_page_revision
             if revision is None:
                 continue

--- a/courses/management/commands/test_backfill_program_certificate_titles.py
+++ b/courses/management/commands/test_backfill_program_certificate_titles.py
@@ -74,7 +74,9 @@ def test_dry_run_by_default_makes_no_db_changes():
 
 
 def test_dry_run_output_reports_planned_change():
-    """Dry-run output names the program, the old and new titles, and the mode."""
+    """Dry-run output is an admin-readable block: readable_id, program title,
+    current and target certificate titles, and a YES/NO change flag.
+    """
     program, _ = _program_with_issued_cert(
         frozen_title="OLD Title", live_title="NEW Title"
     )
@@ -83,8 +85,10 @@ def test_dry_run_output_reports_planned_change():
 
     assert "DRY RUN" in output
     assert program.readable_id in output
-    assert "OLD Title" in output
-    assert "NEW Title" in output
+    assert f"Program Title    : {program.title}" in output
+    assert "Cert Title (now) : OLD Title" in output
+    assert "Cert Title (new) : NEW Title" in output
+    assert "Will change      : YES" in output
 
 
 def test_commit_is_idempotent():
@@ -97,9 +101,9 @@ def test_commit_is_idempotent():
     output = _run("--program", program.readable_id, "--commit")
 
     assert _frozen_title(certificate) == "NEW Title"
-    assert "skipped" in output
-    assert "[changed]" not in output
-    assert "0 revision(s) changed" in output
+    assert "Will change      : NO" in output
+    assert "Will change      : YES" not in output
+    assert "0 revision(s)" in output
 
 
 def test_null_revision_cert_is_skipped_without_error():
@@ -142,7 +146,7 @@ def test_shared_revision_updated_once_for_all_certs():
 
     assert _frozen_title(cert_a) == "NEW Title"
     assert _frozen_title(cert_b) == "NEW Title"
-    assert "(2 certs)" in output
+    assert "2 cert(s)" in output
 
 
 def test_placeholder_live_title_skips_program_without_writing():

--- a/courses/management/commands/test_backfill_program_certificate_titles.py
+++ b/courses/management/commands/test_backfill_program_certificate_titles.py
@@ -11,6 +11,14 @@ from wagtail.models import Revision
 from cms.factories import ProgramPageFactory
 from cms.models import CertificatePage
 from courses.factories import ProgramCertificateFactory
+from courses.management.commands.backfill_program_certificate_titles import (
+    LABEL_CERT_NEW,
+    LABEL_CERT_OLD,
+    LABEL_CHANGE_COMMIT,
+    LABEL_CHANGE_DRY,
+    LABEL_PROGRAM_TITLE,
+    format_field,
+)
 from courses.models import Program, ProgramCertificate
 
 pytestmark = [pytest.mark.django_db]
@@ -42,15 +50,15 @@ def _program_with_issued_cert(frozen_title, live_title):
 
 
 def _run(*args):
-    out = StringIO()
-    call_command("backfill_program_certificate_titles", *args, stdout=out, stderr=out)
+    out, err = StringIO(), StringIO()
+    call_command("backfill_program_certificate_titles", *args, stdout=out, stderr=err)
     return out.getvalue()
 
 
 def _frozen_title(certificate):
     revision = certificate.certificate_page_revision
     revision.refresh_from_db()
-    return revision.as_object().product_name
+    return revision.content["product_name"]
 
 
 def test_commit_updates_frozen_title_to_live_page_value():
@@ -87,10 +95,10 @@ def test_dry_run_output_reports_planned_change():
 
     assert "DRY RUN" in output
     assert program.readable_id in output
-    assert f"Program Title    : {program.title}" in output
-    assert "Cert Title (now) : OLD Title" in output
-    assert "Cert Title (new) : NEW Title" in output
-    assert "Will change      : YES" in output
+    assert format_field(LABEL_PROGRAM_TITLE, program.title) in output
+    assert format_field(LABEL_CERT_OLD, "OLD Title") in output
+    assert format_field(LABEL_CERT_NEW, "NEW Title") in output
+    assert format_field(LABEL_CHANGE_DRY, "YES") in output
 
 
 def test_commit_is_idempotent():
@@ -103,13 +111,13 @@ def test_commit_is_idempotent():
     output = _run("--program", program.readable_id, "--commit")
 
     assert _frozen_title(certificate) == "NEW Title"
-    assert "Will change      : NO" in output
-    assert "Will change      : YES" not in output
+    assert format_field(LABEL_CHANGE_COMMIT, "NO") in output
+    assert format_field(LABEL_CHANGE_COMMIT, "YES") not in output
     assert "0 revision(s)" in output
 
 
 def test_null_revision_cert_is_skipped_without_error():
-    """A certificate with no frozen revision (e.g. revoked) is left untouched."""
+    """A certificate with no frozen revision is left untouched."""
     program, certificate = _program_with_issued_cert(
         frozen_title="OLD Title", live_title="NEW Title"
     )
@@ -121,6 +129,18 @@ def test_null_revision_cert_is_skipped_without_error():
 
     certificate.refresh_from_db()
     assert certificate.certificate_page_revision is None
+
+
+def test_revoked_certificate_is_also_backfilled():
+    """Revoked certs are included (all_objects): their frozen title is fixed too."""
+    program, certificate = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="NEW Title"
+    )
+    ProgramCertificate.all_objects.filter(pk=certificate.pk).update(is_revoked=True)
+
+    _run("--program", program.readable_id, "--commit")
+
+    assert _frozen_title(certificate) == "NEW Title"
 
 
 def test_shared_revision_updated_once_for_all_certs():
@@ -187,7 +207,7 @@ def test_commit_rollback_emits_no_misleading_success_output(mocker):
 
     mocker.patch.object(Revision, "save", autospec=True, side_effect=flaky_save)
 
-    out = StringIO()
+    out, err = StringIO(), StringIO()
     with pytest.raises(DatabaseError):
         call_command(
             "backfill_program_certificate_titles",
@@ -195,12 +215,12 @@ def test_commit_rollback_emits_no_misleading_success_output(mocker):
             program_page.program.readable_id,
             "--commit",
             stdout=out,
-            stderr=out,
+            stderr=err,
         )
 
     output = out.getvalue()
     # No success line, and both frozen titles are unchanged (fully rolled back).
-    assert "Will change      : YES" not in output
+    assert format_field(LABEL_CHANGE_COMMIT, "YES") not in output
     assert _frozen_title(cert_a) == "OLD Title"
     assert _frozen_title(cert_b) == "OLD Title"
 

--- a/courses/management/commands/test_backfill_program_certificate_titles.py
+++ b/courses/management/commands/test_backfill_program_certificate_titles.py
@@ -5,6 +5,8 @@ from io import StringIO
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db import DatabaseError
+from wagtail.models import Revision
 
 from cms.factories import ProgramPageFactory
 from cms.models import CertificatePage
@@ -147,6 +149,60 @@ def test_shared_revision_updated_once_for_all_certs():
     assert _frozen_title(cert_a) == "NEW Title"
     assert _frozen_title(cert_b) == "NEW Title"
     assert "2 cert(s)" in output
+
+
+def test_commit_rollback_emits_no_misleading_success_output(mocker):
+    """If a revision save fails mid-commit, the per-program transaction rolls
+    back and NO output claims a change succeeded — the report block is flushed
+    only after the writes commit, so a rollback leaves nothing behind.
+    """
+    program_page = ProgramPageFactory.create()
+    cert_page = program_page.certificate_page
+    cert_page.product_name = "OLD Title"
+    cert_page.save()
+    cert_page.save_revision()
+    rev_a = cert_page.revisions.last()
+    cert_a = ProgramCertificateFactory.create(
+        program=program_page.program, certificate_page_revision=rev_a
+    )
+    cert_page.save_revision()
+    rev_b = cert_page.revisions.last()
+    cert_b = ProgramCertificateFactory.create(
+        program=program_page.program, certificate_page_revision=rev_b
+    )
+
+    cert_page.product_name = "NEW Title"
+    cert_page.save()
+
+    # Fail the second revision save so the atomic block rolls the first one back.
+    original_save = Revision.save
+    state = {"calls": 0}
+
+    def flaky_save(self, *args, **kwargs):
+        state["calls"] += 1
+        if state["calls"] >= 2:
+            msg = "simulated DB failure"
+            raise DatabaseError(msg)
+        return original_save(self, *args, **kwargs)
+
+    mocker.patch.object(Revision, "save", autospec=True, side_effect=flaky_save)
+
+    out = StringIO()
+    with pytest.raises(DatabaseError):
+        call_command(
+            "backfill_program_certificate_titles",
+            "--program",
+            program_page.program.readable_id,
+            "--commit",
+            stdout=out,
+            stderr=out,
+        )
+
+    output = out.getvalue()
+    # No success line, and both frozen titles are unchanged (fully rolled back).
+    assert "Will change      : YES" not in output
+    assert _frozen_title(cert_a) == "OLD Title"
+    assert _frozen_title(cert_b) == "OLD Title"
 
 
 def test_placeholder_live_title_skips_program_without_writing():

--- a/courses/management/commands/test_backfill_program_certificate_titles.py
+++ b/courses/management/commands/test_backfill_program_certificate_titles.py
@@ -1,0 +1,238 @@
+"""Tests for the backfill_program_certificate_titles management command."""
+
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from cms.factories import ProgramPageFactory
+from cms.models import CertificatePage
+from courses.factories import ProgramCertificateFactory
+from courses.models import Program, ProgramCertificate
+
+pytestmark = [pytest.mark.django_db]
+
+
+def _program_with_issued_cert(frozen_title, live_title):
+    """Create a program whose issued certificate is frozen to ``frozen_title``
+    while the live CMS certificate page now shows ``live_title``.
+
+    Returns ``(program, certificate)``.
+    """
+    program_page = ProgramPageFactory.create()
+    cert_page = program_page.certificate_page
+
+    # Freeze a revision carrying the old title, then issue a cert against it.
+    cert_page.product_name = frozen_title
+    cert_page.save()
+    cert_page.save_revision()
+    certificate = ProgramCertificateFactory.create(
+        program=program_page.program,
+        certificate_page_revision=cert_page.revisions.last(),
+    )
+
+    # The admin has since corrected the live "Certificate Title".
+    cert_page.product_name = live_title
+    cert_page.save()
+
+    return program_page.program, certificate
+
+
+def _run(*args):
+    out = StringIO()
+    call_command("backfill_program_certificate_titles", *args, stdout=out, stderr=out)
+    return out.getvalue()
+
+
+def _frozen_title(certificate):
+    revision = certificate.certificate_page_revision
+    revision.refresh_from_db()
+    return revision.as_object().product_name
+
+
+def test_commit_updates_frozen_title_to_live_page_value():
+    """--commit rewrites each issued cert's frozen product_name to the live title."""
+    program, certificate = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="NEW Title"
+    )
+
+    _run("--program", program.readable_id, "--commit")
+
+    assert _frozen_title(certificate) == "NEW Title"
+
+
+def test_dry_run_by_default_makes_no_db_changes():
+    """Without --commit the command reports but never writes to the DB."""
+    program, certificate = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="NEW Title"
+    )
+
+    _run("--program", program.readable_id)
+
+    assert _frozen_title(certificate) == "OLD Title"
+
+
+def test_dry_run_output_reports_planned_change():
+    """Dry-run output names the program, the old and new titles, and the mode."""
+    program, _ = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="NEW Title"
+    )
+
+    output = _run("--program", program.readable_id)
+
+    assert "DRY RUN" in output
+    assert program.readable_id in output
+    assert "OLD Title" in output
+    assert "NEW Title" in output
+
+
+def test_commit_is_idempotent():
+    """A second --commit run is a no-op: the revision is reported as skipped."""
+    program, certificate = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="NEW Title"
+    )
+
+    _run("--program", program.readable_id, "--commit")
+    output = _run("--program", program.readable_id, "--commit")
+
+    assert _frozen_title(certificate) == "NEW Title"
+    assert "skipped" in output
+    assert "[changed]" not in output
+    assert "0 revision(s) changed" in output
+
+
+def test_null_revision_cert_is_skipped_without_error():
+    """A certificate with no frozen revision (e.g. revoked) is left untouched."""
+    program, certificate = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="NEW Title"
+    )
+    ProgramCertificate.objects.filter(pk=certificate.pk).update(
+        certificate_page_revision=None
+    )
+
+    _run("--program", program.readable_id, "--commit")
+
+    certificate.refresh_from_db()
+    assert certificate.certificate_page_revision is None
+
+
+def test_shared_revision_updated_once_for_all_certs():
+    """Certs issued at the same page revision share one Revision row: a single
+    edit updates them all, and the report counts the certs.
+    """
+    program_page = ProgramPageFactory.create()
+    cert_page = program_page.certificate_page
+    cert_page.product_name = "OLD Title"
+    cert_page.save()
+    cert_page.save_revision()
+    revision = cert_page.revisions.last()
+
+    cert_a = ProgramCertificateFactory.create(
+        program=program_page.program, certificate_page_revision=revision
+    )
+    cert_b = ProgramCertificateFactory.create(
+        program=program_page.program, certificate_page_revision=revision
+    )
+
+    cert_page.product_name = "NEW Title"
+    cert_page.save()
+
+    output = _run("--program", program_page.program.readable_id, "--commit")
+
+    assert _frozen_title(cert_a) == "NEW Title"
+    assert _frozen_title(cert_b) == "NEW Title"
+    assert "(2 certs)" in output
+
+
+def test_placeholder_live_title_skips_program_without_writing():
+    """A live title that is still the CMS placeholder is never stamped onto certs."""
+    program, certificate = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="PLACEHOLDER - Some Program Certificate"
+    )
+
+    output = _run("--program", program.readable_id, "--commit")
+
+    assert _frozen_title(certificate) == "OLD Title"
+    assert "PLACEHOLDER" in output
+
+
+def test_empty_live_title_skips_program_without_writing():
+    """An empty live title is never stamped onto issued certificates."""
+    program, certificate = _program_with_issued_cert(
+        frozen_title="OLD Title", live_title="Temp Title"
+    )
+    # product_name is required at the CMS layer, so force the empty value at the
+    # DB level (bypassing full_clean) to exercise the defensive guard.
+    cert_page = program.page.certificate_page
+    CertificatePage.objects.filter(pk=cert_page.pk).update(product_name="")
+
+    _run("--program", program.readable_id, "--commit")
+
+    assert _frozen_title(certificate) == "OLD Title"
+
+
+def test_no_mode_flag_raises_command_error():
+    """A bare run targets nothing: neither --program nor --all-programs errors."""
+    with pytest.raises(CommandError):
+        _run()
+
+
+def test_both_mode_flags_raise_command_error():
+    """--program and --all-programs are mutually exclusive."""
+    with pytest.raises(CommandError):
+        _run("--program", "program-v1:Org+Foo", "--all-programs")
+
+
+def test_summary_line_reports_totals():
+    """A final summary tallies programs processed, revisions changed, certs affected."""
+    program, _ = _program_with_issued_cert("OLD Title", "NEW Title")
+
+    output = _run("--program", program.readable_id, "--commit")
+
+    assert "Summary" in output
+    assert "1 program" in output
+    assert "1 revision" in output
+    assert "1 cert" in output
+
+
+def test_unknown_program_is_reported_and_other_programs_still_processed():
+    """A missing --program readable_id is reported and skipped, not fatal."""
+    program, certificate = _program_with_issued_cert("OLD Title", "NEW Title")
+
+    output = _run(
+        "--program",
+        "program-v1:Does+NotExist",
+        "--program",
+        program.readable_id,
+        "--commit",
+    )
+
+    assert "Does+NotExist" in output
+    assert _frozen_title(certificate) == "NEW Title"
+
+
+def test_all_programs_processes_clean_programs_and_skips_placeholder():
+    """--all-programs updates every clean program and skips placeholder ones."""
+    _, clean_cert_a = _program_with_issued_cert("OLD A", "NEW A")
+    _, clean_cert_b = _program_with_issued_cert("OLD B", "NEW B")
+    _, placeholder_cert = _program_with_issued_cert(
+        "OLD PH", "PLACEHOLDER - Foo Certificate"
+    )
+
+    _run("--all-programs", "--commit")
+
+    assert _frozen_title(clean_cert_a) == "NEW A"
+    assert _frozen_title(clean_cert_b) == "NEW B"
+    assert _frozen_title(placeholder_cert) == "OLD PH"
+
+
+def test_all_programs_skips_programs_without_cms_page():
+    """--all-programs tolerates programs that have no CMS page / certificate page."""
+    _, clean_cert = _program_with_issued_cert("OLD", "NEW")
+    # A bare program with no CMS page at all (page is None).
+    Program.objects.create(title="Bare", readable_id="program-v1:Bare+NoPage")
+
+    _run("--all-programs", "--commit")  # must not raise
+
+    assert _frozen_title(clean_cert) == "NEW"


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11938

### Description
Issued program certificates **freeze** their "Certificate Title" (`product_name`) into the Wagtail page revision in effect at issue time (`ProgramCertificate.certificate_page_revision`), and the display path reads `certificate_page_revision.as_object().product_name`. So editing the live "Certificate Title" in the CMS does **not** update certificates already issued — they keep their old frozen title until a one-time backfill is run.

This adds a `backfill_program_certificate_titles` management command (workstream 1 of hq#11938, follow-up to hq#11907 / #3695) that rewrites each issued program certificate's frozen `product_name` to the live CMS page value.

```
python manage.py backfill_program_certificate_titles \
    (--program <readable_id> [--program <readable_id> ...] | --all-programs) \
    [--commit]
```

## Behavior & safety

- **Dry-run by default** — reports planned changes; `--commit` is required to write.
- **Mode validation** — exactly one of `--program` (repeatable) / `--all-programs`; neither or both raises `CommandError`, so a bare run touches nothing.
- **Placeholder/empty guard** — skips any program whose live title is empty or still a `"PLACEHOLDER - "` default; placeholder text is never stamped onto real certificates.
- **Idempotent** — revisions already matching the live title are reported `Will change: NO`; a second `--commit` run is a no-op.
- **Distinct-revision dedup** — certs issued at the same page revision share one `Revision` row, so each shared revision is edited once (report shows `(N cert(s))`).
- **Tolerant skips (never crash)** — unknown readable_id, missing CMS page, missing certificate page, and null-revision (revoked) certs are reported and skipped.
- **Rollback-safe output** — each program's report block is built in memory and flushed to stdout only after its writes commit, so a rollback never leaves behind output claiming a change that was undone.
- Per-program writes run inside `transaction.atomic()`; a final `Summary:` line tallies programs (will change / already correct / skipped), revisions changed, and certs affected.

## Output

Every targeted program prints an admin-readable block — `readable_id`, program title, current frozen title, target live title, and a `YES` / `NO` / `SKIPPED` change flag — so the dry-run can be shared with product/admins for sign-off before committing:

```
=== DRY RUN ===

program-v1:UAI+B2C
  Program Title    : UAI B2C Program
  Cert Title (new) : Universal AI 0909
  Cert Title (now) : Universal AI11  (1 cert(s), revision 126)
  Will change      : YES

Summary: 1 program(s), 1 will change, 0 already correct, 0 skipped (1 revision(s), 1 cert(s) affected).
```

In `--commit` mode the block is identical; only the banner changes to `=== COMMIT ===`.

## Write strategy

Rewrites the existing `Revision.content["product_name"]` (per design): simplest, fewest writes, fixes all certs sharing a revision at once. Trade-off — the page's revision-history view will retroactively show the corrected title, which is acceptable for a one-time correction.

## How to test

The command rewrites the **frozen** "Certificate Title" on already-issued program certificates to the **live** CMS value, so you need a program whose live Certificate Title differs from the one frozen on an issued cert.

### 1. Update the "Certificate Title" in Wagtail
1. Open the Wagtail CMS admin (local): `http://mitxonline.odl.local:8013/cms/pages`
2. Go to a **Program** page that already has an issued certificate (e.g. `program-v1:UAI+B2C`) → its child **Certificate** page.
3. Change the **"Certificate Title"** (`product_name`) field to a new value, distinct from the title currently frozen on the issued cert, and **Publish**.

(If the program has no issued certificate yet, issue one for your user via MITx Online Django admin first.)

### 2. Dry-run — preview what would change (no writes)
```
docker compose run --rm web python manage.py backfill_program_certificate_titles --program program-v1:UAI+B2C
```
The edited program reports `Will change: YES`, with `Cert Title (now)` (old frozen value) → `Cert Title (new)` (your new live value). Save the report to a file to share with an admin for sign-off:
```
docker compose run --rm web python manage.py backfill_program_certificate_titles --all-programs > cert_backfill_dryrun.txt 2>/dev/null
```
(The report goes to stdout; `2>/dev/null` drops container startup noise. Colors are auto-stripped when not a TTY.)

### 3. Commit — apply the change
```
docker compose run --rm web python manage.py backfill_program_certificate_titles --program program-v1:UAI+B2C --commit
```
Or for every program at once:
```
docker compose run --rm web python manage.py backfill_program_certificate_titles --all-programs --commit
```

### 4. See the change
- **Re-run the dry-run** — the program now reports `Will change: NO` (frozen title matches live), proving the backfill landed and is idempotent.
- **On the certificate** — open the issued program certificate and confirm it now displays the updated Certificate Title.

### Automated tests
```
docker compose run --rm web uv run pytest courses/management/commands/test_backfill_program_certificate_titles.py
```

## Test plan

- [x] `--commit` rewrites frozen `product_name` to the live title (asserted via the display path `revision.as_object().product_name`)
- [x] Dry-run (default) makes no DB writes and reports the planned change
- [x] Idempotent: second `--commit` reports zero changes
- [x] Placeholder / empty live title → program skipped, no writes
- [x] Null-revision (revoked) cert → not touched
- [x] Shared revision: multiple certs → single edit, all updated
- [x] Rollback-safe: a mid-commit save failure rolls back fully and emits no success output
- [x] Mode validation: neither flag → `CommandError`; both flags → `CommandError`
- [x] `--all-programs` processes clean programs and skips placeholder / page-less ones
- [x] Unknown `--program` readable_id reported and skipped; other programs still processed
- [x] 15 tests pass; `ruff format` + `ruff check` clean
- [x] Verified end-to-end locally: edited a CMS Certificate Title → dry-run showed `YES` → `--commit` applied it → re-run reported `NO`
