### PR TITLE
Use CMS Certificate Title for program verifiable credentials

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -1779,7 +1779,10 @@ def get_verifiable_credentials_payload(
         program = certificate.program
         program_page = program.program_page
         url = get_learn_product_url("programs", program.readable_id)
-        certificate_name = certificate.program.title
+        # Prefer the CMS "Certificate Title" (product_name) so the verifiable
+        # credential carries the same name shown on the certificate, falling back
+        # to the program title when it is unset.
+        certificate_name = certificate_page.product_name or certificate.program.title
         activity_start_date = ProgramEnrollment.all_objects.get(
             user_id=certificate.user_id, program=program
         ).created_on.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/courses/api.py
+++ b/courses/api.py
@@ -1781,8 +1781,11 @@ def get_verifiable_credentials_payload(
         url = get_learn_product_url("programs", program.readable_id)
         # Prefer the CMS "Certificate Title" (product_name) so the verifiable
         # credential carries the same name shown on the certificate, falling back
-        # to the program title when it is unset.
-        certificate_name = certificate_page.product_name or certificate.program.title
+        # to the program title when it is blank. Trim so it matches the frontend
+        # (getCertificateTitle), which also falls back on whitespace-only titles.
+        certificate_name = (
+            certificate_page.product_name or ""
+        ).strip() or certificate.program.title
         activity_start_date = ProgramEnrollment.all_objects.get(
             user_id=certificate.user_id, program=program
         ).created_on.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/courses/api.py
+++ b/courses/api.py
@@ -1779,10 +1779,6 @@ def get_verifiable_credentials_payload(
         program = certificate.program
         program_page = program.program_page
         url = get_learn_product_url("programs", program.readable_id)
-        # Prefer the CMS "Certificate Title" (product_name) so the verifiable
-        # credential carries the same name shown on the certificate, falling back
-        # to the program title when it is blank. Trim so it matches the frontend
-        # (getCertificateTitle), which also falls back on whitespace-only titles.
         certificate_name = (
             certificate_page.product_name or ""
         ).strip() or certificate.program.title

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -3377,6 +3377,7 @@ def test_program_certificate_verifiable_credentials(
     mock_certificate_page = Mock()
     mock_certificate_page.verifiable_credential_criteria = "mock_credential_data"
     mock_certificate_page.should_provision_verifiable_credential = True
+    mock_certificate_page.product_name = "Test Program Certificate"
     mocker.patch("courses.api.get_certificate_page", return_value=mock_certificate_page)
     courses = CourseFactory.create_batch(3)
     course_runs = CourseRunFactory.create_batch(3, course=factory.Iterator(courses))
@@ -3588,6 +3589,9 @@ def test_program_certificate_verifiable_credentials_signing_payload(
 
     mock_certificate_page = Mock()
     mock_certificate_page.verifiable_credential_criteria = "mock_credential_data"
+    # The verifiable credential name should come from the CMS "Certificate Title"
+    # (product_name), not the program title.
+    mock_certificate_page.product_name = "Universal AI"
     payload = get_verifiable_credentials_payload(program_cert, mock_certificate_page)
 
     # Assert the expected payload structure
@@ -3630,8 +3634,8 @@ def test_program_certificate_verifiable_credentials_signing_payload(
                 "criteria": {
                     "narrative": mock_certificate_page.verifiable_credential_criteria
                 },
-                "description": "Jane Smith has successfully completed all modules and earned a Program Certificate in Data Science MicroMasters.",
-                "name": "Data Science MicroMasters",
+                "description": "Jane Smith has successfully completed all modules and earned a Program Certificate in Universal AI.",
+                "name": "Universal AI",
                 "image": {
                     "id": "https://example.com/program-thumbnail.jpg",
                     "type": "Image",
@@ -3642,6 +3646,39 @@ def test_program_certificate_verifiable_credentials_signing_payload(
     }
 
     assert payload == expected_payload
+
+
+@patch("courses.api.ProgramEnrollment.all_objects.get")
+@patch("courses.api.get_thumbnail_url")
+def test_program_verifiable_credential_name_falls_back_to_program_title(
+    mock_get_thumbnail_url, mock_enrollment_get, settings, mocker
+):
+    """The VC name falls back to the program title when product_name is empty."""
+    mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
+    mocker.patch("hubspot_sync.api.upsert_custom_properties")
+
+    mock_enrollment = Mock()
+    mock_enrollment.created_on = datetime(
+        2024, 2, 20, 14, 45, 0, tzinfo=ZoneInfo("UTC")
+    )
+    mock_enrollment_get.return_value = mock_enrollment
+    mock_get_thumbnail_url.return_value = ""
+
+    settings.ENVIRONMENT = "production"
+
+    program_cert = ProgramCertificateFactory.create()
+    program_cert.program.title = "Data Science MicroMasters"
+    program_cert.program.save()
+
+    mock_certificate_page = Mock()
+    mock_certificate_page.verifiable_credential_criteria = "mock_credential_data"
+    mock_certificate_page.product_name = ""
+
+    payload = get_verifiable_credentials_payload(program_cert, mock_certificate_page)
+
+    achievement = payload["credentialSubject"]["achievement"]
+    assert achievement["name"] == "Data Science MicroMasters"
+    assert "Data Science MicroMasters" in achievement["description"]
 
 
 @pytest.mark.parametrize(

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -3648,12 +3648,13 @@ def test_program_certificate_verifiable_credentials_signing_payload(
     assert payload == expected_payload
 
 
+@pytest.mark.parametrize("product_name", ["", "   "])
 @patch("courses.api.ProgramEnrollment.all_objects.get")
 @patch("courses.api.get_thumbnail_url")
 def test_program_verifiable_credential_name_falls_back_to_program_title(
-    mock_get_thumbnail_url, mock_enrollment_get, settings, mocker
+    mock_get_thumbnail_url, mock_enrollment_get, product_name, settings, mocker
 ):
-    """The VC name falls back to the program title when product_name is empty."""
+    """The VC name falls back to the program title when product_name is blank."""
     mocker.patch("hubspot_sync.task_helpers.sync_hubspot_user")
     mocker.patch("hubspot_sync.api.upsert_custom_properties")
 
@@ -3672,7 +3673,7 @@ def test_program_verifiable_credential_name_falls_back_to_program_title(
 
     mock_certificate_page = Mock()
     mock_certificate_page.verifiable_credential_criteria = "mock_credential_data"
-    mock_certificate_page.product_name = ""
+    mock_certificate_page.product_name = product_name
 
     payload = get_verifiable_credentials_payload(program_cert, mock_certificate_page)
 


### PR DESCRIPTION
### What are the relevant tickets?


Follow-up to the certificate-title work ([hq#11907](https://github.com/mitodl/hq/issues/11907), tracked in [hq#11938](https://github.com/mitodl/hq/issues/11938)).

### Description


When a **program** certificate is issued, the verifiable credential (Open Badge) is signed with a `name`. Today that name is the **program title**. This changes it to the CMS **"Certificate Title"** (`CertificatePage.product_name`) so the issued credential matches the title printed on the certificate (and shown on the MIT Learn certificate page).

Falls back to the program title when `product_name` is unset.

- **Going forward only.** This affects credentials signed after this lands. Already-signed verifiable credentials are **not** re-issued (per product direction on #11938).

## Change

`courses/api.py` — `get_verifiable_credentials_payload`, program branch:

```python
certificate_name = certificate_page.product_name or certificate.program.title
```

`certificate_page` is always present here (the caller returns early via `should_provision_verifiable_credential` when it is `None`).

## How to test
Manual:

```
docker compose exec web python manage.py shell

from courses.models import ProgramCertificate
from courses.api import get_certificate_page, get_verifiable_credentials_payload

# pick a cert whose program has a CMS certificate page + the user has an enrollment
cert = ProgramCertificate.objects.first()
page = get_certificate_page(cert)
print("Certificate Title (product_name):", repr(page.product_name))
print("Program title               :", repr(cert.program.title))

payload = get_verifiable_credentials_payload(cert, page)
ach = payload["credentialSubject"]["achievement"]
print("VC name       :", ach["name"])         # -> should be the Certificate Title
print("VC description:", ach["description"])

```


Automated:

```
docker compose run --rm web uv run pytest courses/api_test.py -k verifiable_credential
```

- `test_program_certificate_verifiable_credentials_signing_payload` now sets a CMS `product_name` ("Universal AI") distinct from the program title ("Data Science MicroMasters") and asserts the credential `name`/`description` use the `product_name`.
- `test_program_verifiable_credential_name_falls_back_to_program_title` (new) asserts the fallback to program title when `product_name` is empty.

Manual (optional): issue a new program certificate for a program whose CMS certificate page "Certificate Title" differs from its program title, then inspect the resulting verifiable credential — `credentialSubject.achievement.name` should be the Certificate Title.
