### PR TITLE
Fix pytest config so you can run 'pytest -h'

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,20 +1,25 @@
 """Project conftest"""
 
 import uuid
+from pathlib import Path
 
 import pytest
 from faker import Faker
 from hubspot.crm.objects import SimplePublicObject
 
-from fixtures.b2b import *  # noqa: F403
-from fixtures.common import *  # noqa: F403
-from hubspot_sync.conftest import FAKE_HUBSPOT_ID
-from main import features
+# auto load in fixtures
+pytest_plugins = [
+    str(fixture).replace("/", ".").replace(".py", "")
+    for fixture in Path().glob("fixtures/*.py")
+    if fixture.name != "__init__.py"
+]
 
 
 @pytest.fixture(autouse=True)
 def default_settings(monkeypatch, settings):
     """Set default settings for all tests"""
+    from main import features  # noqa: PLC0415
+
     monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "main.settings")
 
     settings.FEATURES[features.IGNORE_EDX_FAILURES] = False
@@ -43,6 +48,8 @@ def payment_gateway_settings(settings):
 @pytest.fixture(autouse=True)
 def mock_hubspot_api(mocker):
     """Mock the Hubspot CRM API"""
+    from hubspot_sync.conftest import FAKE_HUBSPOT_ID  # noqa: PLC0415
+
     mock_api = mocker.patch("mitol.hubspot_api.api.HubspotApi")
     mock_api.return_value.crm.objects.basic_api.create.return_value = (
         SimplePublicObject(id=FAKE_HUBSPOT_ID)

--- a/fixtures/b2b.py
+++ b/fixtures/b2b.py
@@ -3,12 +3,11 @@
 import pytest
 from opaque_keys.edx.keys import CourseKey
 
-from courses.factories import CourseFactory, CourseRunFactory
-
 
 @pytest.fixture
 def make_contract_ready_course():
     """Return a function that can be used to generate a contract-ready course"""
+    from courses.factories import CourseFactory, CourseRunFactory  # noqa: PLC0415
 
     def _contract_ready_course():
         """

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -10,26 +10,30 @@ from mitol.common.serializers import THIS_IS_NOT_AN_API
 from rest_framework.test import APIClient
 from zeal import zeal_ignore
 
-from users.factories import UserFactory
-
 pytestmark = [pytest.mark.usefixtures("urllib3_mock")]
 
 
 @pytest.fixture
 def user(db):  # noqa: ARG001
     """Creates a user"""
+    from users.factories import UserFactory  # noqa: PLC0415
+
     return UserFactory.create()
 
 
 @pytest.fixture
 def staff_user(db):  # noqa: ARG001
     """Staff user fixture"""
+    from users.factories import UserFactory  # noqa: PLC0415
+
     return UserFactory.create(is_staff=True)
 
 
 @pytest.fixture
 def admin_user(db):  # noqa: ARG001
     """Admin user fixture"""
+    from users.factories import UserFactory  # noqa: PLC0415
+
     return UserFactory.create(is_superuser=True, is_staff=True)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,7 @@ markers = [
   "dont_mock_enrollments",
   "skip_nplusone_check"
 ]
+pythonpath = ["."]
 
 [tool.bumpversion]
 commit = false


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
I found while trying to debug some failing tests that `pytest -h` to show the docs no longer works because our `conftest.py` definitions try to load code that is a) not in `PYTHONPATH` during invocation of `pytest -h` and b) importing factories throws errors because the django app is not initialized (and doesn't need to be).

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to run `pytest -h` locally without error and tests should pass.