### PR TITLE
Add clone_courserun retry for failed edx courserun creation

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -1257,6 +1257,24 @@ EDX_API_CLIENT_TIMEOUT = get_int(
     description="Timeout (in seconds) for requests made via the edX API client",
 )
 
+OPENEDX_COURSE_CLONE_MAX_RETRIES = get_int(
+    name="OPENEDX_COURSE_CLONE_MAX_RETRIES",
+    default=5,
+    description="Maximum number of retry attempts for transient Open edX course clone failures",
+)
+
+OPENEDX_COURSE_CLONE_RETRY_DELAY = get_int(
+    name="OPENEDX_COURSE_CLONE_RETRY_DELAY",
+    default=300,
+    description="Base retry delay in seconds for Open edX course clone retries; each successive retry multiplies this delay",
+)
+
+OPENEDX_COURSE_CLONE_RETRY_JITTER = get_int(
+    name="OPENEDX_COURSE_CLONE_RETRY_JITTER",
+    default=60,
+    description="Maximum number of randomized jitter seconds to add to Open edX course clone retries",
+)
+
 # django debug toolbar only in debug mode
 if DEBUG:
     INSTALLED_APPS += ("debug_toolbar",)

--- a/openedx/tasks.py
+++ b/openedx/tasks.py
@@ -1,17 +1,31 @@
 """Courseware tasks"""
 
 import logging
+import random
 
 import celery
+from edx_api.course_runs.exceptions import CourseRunAPIError
 from django.conf import settings
 from mitol.common.utils.collections import chunks
+from requests.exceptions import HTTPError, RequestException
 
 from main.celery import app
 from openedx import api
+from openedx.exceptions import OpenEdXOAuth2Error
 from users.api import get_user_by_id
 from users.models import User
 
 log = logging.getLogger()
+
+
+def _get_clone_courserun_retry_countdown(current_retry: int) -> int:
+    """Return the countdown in seconds for the next clone retry attempt."""
+
+    attempt_number = current_retry + 1
+    base_delay = settings.OPENEDX_COURSE_CLONE_RETRY_DELAY * attempt_number
+    jitter = random.randint(0, settings.OPENEDX_COURSE_CLONE_RETRY_JITTER)
+
+    return base_delay + jitter
 
 
 @app.task(acks_late=True)
@@ -103,12 +117,49 @@ def update_edx_user_profile(user_id):
     api.update_edx_user_profile(user)
 
 
-@app.task
-def clone_courserun(target_id: int, base_key: str):
+@app.task(
+    bind=True,
+    acks_late=True,
+    max_retries=settings.OPENEDX_COURSE_CLONE_MAX_RETRIES,
+)
+def clone_courserun(self, target_id: int, base_key: str):
     """Queue call to clone an existing course run."""
 
     from courses.models import CourseRun  # noqa: PLC0415
 
     target_course = CourseRun.all_objects.get(pk=target_id)
 
-    api.process_course_run_clone(target_course, base_key)
+    try:
+        api.process_course_run_clone(target_course, base_key)
+    except (
+        CourseRunAPIError,
+        HTTPError,
+        OpenEdXOAuth2Error,
+        RequestException,
+    ) as exc:
+        retry_count = getattr(self.request, "retries", 0)
+        attempt_number = retry_count + 1
+
+        if retry_count >= self.max_retries:
+            log.exception(
+                "clone_courserun exhausted retries for target=%s base=%s after "
+                "%s attempts",
+                target_course.readable_id,
+                base_key,
+                attempt_number,
+            )
+            raise
+
+        countdown = _get_clone_courserun_retry_countdown(retry_count)
+
+        log.warning(
+            "Retrying clone_courserun for target=%s base=%s after %s seconds "
+            "because the Open edX clone request failed on attempt %s/%s: %s",
+            target_course.readable_id,
+            base_key,
+            countdown,
+            attempt_number,
+            self.max_retries + 1,
+            exc,
+        )
+        raise self.retry(exc=exc, countdown=countdown) from exc

--- a/openedx/tasks.py
+++ b/openedx/tasks.py
@@ -4,8 +4,8 @@ import logging
 import random
 
 import celery
-from edx_api.course_runs.exceptions import CourseRunAPIError
 from django.conf import settings
+from edx_api.course_runs.exceptions import CourseRunAPIError
 from mitol.common.utils.collections import chunks
 from requests.exceptions import HTTPError, RequestException
 

--- a/openedx/tasks.py
+++ b/openedx/tasks.py
@@ -18,12 +18,12 @@ from users.models import User
 log = logging.getLogger()
 
 
-def _get_clone_courserun_retry_countdown(current_retry: int) -> int:
+def get_clone_courserun_retry_countdown(current_retry: int) -> int:
     """Return the countdown in seconds for the next clone retry attempt."""
 
     attempt_number = current_retry + 1
     base_delay = settings.OPENEDX_COURSE_CLONE_RETRY_DELAY * attempt_number
-    jitter = random.randint(0, settings.OPENEDX_COURSE_CLONE_RETRY_JITTER)
+    jitter = random.randint(0, settings.OPENEDX_COURSE_CLONE_RETRY_JITTER)  # noqa: S311
 
     return base_delay + jitter
 
@@ -150,7 +150,7 @@ def clone_courserun(self, target_id: int, base_key: str):
             )
             raise
 
-        countdown = _get_clone_courserun_retry_countdown(retry_count)
+        countdown = get_clone_courserun_retry_countdown(retry_count)
 
         log.warning(
             "Retrying clone_courserun for target=%s base=%s after %s seconds "

--- a/openedx/tasks_test.py
+++ b/openedx/tasks_test.py
@@ -1,8 +1,11 @@
 """Courseware tasks"""
 
 import pytest
+from requests.exceptions import HTTPError
 
+from courses.factories import CourseRunFactory
 from openedx import tasks
+from openedx.exceptions import OpenEdXOAuth2Error
 from users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -42,3 +45,72 @@ def test_repair_faulty_openedx_users(mocker, settings, disabled):
     tasks.repair_faulty_openedx_users.delay()
 
     assert patch_repair_users.call_count == (0 if disabled else 1)
+
+
+def test_get_clone_courserun_retry_countdown(mocker, settings):
+    """Retry countdown should scale by attempt and include jitter."""
+    mocker.patch("openedx.tasks.random.randint", return_value=17)
+    settings.OPENEDX_COURSE_CLONE_RETRY_DELAY = 300
+    settings.OPENEDX_COURSE_CLONE_RETRY_JITTER = 60
+
+    assert tasks._get_clone_courserun_retry_countdown(0) == 317
+    assert tasks._get_clone_courserun_retry_countdown(2) == 917
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        HTTPError("500 Server Error"),
+        OpenEdXOAuth2Error("temporary auth failure"),
+    ],
+)
+def test_clone_courserun_retries_transient_errors(mocker, settings, exc):
+    """Transient clone failures should be retried with a countdown."""
+    run = CourseRunFactory.create()
+    settings.OPENEDX_COURSE_CLONE_RETRY_DELAY = 300
+    settings.OPENEDX_COURSE_CLONE_RETRY_JITTER = 60
+    mocker.patch("openedx.tasks.random.randint", return_value=11)
+    mocker.patch("openedx.tasks.api.process_course_run_clone", side_effect=exc)
+    mock_retry = mocker.patch.object(
+        tasks.clone_courserun,
+        "retry",
+        side_effect=RuntimeError("retry called"),
+    )
+
+    with pytest.raises(RuntimeError, match="retry called"):
+        tasks.clone_courserun.run(run.id, "course-v1:MITx+BASE+1T2099")
+
+    mock_retry.assert_called_once_with(exc=exc, countdown=311)
+
+
+def test_clone_courserun_does_not_retry_non_transient_errors(mocker):
+    """Permanent clone failures should bubble up without retrying."""
+    run = CourseRunFactory.create()
+    error = ValueError("Course already exists in edX")
+    mocker.patch("openedx.tasks.api.process_course_run_clone", side_effect=error)
+    mock_retry = mocker.patch.object(tasks.clone_courserun, "retry")
+
+    with pytest.raises(ValueError, match="Course already exists in edX"):
+        tasks.clone_courserun.run(run.id, "course-v1:MITx+BASE+1T2099")
+
+    mock_retry.assert_not_called()
+
+
+def test_clone_courserun_logs_exception_after_retry_exhaustion(mocker, settings):
+    """Final transient clone failure should be escalated once retries are exhausted."""
+    run = CourseRunFactory.create()
+    error = HTTPError("500 Server Error")
+    settings.OPENEDX_COURSE_CLONE_MAX_RETRIES = 1
+    mocker.patch("openedx.tasks.api.process_course_run_clone", side_effect=error)
+    mock_retry = mocker.patch.object(tasks.clone_courserun, "retry")
+    mock_log_exception = mocker.patch("openedx.tasks.log.exception")
+
+    tasks.clone_courserun.request.retries = 1
+    tasks.clone_courserun.max_retries = 1
+
+    with pytest.raises(HTTPError, match="500 Server Error"):
+        tasks.clone_courserun.run(run.id, "course-v1:MITx+BASE+1T2099")
+
+    mock_retry.assert_not_called()
+    mock_log_exception.assert_called_once()
+

--- a/openedx/tasks_test.py
+++ b/openedx/tasks_test.py
@@ -53,8 +53,8 @@ def test_get_clone_courserun_retry_countdown(mocker, settings):
     settings.OPENEDX_COURSE_CLONE_RETRY_DELAY = 300
     settings.OPENEDX_COURSE_CLONE_RETRY_JITTER = 60
 
-    assert tasks._get_clone_courserun_retry_countdown(0) == 317
-    assert tasks._get_clone_courserun_retry_countdown(2) == 917
+    assert tasks.get_clone_courserun_retry_countdown(0) == 317
+    assert tasks.get_clone_courserun_retry_countdown(2) == 917
 
 
 @pytest.mark.parametrize(

--- a/openedx/tasks_test.py
+++ b/openedx/tasks_test.py
@@ -113,4 +113,3 @@ def test_clone_courserun_logs_exception_after_retry_exhaustion(mocker, settings)
 
     mock_retry.assert_not_called()
     mock_log_exception.assert_called_once()
-


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/10113

### Description (What does it do?)
So the behavior is now:
5 retry attempts: warning only
final failure: exception log + task failure
Sentry should receive the terminal failure once



### How can this be tested?
Schedule `clone_courserun.delay(course_run.id, course_run.courseware_id)` 
and watch celery logs
