### PR TITLE
Add test send email endpoint, refactor email sending task slightly

### DIFF
--- a/b2b/mail.py
+++ b/b2b/mail.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from mitol.mail.api import get_message_sender
 from mitol.mail.messages import TemplatedMessage
 
-from b2b.models import DiscountContractAttachmentRedemption
+from b2b.models import ContractPage, DiscountContractAttachmentRedemption
 
 log = logging.getLogger(__name__)
 
@@ -12,6 +12,28 @@ log = logging.getLogger(__name__)
 class EnrollmentCodeAssignmentMessage(TemplatedMessage):
     template_name = "mail/enrollment_code_assignment"
     name = "Enrollment Code Assignment"
+
+
+def get_learn_hostname():
+    from courses.api import ENV_TO_LEARN_HOSTNAME_MAP  # noqa: PLC0415
+
+    return ENV_TO_LEARN_HOSTNAME_MAP.get(settings.ENVIRONMENT, "learn.mit.edu")
+
+
+def send_email_helper(email, code, code_url, organization_name, contract_name):
+    try:
+        with get_message_sender(EnrollmentCodeAssignmentMessage) as sender:
+            sender.build_and_send_message(
+                email,
+                {
+                    "code": code,
+                    "code_url": code_url,
+                    "organization_name": organization_name,
+                    "contract_name": contract_name,
+                },
+            )
+    except:  # pylint: disable=bare-except  # noqa: E722
+        log.exception("Error sending enrollment code assignment email.")
 
 
 def send_enrollment_code_assignment_email(assignment_record_ids):
@@ -22,34 +44,32 @@ def send_enrollment_code_assignment_email(assignment_record_ids):
         assignment_record_ids list[int]: The IDs for DiscountContractAttachmentRedemption records to send emails for
     """
 
-    # Should make this a utility function and move the map somewhere more general
-    from courses.api import ENV_TO_LEARN_HOSTNAME_MAP  # noqa: PLC0415
-
-    learn_hostname = ENV_TO_LEARN_HOSTNAME_MAP.get(
-        settings.ENVIRONMENT, "learn.mit.edu"
-    )
     assignments = list(
         DiscountContractAttachmentRedemption.objects.filter(
             id__in=assignment_record_ids
         ).select_related("discount", "contract")
     )
 
+    learn_hostname = get_learn_hostname()
     for assignment in assignments:
         code = assignment.discount.discount_code
         code_url = f"https://{learn_hostname}/enrollmentcode/{code}"
         organization_name = assignment.contract.organization.name
+        send_email_helper(
+            assignment.assigned_email,
+            code,
+            code_url,
+            organization_name,
+            assignment.contract.name,
+        )
 
-        try:
-            with get_message_sender(EnrollmentCodeAssignmentMessage) as sender:
-                sender.build_and_send_message(
-                    assignment.assigned_email,
-                    {
-                        "assignment": assignment,
-                        "code": code,
-                        "code_url": code_url,
-                        "organization_name": organization_name,
-                        "contract_name": assignment.contract.name,
-                    },
-                )
-        except:  # pylint: disable=bare-except  # noqa: E722
-            log.exception("Error sending enrollment code assignment email.")
+
+def send_test_enrollment_code_assignment_email(email, contract_record_id):
+    contract = ContractPage.objects.get(pk=contract_record_id)
+    send_email_helper(
+        email,
+        "PLACEHOLDER_CODE",
+        "PLACEHOLDER_URL",
+        contract.organization.name,
+        contract.name,
+    )

--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -222,3 +222,9 @@ class BulkAssignResultSerializer(serializers.Serializer):
         child=BulkAssignErrorSerializer(),
         help_text="Records that could not be assigned, with a 'detail' explanation.",
     )
+
+
+class SendTestEmailSerializer(serializers.Serializer):
+    """Serializer for the send_test_email request body."""
+
+    email = serializers.EmailField()

--- a/b2b/tasks.py
+++ b/b2b/tasks.py
@@ -6,7 +6,10 @@ import logging
 from django.core.cache import cache
 from django.db.models import Q
 
-from b2b.mail import send_enrollment_code_assignment_email
+from b2b.mail import (
+    send_enrollment_code_assignment_email,
+    send_test_enrollment_code_assignment_email,
+)
 from main.celery import app
 
 log = logging.getLogger(__name__)
@@ -210,3 +213,10 @@ def queue_update_all_contract_enrollment_sheets():
 @app.task()
 def queue_send_enrollment_code_assignment_email(assignment_record_ids: list[int]):
     send_enrollment_code_assignment_email(assignment_record_ids)
+
+
+@app.task()
+def queue_send_test_enrollment_code_assignment_email(
+    email: str, contract_record_id: int
+):
+    send_test_enrollment_code_assignment_email(email, contract_record_id)

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -750,7 +750,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
     @extend_schema(
         description="Send test assignment email to specified email address. This does not include an enrollment code.",
         request=SendTestEmailSerializer,
-        responses={200: None},
+        responses={200: None, 400: DetailErrorSerializer},
     )
     @action(
         detail=True,

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -40,8 +40,12 @@ from b2b.serializers.v0.manager import (
     ManagerCourseRunSerializer,
     ManagerEnrollmentCodeSerializer,
     ManagerEnrollmentSerializer,
+    SendTestEmailSerializer,
 )
-from b2b.tasks import queue_send_enrollment_code_assignment_email
+from b2b.tasks import (
+    queue_send_enrollment_code_assignment_email,
+    queue_send_test_enrollment_code_assignment_email,
+)
 from courses.models import CourseRun, CourseRunEnrollment
 from ecommerce.models import Discount
 
@@ -742,3 +746,33 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             ManagerEnrollmentCodeSerializer(discount).data,
             status=http_status.HTTP_200_OK,
         )
+
+    @extend_schema(
+        description="Send test assignment email to specified email address. This does not include an enrollment code.",
+        request=SendTestEmailSerializer,
+        responses={200: None},
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="codes/send_test_email",
+    )
+    def send_test_email(self, request, **kwargs):  # noqa: ARG002
+        """
+        Send test assignment email to specified email address. The email will contain placeholder values for the code, but representative data for all other content.
+
+        PUT /api/v0/b2b/orgs/{org_id}/manager/contracts/{contract_id}/codes/send_test_email/
+        """
+
+        contract = self.get_object()
+        serializer = SendTestEmailSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"detail": "Invalid request data."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        email = serializer.validated_data["email"]
+        queue_send_test_enrollment_code_assignment_email.delay(email, contract.id)
+
+        return Response(status=http_status.HTTP_200_OK)

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -617,6 +617,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+  /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/send_test_email/:
+    post:
+      operationId: b2b_manager_organizations_contracts_codes_send_test_email_create
+      description: Send test assignment email to specified email address. This does
+        not include an enrollment code.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: ID of the contract
+        required: true
+      - in: path
+        name: parent_lookup_organization
+        schema:
+          type: integer
+        description: ID of the parent organization
+        required: true
+      tags:
+      - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+        required: true
+      responses:
+        '200':
+          description: No response body
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
       operationId: b2b_manager_organizations_contracts_course_runs_list
@@ -8552,6 +8587,16 @@ components:
       - b2b-error-requires-checkout
       - b2b-error-not-enrollable
       - b2b-enroll-success
+    SendTestEmailRequest:
+      type: object
+      description: Serializer for the send_test_email request body.
+      properties:
+        email:
+          type: string
+          format: email
+          minLength: 1
+      required:
+      - email
     SignatoryItem:
       type: object
       description: Serializer for signatory items used in certificate pages.

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -652,6 +652,12 @@ paths:
       responses:
         '200':
           description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
       operationId: b2b_manager_organizations_contracts_course_runs_list

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -617,6 +617,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+  /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/send_test_email/:
+    post:
+      operationId: b2b_manager_organizations_contracts_codes_send_test_email_create
+      description: Send test assignment email to specified email address. This does
+        not include an enrollment code.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: ID of the contract
+        required: true
+      - in: path
+        name: parent_lookup_organization
+        schema:
+          type: integer
+        description: ID of the parent organization
+        required: true
+      tags:
+      - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+        required: true
+      responses:
+        '200':
+          description: No response body
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
       operationId: b2b_manager_organizations_contracts_course_runs_list
@@ -8552,6 +8587,16 @@ components:
       - b2b-error-requires-checkout
       - b2b-error-not-enrollable
       - b2b-enroll-success
+    SendTestEmailRequest:
+      type: object
+      description: Serializer for the send_test_email request body.
+      properties:
+        email:
+          type: string
+          format: email
+          minLength: 1
+      required:
+      - email
     SignatoryItem:
       type: object
       description: Serializer for signatory items used in certificate pages.

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -652,6 +652,12 @@ paths:
       responses:
         '200':
           description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
       operationId: b2b_manager_organizations_contracts_course_runs_list

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -617,6 +617,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/DetailError'
           description: ''
+  /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/send_test_email/:
+    post:
+      operationId: b2b_manager_organizations_contracts_codes_send_test_email_create
+      description: Send test assignment email to specified email address. This does
+        not include an enrollment code.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: ID of the contract
+        required: true
+      - in: path
+        name: parent_lookup_organization
+        schema:
+          type: integer
+        description: ID of the parent organization
+        required: true
+      tags:
+      - b2b
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+        required: true
+      responses:
+        '200':
+          description: No response body
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
       operationId: b2b_manager_organizations_contracts_course_runs_list
@@ -8552,6 +8587,16 @@ components:
       - b2b-error-requires-checkout
       - b2b-error-not-enrollable
       - b2b-enroll-success
+    SendTestEmailRequest:
+      type: object
+      description: Serializer for the send_test_email request body.
+      properties:
+        email:
+          type: string
+          format: email
+          minLength: 1
+      required:
+      - email
     SignatoryItem:
       type: object
       description: Serializer for signatory items used in certificate pages.

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -652,6 +652,12 @@ paths:
       responses:
         '200':
           description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailError'
+          description: ''
   /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/:
     get:
       operationId: b2b_manager_organizations_contracts_course_runs_list


### PR DESCRIPTION
### Description (What does it do?)
This adds an endpoint which takes an email address and sends out an enrollment code email with placeholder values instead of actual codes. Eventually we'll have a UI treatment for contract managers to send these emails to themselves for review ahead of actually sending them to users 

This approach was chosen in lieu of having a screenshot of the rendered email template or trying to render the email in platform. Among other concerns, the thinking was that displaying the template to the user in product might suggest that they should be editable, which is a much larger lift we don't particularly want to take on at the moment.

### Screenshots (if appropriate):
If you are familiar w/ the emails sent for b2b code preassignment in https://github.com/mitodl/mitxonline/pull/3694/, this will look very familiar. Take note of the placeholder text - that is the only functional difference at the moment.
<img width="1266" height="696" alt="Screenshot 2026-06-24 at 3 11 10 PM" src="https://github.com/user-attachments/assets/45d2943c-f914-4687-8fbc-437d2da14f7c" />


### How can this be tested?
- Set up mailpit and set MITOL_MAIL_CONNECTION_BACKEND='django.core.mail.backends.smtp.EmailBackend'
- Set MITX_ONLINE_EMAIL_HOST and MITX_ONLINE_EMAIL_PORT to wherever mailpit is running.
- With a b2b contract set up, simply make a request to http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_send_test_email_create using an email of your choosing. 
- You should receive a test email in mailpit with placeholders for the code and button link.

### Additional Context
- This is dependent on changes in https://github.com/mitodl/mitxonline/pull/3694/
- As there is no frontend functionality for this at the moment, this PR should be safe to release and iterate on as necessary.