### PR TITLE
Set up ETL view to take an API key or use an ETL-tagged user

### DIFF
--- a/courses/views/internal/__init__.py
+++ b/courses/views/internal/__init__.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Prefetch, Q
 from prefetch import PrefetchOption
 from rest_framework import viewsets
+from rest_framework_api_key.permissions import HasAPIKey
 
 from courses.models import (
     Course,
@@ -29,7 +30,7 @@ class IngestibleCourseViewSet(viewsets.ReadOnlyModelViewSet):
 
     pagination_class = Pagination
     permission_classes = [
-        IsEtlUser,
+        HasAPIKey | IsEtlUser,
     ]
     serializer_class = IngestibleCourseWithCourseRunsSerializer
 

--- a/courses/views/internal/views_test.py
+++ b/courses/views/internal/views_test.py
@@ -4,6 +4,7 @@ import pytest
 from django.urls import reverse
 from faker import Faker
 from rest_framework.test import APIClient
+from rest_framework_api_key.models import APIKey
 
 from courses.constants import (
     COURSE_VARIANT_INDUSTRY,
@@ -50,13 +51,26 @@ def test_is_etl_permission(rf, is_etl, is_superuser):
     assert perm.has_permission(request, {}) == (is_etl or is_superuser)
 
 
+@pytest.mark.parametrize(
+    "use_api_key",
+    [
+        True,
+        False,
+    ],
+)
 @pytest.mark.skip_nplusone_check
-def test_get_ingestible_courses(b2b_courses):
+def test_get_ingestible_courses(b2b_courses, use_api_key):
     """Test that the ingestible courses endpoint returns data as expected."""
 
-    user = UserFactory.create(is_etl=True)
     api_client = APIClient()
-    api_client.force_authenticate(user)
+    headers = {}
+
+    if use_api_key:
+        _, key = APIKey.objects.create_key(name=str(fake.words(3)))
+        headers["Authorization"] = f"Api-Key {key}"
+    else:
+        user = UserFactory.create(is_etl=True)
+        api_client.force_authenticate(user)
 
     _, contracts_by_org_id, _, runs_by_contract, _ = b2b_courses
 
@@ -160,7 +174,9 @@ def test_get_ingestible_courses(b2b_courses):
         )
 
     params = {"page_size": 100}
-    resp = api_client.get(reverse("internal_ingestible_courses-list"), params)
+    resp = api_client.get(
+        reverse("internal_ingestible_courses-list"), params, headers=headers
+    )
 
     assert resp.status_code == 200
 


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11671

### Description (What does it do?)

We worked out using an OIDC client and service account to get the ETL process to auth for the [ETL-specific courses endpoints.](https://github.com/mitodl/mitxonline/pull/3632#issuecomment-4653543113) The changes to enable JWTs to be recognized and used by APISIX went in but caused issues with the separate OAuth flow between edX and MITx Online (resulting in downtime - no one could log into edX).

There's ways to fix the actual issue but in the meantime the ETL does need to be able to get to its special endpoints. We already had [djangorestframework-api-key](https://florimondmanca.github.io/djangorestframework-api-key/) installed in the MITx Online app, so it made sense to _temporarily_ use this while the edX/APISIX/MITx Online OAuth stuff is being worked through.

### How can this be tested?

The automated tests should be updated to test with both an API key and an ETL-flagged user.

1. Check out this branch.
2. Create a new API key. You can do this through [the Django Admin](http://mitxonline.odl.local:9080/admin/rest_framework_api_key/apikey/). (Note that the API key will appear in a banner after you save it. It can be easy to miss and the key is not retrievable once saved.)
3. Hit the ETL courses endpoint. This is a reasonable curl command to do that: `curl -v -H "Authorization: Api-Key $APIKEY" http://mitxonline.odl.local:9080/api/internal/courses/` 
   a. Set `$APIKEY` to the API key
5. See that you get data back.
6. Test again, except without the header - you should get a 403.
7. Also, test hitting the endpoint with a logged-in user in your browser. If the user has the "Is ETL" flag set, they should get data; otherwise, they should get a 403. 

### Additional Context

There were some options being discussed that would allow us to re-enable JWKS in APISIX (re-plumbing the edX auth pipeline, excluding certain routes from JWKS, etc.) - once we settle on something and get it in place, we should go back to using the OAuth2 client credentials flow for the ETL.