### PR TITLE
Add summary statistics to contract retrieve endpoint and remove unassigned codes from /codes output. Add filtering on assigned + redeemed statuses

### DIFF
--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -4,7 +4,12 @@ from datetime import datetime
 
 from rest_framework import serializers
 
-from b2b.models import REDEMPTION_STATUS_UNASSIGNED, ContractPage
+from b2b.models import (
+    REDEMPTION_STATUS_ASSIGNED,
+    REDEMPTION_STATUS_REDEEMED,
+    REDEMPTION_STATUS_UNASSIGNED,
+    ContractPage,
+)
 from b2b.serializers.v0 import ContractPageSerializer
 from courses.models import CourseRun, CourseRunEnrollment
 from ecommerce.models import Discount
@@ -16,6 +21,9 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
     attachment_percentage = serializers.SerializerMethodField()
     total_enrollments = serializers.SerializerMethodField()
     total_codes = serializers.SerializerMethodField()
+    assigned_codes = serializers.SerializerMethodField()
+    unassigned_codes = serializers.SerializerMethodField()
+    redeemed_codes = serializers.SerializerMethodField()
 
     class Meta:
         model = ContractPage
@@ -24,13 +32,35 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
             "attachment_percentage",
             "total_enrollments",
             "total_codes",
+            "assigned_codes",
+            "unassigned_codes",
+            "redeemed_codes",
         ]
         read_only_fields = [
             *ContractPageSerializer.Meta.read_only_fields,
             "attachment_percentage",
             "total_enrollments",
             "total_codes",
+            "assigned_codes",
+            "unassigned_codes",
+            "redeemed_codes",
         ]
+
+    def _get_codes_breakdown(self, obj) -> dict:
+        from b2b.views.v0.manager import is_redeemed_attachment_record  # noqa: PLC0415
+
+        if not hasattr(obj, "_codes_breakdown_cache"):
+            redemptions = obj.prefetched_code_redemptions
+            redeemed = sum(1 for r in redemptions if is_redeemed_attachment_record(r))
+            assigned = len(redemptions) - redeemed
+            total = obj.get_discounts().distinct()[: obj.max_learners].count()
+            obj._codes_breakdown_cache = {  # noqa: SLF001
+                "total": total,
+                REDEMPTION_STATUS_ASSIGNED: assigned,
+                REDEMPTION_STATUS_UNASSIGNED: total - assigned - redeemed,
+                REDEMPTION_STATUS_REDEEMED: redeemed,
+            }
+        return obj._codes_breakdown_cache  # noqa: SLF001
 
     def get_attachment_percentage(self, obj) -> float | None:
         """Calculate attachment percentage if seat-limited."""
@@ -45,8 +75,16 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
         return obj.enrollment_count
 
     def get_total_codes(self, obj) -> int:
-        """Get total number of discount codes for this contract."""
-        return obj.discount_count
+        return self._get_codes_breakdown(obj)["total"]
+
+    def get_assigned_codes(self, obj) -> int:
+        return self._get_codes_breakdown(obj)[REDEMPTION_STATUS_ASSIGNED]
+
+    def get_unassigned_codes(self, obj) -> int:
+        return self._get_codes_breakdown(obj)[REDEMPTION_STATUS_UNASSIGNED]
+
+    def get_redeemed_codes(self, obj) -> int:
+        return self._get_codes_breakdown(obj)[REDEMPTION_STATUS_REDEEMED]
 
 
 class ManagerCourseRunSerializer(serializers.ModelSerializer):

--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -53,7 +53,7 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
             redemptions = obj.prefetched_code_redemptions
             redeemed = sum(1 for r in redemptions if is_redeemed_attachment_record(r))
             assigned = len(redemptions) - redeemed
-            total = obj.get_discounts().distinct()[: obj.max_learners].count()
+            total = obj.max_learners
             obj._codes_breakdown_cache = {  # noqa: SLF001
                 "total": total,
                 REDEMPTION_STATUS_ASSIGNED: assigned,

--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -11,6 +11,7 @@ from b2b.models import (
     ContractPage,
 )
 from b2b.serializers.v0 import ContractPageSerializer
+from b2b.utils import is_redeemed_attachment_record
 from courses.models import CourseRun, CourseRunEnrollment
 from ecommerce.models import Discount
 
@@ -47,7 +48,6 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
         ]
 
     def _get_codes_breakdown(self, obj) -> dict:
-        from b2b.views.v0.manager import is_redeemed_attachment_record  # noqa: PLC0415
 
         if not hasattr(obj, "_codes_breakdown_cache"):
             redemptions = obj.prefetched_code_redemptions

--- a/b2b/utils.py
+++ b/b2b/utils.py
@@ -1,0 +1,7 @@
+from b2b.models import DiscountContractAttachmentRedemption
+
+
+def is_redeemed_attachment_record(
+    assignment_record: DiscountContractAttachmentRedemption,
+) -> bool:
+    return assignment_record.user or assignment_record.redeemed_on

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -42,6 +42,7 @@ from b2b.serializers.v0.manager import (
     ManagerEnrollmentSerializer,
 )
 from b2b.tasks import queue_send_enrollment_code_assignment_email
+from b2b.utils import is_redeemed_attachment_record
 from courses.models import CourseRun, CourseRunEnrollment
 from ecommerce.models import Discount
 
@@ -60,12 +61,6 @@ class CodeAssignment:
     email: str
     name: str
     code: str
-
-
-def is_redeemed_attachment_record(
-    assignment_record: DiscountContractAttachmentRedemption,
-) -> bool:
-    return assignment_record.user or assignment_record.redeemed_on
 
 
 def assign_codes_and_send_emails(

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -21,6 +21,8 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from b2b.constants import CONTRACT_MEMBERSHIP_AUTOS
 from b2b.models import (
+    REDEMPTION_STATUS_ASSIGNED,
+    REDEMPTION_STATUS_REDEEMED,
     ContractPage,
     ContractProgramItem,
     DiscountContractAttachmentRedemption,
@@ -292,6 +294,14 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 description="Filter codes by assigned email, user email, user name, or assigned name.",
                 required=False,
             ),
+            OpenApiParameter(
+                name="status",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description="Filter codes by status. Supported values are assigned and redeemed.",
+                required=False,
+                enum=[REDEMPTION_STATUS_ASSIGNED, REDEMPTION_STATUS_REDEEMED],
+            ),
         ],
     )
     @action(detail=True, methods=["get"])
@@ -305,6 +315,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         """
         contract = self.get_object()
         search_term = request.query_params.get("search_term", "").strip()
+        status_filter = request.query_params.get("status", "").strip()
 
         """
         There are three main cases:
@@ -327,7 +338,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 to_attr="prefetched_redemptions",
             )
 
-            if search_term:
+            if search_term or status_filter:
                 # This filter is slightly complicated because we only want to filter on the latest redemption per discount
                 # In practice, we only expect 1 redemption per code for well-formed contracts,
                 # but that's not enforced at the DB so we need to be a bit clever.
@@ -338,23 +349,25 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                     .distinct("discount_id")
                     .values("pk")
                 )
+                filter_q = Q(contract_redemptions__pk__in=latest_redemption_ids)
+                if search_term:
+                    filter_q &= (
+                        Q(contract_redemptions__assigned_email__icontains=search_term)
+                        | Q(contract_redemptions__user__email__icontains=search_term)
+                        | Q(contract_redemptions__user__name__icontains=search_term)
+                        | Q(contract_redemptions__assigned_name__icontains=search_term)
+                    )
+                if status_filter == REDEMPTION_STATUS_REDEEMED:
+                    filter_q &= Q(contract_redemptions__user__isnull=False) | Q(
+                        contract_redemptions__redeemed_on__isnull=False
+                    )
+                elif status_filter == REDEMPTION_STATUS_ASSIGNED:
+                    filter_q &= Q(contract_redemptions__user__isnull=True) & Q(
+                        contract_redemptions__redeemed_on__isnull=True
+                    )
                 discounts = (
                     contract.get_discounts()
-                    .filter(
-                        Q(contract_redemptions__pk__in=latest_redemption_ids)
-                        & (
-                            Q(
-                                contract_redemptions__assigned_email__icontains=search_term
-                            )
-                            | Q(
-                                contract_redemptions__user__email__icontains=search_term
-                            )
-                            | Q(contract_redemptions__user__name__icontains=search_term)
-                            | Q(
-                                contract_redemptions__assigned_name__icontains=search_term
-                            )
-                        )
-                    )
+                    .filter(filter_q)
                     .distinct()
                     .prefetch_related(prefetch)
                 )

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -4,8 +4,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 
-from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, OuterRef, Prefetch, Q, Subquery
+from django.db.models import Count, Prefetch, Q
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -195,23 +194,9 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         """Get the queryset; add some annotations/etc for computed fields"""
-        courserun_content_type = ContentType.objects.get_for_model(CourseRun)
-        return (
+        qs = (
             ContractPage.objects.select_related("organization")
             .prefetch_related("users")
-            .annotate(
-                discount_count=Count(
-                    Subquery(
-                        Discount.objects.filter(
-                            products__product__is_active=True,
-                            products__product__content_type=courserun_content_type,
-                            products__product__object_id__in=CourseRun.objects.filter(
-                                b2b_contract=OuterRef("pk")
-                            ).all(),
-                        ).values("id")
-                    )
-                )
-            )
             .annotate(
                 enrollment_count=Count(
                     "course_runs__enrollments",
@@ -224,6 +209,17 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 organization__organization_users__is_manager=True,
             )
         )
+        if self.action == "retrieve":
+            qs = qs.prefetch_related(
+                Prefetch(
+                    "code_redemptions",
+                    queryset=DiscountContractAttachmentRedemption.objects.only(
+                        "id", "contract_id", "redeemed_on", "user_id"
+                    ),
+                    to_attr="prefetched_code_redemptions",
+                )
+            )
+        return qs
 
     def get_serializer_class(self):
         """Use different serializers for list vs detail views."""
@@ -381,17 +377,6 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 ).order_by("-num_redemptions", "id")
 
                 codes_for_output = discounts.filter(num_redemptions__gt=0).all()
-
-                # The point of this is to ensure we always get _all_ the redeemed
-                # codes, and then some unredeemed ones if there's space allowed.
-                # I didn't want to just call all() and grab a slice because we might
-                # have _more_ redemptions that we technically allow (if, say, we
-                # adjust the limit down or manually create some redemptions or
-                # something).
-
-                if codes_for_output.count() < contract.max_learners:
-                    # We have seats available, so grab some more codes.
-                    codes_for_output = discounts.all()[: contract.max_learners]
 
         return self.get_paginated_response(
             ManagerEnrollmentCodeSerializer(

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -370,7 +370,8 @@ def test_org_contract_codes(org_setup, manager_drf_client):
         discount_count = contract.get_discounts().count()
         assert discount_count > contract.max_learners
 
-        expected_code_count = contract.max_learners if contract.max_learners > 0 else 1
+        # We don't expect to get anything back if max_learners is > 0 because we have no redeemed or assigned codes
+        expected_code_count = 0 if contract.max_learners > 0 else 1
         contract_codes = [
             discount.discount_code
             for discount in contract.get_discounts()
@@ -378,8 +379,7 @@ def test_org_contract_codes(org_setup, manager_drf_client):
             .all()[:expected_code_count]
         ]
 
-        # Pull the codes - we should get max_learner codes back and they should
-        # match the sorting order above.
+        # Pull the codes - we should get 0 codes back for a contract w/ max learners since we have no redemptions
 
         manager_contract_code_list = reverse(
             "b2b:b2b-manager-org-contract-codes",
@@ -414,6 +414,7 @@ def test_org_contract_codes(org_setup, manager_drf_client):
         # the subset of discounts hasn't changed.
 
         if contract.max_learners > 1:
+            redeemed_and_assigned_count = 1 + len(some_users)
             discounts_to_use = contract.get_discounts().order_by("-id")[:3]
 
             # Create one "assigned" redemption (pre-assigned but not yet claimed)
@@ -428,6 +429,7 @@ def test_org_contract_codes(org_setup, manager_drf_client):
             # This is the unlimited seat one, so just use the same discount 3 times.
             discount_to_use = contract.get_discounts().order_by("id").last()
             discounts_to_use = [discount_to_use, discount_to_use, discount_to_use]
+            redeemed_and_assigned_count = len(some_users)
 
         for idx, user in enumerate(some_users):
             DiscountContractAttachmentRedemption.objects.create(
@@ -440,21 +442,20 @@ def test_org_contract_codes(org_setup, manager_drf_client):
         resp_codes = [resp_code["code"] for resp_code in resp.json()["results"]]
 
         if contract.max_learners > 1:
-            assert len(resp_codes) == expected_code_count
+            assert len(resp_codes) == redeemed_and_assigned_count
 
             # All codes with redemptions (redeemed and assigned) must appear in
-            # the response; the remaining slots are filled with unassigned codes.
+            # the response.
             used_codes = {discount.discount_code for discount in discounts_to_use}
             assert used_codes.issubset(set(resp_codes))
             assert assigned_discount.discount_code in resp_codes
 
-            # Verify all three redemption statuses are represented in the response.
+            # Verify all non-unassigned redemption statuses are represented in the response.
             response_statuses = {
                 code["redemption_status"] for code in resp.json()["results"]
             }
             assert REDEMPTION_STATUS_REDEEMED in response_statuses
             assert REDEMPTION_STATUS_ASSIGNED in response_statuses
-            assert REDEMPTION_STATUS_UNASSIGNED in response_statuses
         else:
             # For the unlimited seat one, we only get back the single code.
 
@@ -607,7 +608,7 @@ def test_org_contract_codes_search_term(org_setup, manager_drf_client):
     # No search_term returns all codes (up to max_learners)
     resp = manager_drf_client.get(url)
     assert resp.status_code == status.HTTP_200_OK
-    assert len(resp.json()["results"]) == contract_1.max_learners
+    assert len(resp.json()["results"]) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -612,6 +612,115 @@ def test_org_contract_codes_search_term(org_setup, manager_drf_client):
 
 
 # ---------------------------------------------------------------------------
+# codes status filter tests
+# ---------------------------------------------------------------------------
+
+
+def _get_codes_for_status(client, url, status_value):
+    resp = client.get(url, {"status": status_value})
+    assert resp.status_code == status.HTTP_200_OK
+    return {r["code"] for r in resp.json()["results"]}
+
+
+def test_org_contract_codes_status_filter(org_setup, manager_drf_client):
+    """Status filter returns only codes matching the requested redemption status."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discounts = list(contract_1.get_discounts().order_by("id")[:3])
+
+    user_a = UserFactory.create(email="alice@example.com")
+
+    # assigned only (no user, no redeemed_on)
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[0],
+        assigned_email="carol@example.com",
+        contract=contract_1,
+    )
+    # redeemed (has user)
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[1],
+        user=user_a,
+        contract=contract_1,
+    )
+    # redeemed (has redeemed_on but no user, e.g. user deleted)
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[2],
+        redeemed_on=now_in_utc(),
+        contract=contract_1,
+    )
+
+    url = reverse(
+        "b2b:b2b-manager-org-contract-codes",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+        },
+    )
+
+    assert _get_codes_for_status(
+        manager_drf_client, url, REDEMPTION_STATUS_ASSIGNED
+    ) == {discounts[0].discount_code}
+
+    assert _get_codes_for_status(
+        manager_drf_client, url, REDEMPTION_STATUS_REDEEMED
+    ) == {
+        discounts[1].discount_code,
+        discounts[2].discount_code,
+    }
+
+
+def test_org_contract_codes_status_and_search_combined(org_setup, manager_drf_client):
+    """Status and search_term filters can be combined."""
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discounts = list(contract_1.get_discounts().order_by("id")[:3])
+
+    user_a = UserFactory.create(email="alice@example.com", name="Alice Smith")
+    user_b = UserFactory.create(email="bob@example.com", name="Bob Jones")
+
+    # assigned to alice email but not redeemed
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[0],
+        assigned_email="alice@example.com",
+        contract=contract_1,
+    )
+    # redeemed by user_a
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[1],
+        user=user_a,
+        contract=contract_1,
+    )
+    # redeemed by user_b
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[2],
+        user=user_b,
+        contract=contract_1,
+    )
+
+    url = reverse(
+        "b2b:b2b-manager-org-contract-codes",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+        },
+    )
+
+    # assigned + search matching alice: only the unredemed code
+    resp = manager_drf_client.get(
+        url, {"status": REDEMPTION_STATUS_ASSIGNED, "search_term": "alice"}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert {r["code"] for r in resp.json()["results"]} == {discounts[0].discount_code}
+
+    # redeemed + search matching alice: only user_a's redeemed code
+    resp = manager_drf_client.get(
+        url, {"status": REDEMPTION_STATUS_REDEEMED, "search_term": "alice"}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert {r["code"] for r in resp.json()["results"]} == {discounts[1].discount_code}
+
+
+# ---------------------------------------------------------------------------
 # assign_code tests
 # ---------------------------------------------------------------------------
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -7038,9 +7038,18 @@ components:
           readOnly: true
         total_codes:
           type: integer
-          description: Get total number of discount codes for this contract.
+          readOnly: true
+        assigned_codes:
+          type: integer
+          readOnly: true
+        unassigned_codes:
+          type: integer
+          readOnly: true
+        redeemed_codes:
+          type: integer
           readOnly: true
       required:
+      - assigned_codes
       - attachment_percentage
       - contract_end
       - contract_start
@@ -7051,9 +7060,11 @@ components:
       - name
       - organization
       - programs
+      - redeemed_codes
       - slug
       - total_codes
       - total_enrollments
+      - unassigned_codes
       - variant_options
       - welcome_message
       - welcome_message_extra

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -372,6 +372,14 @@ paths:
           type: string
         description: Filter codes by assigned email, user email, user name, or assigned
           name.
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - assigned
+          - redeemed
+        description: Filter codes by status. Supported values are assigned and redeemed.
       tags:
       - b2b
       responses:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -7038,9 +7038,18 @@ components:
           readOnly: true
         total_codes:
           type: integer
-          description: Get total number of discount codes for this contract.
+          readOnly: true
+        assigned_codes:
+          type: integer
+          readOnly: true
+        unassigned_codes:
+          type: integer
+          readOnly: true
+        redeemed_codes:
+          type: integer
           readOnly: true
       required:
+      - assigned_codes
       - attachment_percentage
       - contract_end
       - contract_start
@@ -7051,9 +7060,11 @@ components:
       - name
       - organization
       - programs
+      - redeemed_codes
       - slug
       - total_codes
       - total_enrollments
+      - unassigned_codes
       - variant_options
       - welcome_message
       - welcome_message_extra

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -372,6 +372,14 @@ paths:
           type: string
         description: Filter codes by assigned email, user email, user name, or assigned
           name.
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - assigned
+          - redeemed
+        description: Filter codes by status. Supported values are assigned and redeemed.
       tags:
       - b2b
       responses:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -7038,9 +7038,18 @@ components:
           readOnly: true
         total_codes:
           type: integer
-          description: Get total number of discount codes for this contract.
+          readOnly: true
+        assigned_codes:
+          type: integer
+          readOnly: true
+        unassigned_codes:
+          type: integer
+          readOnly: true
+        redeemed_codes:
+          type: integer
           readOnly: true
       required:
+      - assigned_codes
       - attachment_percentage
       - contract_end
       - contract_start
@@ -7051,9 +7060,11 @@ components:
       - name
       - organization
       - programs
+      - redeemed_codes
       - slug
       - total_codes
       - total_enrollments
+      - unassigned_codes
       - variant_options
       - welcome_message
       - welcome_message_extra

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -372,6 +372,14 @@ paths:
           type: string
         description: Filter codes by assigned email, user email, user name, or assigned
           name.
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - assigned
+          - redeemed
+        description: Filter codes by status. Supported values are assigned and redeemed.
       tags:
       - b2b
       responses:


### PR DESCRIPTION
### Description (What does it do?)
Now that we've paginated the API, the frontend doesn't have a particularly good way to grab the breakdown of codes to show to the contract manager:
<img width="659" height="102" alt="Screenshot 2026-06-25 at 12 10 28 PM" src="https://github.com/user-attachments/assets/96502690-9fbc-4981-b5c2-a2c5c4efcc6a" />

Previously, these were just calculated by looking at the total rowset returned from /codes. 

This PR attempts to put that info into the contract retrieve endpoint instead - that endpoint already looked like it was outputting some values like that (most notably a miscalculated `total_codes` value), so it seemed reasonable to add here.


Additionally, this PR removes unassigned codes from the response entirely. 

We no longer actually intend to show unassigned codes in the UI - contract admins shouldn't need to see them as the assign endpoints already handle distributing them automagically. The only codepath which returned them is for contracts which don't have automatic membership types AND a max_learners set (the former case never returns any codes, the latter returns the first one if it exists). We considered adding a query param to filter those out, but as this endpoint already has a bit too many edge cases, we thought this might make it easier to reason about - this makes /codes more like "used/assigned codes"

If we decide later that we do need them in this payload, we can either add a kwarg or create a new endpoint for "available codes".

Lastly, this PR adds filtering on the "status" of a code for the /codes endpoint. Since we've removed unassigned codes from the payload, we only have to worry about support for "assigned" and "redeemed" codes

### Screenshots (if appropriate):
<img width="1418" height="576" alt="Screenshot 2026-06-25 at 2 26 44 PM" src="https://github.com/user-attachments/assets/6689e6e7-3a8c-4624-8825-54ea821acad4" />
<img width="1413" height="664" alt="Screenshot 2026-06-25 at 2 26 58 PM" src="https://github.com/user-attachments/assets/c06e30d3-d614-4b4e-9aa3-9a49d691905b" />


### How can this be tested?
In addition to all tests passing, manual testing can be performed in the following manner.


Common setup
- With a b2b contract set up, assign a few codes using a few different emails and users. You can get the list of codes by visiting http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/codes/, and it's easiest to assign the codes using the [swagger UI for /assign](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_assign_create)

To test the filtering behavior, you'll want to redeem a few codes using the [attach API](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_attach_create).

At the end of setup, you should have at least a few values in redeemed, assigned and unassigned to make subsequent steps easier.

#### Removal of Unassigned codes from /codes
- As long as you've got at least one code that has not been assigned or redeemed, simply hit `http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/codes/` and observe that it is not returned in the resultset.
  - If you've got a lot of codes, in assigned/redeemed state, you can specify a very large page size to get it all in one request for verification

#### Summary Statistics
- Visit http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/
- You should observe that the following fields are populated in the response and are reflective of your contract. The only one which is not self-explanatory is total_codes, and that should match the max_learners set on the contract itself.
```
total_codes
assigned_codes
unassigned_codes
redeemed_codes
```

#### Status filtering
- Visit `http://mitxonline.odl.local:9080/api/v0/b2b/manager/organizations/<org_id>/contracts/<contract_id>/codes/` and specify a status parameter of either "assigned" or "redeemed"
- You should observe that only codes in the matching status are returned.
- Additionally, if you specify a search_term AND a status parameter, both filters should be properly applied.


### Additional Information
Take note - this PR is a branch off of https://github.com/mitodl/mitxonline/pull/3685; in order to simplify the release, this branch will be merged into that PR and the whole thing will be released in one shot.