### PR TITLE
Use more realistic URL in test send email task

### DIFF
--- a/b2b/mail.py
+++ b/b2b/mail.py
@@ -66,10 +66,11 @@ def send_enrollment_code_assignment_email(assignment_record_ids):
 
 def send_test_enrollment_code_assignment_email(email, contract_record_id):
     contract = ContractPage.objects.get(pk=contract_record_id)
+    learn_hostname = get_learn_hostname()
     send_email_helper(
         email,
         "PLACEHOLDER_CODE",
-        "PLACEHOLDER_URL",
+        f"https://{learn_hostname}/enrollmentcode/PLACEHOLDER_CODE",
         contract.organization.name,
         contract.name,
     )


### PR DESCRIPTION
### Description (What does it do?)
Tiny stab in the dark to see if I can fix an observed issue w/ a currently unused API. We're going to add a test send email button for B2B contract admins so they can see what it looks like before sending it to users - to facilitate this I've added an endpoint that sends that email.

In local testing the rendered UI looked like this:
<img width="1279" height="847" alt="Screenshot 2026-06-29 at 11 52 54 AM" src="https://github.com/user-attachments/assets/4ad3c4fb-8fa8-4f57-b721-658a8c8d8fc2" />

That's correct and close to the real template, just uses placeholder values for the code and URL. This is what emails sent through the assign and remind API look like, so that's all good.

Here's what it looked like in outlook when sent from RC.
<img width="786" height="548" alt="Screenshot 2026-06-29 at 11 43 37 AM" src="https://github.com/user-attachments/assets/2e89c815-879e-4791-b2dd-d76685ca1c1e" />

It's worth noting that assign/remind do not exhibit this behavior. This PR just constructs a more plausible looking URL and hopefully that'll address the issue in RC.

### How can this be tested?
You can test it locally by visiting http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_send_test_email_create and sending a test email if you have a contract set up that you are an admin for. This is only sufficient to test that nothing is broken though, since I've only reproduced the malformed behavior on RC at this point. As long as nothing breaks, this will be validated on RC.

As noted above, this endpoint is unused, so there's very little risk in this PR.
