### PR TITLE
Default new certificate page title to courseware title

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -336,7 +336,9 @@ def create_default_certificate_page(
     from cms.models import CertificatePage  # noqa: PLC0415
 
     cert_page = CertificatePage(
-        product_name=f"PLACEHOLDER - {courseware.title} Certificate",
+        # Default to the courseware title so new certificate pages are
+        # display-ready; admins can still overwrite the "Certificate Title".
+        product_name=courseware.title,
         CEUs=f"PLACEHOLDER - {courseware.title} CEUs",
     )
     courseware_page = courseware.page

--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -12,6 +12,7 @@ from wagtail_factories import PageFactory
 
 from cms.api import (
     RESOURCE_PAGE_TITLES,
+    create_default_certificate_page,
     create_default_courseware_page,
     create_featured_items,
     ensure_home_page_and_site,
@@ -288,6 +289,22 @@ def test_create_courseware_page():
 
     with pytest.raises(ValidationError):
         resulting_page = create_default_courseware_page(course.programs[0])
+
+
+@pytest.mark.django_db
+def test_create_default_certificate_page_defaults_to_title():
+    """New certificate pages default the title to the courseware title, not a placeholder."""
+    ensure_home_page_and_site()
+    ensure_product_index()
+    ensure_program_product_index()
+
+    course = CourseFactory.create(page=None)
+    create_default_courseware_page(course)
+
+    cert_page = create_default_certificate_page(course)
+
+    assert cert_page.product_name == course.title
+    assert "PLACEHOLDER" not in cert_page.product_name
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?


Follow-up to the certificate-title work ([hq#11907](https://github.com/mitodl/hq/issues/11907), tracked in [hq#11938](https://github.com/mitodl/hq/issues/11938)). Covers item **B**.

### Description


A certificate page can show `PLACEHOLDER - <name> Certificate` in its **"Certificate Title"** (`CertificatePage.product_name`), because that's what the `create_courseware` command populates when it creates the page. If nobody edits it afterward, the certificate goes out with that placeholder title. This changes the default to the courseware (course/program) title so command-created certificate pages are display-ready out of the box.

This only happens via `create_courseware` — when an admin creates a certificate page directly in the CMS, the "Certificate Title" field starts empty and they type the real title, so no placeholder is ever produced there.

- **Matters now** because the Certificate Title flows into the verifiable credential and the LinkedIn "Add to Profile" name, so a leftover `PLACEHOLDER - …` title would leak into a signed credential.
- The Step-1 backfill ([#3697](https://github.com/mitodl/mitxonline/pull/3697)) cleans up existing placeholder titles; this only stops new ones from being created.
- Admins can still overwrite the "Certificate Title" in the CMS.

## Change

`cms/api.py` — `create_default_certificate_page`:

```python
cert_page = CertificatePage(
    product_name=courseware.title,
    CEUs=f"PLACEHOLDER - {courseware.title} CEUs",
)
```

## How to test

Automated:

```
docker compose run --rm web uv run pytest cms/api_test.py::test_create_default_certificate_page_defaults_to_title
```

- `test_create_default_certificate_page_defaults_to_title` (new) asserts a newly created certificate page's `product_name` equals the courseware title and contains no `PLACEHOLDER` text.

Manual (optional): create a new courseware page via `create_courseware` and confirm the generated certificate page's "Certificate Title" is the courseware title rather than `PLACEHOLDER - … Certificate`.