### PR TITLE
fix: issues with certificate generation

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -15,7 +15,7 @@ import requests
 import reversion
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Exists, OuterRef, Prefetch, Q
 from django_countries import countries
@@ -913,6 +913,22 @@ def process_course_run_grade_certificate(course_run_grade, should_force_create=F
             certificate, created = CourseRunCertificate.objects.get_or_create(
                 user=user, course_run=course_run
             )
+            if not certificate.certificate_page_revision:
+                try:
+                    course_page = course_run.course.page
+                except ObjectDoesNotExist:
+                    log.warning(
+                        "Skipping certificate page revision for user=%s run=%s because course page is missing",
+                        user.id,
+                        course_run.courseware_id,
+                    )
+                else:
+                    if not course_page.certificate_page:
+                        log.warning(
+                            "Skipping certificate page revision for user=%s run=%s because certificate page is missing",
+                            user.id,
+                            course_run.courseware_id,
+                        )
             sync_hubspot_user(user)
             if not certificate.verifiable_credential_id:
                 create_verifiable_credential(certificate)
@@ -920,6 +936,12 @@ def process_course_run_grade_certificate(course_run_grade, should_force_create=F
         except IntegrityError:
             log.warning(
                 f"IntegrityError caught processing certificate for {course_run.courseware_id} for user {user} - certificate was likely already revoked."  # noqa: G004
+            )
+        except Exception:
+            log.exception(
+                "Error processing certificate for user=%s and course_run=%s",
+                user.id,
+                course_run.courseware_id,
             )
     return None, False, False
 
@@ -987,11 +1009,7 @@ def generate_course_run_certificates(  # noqa: C901
         edx_grade_user_iter = exception_logging_generator(
             get_edx_grades_with_users(run, user=user)
         )
-        created_grades_count, updated_grades_count, generated_certificates_count = (
-            0,
-            0,
-            0,
-        )
+        stats = Counter()
         for edx_grade, run_user in edx_grade_user_iter:
             try:
                 course_run_grade, created, updated = ensure_course_run_grade(
@@ -1006,9 +1024,9 @@ def generate_course_run_certificates(  # noqa: C901
                 continue
 
             if created:
-                created_grades_count += 1
+                stats["created_grades"] += 1
             elif updated:
-                updated_grades_count += 1
+                stats["updated_grades"] += 1
 
             # Check certificate generation eligibility
             # When force is True: bypass checks (e.g. webhook path where edX already
@@ -1026,9 +1044,18 @@ def generate_course_run_certificates(  # noqa: C901
                     and run.certificate_available_date <= now
                 )
             ):
-                _, created, deleted = process_course_run_grade_certificate(
-                    course_run_grade=course_run_grade
-                )
+                try:
+                    _, created, deleted = process_course_run_grade_certificate(
+                        course_run_grade=course_run_grade
+                    )
+                except Exception:
+                    stats["failed_certificates"] += 1
+                    log.exception(
+                        "Error creating certificate for user=%s and course_run=%s",
+                        run_user.id,
+                        run.courseware_id,
+                    )
+                    continue
 
                 if deleted:
                     log.warning(
@@ -1042,10 +1069,10 @@ def generate_course_run_certificates(  # noqa: C901
                         run_user,
                         run,
                     )
-                    generated_certificates_count += 1
+                    stats["generated_certificates"] += 1
 
         log.info(
-            f"Finished processing course run {run}: created grades for {created_grades_count} users, updated grades for {updated_grades_count} users, generated certificates for {generated_certificates_count} users"  # noqa: G004
+            f"Finished processing course run {run}: created grades for {stats['created_grades']} users, updated grades for {stats['updated_grades']} users, generated certificates for {stats['generated_certificates']} users, failed certificates for {stats['failed_certificates']} users"  # noqa: G004
         )
 
 
@@ -1214,27 +1241,46 @@ def generate_program_certificate(user, program, force_create=False):  # noqa: FB
             False,
         )
 
-    existing_cert_queryset = ProgramCertificate.all_objects.filter(
+    existing_cert = ProgramCertificate.all_objects.filter(
         user=user, program=program
-    )
-    if existing_cert_queryset.exists():
-        return existing_cert_queryset.first(), False
+    ).first()
+    if existing_cert:
+        return existing_cert, False
 
     if not force_create and not _has_earned_program_cert(user, program):
         return None, False
 
-    program_cert = ProgramCertificate.objects.create(user=user, program=program)
-    if program_cert:
+    program_cert, created = ProgramCertificate.all_objects.get_or_create(
+        user=user,
+        program=program,
+    )
+    if created:
         log.info(
             "Program certificate for [%s] in program [%s] is created.",
             user.edx_username,
             program.title,
         )
+        if not program_cert.certificate_page_revision:
+            try:
+                program_page = program.page
+            except ObjectDoesNotExist:
+                log.warning(
+                    "Skipping program certificate page revision for user=%s program=%s because program page is missing",
+                    user.id,
+                    program.readable_id,
+                )
+            else:
+                if not program_page.certificate_page:
+                    log.warning(
+                        "Skipping program certificate page revision for user=%s program=%s because certificate page is missing",
+                        user.id,
+                        program.readable_id,
+                    )
         sync_hubspot_user(user)
         if not program_cert.verifiable_credential_id:
             create_verifiable_credential(program_cert)
 
-    return program_cert, True
+    return program_cert, created
 
 
 def generate_multiple_programs_certificate(user, programs):

--- a/courses/api.py
+++ b/courses/api.py
@@ -15,7 +15,7 @@ import requests
 import reversion
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Exists, OuterRef, Prefetch, Q
 from django_countries import countries
@@ -914,21 +914,23 @@ def process_course_run_grade_certificate(course_run_grade, should_force_create=F
                 user=user, course_run=course_run
             )
             if not certificate.certificate_page_revision:
-                try:
-                    course_page = course_run.course.page
-                except ObjectDoesNotExist:
+                course = course_run.course
+                if not hasattr(course, "page") or not course.page:
                     log.warning(
                         "Skipping certificate page revision for user=%s run=%s because course page is missing",
                         user.id,
                         course_run.courseware_id,
                     )
-                else:
-                    if not course_page.certificate_page:
-                        log.warning(
-                            "Skipping certificate page revision for user=%s run=%s because certificate page is missing",
-                            user.id,
-                            course_run.courseware_id,
-                        )
+                elif (
+                    hasattr(course, "page")
+                    and course.page
+                    and not course.page.certificate_page
+                ):
+                    log.warning(
+                        "Skipping certificate page revision for user=%s run=%s because certificate page is missing",
+                        user.id,
+                        course_run.courseware_id,
+                    )
             sync_hubspot_user(user)
             if not certificate.verifiable_credential_id:
                 create_verifiable_credential(certificate)
@@ -936,12 +938,6 @@ def process_course_run_grade_certificate(course_run_grade, should_force_create=F
         except IntegrityError:
             log.warning(
                 f"IntegrityError caught processing certificate for {course_run.courseware_id} for user {user} - certificate was likely already revoked."  # noqa: G004
-            )
-        except Exception:
-            log.exception(
-                "Error processing certificate for user=%s and course_run=%s",
-                user.id,
-                course_run.courseware_id,
             )
     return None, False, False
 
@@ -1261,21 +1257,22 @@ def generate_program_certificate(user, program, force_create=False):  # noqa: FB
             program.title,
         )
         if not program_cert.certificate_page_revision:
-            try:
-                program_page = program.page
-            except ObjectDoesNotExist:
+            if not hasattr(program, "page") or not program.page:
                 log.warning(
                     "Skipping program certificate page revision for user=%s program=%s because program page is missing",
                     user.id,
                     program.readable_id,
                 )
-            else:
-                if not program_page.certificate_page:
-                    log.warning(
-                        "Skipping program certificate page revision for user=%s program=%s because certificate page is missing",
-                        user.id,
-                        program.readable_id,
-                    )
+            elif (
+                hasattr(program, "page")
+                and program.page
+                and not program.page.certificate_page
+            ):
+                log.warning(
+                    "Skipping program certificate page revision for user=%s program=%s because certificate page is missing",
+                    user.id,
+                    program.readable_id,
+                )
         sync_hubspot_user(user)
         if not program_cert.verifiable_credential_id:
             create_verifiable_credential(program_cert)

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -109,6 +109,7 @@ from openedx.exceptions import (
     NoEdxApiAuthError,
     UnknownEdxApiEnrollException,
 )
+from users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 FAKE = faker.Factory.create()
@@ -1262,7 +1263,7 @@ def test_generate_course_certificates_self_paced_course(
     )
     generate_course_run_certificates()
     assert (
-        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1} users"
+        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1} users, failed certificates for {0} users"
         in courses_api_logs.info.call_args[0][0]
     )
 
@@ -1311,7 +1312,7 @@ def test_course_certificates_with_course_end_date_self_paced_combination(  # noq
 
     generate_course_run_certificates()
     assert (
-        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1 if end_date else 0} users"
+        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1 if end_date else 0} users, failed certificates for {0} users"
         in courses_api_logs.info.call_args[0][0]
     )
 
@@ -1353,9 +1354,53 @@ def test_generate_course_certificates_with_course_end_date(  # noqa: PLR0913
     )
     generate_course_run_certificates()
     assert (
-        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1} users"
+        f"Finished processing course run {course_run}: created grades for {1} users, updated grades for {0} users, generated certificates for {1} users, failed certificates for {0} users"
         in courses_api_logs.info.call_args[0][0]
     )
+
+
+@patch("courses.signals.upsert_custom_properties")
+def test_generate_course_certificates_failure_isolation(
+    mock_upsert_custom_properties,
+    mocker,
+    courses_api_logs,
+):
+    """A certificate failure for one user should not stop processing for others."""
+    mocker.patch(
+        "hubspot_sync.api.upsert_custom_properties",
+    )
+    course_run = CourseRunFactory.create(certificate_available_date=now_in_utc())
+
+    run_user_1 = UserFactory.create()
+    run_user_2 = UserFactory.create()
+
+    grade_1 = CourseRunGradeFactory.create(
+        course_run=course_run, user=run_user_1, grade=0.5, passed=True
+    )
+    grade_2 = CourseRunGradeFactory.create(
+        course_run=course_run, user=run_user_2, grade=0.5, passed=True
+    )
+
+    mocker.patch(
+        "courses.api.exception_logging_generator",
+        return_value=[(grade_1, run_user_1), (grade_2, run_user_2)],
+    )
+    mocker.patch(
+        "courses.api.ensure_course_run_grade",
+        side_effect=[
+            (grade_1, True, False),
+            (grade_2, True, False),
+        ],
+    )
+    mock_process = mocker.patch(
+        "courses.api.process_course_run_grade_certificate",
+        side_effect=[RuntimeError("simulated cert failure"), (None, False, False)],
+    )
+
+    generate_course_run_certificates(course_run=course_run, force=True)
+
+    assert mock_process.call_count == 2
+    assert "failed certificates for 1 users" in courses_api_logs.info.call_args[0][0]
 
 
 @pytest.mark.parametrize(
@@ -1941,6 +1986,36 @@ def test_generate_program_certificate_already_exist(
     )
     assert result == (program_certificate, False)
     assert len(ProgramCertificate.objects.all()) == 1
+
+
+def test_generate_program_certificate_existing_revoked_returns_existing(
+    user,
+    program_with_empty_requirements,  # noqa: F811
+):
+    """Existing revoked certificates should be returned instead of re-created."""
+    ProgramEnrollment.objects.create(
+        user=user,
+        program=program_with_empty_requirements,
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+    )
+    program_certificate = ProgramCertificateFactory.create(
+        program=program_with_empty_requirements,
+        user=user,
+        is_revoked=True,
+    )
+
+    result = generate_program_certificate(
+        user=user, program=program_with_empty_requirements
+    )
+
+    assert result == (program_certificate, False)
+    assert (
+        ProgramCertificate.all_objects.filter(
+            user=user,
+            program=program_with_empty_requirements,
+        ).count()
+        == 1
+    )
 
 
 def test_program_certificates_access():

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -20,19 +20,16 @@ class Command(BaseCommand):
         parser.add_argument(
             "--live",
             action="store_true",
-            default=False,
             help="Only include live courses/programs in the report.",
         )
         parser.add_argument(
             "--details",
             action="store_true",
-            default=False,
             help="Print detailed rows for each missing item.",
         )
         parser.add_argument(
             "--eligible-users-only",
             action="store_true",
-            default=False,
             help=(
                 "Only include courses/programs where at least one user is eligible "
                 "for certificates."
@@ -40,9 +37,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):  # noqa: ARG002
-        live_only = options["live"]
-        show_details = options["details"]
-        eligible_users_only = options["eligible_users_only"]
+        live_only = options.get("live", False)
+        show_details = options.get("details", False)
+        eligible_users_only = options.get("eligible_users_only", False)
 
         courses_qs = Course.objects.all()
         programs_qs = Program.objects.all()

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -1,0 +1,112 @@
+"""Report missing CMS product and certificate pages for courses and programs."""
+
+from django.core.management.base import BaseCommand
+
+from courses.models import Course, Program
+
+
+class Command(BaseCommand):
+    """Print a report of missing Course/Program pages and certificate child pages."""
+
+    help = (
+        "Report courses/programs that are missing CMS product pages or "
+        "certificate child pages"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--live",
+            action="store_true",
+            help="Only include live courses/programs in the report.",
+        )
+        parser.add_argument(
+            "--details",
+            action="store_true",
+            help="Print detailed rows for each missing item.",
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        live_only = options["live"]
+        show_details = options["details"]
+
+        courses_qs = Course.objects.all()
+        programs_qs = Program.objects.all()
+        if live_only:
+            courses_qs = courses_qs.filter(live=True)
+            programs_qs = programs_qs.filter(live=True)
+
+        missing_course_pages = []
+        missing_course_certificate_pages = []
+        for course in courses_qs:
+            try:
+                course_page = course.page
+            except Course.page.RelatedObjectDoesNotExist:
+                missing_course_pages.append(course)
+                continue
+
+            if not course_page.certificate_page:
+                missing_course_certificate_pages.append(course)
+
+        missing_program_pages = []
+        missing_program_certificate_pages = []
+        for program in programs_qs:
+            try:
+                program_page = program.page
+            except Program.page.RelatedObjectDoesNotExist:
+                missing_program_pages.append(program)
+                continue
+
+            if not program_page.certificate_page:
+                missing_program_certificate_pages.append(program)
+
+        stats = {
+            "missing_course_pages": len(missing_course_pages),
+            "missing_course_certificate_pages": len(missing_course_certificate_pages),
+            "missing_program_pages": len(missing_program_pages),
+            "missing_program_certificate_pages": len(missing_program_certificate_pages),
+        }
+
+        self.stdout.write(
+            self.style.WARNING(
+                f"Courses missing CMS page: {stats['missing_course_pages']}"
+            )
+        )
+        self.stdout.write(
+            self.style.WARNING(
+                "Courses missing CMS certificate page: "
+                f"{stats['missing_course_certificate_pages']}"
+            )
+        )
+        self.stdout.write(
+            self.style.WARNING(
+                f"Programs missing CMS page: {stats['missing_program_pages']}"
+            )
+        )
+        self.stdout.write(
+            self.style.WARNING(
+                "Programs missing CMS certificate page: "
+                f"{stats['missing_program_certificate_pages']}"
+            )
+        )
+
+        if show_details:
+            self._print_items("Course missing page", missing_course_pages)
+            self._print_items(
+                "Course missing certificate page", missing_course_certificate_pages
+            )
+            self._print_items("Program missing page", missing_program_pages)
+            self._print_items(
+                "Program missing certificate page", missing_program_certificate_pages
+            )
+
+        return stats
+
+    def _print_items(self, label, items):
+        if not items:
+            return
+
+        self.stdout.write(self.style.WARNING(f"{label} details:"))
+        for item in items:
+            self.stdout.write(
+                f"- id={item.id} readable_id={item.readable_id} title={item.title}"
+            )

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -23,11 +23,6 @@ class Command(BaseCommand):
             help="Only include live courses/programs in the report.",
         )
         parser.add_argument(
-            "--details",
-            action="store_true",
-            help="Print detailed rows for each missing item.",
-        )
-        parser.add_argument(
             "--eligible-users-only",
             action="store_true",
             help=(
@@ -38,7 +33,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):  # noqa: ARG002
         live_only = options.get("live", False)
-        show_details = options.get("details", False)
         eligible_users_only = options.get("eligible_users_only", False)
 
         courses_qs = Course.objects.all()
@@ -105,15 +99,14 @@ class Command(BaseCommand):
             )
         )
 
-        if show_details:
-            self._print_items("Course missing page", missing_course_pages)
-            self._print_items(
-                "Course missing certificate page", missing_course_certificate_pages
-            )
-            self._print_items("Program missing page", missing_program_pages)
-            self._print_items(
-                "Program missing certificate page", missing_program_certificate_pages
-            )
+        self._print_items("Course missing page", missing_course_pages)
+        self._print_items(
+            "Course missing certificate page", missing_course_certificate_pages
+        )
+        self._print_items("Program missing page", missing_program_pages)
+        self._print_items(
+            "Program missing certificate page", missing_program_certificate_pages
+        )
 
     def _print_items(self, label, items):
         if not items:

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -20,16 +20,19 @@ class Command(BaseCommand):
         parser.add_argument(
             "--live",
             action="store_true",
+            default=False,
             help="Only include live courses/programs in the report.",
         )
         parser.add_argument(
             "--details",
             action="store_true",
+            default=False,
             help="Print detailed rows for each missing item.",
         )
         parser.add_argument(
             "--eligible-users-only",
             action="store_true",
+            default=False,
             help=(
                 "Only include courses/programs where at least one user is eligible "
                 "for certificates."

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -1,8 +1,11 @@
 """Report missing CMS product and certificate pages for courses and programs."""
 
 from django.core.management.base import BaseCommand
+from django.db.models import Exists, OuterRef
 
-from courses.models import Course, Program
+from courses.api import get_eligible_program_certificate_candidates
+from courses.models import Course, CourseRunEnrollment, CourseRunGrade, Program
+from openedx.constants import EDX_ENROLLMENTS_PAID_MODES
 
 
 class Command(BaseCommand):
@@ -24,16 +27,29 @@ class Command(BaseCommand):
             action="store_true",
             help="Print detailed rows for each missing item.",
         )
+        parser.add_argument(
+            "--eligible-users-only",
+            action="store_true",
+            help=(
+                "Only include courses/programs where at least one user is eligible "
+                "for certificates."
+            ),
+        )
 
     def handle(self, *args, **options):  # noqa: ARG002
         live_only = options["live"]
         show_details = options["details"]
+        eligible_users_only = options["eligible_users_only"]
 
         courses_qs = Course.objects.all()
         programs_qs = Program.objects.all()
         if live_only:
             courses_qs = courses_qs.filter(live=True)
             programs_qs = programs_qs.filter(live=True)
+
+        if eligible_users_only:
+            courses_qs = courses_qs.filter(id__in=self._eligible_course_ids())
+            programs_qs = programs_qs.filter(id__in=self._eligible_program_ids())
 
         missing_course_pages = []
         missing_course_certificate_pages = []
@@ -110,3 +126,22 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"- id={item.id} readable_id={item.readable_id} title={item.title}"
             )
+
+    def _eligible_course_ids(self):
+        paid_enrollment = CourseRunEnrollment.objects.filter(
+            user_id=OuterRef("user_id"),
+            run_id=OuterRef("course_run_id"),
+            enrollment_mode__in=EDX_ENROLLMENTS_PAID_MODES,
+        )
+
+        return (
+            CourseRunGrade.objects.filter(passed=True)
+            .annotate(has_paid_enrollment=Exists(paid_enrollment))
+            .filter(has_paid_enrollment=True)
+            .values_list("course_run__course_id", flat=True)
+        )
+
+    def _eligible_program_ids(self):
+        return get_eligible_program_certificate_candidates().values_list(
+            "program_id", flat=True
+        )

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -115,8 +115,6 @@ class Command(BaseCommand):
                 "Program missing certificate page", missing_program_certificate_pages
             )
 
-        return stats
-
     def _print_items(self, label, items):
         if not items:
             return

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -133,12 +133,14 @@ class Command(BaseCommand):
             .annotate(has_paid_enrollment=Exists(paid_enrollment))
             .filter(has_paid_enrollment=True)
             .values_list("course_run__course_id", flat=True)
-        )
+        ).distinct()
 
     def _eligible_program_ids(self):
         """
         Return a queryset of program IDs for which at least one user is eligible for a certificate.
         """
-        return get_eligible_program_certificate_candidates().values_list(
-            "program_id", flat=True
+        return (
+            get_eligible_program_certificate_candidates()
+            .values_list("program_id", flat=True)
+            .distinct()
         )

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -109,6 +109,9 @@ class Command(BaseCommand):
         )
 
     def _print_items(self, label, items):
+        """
+        Print a list of items with their id, readable_id, and title.
+        """
         if not items:
             return
 
@@ -119,6 +122,10 @@ class Command(BaseCommand):
             )
 
     def _eligible_course_ids(self):
+        """
+        Return a queryset of course IDs for which at least one user has passed a
+        course run and has a paid enrollment in that course run.
+        """
         paid_enrollment = CourseRunEnrollment.objects.filter(
             user_id=OuterRef("user_id"),
             run_id=OuterRef("course_run_id"),
@@ -133,6 +140,9 @@ class Command(BaseCommand):
         )
 
     def _eligible_program_ids(self):
+        """
+        Return a queryset of program IDs for which at least one user is eligible for a certificate.
+        """
         return get_eligible_program_certificate_candidates().values_list(
             "program_id", flat=True
         )

--- a/courses/management/commands/report_missing_cms_pages.py
+++ b/courses/management/commands/report_missing_cms_pages.py
@@ -48,25 +48,21 @@ class Command(BaseCommand):
         missing_course_pages = []
         missing_course_certificate_pages = []
         for course in courses_qs:
-            try:
-                course_page = course.page
-            except Course.page.RelatedObjectDoesNotExist:
+            if not hasattr(course, "page") or not course.page:
                 missing_course_pages.append(course)
                 continue
 
-            if not course_page.certificate_page:
+            if not course.page.certificate_page:
                 missing_course_certificate_pages.append(course)
 
         missing_program_pages = []
         missing_program_certificate_pages = []
         for program in programs_qs:
-            try:
-                program_page = program.page
-            except Program.page.RelatedObjectDoesNotExist:
+            if not hasattr(program, "page") or not program.page:
                 missing_program_pages.append(program)
                 continue
 
-            if not program_page.certificate_page:
+            if not program.page.certificate_page:
                 missing_program_certificate_pages.append(program)
 
         stats = {

--- a/courses/management/tests/report_missing_cms_pages_test.py
+++ b/courses/management/tests/report_missing_cms_pages_test.py
@@ -3,8 +3,16 @@
 import pytest
 
 from cms.models import CertificatePage
-from courses.factories import CourseFactory, ProgramFactory
+from courses.factories import (
+    CourseFactory,
+    CourseRunEnrollmentFactory,
+    CourseRunFactory,
+    CourseRunGradeFactory,
+    ProgramEnrollmentFactory,
+    ProgramFactory,
+)
 from courses.management.commands import report_missing_cms_pages
+from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
 pytestmark = [pytest.mark.django_db]
 
@@ -52,3 +60,52 @@ def test_report_missing_cms_pages_live_filter():
     assert non_live_course.live is False
     assert live_program.live is True
     assert non_live_program.live is False
+
+
+def test_report_missing_cms_pages_eligible_users_only_filter():
+    """The --eligible-users-only filter should include only cert-eligible courseware."""
+    eligible_course = CourseFactory.create(page=None)
+    eligible_run = CourseRunFactory.create(course=eligible_course)
+    eligible_enrollment = CourseRunEnrollmentFactory.create(
+        run=eligible_run,
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+    )
+    CourseRunGradeFactory.create(
+        course_run=eligible_run,
+        user=eligible_enrollment.user,
+        passed=True,
+        grade=0.9,
+    )
+
+    # Not eligible due to no paid enrollment
+    ineligible_course = CourseFactory.create(page=None)
+    ineligible_run = CourseRunFactory.create(course=ineligible_course)
+    ineligible_enrollment = CourseRunEnrollmentFactory.create(
+        run=ineligible_run,
+        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+    )
+    CourseRunGradeFactory.create(
+        course_run=ineligible_run,
+        user=ineligible_enrollment.user,
+        passed=True,
+        grade=0.9,
+    )
+
+    eligible_program = ProgramFactory.create(page=None, live=True)
+    ProgramEnrollmentFactory.create(
+        program=eligible_program,
+        enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE,
+        active=True,
+    )
+
+    ineligible_program = ProgramFactory.create(page=None, live=True)
+    ProgramEnrollmentFactory.create(
+        program=ineligible_program,
+        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+        active=True,
+    )
+
+    stats = report_missing_cms_pages.Command().handle(eligible_users_only=True)
+
+    assert stats["missing_course_pages"] == 1
+    assert stats["missing_program_pages"] == 1

--- a/courses/management/tests/report_missing_cms_pages_test.py
+++ b/courses/management/tests/report_missing_cms_pages_test.py
@@ -33,14 +33,14 @@ def test_report_missing_cms_pages_all_buckets():
     ProgramFactory.create()
 
     # Missing course page
-    CourseFactory.create(page=None)
+    missing_course_page = CourseFactory.create(page=None)
 
     # Missing course certificate page
     course_missing_cert_page = CourseFactory.create()
     CertificatePage.objects.descendant_of(course_missing_cert_page.page).delete()
 
     # Missing program page
-    ProgramFactory.create(page=None)
+    missing_program_page = ProgramFactory.create(page=None)
 
     # Missing program certificate page
     program_missing_cert_page = ProgramFactory.create()
@@ -52,6 +52,26 @@ def test_report_missing_cms_pages_all_buckets():
     assert "Courses missing CMS certificate page: 1" in output
     assert "Programs missing CMS page: 1" in output
     assert "Programs missing CMS certificate page: 1" in output
+    assert "Course missing page details:" in output
+    assert (
+        f"- id={missing_course_page.id} readable_id={missing_course_page.readable_id} title={missing_course_page.title}"
+        in output
+    )
+    assert "Course missing certificate page details:" in output
+    assert (
+        f"- id={course_missing_cert_page.id} readable_id={course_missing_cert_page.readable_id} title={course_missing_cert_page.title}"
+        in output
+    )
+    assert "Program missing page details:" in output
+    assert (
+        f"- id={missing_program_page.id} readable_id={missing_program_page.readable_id} title={missing_program_page.title}"
+        in output
+    )
+    assert "Program missing certificate page details:" in output
+    assert (
+        f"- id={program_missing_cert_page.id} readable_id={program_missing_cert_page.readable_id} title={program_missing_cert_page.title}"
+        in output
+    )
 
 
 def test_report_missing_cms_pages_live_filter():
@@ -65,6 +85,8 @@ def test_report_missing_cms_pages_live_filter():
 
     assert "Courses missing CMS page: 1" in output
     assert "Programs missing CMS page: 1" in output
+    assert "Course missing page details:" in output
+    assert "Program missing page details:" in output
     assert live_course.live is True
     assert non_live_course.live is False
     assert live_program.live is True
@@ -118,3 +140,7 @@ def test_report_missing_cms_pages_eligible_users_only_filter():
 
     assert "Courses missing CMS page: 1" in output
     assert "Programs missing CMS page: 1" in output
+    assert "Course missing page details:" in output
+    assert f"readable_id={eligible_course.readable_id}" in output
+    assert "Program missing page details:" in output
+    assert f"readable_id={eligible_program.readable_id}" in output

--- a/courses/management/tests/report_missing_cms_pages_test.py
+++ b/courses/management/tests/report_missing_cms_pages_test.py
@@ -1,0 +1,54 @@
+"""Tests for report_missing_cms_pages command."""
+
+import pytest
+
+from cms.models import CertificatePage
+from courses.factories import CourseFactory, ProgramFactory
+from courses.management.commands import report_missing_cms_pages
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_report_missing_cms_pages_all_buckets():
+    """The command should report all missing-page bucket counts correctly."""
+    # Healthy records
+    CourseFactory.create()
+    ProgramFactory.create()
+
+    # Missing course page
+    CourseFactory.create(page=None)
+
+    # Missing course certificate page
+    course_missing_cert_page = CourseFactory.create()
+    CertificatePage.objects.descendant_of(course_missing_cert_page.page).delete()
+
+    # Missing program page
+    ProgramFactory.create(page=None)
+
+    # Missing program certificate page
+    program_missing_cert_page = ProgramFactory.create()
+    CertificatePage.objects.descendant_of(program_missing_cert_page.page).delete()
+
+    stats = report_missing_cms_pages.Command().handle()
+
+    assert stats["missing_course_pages"] == 1
+    assert stats["missing_course_certificate_pages"] == 1
+    assert stats["missing_program_pages"] == 1
+    assert stats["missing_program_certificate_pages"] == 1
+
+
+def test_report_missing_cms_pages_live_filter():
+    """The --live filter should only include live courseware."""
+    live_course = CourseFactory.create(page=None, live=True)
+    non_live_course = CourseFactory.create(page=None, live=False)
+    live_program = ProgramFactory.create(page=None, live=True)
+    non_live_program = ProgramFactory.create(page=None, live=False)
+
+    stats = report_missing_cms_pages.Command().handle(live=True)
+
+    assert stats["missing_course_pages"] == 1
+    assert stats["missing_program_pages"] == 1
+    assert live_course.live is True
+    assert non_live_course.live is False
+    assert live_program.live is True
+    assert non_live_program.live is False

--- a/courses/management/tests/report_missing_cms_pages_test.py
+++ b/courses/management/tests/report_missing_cms_pages_test.py
@@ -1,5 +1,7 @@
 """Tests for report_missing_cms_pages command."""
 
+from io import StringIO
+
 import pytest
 
 from cms.models import CertificatePage
@@ -15,6 +17,13 @@ from courses.management.commands import report_missing_cms_pages
 from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE
 
 pytestmark = [pytest.mark.django_db]
+
+
+def _run_command(**kwargs):
+    out = StringIO()
+    command = report_missing_cms_pages.Command(stdout=out)
+    command.handle(**kwargs)
+    return out.getvalue()
 
 
 def test_report_missing_cms_pages_all_buckets():
@@ -37,12 +46,12 @@ def test_report_missing_cms_pages_all_buckets():
     program_missing_cert_page = ProgramFactory.create()
     CertificatePage.objects.descendant_of(program_missing_cert_page.page).delete()
 
-    stats = report_missing_cms_pages.Command().handle()
+    output = _run_command()
 
-    assert stats["missing_course_pages"] == 1
-    assert stats["missing_course_certificate_pages"] == 1
-    assert stats["missing_program_pages"] == 1
-    assert stats["missing_program_certificate_pages"] == 1
+    assert "Courses missing CMS page: 1" in output
+    assert "Courses missing CMS certificate page: 1" in output
+    assert "Programs missing CMS page: 1" in output
+    assert "Programs missing CMS certificate page: 1" in output
 
 
 def test_report_missing_cms_pages_live_filter():
@@ -52,10 +61,10 @@ def test_report_missing_cms_pages_live_filter():
     live_program = ProgramFactory.create(page=None, live=True)
     non_live_program = ProgramFactory.create(page=None, live=False)
 
-    stats = report_missing_cms_pages.Command().handle(live=True)
+    output = _run_command(live=True)
 
-    assert stats["missing_course_pages"] == 1
-    assert stats["missing_program_pages"] == 1
+    assert "Courses missing CMS page: 1" in output
+    assert "Programs missing CMS page: 1" in output
     assert live_course.live is True
     assert non_live_course.live is False
     assert live_program.live is True
@@ -105,7 +114,7 @@ def test_report_missing_cms_pages_eligible_users_only_filter():
         active=True,
     )
 
-    stats = report_missing_cms_pages.Command().handle(eligible_users_only=True)
+    output = _run_command(eligible_users_only=True)
 
-    assert stats["missing_course_pages"] == 1
-    assert stats["missing_program_pages"] == 1
+    assert "Courses missing CMS page: 1" in output
+    assert "Programs missing CMS page: 1" in output

--- a/courses/management/tests/report_missing_cms_pages_test.py
+++ b/courses/management/tests/report_missing_cms_pages_test.py
@@ -34,20 +34,17 @@ def test_report_missing_cms_pages_all_buckets():
 
     # Missing course page
     missing_course_page = CourseFactory.create(page=None)
-
     # Missing course certificate page
     course_missing_cert_page = CourseFactory.create()
     CertificatePage.objects.descendant_of(course_missing_cert_page.page).delete()
 
     # Missing program page
     missing_program_page = ProgramFactory.create(page=None)
-
     # Missing program certificate page
     program_missing_cert_page = ProgramFactory.create()
     CertificatePage.objects.descendant_of(program_missing_cert_page.page).delete()
 
     output = _run_command()
-
     assert "Courses missing CMS page: 1" in output
     assert "Courses missing CMS certificate page: 1" in output
     assert "Programs missing CMS page: 1" in output

--- a/courses/models.py
+++ b/courses/models.py
@@ -12,7 +12,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models
 from django.db.models import Exists, OuterRef, Prefetch, Q
@@ -1820,11 +1820,12 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
 
     def save(self, *args, **kwargs):  # noqa: DJ012
         if not self.certificate_page_revision:
-            certificate_page = (
-                self.course_run.course.page.certificate_page
-                if self.course_run.course.page
-                else None
-            )
+            try:
+                course_page = self.course_run.course.page
+            except ObjectDoesNotExist:
+                course_page = None
+
+            certificate_page = course_page.certificate_page if course_page else None
             if certificate_page:
                 self.certificate_page_revision = certificate_page.get_latest_revision()
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -12,7 +12,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models
 from django.db.models import Exists, OuterRef, Prefetch, Q
@@ -1820,12 +1820,12 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
 
     def save(self, *args, **kwargs):  # noqa: DJ012
         if not self.certificate_page_revision:
-            try:
-                course_page = self.course_run.course.page
-            except ObjectDoesNotExist:
-                course_page = None
-
-            certificate_page = course_page.certificate_page if course_page else None
+            certificate_page = (
+                self.course_run.course.page.certificate_page
+                if hasattr(self.course_run.course, "page")
+                and self.course_run.course.page
+                else None
+            )
             if certificate_page:
                 self.certificate_page_revision = certificate_page.get_latest_revision()
 

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -19,6 +19,7 @@ from cms.factories import (
     ProgramPageFactory,
     ResourcePageFactory,
 )
+from cms.models import CertificatePage
 from courses.constants import ENROLL_CHANGE_STATUS_REFUNDED
 from courses.factories import (
     CourseFactory,
@@ -533,6 +534,35 @@ def test_course_run_certificate_clean_allows_missing_page_revision(mocker):
 
     # Should not raise when revision is intentionally unset.
     certificate.clean()
+
+
+def test_course_run_certificate_save_without_course_page(mocker):
+    """Saving should not fail if the course has no CMS page."""
+    mocker.patch(
+        "hubspot_sync.api.upsert_custom_properties",
+    )
+    user = UserFactory.create()
+    course = CourseFactory.create(page=None)
+    course_run = CourseRunFactory.create(course=course)
+
+    certificate = CourseRunCertificateFactory.create(user=user, course_run=course_run)
+
+    assert certificate.certificate_page_revision is None
+
+
+def test_course_run_certificate_save_without_certificate_child_page(mocker):
+    """Saving should not fail if the course page has no live certificate child page."""
+    mocker.patch(
+        "hubspot_sync.api.upsert_custom_properties",
+    )
+    certificate = CourseRunCertificateFactory.create()
+    course_page = certificate.course_run.course.page
+    CertificatePage.objects.descendant_of(course_page).delete()
+
+    certificate.certificate_page_revision = None
+    certificate.save()
+
+    assert certificate.certificate_page_revision is None
 
 
 def test_program_certificate_start_end_dates_and_page_revision(user, mocker):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/11914

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Adds fixes around course and program certificate creation.
- Aligns program certificate creation with course certificate creation to use the overridden save call.
- Adds logging for missing CMS pages.
- Reports failed certificates
- Continue certificate creation if it fails for a user
- Adds a command to check missing CMS pages.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Test task generate_course_certificates does not fail if CMS page is missing for an eligible course run.
  - It should create a certificate with empty revision.
  - It should process next run with CMS pages for course and program and should generate the certificates.
  - There should be no business logic changes.
- Test program certificates task generate_program_certificates works as expected like course certificates task.
- Test the new command by creating all the data that makes a user eligible for a certificate and then delete the course/program CMS page or certificate page, it should report those.