### PR TITLE
Handle no max learners case

### DIFF
--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -55,11 +55,17 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
             redemptions = obj.prefetched_code_redemptions
             redeemed = sum(1 for r in redemptions if is_redeemed_attachment_record(r))
             assigned = len(redemptions) - redeemed
-            total = obj.max_learners
+            total = obj.max_learners if obj.max_learners else 0
+            # Unclear if this is proper treatment for no max_learners
+            # If max_learners == None, right now, this will show:
+            # total == 0, assigned == # of assigned codes, unassigned == 0, redeemed == # of redeemed codes
+            # Meanwhile /codes will show the first code, if it exists.
             obj._codes_breakdown_cache = {  # noqa: SLF001
                 "total": total,
                 REDEMPTION_STATUS_ASSIGNED: assigned,
-                REDEMPTION_STATUS_UNASSIGNED: total - assigned - redeemed,
+                REDEMPTION_STATUS_UNASSIGNED: (total - assigned - redeemed)
+                if obj.max_learners
+                else 0,
                 REDEMPTION_STATUS_REDEEMED: redeemed,
             }
         return obj._codes_breakdown_cache  # noqa: SLF001

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -525,6 +525,81 @@ def test_org_contract_codes_redeemed_by_differs_from_assigned_to(
     assert redeemed_code["redeemed_by"] == "redeemer@example.com"
 
 
+def test_org_contract_detail_no_max_learners(org_setup, manager_drf_client):
+    """
+    The detail endpoint should not error when max_learners is None, and
+    should treat the contract as having zero total/unassigned codes
+    regardless of how many codes have been assigned or redeemed.
+    """
+    _, _, (contract_1, *_), *_ = org_setup
+
+    contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE,
+        max_learners=None,
+        organization=contract_1.organization,
+    )
+    run = CourseRunFactory.create(b2b_contract=contract)
+    with reversion.create_revision():
+        ProductFactory.create(purchasable_object=run)
+
+    created, updated, errored = ensure_enrollment_codes_exist(contract)
+    assert created == 1
+    assert updated == 0
+    assert errored == 0
+
+    detail_url = reverse(
+        "b2b:b2b-manager-org-contract-detail",
+        kwargs={
+            "parent_lookup_organization": contract.organization.id,
+            "pk": contract.id,
+        },
+    )
+
+    resp = manager_drf_client.get(detail_url)
+    assert resp.status_code == status.HTTP_200_OK
+
+    resp_data = resp.json()
+    assert resp_data["total_codes"] == 0
+    assert resp_data["assigned_codes"] == 0
+    assert resp_data["unassigned_codes"] == 0
+    assert resp_data["redeemed_codes"] == 0
+
+    # Redeem the one code that exists, and confirm the breakdown still makes
+    # sense (and doesn't error) with a real redemption in play.
+    discount = contract.get_discounts().order_by("id").first()
+    redeemer = UserFactory.create()
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discount,
+        contract=contract,
+        user=redeemer,
+    )
+
+    resp = manager_drf_client.get(detail_url)
+    assert resp.status_code == status.HTTP_200_OK
+
+    resp_data = resp.json()
+    assert resp_data["total_codes"] == 0
+    assert resp_data["assigned_codes"] == 0
+    assert resp_data["unassigned_codes"] == 0
+    assert resp_data["redeemed_codes"] == 1
+
+    # /codes should show the single code that exists for this contract.
+    codes_url = reverse(
+        "b2b:b2b-manager-org-contract-codes",
+        kwargs={
+            "parent_lookup_organization": contract.organization.id,
+            "pk": contract.id,
+        },
+    )
+
+    resp = manager_drf_client.get(codes_url)
+    assert resp.status_code == status.HTTP_200_OK
+
+    resp_results = resp.json()["results"]
+    assert len(resp_results) == 1
+    assert resp_results[0]["code"] == discount.discount_code
+
+
 # ---------------------------------------------------------------------------
 # codes search_term tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/7588007411/

### Description (What does it do?)
Contracts w/o max_learners set present an edge case for the b2b admin dash APIs. In that case /codes presents up to 1 code (if one exists), and the `contract/<id>/` endpoint blows up trying to calculate a the summary statistics of total/assigned/redeemed/unassigned codes because it can't do math against a max_learners of None.

This change makes it at least not explode. /codes is unchanged, but the summary statistics if max_learners is None or 0 will result in the following summary statistics
```
total -> 0
assigned -> number of non-redeemed DiscountContractAttachmentRecords
redeemed -> number of redeemed DiscountContractAttachmentRecords
unassigned -> 0
```

It may be desirable to do something different, like change the treatment of summary statistics entirely if we have a contract with a max_learners of 0 or None, but I think that will require some coordination with my frontend counterparts


### Screenshots (if appropriate):
<img width="1720" height="768" alt="Screenshot 2026-07-01 at 5 44 03 PM" src="https://github.com/user-attachments/assets/16c940ec-a5c8-49b8-99ce-a0c364217b4a" />


### How can this be tested?
- Set a b2b contract to have max_learners == None.
- Visit the admin page for that contract (`http://learn.odl.local:9080/organization/<org>/contract/<contract>/admin`)
- Observe that the page doesn't throw a 500.

### Additional Context
I kind of expect to throw this code out or substantially revise both the summary stats and the codes we return - as it stands this lets the page render, but the numbers are confusing and the table is bordering on pointless.