### PR TITLE
Indicate no max_learners total and unassigned in API response

### DIFF
--- a/b2b/serializers/v0/manager.py
+++ b/b2b/serializers/v0/manager.py
@@ -55,17 +55,15 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
             redemptions = obj.prefetched_code_redemptions
             redeemed = sum(1 for r in redemptions if is_redeemed_attachment_record(r))
             assigned = len(redemptions) - redeemed
-            total = obj.max_learners if obj.max_learners else 0
-            # Unclear if this is proper treatment for no max_learners
-            # If max_learners == None, right now, this will show:
-            # total == 0, assigned == # of assigned codes, unassigned == 0, redeemed == # of redeemed codes
-            # Meanwhile /codes will show the first code, if it exists.
+            total = obj.max_learners
+            # If max_learners is None, unassigned is not a meaningful metric to expose
+            # Assigned and Redeemed can still be accurate and useful in those cases though
             obj._codes_breakdown_cache = {  # noqa: SLF001
                 "total": total,
                 REDEMPTION_STATUS_ASSIGNED: assigned,
                 REDEMPTION_STATUS_UNASSIGNED: (total - assigned - redeemed)
                 if obj.max_learners
-                else 0,
+                else None,
                 REDEMPTION_STATUS_REDEEMED: redeemed,
             }
         return obj._codes_breakdown_cache  # noqa: SLF001
@@ -82,13 +80,13 @@ class ManagerContractDetailSerializer(ContractPageSerializer):
         """Get total number of enrollments across all contract course runs."""
         return obj.enrollment_count
 
-    def get_total_codes(self, obj) -> int:
+    def get_total_codes(self, obj) -> int | None:
         return self._get_codes_breakdown(obj)["total"]
 
     def get_assigned_codes(self, obj) -> int:
         return self._get_codes_breakdown(obj)[REDEMPTION_STATUS_ASSIGNED]
 
-    def get_unassigned_codes(self, obj) -> int:
+    def get_unassigned_codes(self, obj) -> int | None:
         return self._get_codes_breakdown(obj)[REDEMPTION_STATUS_UNASSIGNED]
 
     def get_redeemed_codes(self, obj) -> int:

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -378,17 +378,11 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             else:
                 discounts = contract.get_discounts().prefetch_related(prefetch)
 
-            if not contract.max_learners:
-                # No learner limit - show first code only, if there is one
-                first = discounts.order_by("id").first()
-                codes_for_output = [first] if first is not None else []
-            else:
-                # Has learner limit - show redeemed codes + enough unused codes to fill remaining seats
-                discounts = discounts.annotate(
-                    num_redemptions=Count("contract_redemptions")
-                ).order_by("-num_redemptions", "id")
+            discounts = discounts.annotate(
+                num_redemptions=Count("contract_redemptions")
+            ).order_by("-num_redemptions", "id")
 
-                codes_for_output = discounts.filter(num_redemptions__gt=0).all()
+            codes_for_output = discounts.filter(num_redemptions__gt=0).all()
 
         return self.get_paginated_response(
             ManagerEnrollmentCodeSerializer(

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -19,7 +19,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from b2b.constants import CONTRACT_MEMBERSHIP_AUTOS
 from b2b.models import (
     REDEMPTION_STATUS_ASSIGNED,
     REDEMPTION_STATUS_REDEEMED,
@@ -321,68 +320,56 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         search_term = request.query_params.get("search_term", "").strip()
         status_filter = request.query_params.get("status", "").strip()
 
-        """
-        There are three main cases:
-        - If the contract has an auto membership type, no codes are needed, so we return an empty list.
-        - If the contract does not have a learner limit, we show the first code only.
-          We don't show individual redemptions because this case is unlikely to be a useful setup for contracts
-        - If the contract has a learner limit, we show all redeemed and assigned codes.
-          This ensures that managers can see all the codes that are currently in use.
-        """
+        # Default behavior is to return all codes for which we have an assignment or redemption.
+        prefetch = Prefetch(
+            "contract_redemptions",
+            queryset=DiscountContractAttachmentRedemption.objects.select_related(
+                "user"
+            ).order_by("-created_on")[:1],
+            to_attr="prefetched_redemptions",
+        )
 
-        # Skip if contract has auto membership type (no codes needed)
-        if contract.membership_type in CONTRACT_MEMBERSHIP_AUTOS:
-            codes_for_output = []
-        else:
-            prefetch = Prefetch(
-                "contract_redemptions",
-                queryset=DiscountContractAttachmentRedemption.objects.select_related(
-                    "user"
-                ).order_by("-created_on")[:1],
-                to_attr="prefetched_redemptions",
+        if search_term or status_filter:
+            # This filter is slightly complicated because we only want to filter on the latest redemption per discount
+            # In practice, we only expect 1 redemption per code for well-formed contracts,
+            # but that's not enforced at the DB so we need to be a bit clever.
+            latest_redemption_ids = (
+                DiscountContractAttachmentRedemption.objects.order_by(
+                    "discount_id", "-created_on"
+                )
+                .distinct("discount_id")
+                .values("pk")
             )
-
-            if search_term or status_filter:
-                # This filter is slightly complicated because we only want to filter on the latest redemption per discount
-                # In practice, we only expect 1 redemption per code for well-formed contracts,
-                # but that's not enforced at the DB so we need to be a bit clever.
-                latest_redemption_ids = (
-                    DiscountContractAttachmentRedemption.objects.order_by(
-                        "discount_id", "-created_on"
-                    )
-                    .distinct("discount_id")
-                    .values("pk")
+            filter_q = Q(contract_redemptions__pk__in=latest_redemption_ids)
+            if search_term:
+                filter_q &= (
+                    Q(contract_redemptions__assigned_email__icontains=search_term)
+                    | Q(contract_redemptions__user__email__icontains=search_term)
+                    | Q(contract_redemptions__user__name__icontains=search_term)
+                    | Q(contract_redemptions__assigned_name__icontains=search_term)
                 )
-                filter_q = Q(contract_redemptions__pk__in=latest_redemption_ids)
-                if search_term:
-                    filter_q &= (
-                        Q(contract_redemptions__assigned_email__icontains=search_term)
-                        | Q(contract_redemptions__user__email__icontains=search_term)
-                        | Q(contract_redemptions__user__name__icontains=search_term)
-                        | Q(contract_redemptions__assigned_name__icontains=search_term)
-                    )
-                if status_filter == REDEMPTION_STATUS_REDEEMED:
-                    filter_q &= Q(contract_redemptions__user__isnull=False) | Q(
-                        contract_redemptions__redeemed_on__isnull=False
-                    )
-                elif status_filter == REDEMPTION_STATUS_ASSIGNED:
-                    filter_q &= Q(contract_redemptions__user__isnull=True) & Q(
-                        contract_redemptions__redeemed_on__isnull=True
-                    )
-                discounts = (
-                    contract.get_discounts()
-                    .filter(filter_q)
-                    .distinct()
-                    .prefetch_related(prefetch)
+            if status_filter == REDEMPTION_STATUS_REDEEMED:
+                filter_q &= Q(contract_redemptions__user__isnull=False) | Q(
+                    contract_redemptions__redeemed_on__isnull=False
                 )
-            else:
-                discounts = contract.get_discounts().prefetch_related(prefetch)
+            elif status_filter == REDEMPTION_STATUS_ASSIGNED:
+                filter_q &= Q(contract_redemptions__user__isnull=True) & Q(
+                    contract_redemptions__redeemed_on__isnull=True
+                )
+            discounts = (
+                contract.get_discounts()
+                .filter(filter_q)
+                .distinct()
+                .prefetch_related(prefetch)
+            )
+        else:
+            discounts = contract.get_discounts().prefetch_related(prefetch)
 
-            discounts = discounts.annotate(
-                num_redemptions=Count("contract_redemptions")
-            ).order_by("-num_redemptions", "id")
+        discounts = discounts.annotate(
+            num_redemptions=Count("contract_redemptions")
+        ).order_by("-num_redemptions", "id")
 
-            codes_for_output = discounts.filter(num_redemptions__gt=0).all()
+        codes_for_output = discounts.filter(num_redemptions__gt=0).all()
 
         return self.get_paginated_response(
             ManagerEnrollmentCodeSerializer(

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -367,16 +367,8 @@ def test_org_contract_codes(org_setup, manager_drf_client):
         discount_count = contract.get_discounts().count()
         assert discount_count > contract.max_learners
 
-        # We don't expect to get anything back if max_learners is > 0 because we have no redeemed or assigned codes
-        expected_code_count = 0 if contract.max_learners > 0 else 1
-        contract_codes = [
-            discount.discount_code
-            for discount in contract.get_discounts()
-            .order_by("id")
-            .all()[:expected_code_count]
-        ]
-
-        # Pull the codes - we should get 0 codes back for a contract w/ max learners since we have no redemptions
+        # We don't expect to get anything back since we have no redeemed or
+        # assigned codes yet, regardless of max_learners.
 
         manager_contract_code_list = reverse(
             "b2b:b2b-manager-org-contract-codes",
@@ -390,20 +382,7 @@ def test_org_contract_codes(org_setup, manager_drf_client):
         assert resp.status_code == status.HTTP_200_OK
 
         resp_codes = [resp_code["code"] for resp_code in resp.json()["results"]]
-        assert len(resp_codes) == expected_code_count
-
-        assert contract_codes == resp_codes
-
-        # Do it again - since we're providing a subset of the codes, it should
-        # be the _same_ codes each time.
-
-        resp = manager_drf_client.get(manager_contract_code_list)
-        assert resp.status_code == status.HTTP_200_OK
-
-        resp_codes = [resp_code["code"] for resp_code in resp.json()["results"]]
-
-        assert len(resp_codes) == expected_code_count
-        assert contract_codes == resp_codes
+        assert resp_codes == []
 
         # Create some redemptions. The API/etc only considers attachment
         # redemptions to count; enrollment (order) redemptions don't matter here.
@@ -528,8 +507,9 @@ def test_org_contract_codes_redeemed_by_differs_from_assigned_to(
 def test_org_contract_detail_no_max_learners(org_setup, manager_drf_client):
     """
     The detail endpoint should not error when max_learners is None, and
-    should treat the contract as having zero total/unassigned codes
-    regardless of how many codes have been assigned or redeemed.
+    should report total/unassigned codes as None (not a meaningful metric
+    without a learner cap) regardless of how many codes have been assigned
+    or redeemed.
     """
     _, _, (contract_1, *_), *_ = org_setup
 
@@ -559,9 +539,9 @@ def test_org_contract_detail_no_max_learners(org_setup, manager_drf_client):
     assert resp.status_code == status.HTTP_200_OK
 
     resp_data = resp.json()
-    assert resp_data["total_codes"] == 0
+    assert resp_data["total_codes"] is None
     assert resp_data["assigned_codes"] == 0
-    assert resp_data["unassigned_codes"] == 0
+    assert resp_data["unassigned_codes"] is None
     assert resp_data["redeemed_codes"] == 0
 
     # Redeem the one code that exists, and confirm the breakdown still makes
@@ -578,9 +558,9 @@ def test_org_contract_detail_no_max_learners(org_setup, manager_drf_client):
     assert resp.status_code == status.HTTP_200_OK
 
     resp_data = resp.json()
-    assert resp_data["total_codes"] == 0
+    assert resp_data["total_codes"] is None
     assert resp_data["assigned_codes"] == 0
-    assert resp_data["unassigned_codes"] == 0
+    assert resp_data["unassigned_codes"] is None
     assert resp_data["redeemed_codes"] == 1
 
     # /codes should show the single code that exists for this contract.

--- a/openapi/specs/oasdiff-err-ignore.txt
+++ b/openapi/specs/oasdiff-err-ignore.txt
@@ -170,3 +170,5 @@ GET /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/ th
 GET /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/codes/ the response's body `type` changed from `array<object>` to `object` for status `200`
 GET /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/ the response's body `type` changed from `array<object>` to `object` for status `200`
 GET /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/course_runs/{course_run_id}/enrollments/ the response's body `type` changed from `array<object>` to `object` for status `200`
+GET /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/ the response property `total_codes` became nullable for the status `200`
+GET /api/v0/b2b/manager/organizations/{parent_lookup_organization}/contracts/{id}/ the response property `unassigned_codes` became nullable for the status `200`

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -7042,12 +7042,14 @@ components:
           readOnly: true
         total_codes:
           type: integer
+          nullable: true
           readOnly: true
         assigned_codes:
           type: integer
           readOnly: true
         unassigned_codes:
           type: integer
+          nullable: true
           readOnly: true
         redeemed_codes:
           type: integer

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -7042,12 +7042,14 @@ components:
           readOnly: true
         total_codes:
           type: integer
+          nullable: true
           readOnly: true
         assigned_codes:
           type: integer
           readOnly: true
         unassigned_codes:
           type: integer
+          nullable: true
           readOnly: true
         redeemed_codes:
           type: integer

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -7042,12 +7042,14 @@ components:
           readOnly: true
         total_codes:
           type: integer
+          nullable: true
           readOnly: true
         assigned_codes:
           type: integer
           readOnly: true
         unassigned_codes:
           type: integer
+          nullable: true
           readOnly: true
         redeemed_codes:
           type: integer


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/7588007411/

### Description (What does it do?)
https://github.com/mitodl/mitxonline/pull/3722 was an interim fix for cases where a contract has no learners - it prevents the admin page from erroring, but the resulting numbers and layout are misleading and confusing. This PR changes some behaviors so we can make the admin dashboard more useful in contracts without a max_learner value set.

- We no longer special case the resultset returned by /codes for SSO contracts or those without a max_learners value. Previously, they would return either no codes (in the former case) or a single code - sensible behaviors when we showed the unredeemed codes in the UI. Since we no longer show unredeemed codes and instead rely on the backend to automatically send out codes, we can remove these special cases. Going forward, /codes will always return all assigned and redeemed codes so that admins can see who is in/invited to the contract.
- In cases where max_learners is unset, we now return None for the total_codes and unassigned values returned on the contract endpoint. If you don't have a seat limit, the total is unbounded and there's no analog for unassigned codes (since that's just the total minus assigned and redeemed)

### How can this be tested?
- Set a b2b contract to have max_learners == None. Make sure you've got at least one assigned code and one redeemed code
- Visit `http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_retrieve` for the specific contract. Observe that total and unassigned are `None`
- Visit http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_list for the same contract. Observe that the response contains all assigned and redeemed rows associated with the contract.

### Additional Context
Making the fields nullable constitutes a breaking change to the API - we should coordinate w/ the subsequent frontend PR to minimize downtime.