### PR TITLE
fix: improve future enrollments and entitlement migration

### DIFF
--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models import Q
@@ -21,7 +22,7 @@ from courses.models import (
 )
 from ecommerce.api import fulfill_completed_order
 from ecommerce.constants import ZERO_PAYMENT_DATA
-from ecommerce.models import Discount, PendingOrder, Product
+from ecommerce.models import Discount, Order, OrderStatus, PendingOrder, Product
 from openedx.api import repair_faulty_edx_user
 from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
 from users.models import GENDER_CHOICES, LegalAddress, User, UserProfile
@@ -855,8 +856,19 @@ class Command(BaseCommand):
             }
 
             self._upgrade_enrollment_modes(verified_rows, existing_enrollments)
+            # Only bulk-create non-verified enrollments here. Verified enrollments
+            # are created atomically inside each order's transaction.atomic() block via
+            # fulfill_completed_order → create_run_enrollments. Creating them here
+            # (before the order loop) leads to inconsistent state if the script is
+            # interrupted: the enrollment exists in the DB but no order is ever created.
+            non_verified_rows = [
+                row
+                for row in rows
+                if row.get("courserunenrollment_enrollment_mode")
+                != EDX_ENROLLMENT_VERIFIED_MODE
+            ]
             total_enrollments += self._bulk_create_enrollments(
-                rows,
+                non_verified_rows,
                 batch_size,
                 edx_enrolled=False,
             )
@@ -876,29 +888,42 @@ class Command(BaseCommand):
             }
             discounts = {d.id: d for d in Discount.objects.filter(id__in=discount_ids)}
 
+            verified_courserun_ids = {row["courserun_id"] for row in verified_rows}
+            courserun_ct_id = ContentType.objects.get(
+                app_label="courses", model="courserun"
+            ).pk
+            existing_fulfilled_order_pairs = set(
+                Order.objects.filter(
+                    state=OrderStatus.FULFILLED,
+                    purchaser_id__in=verified_user_ids,
+                    lines__purchased_content_type_id=courserun_ct_id,
+                    lines__purchased_object_id__in=verified_courserun_ids,
+                ).values_list("purchaser_id", "lines__purchased_object_id")
+            )
+
             id_row_lookup = {
                 row["user_mitxonline_id"]: row
                 for row in rows
                 if row.get("user_mitxonline_id")
             }
-            self._bulk_create_legal_addresses(
-                list(all_users.values()), id_row_lookup, batch_size
-            )
+            unsynced_users = [
+                user
+                for user in all_users.values()
+                if not id_row_lookup.get(user.id, {}).get("openedxuser_has_been_synced")
+            ]
+            self._bulk_create_legal_addresses(unsynced_users, id_row_lookup, batch_size)
             self._bulk_create_user_profiles(
-                list(all_users.values()), id_row_lookup, batch_size, GENDER_MAP
+                unsynced_users, id_row_lookup, batch_size, GENDER_MAP
             )
-
-            for user in all_users.values():
+            for user in unsynced_users:
                 self._repair_user(user, repaired_user_ids)
 
             for row in verified_rows:
                 try:
                     if (
-                        existing_enrollments.get(
-                            (row["user_mitxonline_id"], row["courserun_id"])
-                        )
-                        == EDX_ENROLLMENT_VERIFIED_MODE
-                    ):
+                        row["user_mitxonline_id"],
+                        row["courserun_id"],
+                    ) in existing_fulfilled_order_pairs:
                         continue
 
                     user = all_users.get(row["user_mitxonline_id"])

--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -711,15 +711,19 @@ class Command(BaseCommand):
                         )
                         continue
 
-                    already_enrolled = ProgramEnrollment.all_objects.filter(
+                    existing_enrollment = ProgramEnrollment.all_objects.filter(
                         user=user,
                         program=program,
-                    ).exists()
-                    if already_enrolled:
+                    ).first()
+                    if (
+                        existing_enrollment
+                        and existing_enrollment.enrollment_mode
+                        == EDX_ENROLLMENT_VERIFIED_MODE
+                    ):
                         self.stdout.write(
                             self.style.WARNING(
                                 f"Skipping order creation: user={user.id} is already enrolled "
-                                f"in program={program.id}"
+                                f"in verified mode for program={program.id}"
                             )
                         )
                         continue


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11545

### Description (What does it do?)
<!--- Describe your changes in detail -->
A couple of improvements for edX `future_enrollments` and `entitlement` migration. 
-  If the script was interrupted, verified enrollments could exist without orders. On re-run, the skip condition now checks for an existing fulfilled order, so orphaned enrollments are repaired automatically.  
- Verified enrollments are now excluded from bulk-create and created atomically inside `fulfill_completed_order` , preventing the inconsistent state in the first place.                                                                                                                                                                                
- Users with  `openedxuser_has_been_synced=True` skip legal address, profile, and  repair_faulty_edx_user  calls entirely, improving performance.
- For program entitlements, existing audit program enrollments are no longer skipped — the order is created and the enrollment is upgraded to verified.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Similar instruction as https://github.com/mitodl/mitxonline/pull/3663

For local testing, modify the query in line 805 to be something like:

```
        query = (
            "SELECT user_mitxonline_id, courserun_id, courserunenrollment_enrollment_mode, "
            " product_version_id, discount_id, openedxuser_has_been_synced "
            "FROM ("
            "  VALUES "
            "    (< user_mitxonline_id>, <courserun_id>, 'verified', <product_version_id>, <discount_id>, true),"
            "    (< user_mitxonline_id>, <courserun_id>, 'audit', null, null, true)"
            ") "
            "AS t(user_mitxonline_id, courserun_id, courserunenrollment_enrollment_mode, "
            "product_version_id, discount_id, openedxuser_has_been_synced)"
        )
```
Replace <> with real IDs from your local db

- `user_mitxonline_id` : Your user ID
- `product_version_id` : The revision ID of the course run product
To find out product_version_id, run this query in dbshell.
```
---courserun product ID can be found at admin/ecommerce/product/
postgres=# select id from reversion_version where object_id ='<product ID>' limit 1;
```
-`discount_id` : the discount ID for 100% unlimited discount created in admin/ecommerce/discount/

Run manage.py migrate_edx_data --type future_enrollments

Verify

enrollments created at http://mitxonline.odl.local:8013/admin/courses/courserunenrollment/ 
fulfilled orders created at http://mitxonline.odl.local:8013/admin/

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
