### PR TITLE
fix(openedx): stop retry_failed_edx_enrollments from DoSing the edX enrollment API

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -909,6 +909,24 @@ RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY = get_int(
     default=60 * 30,
     description="How many seconds between retrying failed edX enrollments",
 )
+RETRY_FAILED_EDX_ENROLLMENT_BATCH_SIZE = get_int(
+    name="RETRY_FAILED_EDX_ENROLLMENT_BATCH_SIZE",
+    default=30,
+    description=(
+        "Max failed enrollments retried per invocation of "
+        "retry_failed_edx_enrollments. Keeps the task below Open edX's per-user "
+        "enrollment throttle (120/min for staff service workers)."
+    ),
+)
+RETRY_FAILED_EDX_ENROLLMENT_MAX_AGE_DAYS = get_int(
+    name="RETRY_FAILED_EDX_ENROLLMENT_MAX_AGE_DAYS",
+    default=7,
+    description=(
+        "Failed CourseRunEnrollments older than this are no longer retried, so a "
+        "permanently-broken row cannot keep the retry task DoSing the Open edX "
+        "enrollment API forever. Set to 0 to disable the age cap."
+    ),
+)
 REPAIR_OPENEDX_USERS_FREQUENCY = get_int(
     name="REPAIR_OPENEDX_USERS_FREQUENCY",
     default=60 * 30,

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -1223,35 +1223,118 @@ def enroll_in_edx_course_runs(
 
 def retry_failed_edx_enrollments():
     """
-    Gathers all CourseRunEnrollments with edx_enrolled=False and retries them via the edX API
+    Gathers CourseRunEnrollments with edx_enrolled=False and retries them via the
+    edX API.
+
+    Retries are bounded in three ways so a permanently-broken row cannot pin
+    Open edX's per-user enrollment throttle (staff = 120/min):
+
+      * an age cap (settings.RETRY_FAILED_EDX_ENROLLMENT_MAX_AGE_DAYS) drops
+        rows that have failed for so long they are almost certainly unrecoverable;
+      * a batch size (settings.RETRY_FAILED_EDX_ENROLLMENT_BATCH_SIZE) limits
+        how many rows we hit per invocation;
+      * rows are retried with a single POST to the enrollment endpoint
+        (`force_enrollment=True`, which is an upsert server-side) instead of
+        the GET-then-POST dance in `enroll_in_edx_course_runs`, halving the
+        request cost per row.
 
     Returns:
-        list of CourseRunEnrollment: All CourseRunEnrollments that were successfully retried
+        list of CourseRunEnrollment: All CourseRunEnrollments that were
+        successfully retried in this invocation.
     """
     now = now_in_utc()
-    failed_run_enrollments = courses.models.CourseRunEnrollment.objects.select_related(
+    qs = courses.models.CourseRunEnrollment.objects.select_related(
         "user", "run"
     ).filter(
         user__is_active=True,
         edx_enrolled=False,
         created_on__lt=now - timedelta(minutes=OPENEDX_REPAIR_GRACE_PERIOD_MINS),
     )
+    max_age_days = settings.RETRY_FAILED_EDX_ENROLLMENT_MAX_AGE_DAYS
+    if max_age_days > 0:
+        qs = qs.filter(created_on__gte=now - timedelta(days=max_age_days))
+
+    batch_size = max(1, settings.RETRY_FAILED_EDX_ENROLLMENT_BATCH_SIZE)
+    # `.order_by(...)[:N]` gives us a deterministic slice each pass so we don't
+    # starve rows; oldest-first also matches the intuitive "drain the backlog".
+    batch = list(qs.order_by("created_on")[:batch_size])
+
     succeeded = []
-    for enrollment in failed_run_enrollments:
-        user = enrollment.user
-        course_run = enrollment.run
+    edx_client = get_edx_api_service_client()
+    for enrollment in batch:
         try:
-            enroll_in_edx_course_runs(
-                user, [course_run], mode=enrollment.enrollment_mode
+            _retry_single_enrollment(edx_client, enrollment)
+        except HTTPError as exc:  # noqa: PERF203
+            # 429s are expected under load: log at info level and let the next
+            # scheduled invocation pick this row up. Everything else is a real
+            # error and should surface.
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            if status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+                log.info(
+                    "edX enrollment retry throttled (429) for user %s in %s; "
+                    "will retry on next pass.",
+                    enrollment.user.edx_username,
+                    enrollment.run.courseware_id,
+                )
+            else:
+                log.exception(
+                    "edX enrollment retry failed for user %s in %s",
+                    enrollment.user.edx_username,
+                    enrollment.run.courseware_id,
+                )
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "edX enrollment retry failed for user %s in %s",
+                enrollment.user.edx_username,
+                enrollment.run.courseware_id,
             )
-        except Exception as exc:  # pylint: disable=broad-except
-            log.exception(str(exc))  # noqa: TRY401
         else:
             enrollment.edx_enrolled = True
             enrollment.edx_emails_subscription = True
             enrollment.save_and_log(None)
             succeeded.append(enrollment)
     return succeeded
+
+
+def _retry_single_enrollment(edx_client, enrollment):
+    """
+    POST-only enrollment retry used by `retry_failed_edx_enrollments`.
+
+    Bypasses `existing_edx_enrollment`'s GET to avoid burning a second call
+    against the shared service-worker throttle bucket; Open edX's enrollment
+    endpoint with `force_enrollment=True` is idempotent on the server side.
+    """
+    user = enrollment.user
+    course_run = enrollment.run
+    mode = enrollment.enrollment_mode
+    username = user.edx_username
+
+    try:
+        repair_faulty_edx_user(user)
+    except Exception as exc:
+        msg = f"Failed to verify/create user {username} in OpenEdX"
+        raise OpenEdxUserMissingError(msg) from exc
+
+    if not user.openedx_user_exists:
+        msg = f"User {username} does not exist in OpenEdX and could not be created"
+        raise OpenEdxUserMissingError(msg)
+
+    result = edx_client.enrollments.create_student_enrollment(
+        course_run.courseware_id,
+        mode=mode,
+        username=username,
+        force_enrollment=True,
+    )
+    if not result.is_active:
+        # Mirror the behavior of `enroll_in_edx_course_runs`: a first POST that
+        # returns an inactive enrollment gets one more shot before we give up.
+        result = edx_client.enrollments.create_student_enrollment(
+            course_run.courseware_id,
+            mode=mode,
+            username=username,
+            force_enrollment=True,
+        )
+    return result
 
 
 def unenroll_edx_course_run(run_enrollment):

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -988,46 +988,58 @@ def test_enroll_pro_unknown_fail(settings, mocker, user):
         enroll_in_edx_course_runs(user, [course_run])
 
 
+def _mock_retry_edx_client(mocker, *, is_active=True):
+    """Return a MagicMock edX client wired for the retry-path helper."""
+    client = mocker.MagicMock()
+    client.enrollments.create_student_enrollment = mocker.Mock(
+        return_value=mocker.Mock(is_active=is_active)
+    )
+    mocker.patch("openedx.api.get_edx_api_service_client", return_value=client)
+    mocker.patch("openedx.api.repair_faulty_edx_user", return_value=(None, None))
+    return client
+
+
 @pytest.mark.parametrize("exception_raised", [Exception("An error happened"), None])
 def test_retry_failed_edx_enrollments(mocker, exception_raised):
     """
-    Tests that retry_failed_edx_enrollments loops through enrollments that failed in edX
-    and attempts to enroll them again
+    retry_failed_edx_enrollments should POST once per failed enrollment via the
+    service-worker client, mark successes as edx_enrolled=True, and swallow
+    per-row errors so one bad row does not stop the whole pass.
     """
     with freeze_time(now_in_utc() - timedelta(days=1)):
         failed_enrollments = CourseRunEnrollmentFactory.create_batch(
             3, edx_enrolled=False, user__is_active=True
         )
         CourseRunEnrollmentFactory.create(edx_enrolled=False, user__is_active=False)
-    patched_enroll_in_edx = mocker.patch(
-        "openedx.api.enroll_in_edx_course_runs",
-        side_effect=[None, exception_raised or None, None],
+    client = _mock_retry_edx_client(mocker)
+    # oldest-first ordering matches retry_failed_edx_enrollments
+    ordered = sorted(failed_enrollments, key=lambda e: e.created_on)
+    client.enrollments.create_student_enrollment = mocker.Mock(
+        side_effect=[
+            mocker.Mock(is_active=True),
+            exception_raised or mocker.Mock(is_active=True),
+            mocker.Mock(is_active=True),
+        ]
     )
     patched_log_exception = mocker.patch("openedx.api.log.exception")
     successful_enrollments = retry_failed_edx_enrollments()
 
-    assert patched_enroll_in_edx.call_count == len(failed_enrollments)
+    assert client.enrollments.create_student_enrollment.call_count == len(
+        failed_enrollments
+    )
     assert len(successful_enrollments) == (3 if exception_raised is None else 2)
     assert patched_log_exception.called == bool(exception_raised)
     if exception_raised:
-        failed_enroll_user, failed_enroll_runs = patched_enroll_in_edx.call_args_list[
-            1
-        ][0]
-        expected_successful_enrollments = [
-            e
-            for e in failed_enrollments
-            if e.user != failed_enroll_user and e.run != failed_enroll_runs[0]
-        ]
-        assert {e.id for e in successful_enrollments} == {
-            e.id for e in expected_successful_enrollments
-        }
+        expected_successful_ids = {ordered[0].id, ordered[2].id}
+        assert {e.id for e in successful_enrollments} == expected_successful_ids
         for enrollment in successful_enrollments:
             assert enrollment.edx_emails_subscription is True
 
 
 def test_retry_failed_enroll_grace_period(mocker):
     """
-    Tests that retry_failed_edx_enrollments does not attempt to repair any enrollments that were recently created
+    retry_failed_edx_enrollments must skip enrollments still inside
+    OPENEDX_REPAIR_GRACE_PERIOD_MINS.
     """
     now = now_in_utc()
     with freeze_time(now - timedelta(minutes=OPENEDX_REPAIR_GRACE_PERIOD_MINS - 1)):
@@ -1036,13 +1048,93 @@ def test_retry_failed_enroll_grace_period(mocker):
         older_enrollment = CourseRunEnrollmentFactory.create(
             edx_enrolled=False, user__is_active=True
         )
-    patched_enroll_in_edx = mocker.patch("openedx.api.enroll_in_edx_course_runs")
+    client = _mock_retry_edx_client(mocker)
     successful_enrollments = retry_failed_edx_enrollments()
 
     assert successful_enrollments == [older_enrollment]
-    patched_enroll_in_edx.assert_called_once_with(
-        older_enrollment.user, [older_enrollment.run], mode=EDX_ENROLLMENT_AUDIT_MODE
+    client.enrollments.create_student_enrollment.assert_called_once_with(
+        older_enrollment.run.courseware_id,
+        mode=older_enrollment.enrollment_mode,
+        username=older_enrollment.user.edx_username,
+        force_enrollment=True,
     )
+
+
+def test_retry_failed_enroll_age_cap(settings, mocker):
+    """
+    Enrollments older than RETRY_FAILED_EDX_ENROLLMENT_MAX_AGE_DAYS must be
+    skipped so a permanently-broken row cannot keep the retry task hammering
+    the Open edX throttle forever.
+    """
+    settings.RETRY_FAILED_EDX_ENROLLMENT_MAX_AGE_DAYS = 3
+    now = now_in_utc()
+    with freeze_time(now - timedelta(days=10)):
+        stale = CourseRunEnrollmentFactory.create(
+            edx_enrolled=False, user__is_active=True
+        )
+    with freeze_time(now - timedelta(days=1)):
+        fresh = CourseRunEnrollmentFactory.create(
+            edx_enrolled=False, user__is_active=True
+        )
+    client = _mock_retry_edx_client(mocker)
+
+    successful_enrollments = retry_failed_edx_enrollments()
+
+    assert successful_enrollments == [fresh]
+    assert client.enrollments.create_student_enrollment.call_count == 1
+    stale.refresh_from_db()
+    assert stale.edx_enrolled is False
+
+
+def test_retry_failed_enroll_batch_size(settings, mocker):
+    """
+    Only RETRY_FAILED_EDX_ENROLLMENT_BATCH_SIZE rows should be attempted per
+    invocation; the rest wait for the next scheduled pass so we stay under
+    Open edX's per-user enrollment throttle.
+    """
+    settings.RETRY_FAILED_EDX_ENROLLMENT_BATCH_SIZE = 2
+    with freeze_time(now_in_utc() - timedelta(days=1)):
+        enrollments = CourseRunEnrollmentFactory.create_batch(
+            5, edx_enrolled=False, user__is_active=True
+        )
+    client = _mock_retry_edx_client(mocker)
+
+    successful = retry_failed_edx_enrollments()
+
+    assert client.enrollments.create_student_enrollment.call_count == 2
+    assert len(successful) == 2
+    # oldest-first ordering: the first two rows created inside the freeze block
+    oldest_two_ids = {e.id for e in sorted(enrollments, key=lambda e: e.created_on)[:2]}
+    assert {e.id for e in successful} == oldest_two_ids
+
+
+def test_retry_failed_enroll_throttled_is_soft_failure(mocker):
+    """
+    A 429 from Open edX must not raise, must not mark the row as enrolled,
+    and must log at info (not exception) so Sentry doesn't drown in throttle
+    noise on every 30-minute pass.
+    """
+    with freeze_time(now_in_utc() - timedelta(days=1)):
+        enrollment = CourseRunEnrollmentFactory.create(
+            edx_enrolled=False, user__is_active=True
+        )
+    client = _mock_retry_edx_client(mocker)
+    throttled_response = MockResponse(
+        {"developer_message": "Request was throttled."}, status_code=429
+    )
+    client.enrollments.create_student_enrollment = mocker.Mock(
+        side_effect=HTTPError(response=throttled_response)
+    )
+    patched_log_exception = mocker.patch("openedx.api.log.exception")
+    patched_log_info = mocker.patch("openedx.api.log.info")
+
+    successful = retry_failed_edx_enrollments()
+
+    assert successful == []
+    enrollment.refresh_from_db()
+    assert enrollment.edx_enrolled is False
+    assert patched_log_exception.called is False
+    assert patched_log_info.called is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?

Fixes https://github.com/mitodl/hq/issues/12132 (Sentry `MITXONLINE-2NS`, 310k events since 2023-03-09).

### Description (What does it do?)

`retry_failed_edx_enrollments` was iterating over every failed `CourseRunEnrollment` in a tight loop with no batching, no age cap, and no give-up. Every row cost 1–3 API calls against the shared `login_service_user`, which is `is_staff=True` in the Open edX LMS and therefore capped at **120/min** by [`EnrollmentUserThrottle`](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/enrollments/views.py#L99). A backlog of ~100 stuck rows produced a burst of 200+ requests every 30 minutes and pinned the throttle bucket, so every row 429'd and none ever cleared — a self-perpetuating loop.

Live evidence from the RC/QA celery worker on 2026-07-02:

```
Task openedx.tasks.retry_failed_edx_enrollments[…] succeeded in 44.63s: []
Response - code: 429, content: {"developer_message":"Request was throttled. Expected available in 23 seconds."}
Response - code: 429, content: {"developer_message":"Request was throttled. Expected available in 18 seconds."}
…
```

The task “succeeded in 44s” with an empty result list — 100% 429s. The oldest stuck row was from `2023-10-06` (user `sd-at-mitx`); most others are automation/test residue from `pdpinch+*`, `apptest+*`, `gumaerc@mit.edu`, etc.

This change bounds the retry task three ways, all env-tunable:

- **Age cap** — `RETRY_FAILED_EDX_ENROLLMENT_MAX_AGE_DAYS` (default `7`, `0` disables). Rows whose `created_on` is older than the cap are dropped from the retry set. A 3-year-old failed enrollment is not going to enroll now, and it is the source of the throttle storm.
- **Batch size** — `RETRY_FAILED_EDX_ENROLLMENT_BATCH_SIZE` (default `30`). Only the oldest-N eligible rows are attempted per invocation. With the 30-min beat, a healthy backlog still drains in a couple of passes but never bursts past the 120/min staff bucket.
- **POST-only retry path** — the retry loop no longer calls `enroll_in_edx_course_runs`; it calls `create_student_enrollment(force_enrollment=True)` directly. That endpoint is idempotent server-side, so we skip the pre-flight `GET /api/enrollment/v1/enrollments` and halve the API cost per row.

Also: a `429` from Open edX during retry is now logged at `INFO` (not `exception`) and lets the row roll into the next pass, so Sentry `MITXONLINE-2NS` stops re-firing on every beat.

`enroll_in_edx_course_runs` (used by checkout, admin actions, refunds, and management commands) is **intentionally untouched** — the behavior change is contained to the retry task.

### How can this be tested?

Unit tests cover each bound:

- `test_retry_failed_edx_enrollments` — POST-only path, per-row error is swallowed, successes flip `edx_enrolled=True`.
- `test_retry_failed_enroll_grace_period` — rows younger than `OPENEDX_REPAIR_GRACE_PERIOD_MINS` are still skipped.
- `test_retry_failed_enroll_age_cap` — rows older than the age cap are skipped and `edx_enrolled` stays `False`.
- `test_retry_failed_enroll_batch_size` — only `BATCH_SIZE` rows are attempted per pass, oldest first.
- `test_retry_failed_enroll_throttled_is_soft_failure` — a 429 does not raise, does not flip `edx_enrolled`, and logs at `info` instead of `exception`.

Run: `pytest openedx/api_test.py -k retry_failed`

Manual validation on RC after deploy:

1. Watch `mitxonline-celery-celery-worker` logs during the next `retry_failed_edx_enrollments` invocation — should see ≤ `BATCH_SIZE` attempts, no burst.
2. Grep for `429 Client Error` in celery logs — should drop to zero, or at most a small number that clear on subsequent passes.
3. Check Sentry `MITXONLINE-2NS` — new event rate should fall off a cliff.

### Additional Context

**Ops follow-up (not in this PR):**

- The ~100 stuck rows in RC will be silently dropped from the retry set on the next pass thanks to the age cap; they can then be triaged out-of-band. Nothing here deletes them.
- Longer term, giving the service worker its own throttle scope (`service_user`/`high_service_user`) on the LMS side, or splitting the service worker per calling app, would let us stop sharing a 120/min bucket between the retry loop and real-time checkout enrollments. Separate change.

**Diagnosis notes** for future readers:

- The throttle is *per authenticated user*, and `login_service_user` is `is_staff=True` in the LMS, so it gets the `staff: 120/minute` rate, not the higher `service_user: 800/minute` or `high_service_user: 2000/minute` scopes defined in `REST_FRAMEWORK.DEFAULT_THROTTLE_RATES`. `EnrollmentUserThrottle` ignores those; the rates are hard-coded in the view.
- `existing_edx_enrollment` was making a `GET /api/enrollment/v1/enrollments` per row *before* the POST. Under throttle pressure that GET returned 429 and the code path bailed without ever POSTing, so a row that would have succeeded via `force_enrollment=True` never got the chance.
