### PR TITLE
chore: adds ORM001 and ORM002 to external rules list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ ignore = [
     "W191"
 ]
 fixable = ["ALL"]
+external = ["ORM001", "ORM002"]
 
 typing-modules = ["colour.hints"]
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->

Adds drf_lint ORM001, ORM002 rules to external list so that ruff does not remove if we want to disable those.

PS: Thanks @zawan-ila 