### PR TITLE
JIT discount provisioning for /bulk_assign

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -110,18 +110,21 @@ def assign_codes_and_send_emails(
     return True
 
 
-def _create_discount_codes_for_contract(contract: ContractPage) -> list[Discount]:
+def _create_discount_codes_for_contract(
+    contract: ContractPage, count_to_provision: int
+) -> list[Discount]:
     # TODO: I'm going to need to check this behavior. # noqa: TD002, TD003, FIX002
     # It looks like in trivial cases we'll have a contract with a single product, but that's far from guaranteed
     # We don't surface the product anywhere in the UI - it's all about codes, which kinda implies that this tool works
     # sanely only for contracts w/ a single product? Not sure if that's a safe assumption,
     # but if it isn't we probably need to take a step back and figure out what to do.
     new_discounts = []
-    for product in contract.get_products():
-        discount = _create_discount_with_product(
-            product, Decimal(0), REDEMPTION_TYPE_ONE_TIME
-        )
-        new_discounts.append(discount)
+    for _ in range(count_to_provision):
+        for product in contract.get_products():
+            discount = _create_discount_with_product(
+                product, Decimal(0), REDEMPTION_TYPE_ONE_TIME
+            )
+            new_discounts.append(discount)
 
     return new_discounts
 
@@ -704,7 +707,10 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
             email_assignees
         ):
             # If we are in a contract without a seat limit, provision new discounts for users up to the number required
-            new_discounts = _create_discount_codes_for_contract(contract)
+            count_to_provision = len(email_assignees) - len(available_discounts)
+            new_discounts = _create_discount_codes_for_contract(
+                contract, count_to_provision
+            )
             available_discounts.extend(new_discounts)
 
         for i, record in enumerate(email_assignees):

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -113,18 +113,16 @@ def assign_codes_and_send_emails(
 def _create_discount_codes_for_contract(
     contract: ContractPage, count_to_provision: int
 ) -> list[Discount]:
-    # TODO: I'm going to need to check this behavior. # noqa: TD002, TD003, FIX002
-    # It looks like in trivial cases we'll have a contract with a single product, but that's far from guaranteed
-    # We don't surface the product anywhere in the UI - it's all about codes, which kinda implies that this tool works
-    # sanely only for contracts w/ a single product? Not sure if that's a safe assumption,
-    # but if it isn't we probably need to take a step back and figure out what to do.
     new_discounts = []
+    # Per https://github.com/mitodl/mitxonline/pull/3734#discussion_r3532707128 we expect contracts to have many products
+    # For contract attachment JIT code generation, any product associated w/ the contract should
+    # work for creating the discount code, so we just grab the first one.
+    product = contract.get_products().first()
     for _ in range(count_to_provision):
-        for product in contract.get_products():
-            discount = _create_discount_with_product(
-                product, Decimal(0), REDEMPTION_TYPE_ONE_TIME
-            )
-            new_discounts.append(discount)
+        discount = _create_discount_with_product(
+            product, Decimal(0), REDEMPTION_TYPE_ONE_TIME
+        )
+        new_discounts.append(discount)
 
     return new_discounts
 

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -3,6 +3,7 @@
 import logging
 import uuid
 from dataclasses import dataclass
+from decimal import Decimal
 
 from django.db.models import Count, Prefetch, Q
 from django.shortcuts import get_object_or_404
@@ -19,6 +20,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
+from b2b.api import _create_discount_with_product
 from b2b.constants import CONTRACT_MEMBERSHIP_AUTOS
 from b2b.models import (
     REDEMPTION_STATUS_ASSIGNED,
@@ -50,6 +52,7 @@ from b2b.tasks import (
 )
 from b2b.utils import is_redeemed_attachment_record
 from courses.models import CourseRun, CourseRunEnrollment
+from ecommerce.constants import REDEMPTION_TYPE_ONE_TIME
 from ecommerce.models import Discount
 
 log = logging.getLogger(__name__)
@@ -105,6 +108,22 @@ def assign_codes_and_send_emails(
     )
 
     return True
+
+
+def _create_discount_codes_for_contract(contract: ContractPage) -> list[Discount]:
+    # TODO: I'm going to need to check this behavior. # noqa: TD002, TD003, FIX002
+    # It looks like in trivial cases we'll have a contract with a single product, but that's far from guaranteed
+    # We don't surface the product anywhere in the UI - it's all about codes, which kinda implies that this tool works
+    # sanely only for contracts w/ a single product? Not sure if that's a safe assumption,
+    # but if it isn't we probably need to take a step back and figure out what to do.
+    new_discounts = []
+    for product in contract.get_products():
+        discount = _create_discount_with_product(
+            product, Decimal(0), REDEMPTION_TYPE_ONE_TIME
+        )
+        new_discounts.append(discount)
+
+    return new_discounts
 
 
 class ManagerOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
@@ -680,6 +699,13 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         )
 
         assignments = []
+        contract_max_learners = contract.max_learners
+        if contract_max_learners is None and len(available_discounts) < len(
+            email_assignees
+        ):
+            # If we are in a contract without a seat limit, provision new discounts for users up to the number required
+            new_discounts = _create_discount_codes_for_contract(contract)
+            available_discounts.extend(new_discounts)
 
         for i, record in enumerate(email_assignees):
             email = record["email"]

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -702,9 +702,12 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         )
 
         assignments = []
-        contract_max_learners = contract.max_learners
-        if contract_max_learners is None and len(available_discounts) < len(
-            email_assignees
+        # If we're in a contract type that uses codes, doesnt have a seat limit and we're out of available discounts
+        # Provision enough on the fly to handle the payload
+        if (
+            contract.membership_type not in CONTRACT_MEMBERSHIP_AUTOS
+            and contract.max_learners is None
+            and len(available_discounts) < len(email_assignees)
         ):
             # If we are in a contract without a seat limit, provision new discounts for users up to the number required
             count_to_provision = len(email_assignees) - len(available_discounts)

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -686,7 +686,7 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
         # Provision enough on the fly to handle the payload
         if (
             contract.membership_type not in CONTRACT_MEMBERSHIP_AUTOS
-            and contract.max_learners is None
+            and not contract.max_learners
             and len(available_discounts) < len(email_assignees)
         ):
             # If we are in a contract without a seat limit, provision new discounts for users up to the number required

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -23,6 +23,7 @@ from b2b.serializers.v0 import (
 from b2b.serializers.v0.manager import ManagerEnrollmentSerializer
 from courses.factories import CourseRunFactory
 from courses.models import CourseRunEnrollment
+from ecommerce.constants import REDEMPTION_TYPE_ONE_TIME
 from ecommerce.factories import ProductFactory
 from main.test_utils import assert_drf_json_equal
 from users.factories import UserFactory
@@ -1374,6 +1375,75 @@ def test_bulk_assign_insufficient_codes(org_setup, manager_drf_client, mocker):
     assert len(resp_data["assigned"]) == available_count
     assert len(resp_data["errors"]) == 2
     assert all("No available code." in err["detail"] for err in resp_data["errors"])
+
+
+def test_bulk_assign_provisions_codes_for_uncapped_contract(
+    org_setup, manager_drf_client, mocker
+):
+    """bulk_assign provisions new one-time codes on the fly for contracts with no max_learners."""
+    mocker.patch("b2b.views.v0.manager.queue_send_enrollment_code_assignment_email")
+    _, _, (contract_1, *_), *_ = org_setup
+
+    # Build a contract with no seat cap and a single product, in the same org
+    # the manager already has access to, so we get an easy 1:1 relationship
+    # between provisioned discounts and requested assignments.
+    uncapped_contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE,
+        max_learners=None,
+        organization=contract_1.organization,
+    )
+    course_run = CourseRunFactory.create(b2b_contract=uncapped_contract)
+    with reversion.create_revision():
+        ProductFactory.create(purchasable_object=course_run)
+
+    created, updated, errored = ensure_enrollment_codes_exist(uncapped_contract)
+    assert created == 1
+    assert updated == 0
+    assert errored == 0
+
+    # Only one code exists so far, but we're requesting three assignments.
+    records = [
+        {"email": "learner1@example.com", "name": "Learner One"},
+        {"email": "learner2@example.com", "name": "Learner Two"},
+        {"email": "learner3@example.com", "name": "Learner Three"},
+    ]
+
+    bulk_assign_url = reverse(
+        "b2b:b2b-manager-org-contract-bulk-assign",
+        kwargs={
+            "parent_lookup_organization": uncapped_contract.organization.id,
+            "pk": uncapped_contract.id,
+        },
+    )
+
+    resp = manager_drf_client.post(bulk_assign_url, data=records, format="json")
+
+    assert resp.status_code == status.HTTP_200_OK
+
+    resp_data = resp.json()
+    assert len(resp_data["assigned"]) == 3
+    assert len(resp_data["errors"]) == 0
+
+    assigned_emails = {code["assigned_to"] for code in resp_data["assigned"]}
+    assert assigned_emails == {
+        "learner1@example.com",
+        "learner2@example.com",
+        "learner3@example.com",
+    }
+
+    # The pre-existing code plus two newly provisioned one-time codes should
+    # cover all three assignments.
+    contract_discounts = uncapped_contract.get_discounts()
+    assert contract_discounts.count() == 3
+    assert (
+        contract_discounts.filter(redemption_type=REDEMPTION_TYPE_ONE_TIME).count() == 2
+    )
+    assert (
+        DiscountContractAttachmentRedemption.objects.filter(
+            contract=uncapped_contract
+        ).count()
+        == 3
+    )
 
 
 def test_bulk_assign_skips_already_assigned_or_redeemed(

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -1330,10 +1330,12 @@ def test_bulk_assign(org_setup, manager_drf_client, mocker):
 def test_bulk_assign_insufficient_codes(org_setup, manager_drf_client, mocker):
     """bulk_assign reports errors for records that exceed the number of available codes."""
     mocker.patch("b2b.views.v0.manager.queue_send_enrollment_code_assignment_email")
-    _, _, _, (contract_2, *_), *_ = org_setup
+    # contract_1 has a real (non-zero) max_learners cap, so it never falls
+    # into the on-the-fly provisioning codepath used for uncapped contracts.
+    _, _, (contract_1, *_), *_ = org_setup
 
     available_count = (
-        contract_2.get_discounts().filter(contract_redemptions__isnull=True).count()
+        contract_1.get_discounts().filter(contract_redemptions__isnull=True).count()
     )
 
     # Request two more than are available so we get predictable errors.
@@ -1342,8 +1344,8 @@ def test_bulk_assign_insufficient_codes(org_setup, manager_drf_client, mocker):
     bulk_assign_url = reverse(
         "b2b:b2b-manager-org-contract-bulk-assign",
         kwargs={
-            "parent_lookup_organization": contract_2.organization.id,
-            "pk": contract_2.id,
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
         },
     )
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12207

### Description (What does it do?)
This changes the the behavior of bulk_assign when used on a codes contract that does not have a max_learners limit set. If that endpoint is hit with a payload that contains more than the number of available (i.e. not redeemed or assigned) discount codes, it will now provision new Discount objects on the fly using the first product associated with the contract.

### How can this be tested?
The approach I took is as follows:

With main checked out:
- Create a b2b contract with discount codes, and ensure you're a manager for the containing organization. 
- Assign all existing codes to any email addresses you like either via the learn b2b admin page or by directly using the [bulk_assign swagger endpoint](http://mitxonline.odl.local:9080/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_bulk_assign_create). 
  - The codes don't need to be redeemed, so the emails can be anything valid.
- Set max_learners = None for this contract within the shell.
```
from b2b.models import *
contract = ContractPage.objects.get(id=<ID_of_contract>)
contract.max_learners = None
contract.save()
```
- Attempt to assign one or more contacts and observe that you receive `No available code.` errors.
- Switch to this branch, restart your container, reauthenticate if necessary and attempt to assign one or more codes to new emails again. This time you should see that you no longer get an error and the new assignments should be visible on the admin dashboard or via the /codes endpoint.

### Additional Context
- James has put together a ticket which would see us further invest in the idea of moving away from pregenerated codes in favor of JIT discount code generation at https://github.com/mitodl/hq/issues/12211