### PR TITLE
Add local-dev Docker target for ol-infrastructure Tilt stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,13 +70,26 @@ FROM django-server AS production
 
 COPY --from=node /src /src
 
+# ─── Local-dev target (ol-infrastructure local-dev k8s/Tilt stack) ───────────
+# Runtime user owns /src (live-synced source), plus dev deps (pytest, ipdb, …)
+# and watchfiles for granian --reload.
+FROM production AS local-dev
+
+USER root
+RUN chown -R mitodl:mitodl /src
+USER mitodl
+
+RUN --mount=type=cache,target=/opt/uv-cache,uid=1000,gid=1000 \
+    uv sync --frozen --no-install-project
+RUN uv pip install watchfiles
+
 FROM code AS jupyter-notebook
 
 RUN uv pip install --force-reinstall jupyter
 
 USER mitodl
 
-# ─── Development target ───────────────────────────────────────────────────────
+# ─── Development target (docker compose) ─────────────────────────────────────
 FROM django-server AS development
 
 RUN --mount=type=cache,target=/opt/uv-cache,uid=1000,gid=1000 \


### PR DESCRIPTION
### What are the relevant tickets?

- For https://github.com/mitodl/ol-infrastructure/pull/4909

### Description (What does it do?)

Companion to https://github.com/mitodl/ol-infrastructure/pull/4909 (hot reload in the local-dev Tilt stack):

Adds a `local-dev` build target: `production` plus a runtime-user-owned `/src` (so Tilt can live-sync source into the container), the dev dependency group (pytest, ipdb, etc.), and watchfiles (for granian `--reload`). The production stage is unchanged.


### How can this be tested?

1. If using learn docker-compose stack, rebuild. All should work.
    - NOTE: If you're on a mac and haven't rebuilt recently, it might be slower due to the ol-python-base image, unrelated to these changes in this PR. Mac arm64 target coming soon
2. If using local-dev stack in ol-infra, see https://github.com/mitodl/ol-infrastructure/pull/4909

