### PR TITLE
Add some viz into misconfigured contracts

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -118,6 +118,12 @@ def _create_discount_codes_for_contract(
     # For contract attachment JIT code generation, any product associated w/ the contract should
     # work for creating the discount code, so we just grab the first one.
     product = contract.get_products().first()
+    if not product:
+        log.exception(
+            "Contract %s has no product, cannot provision JIT discount codes", contract
+        )
+        return new_discounts
+
     for _ in range(count_to_provision):
         discount = _create_discount_with_product(
             product, Decimal(0), REDEMPTION_TYPE_ONE_TIME

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -1428,6 +1428,51 @@ def test_bulk_assign_provisions_codes_for_uncapped_contract(
     )
 
 
+def test_bulk_assign_no_product_for_uncapped_contract(
+    org_setup, manager_drf_client, mocker, caplog
+):
+    """bulk_assign doesnt attempt JIT code provisioning for a misconfigured contract without a product."""
+    mocker.patch("b2b.views.v0.manager.queue_send_enrollment_code_assignment_email")
+    _, _, (contract_1, *_), *_ = org_setup
+
+    uncapped_contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE,
+        max_learners=None,
+        organization=contract_1.organization,
+    )
+
+    records = [
+        {"email": "learner1@example.com", "name": "Learner One"},
+        {"email": "learner2@example.com", "name": "Learner Two"},
+    ]
+
+    bulk_assign_url = reverse(
+        "b2b:b2b-manager-org-contract-bulk-assign",
+        kwargs={
+            "parent_lookup_organization": uncapped_contract.organization.id,
+            "pk": uncapped_contract.id,
+        },
+    )
+
+    resp = manager_drf_client.post(bulk_assign_url, data=records, format="json")
+
+    assert resp.status_code == status.HTTP_200_OK
+
+    resp_data = resp.json()
+    assert len(resp_data["assigned"]) == 0
+    assert len(resp_data["errors"]) == 2
+    assert all("No available code." in err["detail"] for err in resp_data["errors"])
+
+    assert uncapped_contract.get_discounts().count() == 0
+    assert (
+        DiscountContractAttachmentRedemption.objects.filter(
+            contract=uncapped_contract
+        ).count()
+        == 0
+    )
+    assert "has no product" in caplog.text
+
+
 def test_bulk_assign_skips_already_assigned_or_redeemed(
     org_setup, manager_drf_client, mocker
 ):


### PR DESCRIPTION
### Description (What does it do?)
In testing https://github.com/mitodl/mitxonline/pull/3734/ I ran into a hiccup where things don't behave as you'd think if a contract doesn't have at least one product associated with it during JIT discount provisioning. While the discount provisioning worked, the enrollment code wasn't usable, and most other aspects of the B2B admin dashboard were also incorrect/misleading

Since [contracts without products are useless](https://mitodl.slack.com/archives/C0BEW5UHPJ8/p1783609961274279?thread_ts=1783447081.511689&cid=C0BEW5UHPJ8), rather than trying to handle issues from this setup, we'll just punt on it. This now logs an error to sentry and otherwise skips JIT provisioning. This at least means users and maintainers will have some visibility into what's going on!

### How can this be tested?
- Set up a b2b code-based contract w/ no max_learners and make yourself a manager. Preassign/redeem all codes (or delete all associated Discounts)
- Unlink the all products from the contract 
- Attempt to bulk_assign a code. You should get a `No available code.` for each assignment requested in the response.