### PR TITLE
feat: add backfill_b2b_program_enrollments management command

### DIFF
--- a/b2b/management/commands/backfill_b2b_program_enrollments.py
+++ b/b2b/management/commands/backfill_b2b_program_enrollments.py
@@ -1,0 +1,150 @@
+"""Backfill missing B2B program enrollments.
+
+Users who enrolled in a B2B course run before the automatic program-enrollment
+forward fix (b2b.api._enroll_in_program_for_b2b) may be missing the
+ProgramEnrollment that should accompany their course enrollment.
+
+This command finds those users and enrolls them in the appropriate program,
+mirroring the forward fix exactly (same validation against the contract and the
+same courses.api.create_program_enrollments helper, which is idempotent and
+writes an audit row).
+
+Only *unambiguous* cases are backfilled: the enrolled course must map to exactly
+one program within the run's contract. Ambiguous cases (course belongs to two or
+more programs in the same contract) are reported and skipped for manual review.
+"""
+
+import logging
+
+from django.core.management import BaseCommand
+from django.db.models import Q
+
+from courses.api import create_program_enrollments
+from courses.models import CourseRunEnrollment, Program, ProgramEnrollment
+from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Backfill missing B2B program enrollments."""
+
+    help = """Backfill missing B2B program enrollments.
+
+For each active B2B course-run enrollment, ensure the user is also enrolled in
+the program the course belongs to within that run's contract. Only unambiguous
+matches (course in exactly one contract program) are backfilled; ambiguous
+matches are reported and skipped."""
+
+    def add_arguments(self, parser):
+        """Add command line arguments."""
+
+        parser.add_argument(
+            "--user", type=str, help="Limit to the specified username or email."
+        )
+        parser.add_argument(
+            "--commit",
+            action="store_true",
+            default=False,
+            help=(
+                "Commit changes. Otherwise, this will produce output but won't "
+                "make any changes."
+            ),
+        )
+
+    def handle(self, *args, **kwargs):  # noqa: ARG002
+        """Perform the backfill."""
+
+        specific_user = kwargs.pop("user", None)
+        commit = kwargs.pop("commit", False)
+
+        if not commit:
+            self.stdout.write(
+                self.style.WARNING("Commit flag not set - no changes will be made.")
+            )
+
+        enrollments = (
+            CourseRunEnrollment.objects.filter(run__b2b_contract__isnull=False)
+            .select_related("user", "run", "run__course", "run__b2b_contract")
+        )
+
+        if specific_user:
+            enrollments = enrollments.filter(
+                Q(user__email=specific_user) | Q(user__username=specific_user)
+            )
+
+        created_count = 0
+        already_enrolled = 0
+        no_program = 0
+        ambiguous = []
+
+        self.stdout.write(
+            f"Scanning {enrollments.count()} active B2B course-run enrollment(s)..."
+        )
+
+        for enrollment in enrollments:
+            user = enrollment.user
+            contract = enrollment.run.b2b_contract
+            course = enrollment.run.course
+
+            # Programs attached to this contract that also contain this course.
+            contract_program_ids = contract.contract_programs.values_list(
+                "program_id", flat=True
+            )
+            candidate_programs = list(
+                Program.objects.filter(id__in=contract_program_ids)
+                .filter(all_requirements__course=course)
+                .distinct()
+            )
+
+            if not candidate_programs:
+                no_program += 1
+                continue
+
+            if len(candidate_programs) > 1:
+                ambiguous.append((user, course, contract, candidate_programs))
+                continue
+
+            program = candidate_programs[0]
+
+            if ProgramEnrollment.all_objects.filter(
+                user=user, program=program
+            ).exists():
+                already_enrolled += 1
+                continue
+
+            self.stdout.write(
+                f"\t{user.email}: enrolling in program {program.readable_id} "
+                f"(via course {course.readable_id}, contract {contract})"
+            )
+
+            if commit:
+                create_program_enrollments(
+                    user, [program], enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+                )
+            created_count += 1
+
+        self.stdout.write("")
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{'Created' if commit else 'Would create'} {created_count} "
+                "program enrollment(s)."
+            )
+        )
+        self.stdout.write(f"Already enrolled (skipped): {already_enrolled}")
+        self.stdout.write(f"No matching program (skipped): {no_program}")
+        self.stdout.write(
+            f"Ambiguous - course in 2+ contract programs (skipped): {len(ambiguous)}"
+        )
+
+        if ambiguous:
+            self.stdout.write("")
+            self.stdout.write(
+                self.style.WARNING("Ambiguous cases needing manual review:")
+            )
+            for user, course, contract, programs in ambiguous:
+                program_ids = ", ".join(p.readable_id for p in programs)
+                self.stdout.write(
+                    f"\t{user.email}: course {course.readable_id} in "
+                    f"contract {contract} maps to programs [{program_ids}]"
+                )

--- a/b2b/management/commands/backfill_b2b_program_enrollments.py
+++ b/b2b/management/commands/backfill_b2b_program_enrollments.py
@@ -63,10 +63,9 @@ matches are reported and skipped."""
                 self.style.WARNING("Commit flag not set - no changes will be made.")
             )
 
-        enrollments = (
-            CourseRunEnrollment.objects.filter(run__b2b_contract__isnull=False)
-            .select_related("user", "run", "run__course", "run__b2b_contract")
-        )
+        enrollments = CourseRunEnrollment.objects.filter(
+            run__b2b_contract__isnull=False
+        ).select_related("user", "run", "run__course", "run__b2b_contract")
 
         if specific_user:
             enrollments = enrollments.filter(

--- a/b2b/management/tests/backfill_b2b_program_enrollments_test.py
+++ b/b2b/management/tests/backfill_b2b_program_enrollments_test.py
@@ -112,7 +112,7 @@ def test_backfill_skips_ambiguous_course():
 def test_backfill_skips_course_not_in_any_program():
     """A B2B enrollment whose course maps to no contract program is skipped."""
 
-    enrollment, program = _setup_b2b_enrollment(link_contract_program=False)
+    enrollment, _program = _setup_b2b_enrollment(link_contract_program=False)
 
     call_command(COMMAND, "--commit")
 

--- a/b2b/management/tests/backfill_b2b_program_enrollments_test.py
+++ b/b2b/management/tests/backfill_b2b_program_enrollments_test.py
@@ -1,0 +1,133 @@
+"""Tests for the backfill_b2b_program_enrollments command."""
+
+import pytest
+from django.core.management import call_command
+
+from b2b.constants import CONTRACT_MEMBERSHIP_MANAGED
+from b2b.factories import ContractPageFactory
+from b2b.models import ContractProgramItem
+from courses.factories import (
+    CourseFactory,
+    CourseRunEnrollmentFactory,
+    CourseRunFactory,
+    ProgramFactory,
+)
+from courses.models import ProgramEnrollment
+
+pytestmark = [pytest.mark.django_db]
+
+COMMAND = "backfill_b2b_program_enrollments"
+
+
+def _setup_b2b_enrollment(*, add_course_to_program=True, link_contract_program=True):
+    """Create a user enrolled in a B2B course run, plus a contract program.
+
+    Returns (enrollment, program).
+    """
+
+    contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_MANAGED,
+    )
+    program = ProgramFactory.create()
+    course = CourseFactory.create()
+
+    if add_course_to_program:
+        program.add_requirement(course)
+
+    if link_contract_program:
+        ContractProgramItem.objects.create(
+            contract=contract, program=program, sort_order=0
+        )
+
+    run = CourseRunFactory.create(course=course, b2b_contract=contract)
+    enrollment = CourseRunEnrollmentFactory.create(run=run)
+
+    return enrollment, program
+
+
+def test_backfill_creates_missing_program_enrollment():
+    """An unambiguous B2B enrollment should get a ProgramEnrollment on commit."""
+
+    enrollment, program = _setup_b2b_enrollment()
+
+    call_command(COMMAND, "--commit")
+
+    assert ProgramEnrollment.objects.filter(
+        user=enrollment.user, program=program
+    ).exists()
+
+
+def test_backfill_dry_run_creates_nothing():
+    """Without --commit, no ProgramEnrollment should be created."""
+
+    enrollment, program = _setup_b2b_enrollment()
+
+    call_command(COMMAND)
+
+    assert not ProgramEnrollment.objects.filter(
+        user=enrollment.user, program=program
+    ).exists()
+
+
+def test_backfill_is_idempotent():
+    """Running twice should not error or duplicate enrollments."""
+
+    enrollment, program = _setup_b2b_enrollment()
+
+    call_command(COMMAND, "--commit")
+    call_command(COMMAND, "--commit")
+
+    assert (
+        ProgramEnrollment.all_objects.filter(
+            user=enrollment.user, program=program
+        ).count()
+        == 1
+    )
+
+
+def test_backfill_skips_ambiguous_course():
+    """A course in 2+ contract programs should be skipped, not enrolled."""
+
+    contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_MANAGED,
+    )
+    course = CourseFactory.create()
+    program_a = ProgramFactory.create()
+    program_b = ProgramFactory.create()
+
+    for program in (program_a, program_b):
+        program.add_requirement(course)
+        ContractProgramItem.objects.create(
+            contract=contract, program=program, sort_order=0
+        )
+
+    run = CourseRunFactory.create(course=course, b2b_contract=contract)
+    enrollment = CourseRunEnrollmentFactory.create(run=run)
+
+    call_command(COMMAND, "--commit")
+
+    assert not ProgramEnrollment.objects.filter(user=enrollment.user).exists()
+
+
+def test_backfill_skips_course_not_in_any_program():
+    """A B2B enrollment whose course maps to no contract program is skipped."""
+
+    enrollment, program = _setup_b2b_enrollment(link_contract_program=False)
+
+    call_command(COMMAND, "--commit")
+
+    assert not ProgramEnrollment.objects.filter(user=enrollment.user).exists()
+
+
+def test_backfill_ignores_non_b2b_enrollments():
+    """Enrollments in runs without a B2B contract are untouched."""
+
+    program = ProgramFactory.create()
+    course = CourseFactory.create()
+    program.add_requirement(course)
+    run = CourseRunFactory.create(course=course, b2b_contract=None)
+    enrollment = CourseRunEnrollmentFactory.create(run=run)
+
+    call_command(COMMAND, "--commit")
+
+    assert not ProgramEnrollment.objects.filter(user=enrollment.user).exists()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11333

### Description (What does it do?)
This PR adds a management command to backfill missing B2B program enrollments for users who enrolled in a B2B course run before the automatic program-enrollment forward fix (b2b.api._enroll_in_program_for_b2b) existed.

When a user enrolls in a B2B course run, they should also be enrolled in the program that course belongs to within the run's contract. The forward fix now handles this automatically at enrollment time, but users who enrolled earlier may be missing the ProgramEnrollment that should accompany their course enrollment. This command finds and repairs those cases.

For each active B2B course-run enrollment, the command ensures the user is also enrolled in the program the course belongs to within that run's contract. It mirrors the forward fix exactly — same contract validation and the same idempotent courses.api.create_program_enrollments helper (which writes an audit row) — so behavior stays consistent.

Only unambiguous cases are backfilled: the enrolled course must map to exactly one program within the run's contract. Each enrollment falls into one of four outcomes, reported as counts at the end:

Created — course maps to exactly one contract program and the user had no program enrollment; the enrollment is created.
Already enrolled — the program enrollment already exists; skipped.
No matching program — the course isn't part of any program in the contract; skipped.
Ambiguous — the course belongs to two or more programs in the same contract; reported with details and skipped for manual review.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

**1. Seed test data** covering all four outcomes (created / already-enrolled / no-program / ambiguous) under a single contract. Paste this block as-is — it prints the generated user emails and the expected result for each:

```bash
docker compose run --rm web python manage.py shell <<'PY'
import uuid

from b2b.factories import ContractPageFactory
from b2b.models import ContractPage, ContractProgramItem
from courses.api import create_program_enrollments
from courses.factories import (
    CourseFactory,
    CourseRunEnrollmentFactory,
    CourseRunFactory,
    ProgramFactory,
)
from courses.models import CourseRun, ProgramEnrollment
from openedx.constants import EDX_ENROLLMENT_VERIFIED_MODE
from users.factories import UserFactory

TAG = "backfilltest"
SUF = uuid.uuid4().hex[:8]  # unique per run so re-runs never collide


def new_program(label):
    return ProgramFactory.create(
        title=f"{TAG} {label}",
        readable_id=f"program-v1:{TAG}+{label.replace(' ', '')}+{SUF}",
    )


def new_b2b_run(contract):
    course = CourseFactory.create(readable_id=f"course-v1:{TAG}+{uuid.uuid4().hex[:8]}")
    return CourseRunFactory.create(course=course, b2b_contract=contract)


def link(contract, program):
    # skip_run_creation avoids queueing the async contract-run task
    ContractProgramItem(contract=contract, program=program).save(skip_run_creation=True)


# Clean up leftovers from a previous run. CourseRun -> ContractPage is
# DO_NOTHING, so delete the runs (cascading to enrollments) before the contracts.
old = ContractPage.objects.filter(name__startswith=TAG)
if old.exists():
    CourseRun.objects.filter(b2b_contract__in=old).delete()
    old.delete()

contract = ContractPageFactory.create(name=f"{TAG} Contract")
print(f"\nContract: {contract} (id={contract.id})")

# [1] BACKFILL NEEDED -> should be CREATED
prog1 = new_program("Program One")
link(contract, prog1)
run1 = new_b2b_run(contract)
prog1.add_requirement(run1.course)
prog1.refresh_from_db()
u1 = UserFactory.create(username=f"{TAG}_backfill_{SUF}", email=f"{TAG}_backfill_{SUF}@example.com")
CourseRunEnrollmentFactory.create(user=u1, run=run1)
print(f"[1] CREATED   : {u1.email}")

# [2] ALREADY ENROLLED -> should be SKIPPED
u2 = UserFactory.create(username=f"{TAG}_already_{SUF}", email=f"{TAG}_already_{SUF}@example.com")
CourseRunEnrollmentFactory.create(user=u2, run=run1)
create_program_enrollments(u2, [prog1], enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE)
print(f"[2] ALREADY   : {u2.email}")

# [3] NO MATCHING PROGRAM -> should be SKIPPED
run_orphan = new_b2b_run(contract)  # course not in any contract program
u3 = UserFactory.create(username=f"{TAG}_noprog_{SUF}", email=f"{TAG}_noprog_{SUF}@example.com")
CourseRunEnrollmentFactory.create(user=u3, run=run_orphan)
print(f"[3] NO PROGRAM: {u3.email}")

# [4] AMBIGUOUS (course in two contract programs) -> should be REPORTED + SKIPPED
prog_a, prog_b = new_program("Ambig A"), new_program("Ambig B")
link(contract, prog_a)
link(contract, prog_b)
run_ambig = new_b2b_run(contract)
prog_a.add_requirement(run_ambig.course)
prog_b.add_requirement(run_ambig.course)
u4 = UserFactory.create(username=f"{TAG}_ambig_{SUF}", email=f"{TAG}_ambig_{SUF}@example.com")
CourseRunEnrollmentFactory.create(user=u4, run=run_ambig)
print(f"[4] AMBIGUOUS : {u4.email}")

print("\nExpected on full run: Created 1, Already 1, No-program 1, Ambiguous 1")
print(f"Single-user test:\n  --user {u1.email} --commit")
PY
```

**2. Run a dry run** and confirm no changes are made — the eligible user appears under "Would create", the counts read Created 1 / Already 1 / No-program 1 / Ambiguous 1 for the seeded data, and the ambiguous case is listed under "manual review":

```bash
docker compose run --rm web python manage.py backfill_b2b_program_enrollments
```

**3. Commit** and confirm the missing `ProgramEnrollment` is actually created:

```bash
docker compose run --rm web python manage.py backfill_b2b_program_enrollments --commit
```

**4. Verify idempotency** — re-run with `--commit`; the previously created enrollment is now reported as "already enrolled" with 0 created.

**5. Verify `--user` scoping** — run against a single username/email (printed by the seed script) and confirm only that user's enrollment is scanned:

```bash
docker compose run --rm web python manage.py backfill_b2b_program_enrollments \
  --user <username_or_email> --commit
```

**6. Check the skip paths** — the no-program user is counted under "No matching program", the ambiguous user is listed for manual review and never enrolled, and the already-enrolled user is left untouched.

> **Note:** the seeded rows are prefixed with `backfilltest`. Because the command scans **all** B2B enrollments in the DB, your counts may be higher than the seeded scenarios if other B2B enrollments already exist locally.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
