### PR TITLE
fix(openedx): stop dead-lettered enrollment failures from paging Sentry

### DIFF
--- a/openedx/api.py
+++ b/openedx/api.py
@@ -1291,16 +1291,26 @@ def retry_failed_edx_enrollments():
                 user, [course_run], mode=enrollment.enrollment_mode
             )
         except Exception as exc:  # pylint: disable=broad-except
-            log.exception(str(exc))  # noqa: TRY401
             if not _is_permanent_enrollment_failure(exc):
+                # transient/unexpected - worth a Sentry event since it may
+                # signal a real edX outage or a new failure mode
+                log.exception(str(exc))  # noqa: TRY401
                 continue
+            # permanent, per-enrollment failure that is already tracked via
+            # edx_enrollment_retry_count and visible in the admin - logging
+            # this at ERROR would send a Sentry event on every one of
+            # OPENEDX_ENROLLMENT_REPAIR_MAX_RETRIES attempts for every broken
+            # enrollment, which is exactly what buried MITXONLINE-5Q0 in 1.26M+
+            # events. Log it at WARNING (kept in app logs, no Sentry issue)
+            # instead.
+            log.warning(str(exc), exc_info=True)
             enrollment.edx_enrollment_retry_count += 1
             enrollment.save(update_fields=["edx_enrollment_retry_count"])
             if (
                 enrollment.edx_enrollment_retry_count
                 >= OPENEDX_ENROLLMENT_REPAIR_MAX_RETRIES
             ):
-                log.error(  # noqa: TRY400 - traceback already logged above via log.exception
+                log.warning(
                     "Giving up on edX enrollment repair for user %s in course run "
                     "%s after %d failed attempts - will not be retried automatically",
                     user.edx_username,

--- a/openedx/api.py
+++ b/openedx/api.py
@@ -1210,12 +1210,11 @@ def enroll_in_edx_course_runs(
                     )
             results.append(enrollment)
         except HTTPError as exc:  # noqa: PERF203
-            log.error(  # noqa: TRY400
-                "Failed to enroll user %s in course run %s with mode %s.",
-                user.edx_username,
-                course_run.courseware_id,
-                mode,
-            )
+            # logging is left to callers, who are best positioned to decide
+            # the right level - retry_failed_edx_enrollments demotes
+            # permanent per-enrollment failures to WARNING to avoid paging
+            # Sentry on every retry (see MITXONLINE-5Q0); an unconditional
+            # log.error here would page Sentry regardless of that decision.
             raise EdxApiEnrollErrorException(user, course_run, exc) from exc
         except Exception as exc:  # pylint: disable=broad-except
             raise UnknownEdxApiEnrollException(user, course_run, exc) from exc
@@ -1303,7 +1302,13 @@ def retry_failed_edx_enrollments():
             # enrollment, which is exactly what buried MITXONLINE-5Q0 in 1.26M+
             # events. Log it at WARNING (kept in app logs, no Sentry issue)
             # instead.
-            log.warning(str(exc), exc_info=True)
+            log.warning(
+                "edX enrollment repair failed permanently for user %s in course run %s (%s)",
+                user.edx_username,
+                course_run.courseware_id,
+                type(exc).__name__,
+                exc_info=True,
+            )
             enrollment.edx_enrollment_retry_count += 1
             enrollment.save(update_fields=["edx_enrollment_retry_count"])
             if (

--- a/openedx/api_test.py
+++ b/openedx/api_test.py
@@ -1187,8 +1187,8 @@ def test_retry_failed_edx_enrollments_dead_letters_at_max_retries(mocker):
         "openedx.api.enroll_in_edx_course_runs",
         side_effect=_permanent_enroll_error(enrollment.user, enrollment.run),
     )
-    mocker.patch("openedx.api.log.exception")
-    patched_log_error = mocker.patch("openedx.api.log.error")
+    patched_log_exception = mocker.patch("openedx.api.log.exception")
+    patched_log_warning = mocker.patch("openedx.api.log.warning")
 
     retry_failed_edx_enrollments()
 
@@ -1196,8 +1196,11 @@ def test_retry_failed_edx_enrollments_dead_letters_at_max_retries(mocker):
     assert (
         enrollment.edx_enrollment_retry_count == OPENEDX_ENROLLMENT_REPAIR_MAX_RETRIES
     )
-    patched_log_error.assert_called_once()
-    assert "Giving up" in patched_log_error.call_args[0][0]
+    # permanent failures must not reach Sentry via log.exception - only the
+    # give-up message, at WARNING, so it stays out of Sentry too
+    patched_log_exception.assert_not_called()
+    assert patched_log_warning.call_count == 2
+    assert "Giving up" in patched_log_warning.call_args_list[-1][0][0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #3726 (dead-letter chronically-failing enrollment repairs). N/A - no linked issue.

### Description (What does it do?)
`openedx.api.retry_failed_edx_enrollments` already caps retries and excludes permanently-broken enrollments from future runs (`edx_enrollment_retry_count >= OPENEDX_ENROLLMENT_REPAIR_MAX_RETRIES`), tracked in `courses/models.py` and surfaced via the `repair_exhausted` admin filter in `courses/admin.py`.

However, every one of those retry attempts (and the final give-up message) was still logged via `log.exception` / `log.error`. Since Sentry's `LoggingIntegration` (`main/sentry.py`) creates an issue for anything at `ERROR`+ by default, this meant every attempt against an already-known-broken enrollment generated a full Sentry event with traceback - the same failure mode that buried MITXONLINE-5Q0 in 1.26M+ Sentry events before the retry cap existed in #3726.

This PR splits the logging by failure class in `openedx/api.py`:
- **Permanent, per-enrollment failures** (the ones that count toward the dead-letter cap, e.g. `OpenEdxUserMissingError`, 4xx `EdxApiEnrollErrorException`) now log at `WARNING` - still visible in app logs, but below Sentry's event threshold. These are already tracked via `edx_enrollment_retry_count` and visible in the Django admin, so nothing is silently lost.
- **Transient/unexpected failures** (network errors, 5xx, 429s, unknown exceptions) still use `log.exception` at `ERROR`, since those may indicate a real edX outage or a new failure mode worth alerting on.

### Screenshots (if appropriate):
N/A - backend logging change only.

### How can this be tested?
Ran the full `openedx/api_test.py` suite (`docker compose run --rm web pytest openedx/api_test.py`) - 117 passed, 6 skipped. Updated `test_retry_failed_edx_enrollments_dead_letters_at_max_retries` to assert that `log.exception` is never called for permanent failures and that both the per-attempt and give-up messages go through `log.warning` instead.

A reviewer can validate by inspecting `openedx/api.py::retry_failed_edx_enrollments` and confirming: the transient branch (`if not _is_permanent_enrollment_failure(exc)`) still calls `log.exception`, while the permanent branch calls `log.warning` for both the per-attempt log and the "Giving up on edX enrollment repair..." message.

### Additional Context
`SENTRY_LOG_LEVEL` defaults to `ERROR` (`main/settings.py`), and `LoggingIntegration(level=log_level)` in `main/sentry.py` uses that as the event-creation threshold, so `WARNING`-level logs are still captured as breadcrumbs but do not create standalone Sentry issues.