### PR TITLE
Fixing Certificate detail lookup issue v2

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -1783,6 +1783,22 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
     class Meta:
         unique_together = ("user", "course_run")
 
+    @classmethod
+    def queryable_queryset(cls):
+        """Return certificates that should be exposed by the public APIs."""
+        return cls.all_objects.filter(is_revoked=False, issue_date__lte=now_in_utc())
+
+    @classmethod
+    def api_detail_queryset(cls):
+        """Return the queryset used by the certificate detail API."""
+        return cls.queryable_queryset().prefetch_related(
+            Prefetch(
+                "course_run__course__programs",
+                queryset=Program.objects.filter(b2b_only=False),
+            ),
+            "user",
+        )
+
     def get_certified_object_id(self):
         return self.course_run_id
 
@@ -1868,6 +1884,16 @@ class ProgramCertificate(TimestampedModel, BaseCertificate):
 
     class Meta:
         unique_together = ("user", "program")
+
+    @classmethod
+    def queryable_queryset(cls):
+        """Return certificates that should be exposed by the public APIs."""
+        return cls.all_objects.filter(is_revoked=False, issue_date__lte=now_in_utc())
+
+    @classmethod
+    def api_detail_queryset(cls):
+        """Return the queryset used by the certificate detail API."""
+        return cls.queryable_queryset().prefetch_related("user")
 
     def get_certified_object_id(self):
         return self.program_id
@@ -2050,7 +2076,7 @@ class CourseRunEnrollmentCertificatePrefetcher(Prefetcher):
     @staticmethod
     def filter(course_run_and_user_ids):
         if not course_run_and_user_ids:
-            return CourseRunCertificate.objects.none()
+            return CourseRunCertificate.queryable_queryset().none()
 
         id_filters = Q()
 
@@ -2059,7 +2085,7 @@ class CourseRunEnrollmentCertificatePrefetcher(Prefetcher):
         for course_run_id, user_id in course_run_and_user_ids:
             id_filters |= Q(course_run_id=course_run_id, user_id=user_id)
 
-        return CourseRunCertificate.objects.filter(id_filters)
+        return CourseRunCertificate.queryable_queryset().filter(id_filters)
 
     @staticmethod
     def reverse_mapper(certificate):
@@ -2159,7 +2185,7 @@ class CourseRunEnrollment(EnrollmentModel):
         if hasattr(self, "_certificate"):
             return self._certificate
         else:
-            return CourseRunCertificate.objects.filter(
+            return CourseRunCertificate.queryable_queryset().filter(
                 course_run_id=self.run_id, user_id=self.user_id
             ).first()
 
@@ -2236,7 +2262,7 @@ class ProgramEnrollmentCertificatePrefetcher(Prefetcher):
     @staticmethod
     def filter(program_and_user_ids):
         if not program_and_user_ids:
-            return ProgramCertificate.objects.none()
+            return ProgramCertificate.queryable_queryset().none()
 
         id_filters = Q()
 
@@ -2245,7 +2271,7 @@ class ProgramEnrollmentCertificatePrefetcher(Prefetcher):
         for program_id, user_id in program_and_user_ids:
             id_filters |= Q(program_id=program_id, user_id=user_id)
 
-        return ProgramCertificate.objects.filter(id_filters)
+        return ProgramCertificate.queryable_queryset().filter(id_filters)
 
     @staticmethod
     def reverse_mapper(certificate):
@@ -2301,7 +2327,7 @@ class ProgramEnrollment(EnrollmentModel):
         if hasattr(self, "_certificate"):
             return self._certificate
         else:
-            return ProgramCertificate.objects.filter(
+            return ProgramCertificate.queryable_queryset().filter(
                 program_id=self.program_id, user_id=self.user_id
             ).first()
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -2185,9 +2185,11 @@ class CourseRunEnrollment(EnrollmentModel):
         if hasattr(self, "_certificate"):
             return self._certificate
         else:
-            return CourseRunCertificate.queryable_queryset().filter(
-                course_run_id=self.run_id, user_id=self.user_id
-            ).first()
+            return (
+                CourseRunCertificate.queryable_queryset()
+                .filter(course_run_id=self.run_id, user_id=self.user_id)
+                .first()
+            )
 
     @cached_property
     def grades(self) -> list["CourseRunGrade"]:
@@ -2327,9 +2329,11 @@ class ProgramEnrollment(EnrollmentModel):
         if hasattr(self, "_certificate"):
             return self._certificate
         else:
-            return ProgramCertificate.queryable_queryset().filter(
-                program_id=self.program_id, user_id=self.user_id
-            ).first()
+            return (
+                ProgramCertificate.queryable_queryset()
+                .filter(program_id=self.program_id, user_id=self.user_id)
+                .first()
+            )
 
     def get_run_enrollments(self):
         """

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -76,7 +76,9 @@ def get_program_certificate_by_enrollment(enrollment, program=None):
         program_id = enrollment.program_id
     # Using IDs because we don't need the actual record and this avoids redundant queries
     try:
-        return ProgramCertificate.objects.get(user_id=user_id, program_id=program_id)
+        return ProgramCertificate.queryable_queryset().get(
+            user_id=user_id, program_id=program_id
+        )
     except ProgramCertificate.DoesNotExist:
         return None
 

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -982,19 +982,20 @@ class CourseCertificateRetrieveViewSet(_BaseCertificateRetrieveViewSet):
     """Viewset to read a single course certificate"""
 
     serializer_class = CourseRunCertificateSerializer
-    queryset = CourseRunCertificate.objects.prefetch(
-        PrefetchOption(
-            "course_run__course__programs",
-            queryset=Program.objects.filter(b2b_only=False),
-        )
-    ).prefetch_related("user")
+
+    def get_queryset(self):
+        """Return the current queryable course certificate queryset."""
+        return CourseRunCertificate.api_detail_queryset()
 
 
 class ProgramCertificateRetrieveViewSet(_BaseCertificateRetrieveViewSet):
     """Viewset to read a single course certificate"""
 
     serializer_class = ProgramCertificateSerializer
-    queryset = ProgramCertificate.objects.prefetch_related("user")
+
+    def get_queryset(self):
+        """Return the current queryable program certificate queryset."""
+        return ProgramCertificate.api_detail_queryset()
 
 
 class UserProgramEnrollmentsViewSet(viewsets.ViewSet):

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -43,10 +43,12 @@ from courses.factories import (
 )
 from courses.models import (
     Course,
+    CourseRunCertificate,
     CourseRunEnrollment,
     CoursesTopic,
     PaidProgram,
     Program,
+    ProgramCertificate,
     ProgramEnrollment,
 )
 from courses.serializers.v2.certificates import (
@@ -75,7 +77,12 @@ from courses.views.test_utils import (
     num_queries_from_department,
     num_queries_from_programs,
 )
-from courses.views.v2 import Pagination, ProgramFilterSet
+from courses.views.v2 import (
+    CourseCertificateRetrieveViewSet,
+    Pagination,
+    ProgramCertificateRetrieveViewSet,
+    ProgramFilterSet,
+)
 from ecommerce.factories import OrderFactory, ProductFactory
 from ecommerce.models import OrderStatus, Product
 from main import features
@@ -1283,6 +1290,37 @@ def test_get_course_certificate():
         reverse("v2:course_certificates_api-detail", kwargs={"uuid": uuid.uuid4()})
     )
     assert resp404.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_course_certificate_viewset_uses_runtime_queryset(mocker):
+    """Course certificate detail queryset should be rebuilt per request."""
+    queryset = mocker.sentinel.course_queryset
+    api_detail_queryset = mocker.patch.object(
+        CourseRunCertificate,
+        "api_detail_queryset",
+        return_value=queryset,
+    )
+
+    view = CourseCertificateRetrieveViewSet()
+
+    assert view.get_queryset() is queryset
+    api_detail_queryset.assert_called_once_with()
+
+
+def test_program_certificate_viewset_uses_runtime_queryset(mocker):
+    """Program certificate detail queryset should be rebuilt per request."""
+    queryset = mocker.sentinel.program_queryset
+    api_detail_queryset = mocker.patch.object(
+        ProgramCertificate,
+        "api_detail_queryset",
+        return_value=queryset,
+    )
+
+    view = ProgramCertificateRetrieveViewSet()
+
+    assert view.get_queryset() is queryset
+    api_detail_queryset.assert_called_once_with()
+
 
 
 def test_get_course_certificate_future_issue_date():

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -1322,7 +1322,6 @@ def test_program_certificate_viewset_uses_runtime_queryset(mocker):
     api_detail_queryset.assert_called_once_with()
 
 
-
 def test_get_course_certificate_future_issue_date():
     """Test that get_course_certificate returns 404 for certificates with a future issue_date."""
     courseware_page = CoursePageFactory.create()

--- a/courses/views/v3/views_test.py
+++ b/courses/views/v3/views_test.py
@@ -210,7 +210,7 @@ def test_user_enrollments_list(
 
 def test_user_enrollments_exposed_certificates_are_queryable_in_v2(
     user_drf_client,
-    user_with_enrollments_and_certificates: UserWithEnrollmentsAndCerts,  # noqa: ARG001
+    user_with_enrollments_and_certificates: UserWithEnrollmentsAndCerts,
 ):
     """Course certificate UUIDs returned by v3 enrollments should resolve via v2."""
     resp = user_drf_client.get(reverse("v3:user_enrollments_api-list"))
@@ -541,7 +541,7 @@ def test_program_enrollments(
 
 def test_program_enrollments_exposed_certificates_are_queryable_in_v2(
     user_drf_client,
-    user_with_enrollments_and_certificates: UserWithEnrollmentsAndCerts,  # noqa: ARG001
+    user_with_enrollments_and_certificates: UserWithEnrollmentsAndCerts,
 ):
     """Program certificate UUIDs returned by v3 enrollments should resolve via v2."""
     resp = user_drf_client.get(reverse("v3:user_program_enrollments_api-list"))

--- a/courses/views/v3/views_test.py
+++ b/courses/views/v3/views_test.py
@@ -208,6 +208,32 @@ def test_user_enrollments_list(
     ]
 
 
+def test_user_enrollments_exposed_certificates_are_queryable_in_v2(
+    user_drf_client,
+    user_with_enrollments_and_certificates: UserWithEnrollmentsAndCerts,  # noqa: ARG001
+):
+    """Course certificate UUIDs returned by v3 enrollments should resolve via v2."""
+    resp = user_drf_client.get(reverse("v3:user_enrollments_api-list"))
+
+    assert resp.status_code == status.HTTP_200_OK
+
+    client = APIClient()
+    for enrollment_data in resp.json():
+        certificate = enrollment_data["certificate"]
+        if certificate is None:
+            continue
+
+        cert_resp = client.get(
+            reverse(
+                "v2:course_certificates_api-detail",
+                kwargs={"uuid": certificate["uuid"]},
+            )
+        )
+        assert cert_resp.status_code == status.HTTP_200_OK
+        assert cert_resp.json()["uuid"] == certificate["uuid"]
+        assert cert_resp.json()["course_run"]["id"] == enrollment_data["run"]["id"]
+
+
 def test_user_enrollments_list_filter_org_id(
     user_drf_client,
     b2b_courses: B2BCourses,
@@ -511,6 +537,32 @@ def test_program_enrollments(
         }
         for program_enrollment in program_enrollments
     ]
+
+
+def test_program_enrollments_exposed_certificates_are_queryable_in_v2(
+    user_drf_client,
+    user_with_enrollments_and_certificates: UserWithEnrollmentsAndCerts,  # noqa: ARG001
+):
+    """Program certificate UUIDs returned by v3 enrollments should resolve via v2."""
+    resp = user_drf_client.get(reverse("v3:user_program_enrollments_api-list"))
+
+    assert resp.status_code == status.HTTP_200_OK
+
+    client = APIClient()
+    for enrollment_data in resp.json():
+        certificate = enrollment_data["certificate"]
+        if certificate is None:
+            continue
+
+        cert_resp = client.get(
+            reverse(
+                "v2:program_certificates_api-detail",
+                kwargs={"uuid": certificate["uuid"]},
+            )
+        )
+        assert cert_resp.status_code == status.HTTP_200_OK
+        assert cert_resp.json()["uuid"] == certificate["uuid"]
+        assert cert_resp.json()["program"]["id"] == enrollment_data["program"]["id"]
 
 
 def test_program_enrollments_future_program_cert(user_drf_client, user):


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/12149

### Description (What does it do?)
<!--- Describe your changes in detail -->

What changed:
Centralized “queryable certificate” logic in courses/models.py
Switched the certificate detail viewsets in courses/views/v2/__init__.py to build their querysets in get_queryset() at request time
Updated related certificate lookup paths to use the shared queryable queryset helper
Added regression tests:
request-time queryset tests in courses/views/v2/views_test.py
cross-endpoint parity tests in courses/views/v3/views_test.py

### How can this be tested?
