### PR TITLE
Filter active cert issue_date in db query

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -17,6 +17,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator, RegexVa
 from django.db import models
 from django.db.models import Exists, OuterRef, Prefetch, Q
 from django.db.models.constraints import CheckConstraint, UniqueConstraint
+from django.db.models.functions import Now
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -1715,11 +1716,7 @@ class ActiveCertificatesManager(CertificatesManager):
         Returns:
             QuerySet: queryset for un-revoked certificates
         """
-        return (
-            super()
-            .get_queryset()
-            .filter(is_revoked=False, issue_date__lte=now_in_utc())
-        )
+        return super().get_queryset().filter(is_revoked=False, issue_date__lte=Now())
 
 
 class BaseCertificate(models.Model):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/hq/issues/12149

### Description (What does it do?)
<!--- Describe your changes in detail -->
This ensures it's never possible to query for certificates with a stale filter on `issue_date`.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This is a subtle error and hard to reproduce so tests passing should be adequate.
