### PR TITLE
feat: update to latest revision command

### DIFF
--- a/courses/management/commands/migrate_certificate_revisions.py
+++ b/courses/management/commands/migrate_certificate_revisions.py
@@ -1,0 +1,166 @@
+"""
+Management command to migrate CourseRunCertificates/ProgramCertificates for a
+course, course run, or program to the latest certificate page revision.
+
+By default, only certificates that don't have a certificate_page_revision
+associated are updated. Pass --all to update every certificate for the
+course/run/program, even ones that already have a revision set.
+
+Check the usages of this command below:
+
+1. Update certificates with no revision associated, for a course
+./manage.py migrate_certificate_revisions --course=<course_readable_id>
+
+2. Update ALL certificates (including ones that already have a revision), for a course
+./manage.py migrate_certificate_revisions --course=<course_readable_id> --all
+
+3. Same operations, but for a single course run
+./manage.py migrate_certificate_revisions --courserun=<course_run_courseware_id>
+./manage.py migrate_certificate_revisions --courserun=<course_run_courseware_id> --all
+
+4. Same operations, but for a program
+./manage.py migrate_certificate_revisions --program=<program_readable_id>
+./manage.py migrate_certificate_revisions --program=<program_readable_id> --all
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from courses.models import (
+    Course,
+    CourseRun,
+    CourseRunCertificate,
+    Program,
+    ProgramCertificate,
+)
+
+
+class Command(BaseCommand):
+    """
+    Invoke with:
+
+        python manage.py migrate_certificate_revisions
+    """
+
+    help = (
+        "Migrate certificates of a course/course run/program to the latest "
+        "certificate page revision. By default only certificates with no revision "
+        "associated are updated; use --all to update every certificate for the "
+        "course/run/program."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--course", type=str, help="The 'readable_id' value for a Course"
+        )
+        parser.add_argument(
+            "--courserun", type=str, help="The 'courseware_id' value for a CourseRun"
+        )
+        parser.add_argument(
+            "--program", type=str, help="The 'readable_id' value for a Program"
+        )
+        parser.add_argument(
+            "--all",
+            dest="update_all",
+            action="store_true",
+            required=False,
+            help=(
+                "Update all certificates for the course/run/program to the latest "
+                "revision. By default, only certificates with no revision "
+                "associated are updated."
+            ),
+        )
+
+        super().add_arguments(parser)
+
+    def _resolve_certificate_scope(self, course_id, run_id, program_id):
+        """Resolve the certificate page, label, and certificate queryset for the target"""
+        if course_id:
+            try:
+                course = Course.objects.get(readable_id=course_id)
+            except Course.DoesNotExist:
+                message = f"Could not find course with readable_id={course_id}."
+                raise CommandError(message)  # noqa: B904
+
+            return (
+                course.certificate_page,
+                f"course {course.readable_id}",
+                CourseRunCertificate.all_objects.filter(course_run__course=course),
+            )
+
+        if run_id:
+            try:
+                course_run = CourseRun.objects.get(courseware_id=run_id)
+            except CourseRun.DoesNotExist:
+                message = f"Could not find course run with courseware_id={run_id}."
+                raise CommandError(message)  # noqa: B904
+
+            return (
+                course_run.course.certificate_page,
+                f"course run {course_run.courseware_id}",
+                CourseRunCertificate.all_objects.filter(course_run=course_run),
+            )
+
+        try:
+            program = Program.objects.get(readable_id=program_id)
+        except Program.DoesNotExist:
+            message = f"Could not find program with readable_id={program_id}."
+            raise CommandError(message)  # noqa: B904
+
+        return (
+            program.certificate_page,
+            f"program {program.readable_id}",
+            ProgramCertificate.all_objects.filter(program=program),
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Handle command execution"""
+
+        course_id = options.get("course")
+        run_id = options.get("courserun")
+        program_id = options.get("program")
+        update_all = options.get("update_all")
+
+        provided = [value for value in (course_id, run_id, program_id) if value]
+        if not provided:
+            message = "The command needs one of --course, --courserun, or --program."
+            raise CommandError(message)
+
+        if len(provided) > 1:
+            message = "Provide only one of --course, --courserun, or --program."
+            raise CommandError(message)
+
+        certificate_page, courseware_label, certificates = (
+            self._resolve_certificate_scope(course_id, run_id, program_id)
+        )
+
+        if not certificate_page:
+            message = f"No certificate page found for {courseware_label}."
+            raise CommandError(message)
+
+        latest_revision = certificate_page.get_latest_revision()
+        if not latest_revision:
+            message = f"Certificate page {certificate_page} for {courseware_label} has no revisions."
+            raise CommandError(message)
+
+        if not update_all:
+            certificates = certificates.filter(certificate_page_revision__isnull=True)
+        else:
+            answer = input(
+                self.style.WARNING(
+                    f"This will update ALL certificates for {courseware_label} to "
+                    f"revision {latest_revision.pk}, including ones that already "
+                    "have a revision set. Continue? (y/n): "
+                )
+            ).lower()
+            if answer != "y":
+                self.stdout.write(self.style.WARNING("Aborted. No changes made."))
+                return
+
+        updated_count = certificates.update(certificate_page_revision=latest_revision)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Updated {updated_count} certificate(s) for {courseware_label} to "
+                f"revision {latest_revision.pk}."
+            )
+        )

--- a/courses/management/commands/migrate_certificate_revisions.py
+++ b/courses/management/commands/migrate_certificate_revisions.py
@@ -139,9 +139,7 @@ class Command(BaseCommand):
 
         latest_revision = certificate_page.get_latest_revision()
         if not latest_revision:
-            message = (
-                f"Certificate page '{certificate_page.title}' (id={certificate_page.pk}) for {courseware_label} has no revisions."
-            )
+            message = f"Certificate page '{certificate_page.title}' (id={certificate_page.pk}) for {courseware_label} has no revisions."
             raise CommandError(message)
 
         if not update_all:

--- a/courses/management/commands/migrate_certificate_revisions.py
+++ b/courses/management/commands/migrate_certificate_revisions.py
@@ -139,7 +139,9 @@ class Command(BaseCommand):
 
         latest_revision = certificate_page.get_latest_revision()
         if not latest_revision:
-            message = f"Certificate page {certificate_page} for {courseware_label} has no revisions."
+            message = (
+                f"Certificate page '{certificate_page.title}' (id={certificate_page.pk}) for {courseware_label} has no revisions."
+            )
             raise CommandError(message)
 
         if not update_all:

--- a/courses/management/commands/migrate_certificate_revisions.py
+++ b/courses/management/commands/migrate_certificate_revisions.py
@@ -147,7 +147,7 @@ class Command(BaseCommand):
         else:
             answer = input(
                 self.style.WARNING(
-                    f"This will update ALL certificates for {courseware_label} to "
+                    f"This will update {len(certificates)} certificates for {courseware_label} to "
                     f"revision {latest_revision.pk}, including ones that already "
                     "have a revision set. Continue? (y/n): "
                 )

--- a/courses/management/tests/migrate_certificate_revisions_test.py
+++ b/courses/management/tests/migrate_certificate_revisions_test.py
@@ -146,7 +146,24 @@ def test_migrate_certificate_revisions_course_no_certificate_page():
     )
 
 
+def test_migrate_certificate_revisions_certificate_page_has_no_revisions():
+    """Command should fail if the certificate page exists but has no revisions."""
+    course = CourseFactory.create(page__certificate_page__product_name="product")
+    certificate_page = course.certificate_page
+    certificate_page.revisions.all().delete()
+
+    run = CourseRunFactory.create(course=course)
+    CourseRunCertificateFactory.create(course_run=run)
+
+    with pytest.raises(CommandError) as command_error:
+        migrate_certificate_revisions.Command().handle(course=course.readable_id)
+
+    assert f"course {course.readable_id}" in str(command_error.value)
+    assert "has no revisions" in str(command_error.value)
+
+
 @pytest.mark.parametrize("kind", ["course", "courserun", "program"])
+
 def test_migrate_certificate_revisions_missing_only(kind):
     """By default, only certificates missing a revision should be updated"""
     certificate_page, cert_with_revision, cert_without_revision, handle_kwargs = (

--- a/courses/management/tests/migrate_certificate_revisions_test.py
+++ b/courses/management/tests/migrate_certificate_revisions_test.py
@@ -163,7 +163,6 @@ def test_migrate_certificate_revisions_certificate_page_has_no_revisions():
 
 
 @pytest.mark.parametrize("kind", ["course", "courserun", "program"])
-
 def test_migrate_certificate_revisions_missing_only(kind):
     """By default, only certificates missing a revision should be updated"""
     certificate_page, cert_with_revision, cert_without_revision, handle_kwargs = (

--- a/courses/management/tests/migrate_certificate_revisions_test.py
+++ b/courses/management/tests/migrate_certificate_revisions_test.py
@@ -1,0 +1,191 @@
+"""Tests for migrate_certificate_revisions management command"""
+
+import pytest
+from django.core.management.base import CommandError
+
+from courses.factories import (
+    CourseFactory,
+    CourseRunCertificateFactory,
+    CourseRunFactory,
+    ProgramCertificateFactory,
+    ProgramFactory,
+)
+from courses.management.commands import migrate_certificate_revisions
+from courses.models import CourseRunCertificate, ProgramCertificate
+from users.factories import UserFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture(autouse=True)
+def _mock_hubspot(mocker):
+    mocker.patch("hubspot_sync.api.upsert_custom_properties")
+
+
+def _make_course_certs():
+    """Create a course with one certificate that has a revision and one that doesn't"""
+    course = CourseFactory.create(page__certificate_page__product_name="product")
+    certificate_page = course.certificate_page
+    # Establish an initial revision so the first certificate below picks one up.
+    certificate_page.save_revision()
+
+    run_a = CourseRunFactory.create(course=course)
+    run_b = CourseRunFactory.create(course=course)
+    cert_with_revision = CourseRunCertificateFactory.create(course_run=run_a)
+    cert_without_revision = CourseRunCertificateFactory.create(course_run=run_b)
+    CourseRunCertificate.all_objects.filter(pk=cert_without_revision.pk).update(
+        certificate_page_revision=None
+    )
+    return (
+        certificate_page,
+        cert_with_revision,
+        cert_without_revision,
+        {"course": course.readable_id},
+    )
+
+
+def _make_course_run_certs():
+    """Create a course run with one certificate that has a revision and one that doesn't"""
+    course = CourseFactory.create(page__certificate_page__product_name="product")
+    certificate_page = course.certificate_page
+    # Establish an initial revision so the first certificate below picks one up.
+    certificate_page.save_revision()
+
+    run = CourseRunFactory.create(course=course)
+    cert_with_revision = CourseRunCertificateFactory.create(
+        course_run=run, user=UserFactory.create()
+    )
+    cert_without_revision = CourseRunCertificateFactory.create(
+        course_run=run, user=UserFactory.create()
+    )
+    CourseRunCertificate.all_objects.filter(pk=cert_without_revision.pk).update(
+        certificate_page_revision=None
+    )
+    return (
+        certificate_page,
+        cert_with_revision,
+        cert_without_revision,
+        {"courserun": run.courseware_id},
+    )
+
+
+def _make_program_certs():
+    """Create a program with one certificate that has a revision and one that doesn't"""
+    program = ProgramFactory.create(page__certificate_page__product_name="product")
+    certificate_page = program.certificate_page
+    # Establish an initial revision so the first certificate below picks one up.
+    certificate_page.save_revision()
+
+    cert_with_revision = ProgramCertificateFactory.create(
+        program=program, user=UserFactory.create()
+    )
+    cert_without_revision = ProgramCertificateFactory.create(
+        program=program, user=UserFactory.create()
+    )
+    ProgramCertificate.all_objects.filter(pk=cert_without_revision.pk).update(
+        certificate_page_revision=None
+    )
+    return (
+        certificate_page,
+        cert_with_revision,
+        cert_without_revision,
+        {"program": program.readable_id},
+    )
+
+
+CERT_SETUPS = {
+    "course": _make_course_certs,
+    "courserun": _make_course_run_certs,
+    "program": _make_program_certs,
+}
+
+
+@pytest.mark.parametrize(
+    "handle_kwargs, expected_message",  # noqa: PT006
+    [
+        ({}, "The command needs one of --course, --courserun, or --program."),
+        (
+            {"course": "a", "program": "b"},
+            "Provide only one of --course, --courserun, or --program.",
+        ),
+        (
+            {"course": "a", "courserun": "b", "program": "c"},
+            "Provide only one of --course, --courserun, or --program.",
+        ),
+        (
+            {"course": "does-not-exist"},
+            "Could not find course with readable_id=does-not-exist.",
+        ),
+        (
+            {"courserun": "does-not-exist"},
+            "Could not find course run with courseware_id=does-not-exist.",
+        ),
+        (
+            {"program": "does-not-exist"},
+            "Could not find program with readable_id=does-not-exist.",
+        ),
+    ],
+)
+def test_migrate_certificate_revisions_validation_errors(
+    handle_kwargs, expected_message
+):
+    """Command should raise a CommandError for invalid/missing arguments"""
+    with pytest.raises(CommandError) as command_error:
+        migrate_certificate_revisions.Command().handle(**handle_kwargs)
+    assert str(command_error.value) == expected_message
+
+
+def test_migrate_certificate_revisions_course_no_certificate_page():
+    """Command should fail if the course has no certificate page"""
+    course = CourseFactory.create(page=None)
+    with pytest.raises(CommandError) as command_error:
+        migrate_certificate_revisions.Command().handle(course=course.readable_id)
+    assert (
+        str(command_error.value)
+        == f"No certificate page found for course {course.readable_id}."
+    )
+
+
+@pytest.mark.parametrize("kind", ["course", "courserun", "program"])
+def test_migrate_certificate_revisions_missing_only(kind):
+    """By default, only certificates missing a revision should be updated"""
+    certificate_page, cert_with_revision, cert_without_revision, handle_kwargs = (
+        CERT_SETUPS[kind]()
+    )
+    old_revision = cert_with_revision.certificate_page_revision
+    new_revision = certificate_page.save_revision()
+
+    migrate_certificate_revisions.Command().handle(**handle_kwargs)
+
+    cert_with_revision.refresh_from_db()
+    cert_without_revision.refresh_from_db()
+
+    assert old_revision is not None
+    assert cert_with_revision.certificate_page_revision == old_revision
+    assert cert_without_revision.certificate_page_revision == new_revision
+
+
+@pytest.mark.parametrize("kind", ["course", "courserun", "program"])
+@pytest.mark.parametrize("confirm_answer", ["y", "Y", "n", ""])
+def test_migrate_certificate_revisions_all_confirmation(mocker, kind, confirm_answer):
+    """--all should prompt for confirmation and only update when the user accepts"""
+    certificate_page, cert_with_revision, cert_without_revision, handle_kwargs = (
+        CERT_SETUPS[kind]()
+    )
+    old_revision = cert_with_revision.certificate_page_revision
+    new_revision = certificate_page.save_revision()
+
+    mock_input = mocker.patch("builtins.input", return_value=confirm_answer)
+
+    migrate_certificate_revisions.Command().handle(update_all=True, **handle_kwargs)
+
+    mock_input.assert_called_once()
+    cert_with_revision.refresh_from_db()
+    cert_without_revision.refresh_from_db()
+
+    if confirm_answer.lower() == "y":
+        assert cert_with_revision.certificate_page_revision == new_revision
+        assert cert_without_revision.certificate_page_revision == new_revision
+    else:
+        assert cert_with_revision.certificate_page_revision == old_revision
+        assert cert_without_revision.certificate_page_revision is None


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/12298

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a command to update certificates to the latest revision. Provides options for course, run, and program certificates. Updates certificates with missing revisions by default and provides `--all` to update all certificates including the ones with revisions.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Create test data, like some certificates for courses and programs, with some pointing to the latest revision and some to older ones. Create some certificates with no revisions (This can only be done via shell or from admin in case certificate page in cms does not exist.)
- Now run different variants of the command to test different cases.

```
1. Update certificates with no revision associated, for a course
./manage.py migrate_certificate_revisions --course=<course_readable_id>

2. Update ALL certificates (including ones that already have a revision), for a course
./manage.py migrate_certificate_revisions --course=<course_readable_id> --all

3. Same operations, but for a single course run
./manage.py migrate_certificate_revisions --courserun=<course_run_courseware_id>
./manage.py migrate_certificate_revisions --courserun=<course_run_courseware_id> --all

4. Same operations, but for a program
./manage.py migrate_certificate_revisions --program=<program_readable_id>
./manage.py migrate_certificate_revisions --program=<program_readable_id> --all

```