### PR TITLE
Guard HubSpot associations against missing IDs

### DIFF
--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import time
 from decimal import Decimal
 from typing import List  # noqa: UP035
 
@@ -1573,6 +1574,52 @@ def sync_deal_line_hubspot_ids_to_db(order, hubspot_order_id) -> bool:
     return matches == expected_matches
 
 
+_ASSOCIATION_RETRY_DELAYS = (1, 2, 4)  # seconds between attempts (3 total tries)
+
+
+def _associate_objects_with_retry(
+    from_type: str,
+    from_id: str,
+    to_type: str,
+    to_id: str,
+    assoc_type: str,
+) -> None:
+    """Call associate_objects_request with exponential-backoff retry on transient errors.
+
+    Retries up to len(_ASSOCIATION_RETRY_DELAYS) times on ApiException or
+    TooManyRequestsException before re-raising the last exception.
+    """
+    last_exc: Exception | None = None
+    for attempt, delay in enumerate(
+        (None, *_ASSOCIATION_RETRY_DELAYS), start=1
+    ):
+        if delay is not None:
+            log.warning(
+                "Retrying association (%s→%s) attempt %d after %ds",
+                from_type,
+                to_type,
+                attempt,
+                delay,
+            )
+            time.sleep(delay)
+        try:
+            wait_for_hubspot_rate_limit()
+            associate_objects_request(from_type, from_id, to_type, to_id, assoc_type)
+            return
+        except (ApiException, TooManyRequestsException) as exc:
+            last_exc = exc
+            log.warning(
+                "Association (%s %s → %s %s) failed on attempt %d: %s",
+                from_type,
+                from_id,
+                to_type,
+                to_id,
+                attempt,
+                exc,
+            )
+    raise last_exc
+
+
 def get_hubspot_id_for_object(  # noqa: C901
     obj: Order or Product or Line or User,
     raise_error: bool = False,  # noqa: FBT001, FBT002
@@ -1596,6 +1643,7 @@ def get_hubspot_id_for_object(  # noqa: C901
     ).first()
     if hubspot_obj:
         return hubspot_obj.hubspot_id
+    wait_for_hubspot_rate_limit()
     if isinstance(obj, User):
         try:
             hubspot_obj = find_contact(obj.email)
@@ -1669,8 +1717,16 @@ def sync_line_item_with_hubspot(line: Line) -> SimplePublicObject:
     )
     # Associate the parent deal with the line item
     deal_hubspot_id = get_hubspot_id_for_object(line.order)
+    if not deal_hubspot_id:
+        log.info(
+            "No HubSpot ID found for order %d; syncing deal before associating line %d",
+            line.order.id,
+            line.id,
+        )
+        sync_deal_with_hubspot(line.order)
+        deal_hubspot_id = get_hubspot_id_for_object(line.order)
     if deal_hubspot_id:
-        associate_objects_request(
+        _associate_objects_with_retry(
             HubspotObjectType.LINES.value,
             result.id,
             HubspotObjectType.DEALS.value,
@@ -1679,7 +1735,7 @@ def sync_line_item_with_hubspot(line: Line) -> SimplePublicObject:
         )
     else:
         log.warning(
-            "No HubSpot ID found for order %d; skipping line-deal association for line %d",
+            "No HubSpot ID found for order %d after sync; skipping line-deal association for line %d",
             line.order.id,
             line.id,
         )
@@ -1721,8 +1777,16 @@ def sync_deal_with_hubspot(order: Order) -> SimplePublicObject | None:
     )
     # Create association between deal and contact
     contact_hubspot_id = get_hubspot_id_for_object(order.purchaser)
+    if not contact_hubspot_id:
+        log.info(
+            "No HubSpot ID found for purchaser %d; syncing contact before associating deal %d",
+            order.purchaser.id,
+            order.id,
+        )
+        sync_contact_with_hubspot(order.purchaser)
+        contact_hubspot_id = get_hubspot_id_for_object(order.purchaser)
     if contact_hubspot_id:
-        associate_objects_request(
+        _associate_objects_with_retry(
             HubspotObjectType.DEALS.value,
             result.id,
             HubspotObjectType.CONTACTS.value,
@@ -1731,7 +1795,7 @@ def sync_deal_with_hubspot(order: Order) -> SimplePublicObject | None:
         )
     else:
         log.warning(
-            "No HubSpot ID found for purchaser %d; skipping deal-contact association for order %d",
+            "No HubSpot ID found for purchaser %d after sync; skipping deal-contact association for order %d",
             order.purchaser.id,
             order.id,
         )

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1592,7 +1592,9 @@ def _associate_objects_with_retry(
     """
     last_exc: Exception | None = None
     for attempt in range(1, _ASSOCIATION_MAX_ATTEMPTS + 1):
-        delay = _ASSOCIATION_INITIAL_RETRY_DELAY * 2 ** (attempt - 2) if attempt > 1 else 0
+        delay = (
+            _ASSOCIATION_INITIAL_RETRY_DELAY * 2 ** (attempt - 2) if attempt > 1 else 0
+        )
         if delay:
             log.warning(
                 "Retrying association (%s→%s) attempt %d after %ds",

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1668,13 +1668,21 @@ def sync_line_item_with_hubspot(line: Line) -> SimplePublicObject:
         content_type, HubspotObjectType.LINES.value, object_id=line.id, body=body
     )
     # Associate the parent deal with the line item
-    associate_objects_request(
-        HubspotObjectType.LINES.value,
-        result.id,
-        HubspotObjectType.DEALS.value,
-        get_hubspot_id_for_object(line.order),
-        HubspotAssociationType.LINE_DEAL.value,
-    )
+    deal_hubspot_id = get_hubspot_id_for_object(line.order)
+    if deal_hubspot_id:
+        associate_objects_request(
+            HubspotObjectType.LINES.value,
+            result.id,
+            HubspotObjectType.DEALS.value,
+            deal_hubspot_id,
+            HubspotAssociationType.LINE_DEAL.value,
+        )
+    else:
+        log.warning(
+            "No HubSpot ID found for order %d; skipping line-deal association for line %d",
+            line.order.id,
+            line.id,
+        )
     return result
 
 
@@ -1712,13 +1720,21 @@ def sync_deal_with_hubspot(order: Order) -> SimplePublicObject | None:
         content_type, HubspotObjectType.DEALS.value, object_id=order.id, body=body
     )
     # Create association between deal and contact
-    associate_objects_request(
-        HubspotObjectType.DEALS.value,
-        result.id,
-        HubspotObjectType.CONTACTS.value,
-        get_hubspot_id_for_object(order.purchaser),
-        HubspotAssociationType.DEAL_CONTACT.value,
-    )
+    contact_hubspot_id = get_hubspot_id_for_object(order.purchaser)
+    if contact_hubspot_id:
+        associate_objects_request(
+            HubspotObjectType.DEALS.value,
+            result.id,
+            HubspotObjectType.CONTACTS.value,
+            contact_hubspot_id,
+            HubspotAssociationType.DEAL_CONTACT.value,
+        )
+    else:
+        log.warning(
+            "No HubSpot ID found for purchaser %d; skipping deal-contact association for order %d",
+            order.purchaser.id,
+            order.id,
+        )
 
     for line in order.lines.all():
         sync_line_item_with_hubspot(line)
@@ -1755,6 +1771,11 @@ def sync_deal_with_hubspot_targeted(  # noqa: C901
     deal_input = _build_target_deal_message(order, hubspot_client)
     dealname = deal_input.properties.get("dealname")
     unique_app_id = deal_input.properties.get("unique_app_id")
+
+    # Ensure all products for this order's lines exist in the target account before
+    # creating the deal, so that line items can reference valid product IDs.
+    for line in order.lines.all():
+        _ensure_target_hubspot_product_for_line(line, hubspot_client)
 
     # Check if deal already exists by dealname first
     existing_deal_id = _find_target_deal_id_by_dealname(hubspot_client, dealname)
@@ -2564,6 +2585,11 @@ def _sync_cart_add_deal_with_hubspot(
 
     # Extract unique_app_id from deal input to check for existing deals
     unique_app_id = deal_input.properties.get("unique_app_id")
+
+    # Ensure all products for this order's lines exist in the target account before
+    # creating the deal, so that line items can reference valid product IDs.
+    for line in order.lines.all():
+        _ensure_target_hubspot_product_for_line(line, hubspot_client)
 
     # Use the same dual lookup logic as checkout flow to prevent duplicates
     existing_deal_id = _find_target_deal_id_by_dealname(

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1590,9 +1590,7 @@ def _associate_objects_with_retry(
     TooManyRequestsException before re-raising the last exception.
     """
     last_exc: Exception | None = None
-    for attempt, delay in enumerate(
-        (None, *_ASSOCIATION_RETRY_DELAYS), start=1
-    ):
+    for attempt, delay in enumerate((None, *_ASSOCIATION_RETRY_DELAYS), start=1):
         if delay is not None:
             log.warning(
                 "Retrying association (%s→%s) attempt %d after %ds",

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1574,7 +1574,8 @@ def sync_deal_line_hubspot_ids_to_db(order, hubspot_order_id) -> bool:
     return matches == expected_matches
 
 
-_ASSOCIATION_RETRY_DELAYS = (1, 2, 4)  # seconds between attempts (3 total tries)
+_ASSOCIATION_MAX_ATTEMPTS = 4  # 1 initial attempt + 3 retries
+_ASSOCIATION_INITIAL_RETRY_DELAY = 1  # seconds; doubles each retry
 
 
 def _associate_objects_with_retry(
@@ -1586,12 +1587,13 @@ def _associate_objects_with_retry(
 ) -> None:
     """Call associate_objects_request with exponential-backoff retry on transient errors.
 
-    Retries up to len(_ASSOCIATION_RETRY_DELAYS) times on ApiException or
+    Retries up to _ASSOCIATION_MAX_ATTEMPTS - 1 times on ApiException or
     TooManyRequestsException before re-raising the last exception.
     """
     last_exc: Exception | None = None
-    for attempt, delay in enumerate((None, *_ASSOCIATION_RETRY_DELAYS), start=1):
-        if delay is not None:
+    for attempt in range(1, _ASSOCIATION_MAX_ATTEMPTS + 1):
+        delay = _ASSOCIATION_INITIAL_RETRY_DELAY * 2 ** (attempt - 2) if attempt > 1 else 0
+        if delay:
             log.warning(
                 "Retrying association (%s→%s) attempt %d after %ds",
                 from_type,

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1605,8 +1605,6 @@ def _associate_objects_with_retry(
             associate_objects_request(from_type, from_id, to_type, to_id, assoc_type)
         except (ApiException, TooManyRequestsException) as exc:
             last_exc = exc
-        else:
-            return
             log.warning(
                 "Association (%s %s → %s %s) failed on attempt %d: %s",
                 from_type,
@@ -1616,6 +1614,8 @@ def _associate_objects_with_retry(
                 attempt,
                 exc,
             )
+        else:
+            return
     raise last_exc
 
 

--- a/hubspot_sync/api.py
+++ b/hubspot_sync/api.py
@@ -1605,9 +1605,10 @@ def _associate_objects_with_retry(
         try:
             wait_for_hubspot_rate_limit()
             associate_objects_request(from_type, from_id, to_type, to_id, assoc_type)
-            return
         except (ApiException, TooManyRequestsException) as exc:
             last_exc = exc
+        else:
+            return
             log.warning(
                 "Association (%s %s → %s %s) failed on attempt %d: %s",
                 from_type,

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -1002,6 +1002,9 @@ def test_sync_cart_add_deal_with_hubspot_sets_checkout_abandoned_stage(
     mocker.patch(
         "hubspot_sync.api._find_target_deal_id_by_unique_app_id", return_value=None
     )
+    mocker.patch(
+        "hubspot_sync.api._ensure_target_hubspot_product_for_line", return_value=None
+    )
     mock_normalize = mocker.patch(
         "hubspot_sync.api._normalize_deal_properties_for_target_account"
     )
@@ -1045,6 +1048,9 @@ def test_sync_cart_add_deal_with_hubspot_normalizes_stage_after_override(
     mocker.patch("hubspot_sync.api._find_target_deal_id_by_dealname", return_value=None)
     mocker.patch(
         "hubspot_sync.api._find_target_deal_id_by_unique_app_id", return_value=None
+    )
+    mocker.patch(
+        "hubspot_sync.api._ensure_target_hubspot_product_for_line", return_value=None
     )
 
     def _normalize_to_created(_client, deal_input):

--- a/hubspot_sync/api_test.py
+++ b/hubspot_sync/api_test.py
@@ -489,6 +489,24 @@ def test_sync_deal_with_hubspot(mocker, mock_hubspot_api, hubspot_order):
     )
 
 
+def test_sync_deal_with_hubspot_syncs_contact_when_missing(
+    mocker, mock_hubspot_api, hubspot_order
+):
+    """When no contact HubSpot ID exists, sync_deal_with_hubspot should sync the contact and retry."""
+    mocker.patch("hubspot_sync.api.sync_line_item_with_hubspot", autospec=True)
+    mock_sync_contact = mocker.patch(
+        "hubspot_sync.api.sync_contact_with_hubspot", autospec=True
+    )
+    # Sequence: order lookup (discarded), purchaser first check (None→retry), purchaser after sync
+    mock_get_id = mocker.patch("hubspot_sync.api.get_hubspot_id_for_object")
+    mock_get_id.side_effect = [None, None, "contact-hs-id"]
+
+    api.sync_deal_with_hubspot(hubspot_order)
+
+    mock_sync_contact.assert_called_once_with(hubspot_order.purchaser)
+    mock_hubspot_api.return_value.crm.associations.v4.basic_api.create_default.assert_called_once()
+
+
 def test_sync_deal_with_hubspot_skips_b2b_users(mocker, mock_hubspot_api):
     """Test that B2B users are skipped and not synced to HubSpot for deals"""
     order = OrderFactory.create()
@@ -647,6 +665,68 @@ def test_sync_line_item_with_hubspot(
         to_object_type=api.HubspotObjectType.DEALS.value,
         to_object_id=hubspot_order_id,
     )
+
+
+def test_sync_line_item_with_hubspot_syncs_deal_when_missing(
+    mocker, mock_hubspot_api, hubspot_order
+):
+    """When no deal HubSpot ID exists, sync_line_item_with_hubspot should sync the deal and retry."""
+    line = hubspot_order.lines.first()
+    mock_sync_deal = mocker.patch(
+        "hubspot_sync.api.sync_deal_with_hubspot", autospec=True
+    )
+    # Sequence: line lookup (discarded), order first check (None→retry), order after sync
+    mock_get_id = mocker.patch("hubspot_sync.api.get_hubspot_id_for_object")
+    mock_get_id.side_effect = [None, None, "deal-hs-id"]
+
+    api.sync_line_item_with_hubspot(line)
+
+    mock_sync_deal.assert_called_once_with(hubspot_order)
+    mock_hubspot_api.return_value.crm.associations.v4.basic_api.create_default.assert_called_once()
+
+
+def test_associate_objects_with_retry_succeeds_on_first_attempt(mocker):
+    """No sleep or extra calls when the association succeeds immediately."""
+    mock_associate = mocker.patch(
+        "hubspot_sync.api.associate_objects_request", return_value=None
+    )
+    mock_sleep = mocker.patch("hubspot_sync.api.time.sleep")
+    mocker.patch("hubspot_sync.api.wait_for_hubspot_rate_limit")
+
+    api._associate_objects_with_retry("lines", "1", "deals", "2", "line_to_deal")  # noqa: SLF001
+
+    mock_associate.assert_called_once_with("lines", "1", "deals", "2", "line_to_deal")
+    mock_sleep.assert_not_called()
+
+
+def test_associate_objects_with_retry_retries_on_api_exception(mocker):
+    """Should retry on ApiException and succeed if a later attempt works."""
+    exc = ApiException(status=500)
+    mock_associate = mocker.patch(
+        "hubspot_sync.api.associate_objects_request",
+        side_effect=[exc, exc, None],
+    )
+    mock_sleep = mocker.patch("hubspot_sync.api.time.sleep")
+    mocker.patch("hubspot_sync.api.wait_for_hubspot_rate_limit")
+
+    api._associate_objects_with_retry("lines", "1", "deals", "2", "line_to_deal")  # noqa: SLF001
+
+    assert mock_associate.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+def test_associate_objects_with_retry_raises_after_exhausting_retries(mocker):
+    """Should raise the last exception once all retry attempts are exhausted."""
+    exc = ApiException(status=500)
+    mocker.patch(
+        "hubspot_sync.api.associate_objects_request",
+        side_effect=exc,
+    )
+    mocker.patch("hubspot_sync.api.time.sleep")
+    mocker.patch("hubspot_sync.api.wait_for_hubspot_rate_limit")
+
+    with pytest.raises(ApiException):
+        api._associate_objects_with_retry("lines", "1", "deals", "2", "line_to_deal")  # noqa: SLF001
 
 
 @pytest.mark.parametrize("match_all", [True, False])


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
There's an issue when creating deals in hubspot for the following free program/course 
program-v1:UAI+B2C.1.  This is a UAI program/course so any deal created for it should be created in the Xpro hubspot account.  My thought is that this is happening because the product record in Hubspot for program-v1:UAI+B2C.1 was only created in the MItx Online hubspot account and not in the Xpro account.  All UAI courses and program deals are created in the Xpro account.  This results in errors when trying to create a deal and associate it with the product or contact in the Xpro account if the product or contact does not exist.

This PR ensures that the product and contact exist in hubspot, and adds some retry logic if the requests to create those records fail, before trying to associate the deal with the contact and product record.

### How can this be tested?
You can create a UAI course that does not have a hubspot product record.  Make sure that course is free to enroll.  Then attempt to enroll into the course and verify that a contact and product record are created in the Xpro dev hubspot account.
