### PR TITLE
fix: pin migrated entitlement orders to $0 product_version to reflect edX payment  

### DIFF
--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -640,7 +640,7 @@ class Command(BaseCommand):
             )
         )
 
-    def _migrate_entitlements(self, conn, options):
+    def _migrate_entitlements(self, conn, options):  # noqa: PLR0915
         """
         Migrate entitlement from edX to MITx Online. Create program Order instances.
         """

--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -711,6 +711,18 @@ class Command(BaseCommand):
                         )
                         continue
 
+                    if (
+                        product_version.content_type_id != product.content_type_id
+                        or product_version.field_dict.get("id") != product.id
+                    ):
+                        self.stdout.write(
+                            self.style.ERROR(
+                                f"product_version={product_version.id} does not match "
+                                f"product={product.id} for row: {row}"
+                            )
+                        )
+                        continue
+
                     existing_enrollment = ProgramEnrollment.all_objects.filter(
                         user=user,
                         program=program,
@@ -732,6 +744,19 @@ class Command(BaseCommand):
                         order = PendingOrder.create_from_product(
                             product, user, discount=None
                         )
+                        # create_from_product always pins the Line to the product's
+                        # most recent reversion Version. Re-pin it to the historical
+                        # version recorded at the time the entitlement was granted,
+                        # so the order reflects the price that was actually paid.
+                        line = order.lines.get(
+                            purchased_object_id=product.object_id,
+                            purchased_content_type_id=product.content_type_id,
+                        )
+                        if line.product_version_id != product_version.id:
+                            line.product_version = product_version
+                            line.save(update_fields=["product_version"])
+                            order.total_price_paid = line.discounted_price
+                            order.save(update_fields=["total_price_paid"])
                         fulfill_completed_order(
                             order,
                             payment_data=ZERO_PAYMENT_DATA,

--- a/courses/management/commands/migrate_edx_data.py
+++ b/courses/management/commands/migrate_edx_data.py
@@ -649,6 +649,8 @@ class Command(BaseCommand):
 
         cur = conn.cursor()
 
+        product_content_type_id = ContentType.objects.get_for_model(Product).id
+
         query = (
             "SELECT * FROM edxorg_to_mitxonline_program_entitlements "
             "WHERE order_id IS NULL"
@@ -712,7 +714,7 @@ class Command(BaseCommand):
                         continue
 
                     if (
-                        product_version.content_type_id != product.content_type_id
+                        product_version.content_type_id != product_content_type_id
                         or product_version.field_dict.get("id") != product.id
                     ):
                         self.stdout.write(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10382

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates `migrate_edx_data -- type entitlements` command to pin the entitlement order's Line to the `product_version_id` ($0 on production) for the edX paid entitlements and these edX entitlement order reflects $0 total price paid on Learn.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Ensure you setup programs, program products locally

To use your local data, modify the query in line 652 to be something like:

```
  query = (
      "SELECT program_id, user_mitxonline_id, contenttype_id, product_version_id "
      "FROM ("
      "  VALUES "
      "    (1, 1, 61, 1),"
      "    (2, 1, 61, 5)"
      ") AS t(program_id, user_mitxonline_id, contenttype_id, product_version_id)"
  )
```
`user_mitxonline_id` is your user ID
To find out `contenttype_id` for program, run this query in dbshell
```
postgres=# select * from django_content_type where model='program';
 id | app_label |  model  
----+-----------+---------
 61 | courses   | program
(1 row)

```
To find out `product_version_id` for a program, run this query in dbshell. 
```
---program product ID is on admin/ecommerce/product/<program product ID>
postgres=# select id from reversion_version where object_id ='<program product ID>' limit 1;
```

Run `manage.py migrate_edx_data --type entitlements`

Verify 
- program orders created at http://mitxonline.odl.local:8013/admin/ecommerce/fulfilledorder/ with the product version price you pin in the above step
- program enrollments created at http://mitxonline.odl.local:8013/admin/courses/programenrollment/
- paid program enrollments at http://mitxonline.odl.local:8013/admin/courses/paidprogram/

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->

