### PR TITLE
Tag enrollment code assignment emails via mailgun tag header

### DIFF
--- a/b2b/mail.py
+++ b/b2b/mail.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 from django.conf import settings
 from mitol.mail.api import get_message_sender
@@ -32,7 +33,7 @@ def get_learn_hostname():
 def send_email_helper(email, code, code_url, organization_name, contract_name):
     try:
         with get_message_sender(EnrollmentCodeAssignmentMessage) as sender:
-            sender.build_and_send_message(
+            message = sender.build_message(
                 email,
                 {
                     "code": code,
@@ -41,6 +42,21 @@ def send_email_helper(email, code, code_url, organization_name, contract_name):
                     "contract_name": contract_name,
                 },
             )
+            # send_message swallows exceptions, so we'll favor direct calls to message.send()
+            message.send()
+
+            # The message_id is primarily to be used to tie back to mailgun webhook events unambiguously
+            # In the case of a local SMTP server the message_id will be none so we just generate a UUID
+            if (
+                settings.MITOL_MAIL_CONNECTION_BACKEND
+                == "anymail.backends.mailgun.EmailBackend"
+            ):
+                recipient_status = message.anymail_status.recipients.get(email)
+                message_id = recipient_status.message_id if recipient_status else None
+            else:
+                message_id = str(uuid.uuid4())
+
+            return message_id
     except:  # pylint: disable=bare-except  # noqa: E722
         log.exception("Error sending enrollment code assignment email.")
 

--- a/b2b/mail.py
+++ b/b2b/mail.py
@@ -8,10 +8,19 @@ from b2b.models import ContractPage, DiscountContractAttachmentRedemption
 
 log = logging.getLogger(__name__)
 
+ENROLLMENT_CODE_ASSINGMENT_TAG = "enrollment-code-assignment"
+
 
 class EnrollmentCodeAssignmentMessage(TemplatedMessage):
     template_name = "mail/enrollment_code_assignment"
     name = "Enrollment Code Assignment"
+
+    @staticmethod
+    def get_default_headers() -> dict:
+        base_headers = TemplatedMessage.get_default_headers()
+        headers = base_headers.copy()
+        headers["X-Mailgun-Tag"] = ENROLLMENT_CODE_ASSINGMENT_TAG
+        return headers
 
 
 def get_learn_hostname():

--- a/b2b/mail_test.py
+++ b/b2b/mail_test.py
@@ -1,0 +1,126 @@
+"""Tests for B2B mail."""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from anymail.message import AnymailRecipientStatus, AnymailStatus
+from django.test import override_settings
+
+from b2b.mail import EnrollmentCodeAssignmentMessage, send_email_helper
+
+pytestmark = [pytest.mark.django_db]
+
+EMAIL = "learner@example.com"
+CODE = "SOMECODE"
+CODE_URL = "https://learn.mit.edu/enrollmentcode/SOMECODE"
+ORGANIZATION_NAME = "Test Org"
+CONTRACT_NAME = "Test Contract"
+
+MAILGUN_BACKEND = "anymail.backends.mailgun.EmailBackend"
+SMTP_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+
+def make_fake_message(mocker, message_id=None, send_side_effect=None):
+    """
+    Bypass real message construction (template rendering/premailer) by patching
+    EnrollmentCodeAssignmentMessage.create to hand back a fake message object we
+    control directly, with anymail_status pre-populated as if already sent.
+    """
+    message = MagicMock()
+    message.anymail_status = AnymailStatus()
+    if message_id is not None:
+        message.anymail_status.set_recipient_status(
+            {EMAIL: AnymailRecipientStatus(message_id=message_id, status="queued")}
+        )
+    if send_side_effect is not None:
+        message.send.side_effect = send_side_effect
+    mocker.patch.object(EnrollmentCodeAssignmentMessage, "create", return_value=message)
+    return message
+
+
+@override_settings(MITOL_MAIL_CONNECTION_BACKEND=MAILGUN_BACKEND)
+def test_send_email_helper_returns_mailgun_message_id(mocker):
+    """When using the mailgun backend, the mailgun message id should be returned."""
+    make_fake_message(mocker, message_id="mailgun-message-id-123")
+
+    message_id = send_email_helper(
+        EMAIL, CODE, CODE_URL, ORGANIZATION_NAME, CONTRACT_NAME
+    )
+
+    assert message_id == "mailgun-message-id-123"
+
+
+@override_settings(MITOL_MAIL_CONNECTION_BACKEND=MAILGUN_BACKEND)
+def test_send_email_helper_returns_none_when_mailgun_status_missing(mocker):
+    """
+    If the mailgun backend is configured but no recipient status ends up on the
+    message (e.g. the send didn't populate it), we should get None back rather
+    than raising.
+    """
+    make_fake_message(mocker)
+
+    message_id = send_email_helper(
+        EMAIL, CODE, CODE_URL, ORGANIZATION_NAME, CONTRACT_NAME
+    )
+
+    assert message_id is None
+
+
+@override_settings(MITOL_MAIL_CONNECTION_BACKEND=SMTP_BACKEND)
+def test_send_email_helper_returns_uuid_for_non_mailgun_backend(mocker):
+    """When not using the mailgun backend (e.g. local SMTP), a UUID should be generated instead."""
+    make_fake_message(mocker)
+
+    message_id = send_email_helper(
+        EMAIL, CODE, CODE_URL, ORGANIZATION_NAME, CONTRACT_NAME
+    )
+
+    assert message_id is not None
+    assert uuid.UUID(message_id, version=4)
+
+
+@override_settings(MITOL_MAIL_CONNECTION_BACKEND=SMTP_BACKEND)
+def test_send_email_helper_generates_unique_uuids_for_non_mailgun_backend(mocker):
+    """Each send on a non-mailgun backend should get its own unique fallback id."""
+    make_fake_message(mocker)
+
+    first_id = send_email_helper(
+        EMAIL, CODE, CODE_URL, ORGANIZATION_NAME, CONTRACT_NAME
+    )
+    second_id = send_email_helper(
+        EMAIL, CODE, CODE_URL, ORGANIZATION_NAME, CONTRACT_NAME
+    )
+
+    assert first_id != second_id
+
+
+@override_settings(MITOL_MAIL_CONNECTION_BACKEND=SMTP_BACKEND)
+def test_send_email_helper_ignores_mailgun_status_on_non_mailgun_backend(mocker):
+    """
+    Even if anymail_status happens to be populated (e.g. leftover from a prior
+    send), a non-mailgun backend should still return a generated UUID rather
+    than the mailgun message id.
+    """
+    make_fake_message(mocker, message_id="mailgun-message-id-should-be-ignored")
+
+    message_id = send_email_helper(
+        EMAIL, CODE, CODE_URL, ORGANIZATION_NAME, CONTRACT_NAME
+    )
+
+    assert message_id != "mailgun-message-id-should-be-ignored"
+    assert uuid.UUID(message_id, version=4)
+
+
+@override_settings(MITOL_MAIL_CONNECTION_BACKEND=MAILGUN_BACKEND)
+def test_send_email_helper_logs_and_returns_none_on_send_error(mocker):
+    """If sending raises, the exception should be logged and swallowed, returning None."""
+    make_fake_message(mocker, send_side_effect=ConnectionError("boom"))
+    patched_logger = mocker.patch("b2b.mail.log")
+
+    message_id = send_email_helper(
+        EMAIL, CODE, CODE_URL, ORGANIZATION_NAME, CONTRACT_NAME
+    )
+
+    assert message_id is None
+    patched_logger.exception.assert_called_once()


### PR DESCRIPTION
### What are the relevant tickets?
Small part of https://github.com/mitodl/hq/issues/12114

### Description (What does it do?)
This adds a [mailgun tag](https://mailgun-docs.redoc.ly/docs/mailgun/user-manual/tracking-messages/#tags) for the enrollment code assignment emails sent by the B2B dashboard and retrieves/generates a [message_id](https://www.mailgun.com/glossary/message-id/) for anything sent

The forthcoming functionality to store email deliverability status for display depends on one of two approaches:
- Calling the Mailgun events API and filtering down to emails we care about in a downstream task. This is what xpro does, though as email delivery is asynchronous and unpredictable, this raises questions about how close to real time the data would be available.
- Setting up webhooks and processing events for emails we care about. This has the potential to be closer to real time than pulling events on a cadence, at the cost of needing to process spiky workloads asynchronously

In either case we need to be able to store the message id we sent so that when we get an event in either manner, we are able to unambiguously tie it back to the email we sent. If we don't have that value and a user, for example, received multiple enrollment code emails, we wouldn't know for sure which one an event corresponded to.

In a subsequent PR, we'll add fields to the DiscountContractAttachmentRedemption records to persist these values for lookup when we process deliverability events, and the values we get back from those event payloads will be used to update email deliverability status fields on the corresponding record.

### Screenshots (if appropriate):
<img width="1305" height="755" alt="Screenshot 2026-07-16 at 11 49 43 AM" src="https://github.com/user-attachments/assets/0e67f564-4745-40ba-93d4-3248b6f5ea69" />


### How can this be tested?
- Set up mailpit and set MITOL_MAIL_CONNECTION_BACKEND='django.core.mail.backends.smtp.EmailBackend'
- Set MITX_ONLINE_EMAIL_HOST and MITX_ONLINE_EMAIL_PORT to wherever mailpit is running.
- For a b2b contract you are an admin for, assign a code.
- In mailpit you should get an invitation, and if you look at its headers there should be a `X-Mailgun-Tag: enrollment-code-assignment` header.

Mailgun can't be as easily tested, so we'll verify that in CI/RC. That said I did run the following snippet in RC to validate the behavior of how we pull the message_id from the sent message:
```
from mitol.mail.api import get_message_sender

from b2b.mail import EnrollmentCodeAssignmentMessage, get_learn_hostname

# EDIT ME before running
TEST_RECIPIENT = "dansubak+testingmessageid@mit.edu"
TEST_CODE = "TESTCODE123"
TEST_ORGANIZATION_NAME = "Test Organization"
TEST_CONTRACT_NAME = "Test Contract"

learn_hostname = get_learn_hostname()
code_url = f"https://{learn_hostname}/enrollmentcode/{TEST_CODE}"

with get_message_sender(EnrollmentCodeAssignmentMessage) as sender:
    message = sender.build_message(
        TEST_RECIPIENT,
        {
            "code": TEST_CODE,
            "code_url": code_url,
            "organization_name": TEST_ORGANIZATION_NAME,
            "contract_name": TEST_CONTRACT_NAME,
        },
    )
    message.send()

    print("anymail_status:", repr(message.anymail_status))
    recipient_status = message.anymail_status.recipients.get(TEST_RECIPIENT)
    message_id = recipient_status.message_id if recipient_status else None
    print(f"mailgun message_id for {TEST_RECIPIENT}: {message_id}")
```

