### PR TITLE
Text changes for enrollment code email

### DIFF
--- a/b2b/templates/mail/enrollment_code_assignment/body.html
+++ b/b2b/templates/mail/enrollment_code_assignment/body.html
@@ -13,7 +13,7 @@
               <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px;"><strong>{{ organization_name }}</strong> has provided you with access to <strong>{{ contract_name }}</strong> on MIT Learn.</p>
-                      <p style="margin: 20px 0 10px;">Claim your seat to view your available courses and begin learning.</p>
+                      <p style="margin: 20px 0 10px;">Enroll to access your courses and begin learning.</p>
                   </td>
               </tr>
               <tr>
@@ -34,7 +34,7 @@
               padding: 16px;
               color: #fff;
               display: block;
-              border-radius: 4px;">Claim Your Seat</a>
+              border-radius: 4px;">Enroll</a>
                               </td>
                           </tr>
                       </table>


### PR DESCRIPTION
### Description (What does it do?)
Just makes a few changes at @steven-hatch's suggestion.
`Claim your seat to view your available courses and begin learning.` -> `Enroll to access your courses and begin learning.`
and
`Claim Your Seat` -> `Enroll`

### Screenshots (if appropriate):
<img width="1278" height="841" alt="Screenshot 2026-07-16 at 2 45 27 PM" src="https://github.com/user-attachments/assets/ce68ee33-64b4-4c23-b41a-fb5f6a141802" />


### How can this be tested?
- Set up mailpit and set MITOL_MAIL_CONNECTION_BACKEND='django.core.mail.backends.smtp.EmailBackend'
- Set MITX_ONLINE_EMAIL_HOST and MITX_ONLINE_EMAIL_PORT to wherever mailpit is running.
- For a b2b contract you are an admin for, assign a code.
- Observe that the email text has the specified changes

### Additional Context
See https://github.com/mitodl/mit-learn/pull/3630 for the bulk of the recommended changes.