### PR TITLE
Short circuit empty list

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -75,6 +75,12 @@ class CodeAssignment:
 def assign_codes_and_send_emails(
     assignments: list[CodeAssignment], assigning_user
 ) -> bool:
+    # If we're passed an empty list, short circuit and return true
+    # This can happen in bulk_assign if all users in the payload have already
+    # been assigned or redeemed a code for the contract
+    if not assignments:
+        return True
+
     assignment_records = []
     for assignment in assignments:
         # For bulk_create, we have to set the auto timestamps manually.

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -2131,15 +2131,14 @@ def test_assign_codes_and_send_emails_bulk_create_failure(
 
 
 def test_assign_codes_and_send_emails_empty_list(org_setup, mock_email_task):
-    """An empty assignments list creates no records but still queues the task."""
-    # This functionality should be removed in the future and replaced with an early return.
+    """An empty assignments list creates no records and dispatches no task."""
     manager_user, *_ = org_setup
 
     result = assign_codes_and_send_emails([], manager_user)
 
     assert result is True
     assert not DiscountContractAttachmentRedemption.objects.exists()
-    mock_email_task.delay.assert_called_once_with([])
+    mock_email_task.delay.assert_not_called()
 
 
 def test_assign_codes_and_send_emails_timestamps_are_set(org_setup, mock_email_task):


### PR DESCRIPTION
### Description (What does it do?)
In reviewing a set of tests written for some of our b2b admin dash API endpoints and helper methods, we found that we're [dispatching pointless tasks](https://github.com/mitodl/mitxonline/pull/3756#discussion_r3603800257) if a payload has everything filtered out. This can happen due to all emails already having an assigned or redeemed code - the response is correct, but we're doing more work than we need to.

This PR simply short circuits it. Once the abovelinked PR lands, I'll rebase and update the test.

### How can this be tested?
Tests should pass.

- Visit a b2b contract you're an admin for and attempt to assign a code to an email that has an outstanding assignment or has redeemed a code in that contract.
- You should not observe a `queue_send_enrollment_code_assignment_email` task being fired.