### PR TITLE
Remove auth requirement for post-checkout page; add backoffice API logs

### DIFF
--- a/ecommerce/views/legacy/__init__.py
+++ b/ecommerce/views/legacy/__init__.py
@@ -798,6 +798,9 @@ class CheckoutCallbackView(View):
     Handle a checkout cancellation or receipt
     """
 
+    authentication_classes = []  # disables authentication
+    permission_classes = []  # disables permission
+
     def __init__(self, *args, **kwargs):  # noqa: ARG002
         self.logger = logging.getLogger(__name__)
 
@@ -836,15 +839,10 @@ class CheckoutCallbackView(View):
                 },
             )
         else:
-            if not PaymentGateway.validate_processor_response(
+            processor_response = PaymentGateway.get_formatted_response(
                 settings.ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
-            ):
-                log.info("Could not validate payment response for order")
-            else:
-                processor_response = PaymentGateway.get_formatted_response(
-                    settings.ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
-                )
-            log.error(
+            )
+            self.logger.error(
                 "Checkout callback unknown error for transaction_id %s, state %s, reason_code %s, message %s, and ProcessorResponse %s",
                 processor_response.transaction_id,
                 order_state,
@@ -867,6 +865,23 @@ class CheckoutCallbackView(View):
         clear out the stored basket)
         3. Perform any enrollments, account status changes, etc.
         """
+
+        if not PaymentGateway.validate_processor_response(
+            settings.ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
+        ):
+            user_email = (
+                "anonymous"
+                if not request.user or request.user.is_anomymous
+                else request.user.email
+            )
+
+            self.logger.error(
+                "CheckoutCallbackView: unable to validate the processor payload for user %s",
+                user_email,
+            )
+            return Response(
+                "Unable to validate request.", status=status.HTTP_403_UNAUTHORIZED
+            )
 
         with transaction.atomic():
             order = api.get_order_from_cybersource_payment_response(request)
@@ -919,6 +934,16 @@ class BackofficeCallbackView(APIView):
         This endpoint is called by Cybersource as a server-to-server call
         to respond with the payment details.
         """
+        if not PaymentGateway.validate_processor_response(
+            settings.ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, request
+        ):
+            log.error(
+                "BackofficeCallbackView: unable to validate the processor payload from CyberSource"
+            )
+            return Response(
+                "Unable to validate request.", status=status.HTTP_401_UNAUTHORIZED
+            )
+
         with transaction.atomic():
             order = api.get_order_from_cybersource_payment_response(request)
 

--- a/ecommerce/views/legacy/views_test.py
+++ b/ecommerce/views/legacy/views_test.py
@@ -10,7 +10,9 @@ from django.forms.models import model_to_dict
 from django.test import Client, RequestFactory
 from django.urls import reverse
 from mitol.common.utils.datetime import now_in_utc
+from mitol.payment_gateway.api import PaymentGateway
 from rest_framework import status
+from reversion.models import Version
 
 from b2b.factories import ContractPageFactory
 from courses.factories import CourseRunFactory, ProgramFactory, ProgramRunFactory
@@ -22,12 +24,14 @@ from ecommerce.constants import (
     PAYMENT_TYPE_CUSTOMER_SUPPORT,
     PAYMENT_TYPE_FINANCIAL_ASSISTANCE,
     REDEMPTION_TYPE_ONE_TIME,
+    REFERENCE_NUMBER_PREFIX,
 )
 from ecommerce.discounts import DiscountType
 from ecommerce.factories import (
     BasketFactory,
     BasketItemFactory,
     DiscountFactory,
+    LineFactory,
     ProductFactory,
     UnlimitedUseDiscountFactory,
 )
@@ -1273,7 +1277,6 @@ def test_checkout_api_result(  # noqa: PLR0913
 
 @pytest.mark.skip_nplusone_check
 def test_checkout_api_result_verification_failure(
-    user_client,
     api_client,
     mocker,
     user,
@@ -1301,8 +1304,8 @@ def test_checkout_api_result_verification_failure(
 
     resp = api_client.post(reverse("checkout_result_api"), payload)
 
-    # checkout_result_api will always respond with a 403 if validate_processor_response returns False
-    assert resp.status_code == 403
+    # the validation gets checked sooner now, and returns a 401
+    assert resp.status_code == 401
 
 
 @pytest.mark.skip_nplusone_check
@@ -1561,3 +1564,93 @@ def test_program_product_purchasing(user, user_drf_client):
     assert ProgramEnrollment.objects.filter(
         user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
     ).exists()
+
+
+def test_backoffice_callback_invalid_payload(mocker, client):
+    """Test that the backoffice API fails out early if the payload is invalid."""
+
+    payload = {
+        "signature": "123456",
+        "waffles": "",
+        "signed_field_names": "waffles",
+    }
+
+    mocked_get_order = mocker.patch(
+        "ecommerce.api.get_order_from_cybersource_payment_response"
+    )
+
+    response = client.post(reverse("checkout_result_api"), payload)
+
+    assert response.status_code == 401
+    mocked_get_order.assert_not_called()
+
+
+def test_backoffice_callback_bad_order(mocker, client, settings):
+    """Test that the backoffice API returns 404 if there's no order."""
+
+    last_order = Order.objects.order_by("pk").last()
+    max_order_id = (last_order.id if last_order else 0) + 200
+
+    payload = {
+        "req_consumer_id": "bob@doe.local",
+        "req_customer_ip_address": "127.0.0.1",
+        "req_reference_number": f"{REFERENCE_NUMBER_PREFIX}{settings.ENVIRONMENT}-{max_order_id}",
+        "req_line_item_count": 0,
+    }
+
+    mocked_processor = mocker.patch(
+        "ecommerce.api.process_cybersource_payment_response"
+    )
+
+    payload = PaymentGateway.get_gateway_class(  # noqa: SLF001
+        settings.ECOMMERCE_DEFAULT_PAYMENT_GATEWAY
+    )._sign_cybersource_payload(payload)
+
+    response = client.post(reverse("checkout_result_api"), payload)
+
+    assert response.status_code == 404
+    mocked_processor.assert_not_called()
+
+
+def test_backoffice_callback_good_order(mocker, client, settings):
+    """Test that the backoffice API fullfils the order if it's good."""
+
+    with reversion.create_revision():
+        product = ProductFactory.create()
+
+    product_version = Version.objects.get_for_object(product).first()
+
+    order_line = LineFactory.create(product_version=product_version)
+    order = order_line.order
+
+    # Ultimately, don't really care that much about the payload
+    # A successful one is fine - fully testing fulfillment is done elsewhere
+    payload = {
+        "req_consumer_id": "bob@doe.local",
+        "req_customer_ip_address": "127.0.0.1",
+        "req_reference_number": order.reference_number,
+        "req_line_item_count": 1,
+        "req_item_0_code": order_line.courseware,
+        "req_item_0_name": order_line.courseware,
+        "req_item_0_sku": order_line.product.id,
+        "req_item_0_unit_price": order_line.total_price,
+        "req_item_0_tax_amount": 0,
+        "req_item_0_quantity": 1,
+        "message": "Completed",
+        "reason_code": "",
+        "transaction_id": "12345abcde",
+        "decision": "ACCEPT",
+    }
+
+    mocked_processor = mocker.patch(
+        "ecommerce.api.process_cybersource_payment_response"
+    )
+
+    payload = PaymentGateway.get_gateway_class(  # noqa: SLF001
+        settings.ECOMMERCE_DEFAULT_PAYMENT_GATEWAY
+    )._sign_cybersource_payload(payload)
+
+    response = client.post(reverse("checkout_result_api"), payload)
+
+    assert response.status_code == 200
+    mocked_processor.assert_called()


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#12460

### Description (What does it do?)

This PR does two main things:

- Removes the authentication requirement for `/checkout/result`. This endpoint only accepts a POST and expects a CyberSource payload to process; it didn't really need authentication and that may have been tripping some people up.
- Adds more logging to the backoffice endpoint - `/api/checkout/result`. If the payload posted to this endpoint is invalid, this will generate a 401 Unauthorized message; now it will log when that happens, so we can have a better chance of tracking down issues with the webhook.

As part of these changes, this PR also:

- Adds some tests for the backoffice API endpoint. There weren't any before. (Mostly because this didn't really do much that was special, but now there are some tests to make sure the data is validated properly.)
- Updates both endpoints to validate the payload at the very start of the process. Neither of these endpoints require authentication so the app should be making sure that the payload is valid for processing before doing anything with it.

### How can this be tested?

Automated tests should pass.

To test the user facing endpoint: You will need to set up CyberSource integration so you can complete the checkout process. Then, start the checkout process, and clear your MITx Online session once you get into CyberSource. You should be able to do this by loading the app up in a separate tab, opening the dev tools and clearing the cookies/etc. Complete your checkout and you should be redirected back to the app, where you will be logged out. It should still process your order and fulfill it, so you should be able to check orders to see that yours has gone through.

To test the webhook endpoint: You will need to construct a payload and post it to the `/api/checkout/result/` endpoint.  An invalid payload should result in a `401 Unauthorized` error. A valid one should be processed successfully. It's probably easiest to look at the automated tests for these to see how these payloads are generated. If you're trying to generate a signed, valid payload, it would also help to see how the signing works - this is in ol-django [starting here](https://github.com/mitodl/ol-django/blob/acd7e88ddce60d0d8094cce4077b459dddef089e/src/payment_gateway/mitol/payment_gateway/api.py#L473).

A similar method can be used to test the customer facing endpoint as well - if you post an invalid/unsigned payload to `/checkout/result/` you should get a 401 error there too.

In either case, invalid payloads should generate an error-level log, which should be picked up by Sentry.

Note that there is a bare minimum payload - you at least need to send:

```json
{
    "signature": "",
    "signed_field_names": "a_field",
    "a_field": ""
}
```

The signing functions expect at least this much to be able to generate a signature.
