### PR TITLE
Change font color, make sure that the button is 120px, make sure the button is left aligned in outlook

### DIFF
--- a/b2b/templates/mail/enrollment_code_assignment/body.html
+++ b/b2b/templates/mail/enrollment_code_assignment/body.html
@@ -6,12 +6,12 @@
       <td style="background-color: #ffffff;">
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 20px; line-height: 24px; color: #000000; font-weight: bold;">
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 20px; line-height: 24px; color: #212326; font-weight: bold;">
                       You've been invited to learn with MIT.
                   </td>
               </tr>
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #212326;">
                       <p style="margin: 0 0 10px;"><strong>{{ organization_name }}</strong> has provided you with access to <strong>{{ contract_name }}</strong> on MIT Learn.</p>
                       <p style="margin: 20px 0 10px;">Enroll to access your courses and begin learning.</p>
                   </td>
@@ -19,9 +19,9 @@
               <tr>
                   <td style="padding: 0 20px 20px;">
                       <!-- Button : BEGIN -->
-                      <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
+                      <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0;">
                           <tr>
-                              <td class="button-td button-td-primary" style="border-radius: 4px; background: #a31f34;">
+                              <td class="button-td button-td-primary" width="120" style="border-radius: 4px; background: #a31f34; width: 120px;">
                                    <a class="button-a button-a-primary" href="{{code_url}}" style="
               background: #a31f34;
               border: 1px solid #a31f34;
@@ -34,6 +34,8 @@
               padding: 16px;
               color: #fff;
               display: block;
+              width: 120px;
+              box-sizing: border-box;
               border-radius: 4px;">Enroll</a>
                               </td>
                           </tr>
@@ -42,13 +44,13 @@
                   </td>
               </tr>
               <tr>
-                <td style="padding: 0 20px 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                <td style="padding: 0 20px 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #212326;">
                     <p>If you're unable to use the button above, copy and paste this link into your browser:</p>
                     {{code_url}}
                 </td>
               </tr>
               <tr>
-                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #212326;">
                       <p>Welcome to MIT Learn,</p>
                       <p><strong>MIT Learn Team</strong></p>
                   </td>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12472

### Description (What does it do?)
Steve requested a few changes to the enrollment code email:
- The button should be 120px wide (previously it was determined by the button text width)
- Text should be #212326
- Button should be left aligned (in outlook app, it appears center aligned)

### Screenshots (if appropriate):
Before (in MacOS Outlook):
<img width="1301" height="815" alt="Screenshot 2026-07-21 at 10 38 32 AM" src="https://github.com/user-attachments/assets/034b28f0-3603-45df-922b-1608fd6b2603" />

After (in MacOS Outlook):
<img width="1307" height="831" alt="Screenshot 2026-07-21 at 10 38 48 AM" src="https://github.com/user-attachments/assets/320f2e78-626b-4d47-b1e2-004bae933391" />


### How can this be tested?
- Set up mailpit and set MITOL_MAIL_CONNECTION_BACKEND='django.core.mail.backends.smtp.EmailBackend'
- Set MITX_ONLINE_EMAIL_HOST and MITX_ONLINE_EMAIL_PORT to wherever mailpit is running.
- For a b2b contract you are an admin for, assign a code or send a test email using the b2b admin dash.
- Observe that the email text has the specified changes
- Download the raw message in mailpit. This will give you a `.eml` file
- Open that file with Outlook, observe that the button is left-aligned.
