### PR TITLE
Add redirect for terms, privacy, and honor code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,8 @@ MITOL_APIGATEWAY_USERINFO_UPDATE=True
 # Host for Digital Credentials issuer-coordinator service
 VERIFIABLE_CREDENTIAL_SIGNER_URL=http://dcc.odl.local:4005/instance/test/credentials/issue
 VERIFIABLE_CREDENTIAL_BEARER_TOKEN='test'
+
+# MIT Learn URLs (defaults point to production Learn; override to point at a local Learn instance)
+MIT_LEARN_TERMS_URL=https://learn.mit.edu/terms
+MIT_LEARN_PRIVACY_URL=https://learn.mit.edu/privacy
+MIT_LEARN_HONOR_CODE_URL=https://learn.mit.edu/honor_code

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -119,8 +119,8 @@
             </div>
             <div class="cer-footer-info">
                 <ul class="links">
-                    <li><a href="https://learn.mit.edu/terms">Terms of Services</a></li>
-                    <li><a href="https://learn.mit.edu/privacy">Privacy Policy</a></li>
+                    <li><a href="{{ mit_learn_terms_url }}">Terms of Services</a></li>
+                    <li><a href="{{ mit_learn_privacy_url }}">Privacy Policy</a></li>
                 </ul>
                 {% block copyright %}
                     {% include "copyright.html" %}

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -119,8 +119,8 @@
             </div>
             <div class="cer-footer-info">
                 <ul class="links">
-                    <li><a href="/terms-of-service/">Terms of Services</a></li>
-                    <li><a href="/privacy-policy/">Privacy Policy</a></li>
+                    <li><a href="https://learn.mit.edu/terms">Terms of Services</a></li>
+                    <li><a href="https://learn.mit.edu/privacy">Privacy Policy</a></li>
                 </ul>
                 {% block copyright %}
                     {% include "copyright.html" %}

--- a/courses/templates/mail/partials/_uai_footer.html
+++ b/courses/templates/mail/partials/_uai_footer.html
@@ -5,5 +5,5 @@
 {% else %}
 MIT Open Learning, 600 Technology Square, NE49-2000, Cambridge, MA 02139
 <br>
-&copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="https://learn.mit.edu/terms" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="https://learn.mit.edu/privacy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
+&copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ mit_learn_terms_url }}" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="{{ mit_learn_privacy_url }}" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
 {% endif %}

--- a/courses/templates/mail/partials/_uai_footer.html
+++ b/courses/templates/mail/partials/_uai_footer.html
@@ -5,5 +5,5 @@
 {% else %}
 MIT Open Learning, 600 Technology Square, NE49-2000, Cambridge, MA 02139
 <br>
-&copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ base_url }}/terms-of-service" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="{{ base_url }}/privacy-policy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
+&copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="https://learn.mit.edu/terms" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="https://learn.mit.edu/privacy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
 {% endif %}

--- a/ecommerce/templates/mail/product_order_receipt/body.html
+++ b/ecommerce/templates/mail/product_order_receipt/body.html
@@ -88,6 +88,6 @@
     <div style="text-align: center">
         MIT Open Learning, 600 Technology Square, NE49-2000, Cambridge, MA 02139
         <br>
-        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ base_url }}/terms-of-service" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="{{ base_url }}/privacy-policy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
+        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="https://learn.mit.edu/terms" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="https://learn.mit.edu/privacy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
     </div>
 {% endblock %}

--- a/ecommerce/templates/mail/product_order_receipt/body.html
+++ b/ecommerce/templates/mail/product_order_receipt/body.html
@@ -88,6 +88,6 @@
     <div style="text-align: center">
         MIT Open Learning, 600 Technology Square, NE49-2000, Cambridge, MA 02139
         <br>
-        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="https://learn.mit.edu/terms" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="https://learn.mit.edu/privacy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
+        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ mit_learn_terms_url }}" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="{{ mit_learn_privacy_url }}" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
     </div>
 {% endblock %}

--- a/frontend/public/src/flow/declarations.js
+++ b/frontend/public/src/flow/declarations.js
@@ -26,6 +26,9 @@ declare type Settings = {
   unified_ecommerce_url: ?string,
   oidc_login_url: ?string,
   mit_learn_dashboard_url: ?string,
+  mit_learn_terms_url: ?string,
+  mit_learn_privacy_url: ?string,
+  mit_learn_honor_code_url: ?string,
   api_gateway_enabled: boolean,
 }
 declare var SETTINGS: Settings

--- a/frontend/public/src/lib/urls.js
+++ b/frontend/public/src/lib/urls.js
@@ -54,9 +54,9 @@ export const routes = {
   orderReceipt: "/orders/receipt/:orderId",
 
   informationLinks: include("", {
-    termsOfService: "terms-of-service",
-    privacyPolicy:  "privacy-policy",
-    honorCode:      "honor-code"
+    termsOfService: "https://learn.mit.edu/terms",
+    privacyPolicy:  "https://learn.mit.edu/privacy",
+    honorCode:      "https://learn.mit.edu/honor_code"
   }),
 
   learnerRecords:      "/records/:program/",

--- a/frontend/public/src/lib/urls.js
+++ b/frontend/public/src/lib/urls.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS:false */
 import { include } from "named-urls"
 import qs from "query-string"
 
@@ -54,9 +55,12 @@ export const routes = {
   orderReceipt: "/orders/receipt/:orderId",
 
   informationLinks: include("", {
-    termsOfService: "https://learn.mit.edu/terms",
-    privacyPolicy:  "https://learn.mit.edu/privacy",
-    honorCode:      "https://learn.mit.edu/honor_code"
+    termsOfService:
+      SETTINGS.mit_learn_terms_url || "https://learn.mit.edu/terms",
+    privacyPolicy:
+      SETTINGS.mit_learn_privacy_url || "https://learn.mit.edu/privacy",
+    honorCode:
+      SETTINGS.mit_learn_honor_code_url || "https://learn.mit.edu/honor_code"
   }),
 
   learnerRecords:      "/records/:program/",

--- a/mail/api.py
+++ b/mail/api.py
@@ -95,7 +95,13 @@ def can_email_user(user):
 
 def get_base_context():
     """Returns a dict of context variables that are needed in all emails"""
-    return {"base_url": settings.SITE_BASE_URL, "site_name": settings.SITE_NAME}
+    return {
+        "base_url": settings.SITE_BASE_URL,
+        "site_name": settings.SITE_NAME,
+        "mit_learn_terms_url": settings.MIT_LEARN_TERMS_URL,
+        "mit_learn_privacy_url": settings.MIT_LEARN_PRIVACY_URL,
+        "mit_learn_honor_code_url": settings.MIT_LEARN_HONOR_CODE_URL,
+    }
 
 
 def context_for_user(*, user=None, extra_context=None):

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -56,6 +56,9 @@ def test_context_for_user(settings, test_user, extra_context):
     assert context_for_user(user=test_user, extra_context=extra_context) == {
         "base_url": settings.SITE_BASE_URL,
         "site_name": settings.SITE_NAME,
+        "mit_learn_terms_url": settings.MIT_LEARN_TERMS_URL,
+        "mit_learn_privacy_url": settings.MIT_LEARN_PRIVACY_URL,
+        "mit_learn_honor_code_url": settings.MIT_LEARN_HONOR_CODE_URL,
         **(extra_context or {}),
         **user_ctx,
     }

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -295,7 +295,7 @@
                         {% block footer-address %}
                         MIT Open Learning, 600 Technology Square, NE49-2000, Cambridge, MA 02139
                         <br>
-                        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="https://learn.mit.edu/terms" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="https://learn.mit.edu/privacy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
+                        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ mit_learn_terms_url }}" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="{{ mit_learn_privacy_url }}" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
                         {% endblock %}
                     </td>
                 </tr>

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -295,7 +295,7 @@
                         {% block footer-address %}
                         MIT Open Learning, 600 Technology Square, NE49-2000, Cambridge, MA 02139
                         <br>
-                        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ base_url }}/terms-of-service" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="{{ base_url }}/privacy-policy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
+                        &copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="https://learn.mit.edu/terms" style="color: #b0b0b0; text-decoration: underline;">Terms of Service</a> and <a href="https://learn.mit.edu/privacy" style="color: #b0b0b0; text-decoration: underline;">Privacy Policy</a>
                         {% endblock %}
                     </td>
                 </tr>

--- a/mail/views.py
+++ b/mail/views.py
@@ -1,6 +1,5 @@
 """Mail views"""
 
-from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
@@ -42,7 +41,7 @@ class EmailDebuggerView(View):
             return JsonResponse({"error": "invalid input"})
 
         email_type = form.cleaned_data["email_type"]
-        context = {"base_url": settings.SITE_BASE_URL, "site_name": settings.SITE_NAME}
+        context = api.get_base_context()
 
         email_extra_context = EMAIL_DEBUG_EXTRA_CONTEXT.get(email_type, {})
         context.update(email_extra_context)

--- a/main/constants.py
+++ b/main/constants.py
@@ -59,3 +59,10 @@ DISALLOWED_CURRENCY_TYPES = [
 ]
 
 USER_REGISTRATION_FAILED_MSG = "Unable to register at this time, please try again later"
+
+# Maps the value of settings.ENVIRONMENT to the hostname for that environment's Learn instance
+ENV_TO_LEARN_HOSTNAME_MAP = {
+    "production": "learn.mit.edu",
+    "rc": "rc.learn.mit.edu",
+    "ci": "ci.learn.mit.edu",
+}

--- a/main/context_processors.py
+++ b/main/context_processors.py
@@ -26,4 +26,7 @@ def configuration_context(request):  # noqa: ARG001
     """
     return {
         "site_name": settings.SITE_NAME,
+        "mit_learn_terms_url": settings.MIT_LEARN_TERMS_URL,
+        "mit_learn_privacy_url": settings.MIT_LEARN_PRIVACY_URL,
+        "mit_learn_honor_code_url": settings.MIT_LEARN_HONOR_CODE_URL,
     }

--- a/main/settings.py
+++ b/main/settings.py
@@ -656,6 +656,24 @@ MIT_LEARN_DASHBOARD_URL = get_string(
     description="Dashboard URL for UAI enrollment emails",
 )
 
+MIT_LEARN_TERMS_URL = get_string(
+    name="MIT_LEARN_TERMS_URL",
+    default="https://learn.mit.edu/terms",
+    description="Terms of service URL",
+)
+
+MIT_LEARN_PRIVACY_URL = get_string(
+    name="MIT_LEARN_PRIVACY_URL",
+    default="https://learn.mit.edu/privacy",
+    description="Privacy policy URL",
+)
+
+MIT_LEARN_HONOR_CODE_URL = get_string(
+    name="MIT_LEARN_HONOR_CODE_URL",
+    default="https://learn.mit.edu/honor_code",
+    description="Honor code URL",
+)
+
 # Logging configuration
 LOG_LEVEL = get_string(
     name="MITX_ONLINE_LOG_LEVEL", default="INFO", description="The log level default"

--- a/main/settings.py
+++ b/main/settings.py
@@ -33,6 +33,7 @@ from mitol.scim.settings.scim import *  # noqa: F403
 from redbeat import RedBeatScheduler
 
 from main.celery_utils import OffsettingSchedule
+from main.constants import ENV_TO_LEARN_HOSTNAME_MAP
 from main.env import get_float
 from main.sentry import init_sentry
 from openapi.settings_spectacular import open_spectacular_settings
@@ -658,19 +659,19 @@ MIT_LEARN_DASHBOARD_URL = get_string(
 
 MIT_LEARN_TERMS_URL = get_string(
     name="MIT_LEARN_TERMS_URL",
-    default="https://learn.mit.edu/terms",
+    default=f"https://{ENV_TO_LEARN_HOSTNAME_MAP.get(ENVIRONMENT, 'learn.mit.edu')}/terms",
     description="Terms of service URL",
 )
 
 MIT_LEARN_PRIVACY_URL = get_string(
     name="MIT_LEARN_PRIVACY_URL",
-    default="https://learn.mit.edu/privacy",
+    default=f"https://{ENV_TO_LEARN_HOSTNAME_MAP.get(ENVIRONMENT, 'learn.mit.edu')}/privacy",
     description="Privacy policy URL",
 )
 
 MIT_LEARN_HONOR_CODE_URL = get_string(
     name="MIT_LEARN_HONOR_CODE_URL",
-    default="https://learn.mit.edu/honor_code",
+    default=f"https://{ENV_TO_LEARN_HOSTNAME_MAP.get(ENVIRONMENT, 'learn.mit.edu')}/honor_code",
     description="Honor code URL",
 )
 

--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -37,7 +37,7 @@
         <div class="links-row">
             <ul class="links">
               <li><a href="/about-us/">About Us</a></li>
-              <li><a href="https://learn.mit.edu/terms">Terms of Service</a></li>
+              <li><a href="{{ mit_learn_terms_url }}">Terms of Service</a></li>
               <li>
                 <a
                   target="_blank"
@@ -46,8 +46,8 @@
                   >Accessibility
                 </a>
               </li>
-              <li><a href="https://learn.mit.edu/privacy">Privacy Policy</a></li>
-              <li><a href="https://learn.mit.edu/honor_code">Honor Code</a></li>
+              <li><a href="{{ mit_learn_privacy_url }}">Privacy Policy</a></li>
+              <li><a href="{{ mit_learn_honor_code_url }}">Honor Code</a></li>
               <li><a href="https://mitxonline.zendesk.com/hc/en-us/requests/new">Contact Us</a></li>
             </ul>
         </div>

--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -37,7 +37,7 @@
         <div class="links-row">
             <ul class="links">
               <li><a href="/about-us/">About Us</a></li>
-              <li><a href="/terms-of-service/">Terms of Service</a></li>
+              <li><a href="https://learn.mit.edu/terms">Terms of Service</a></li>
               <li>
                 <a
                   target="_blank"
@@ -46,8 +46,8 @@
                   >Accessibility
                 </a>
               </li>
-              <li><a href="/privacy-policy/">Privacy Policy</a></li>
-              <li><a href="/honor-code/">Honor Code</a></li>
+              <li><a href="https://learn.mit.edu/privacy">Privacy Policy</a></li>
+              <li><a href="https://learn.mit.edu/honor_code">Honor Code</a></li>
               <li><a href="https://mitxonline.zendesk.com/hc/en-us/requests/new">Contact Us</a></li>
             </ul>
         </div>

--- a/main/utils.py
+++ b/main/utils.py
@@ -52,6 +52,9 @@ def get_js_settings(request: HttpRequest):  # noqa: ARG001
         "oidc_login_url": None,
         "api_gateway_enabled": not settings.MITOL_APIGATEWAY_DISABLE_MIDDLEWARE,
         "mit_learn_dashboard_url": settings.MIT_LEARN_DASHBOARD_URL,
+        "mit_learn_terms_url": settings.MIT_LEARN_TERMS_URL,
+        "mit_learn_privacy_url": settings.MIT_LEARN_PRIVACY_URL,
+        "mit_learn_honor_code_url": settings.MIT_LEARN_HONOR_CODE_URL,
     }
 
 

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -56,6 +56,9 @@ def test_get_js_settings(settings, rf):
         "oidc_login_url": None,
         "api_gateway_enabled": not settings.MITOL_APIGATEWAY_DISABLE_MIDDLEWARE,
         "mit_learn_dashboard_url": settings.MIT_LEARN_DASHBOARD_URL,
+        "mit_learn_terms_url": settings.MIT_LEARN_TERMS_URL,
+        "mit_learn_privacy_url": settings.MIT_LEARN_PRIVACY_URL,
+        "mit_learn_honor_code_url": settings.MIT_LEARN_HONOR_CODE_URL,
     }
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12031

### Description (What does it do?)
Replaces mitxonline's hardcoded links to its own Terms of Service, Privacy Policy, and Honor Code pages with links to their MIT Learn equivalents, since Learn's terms of service already cover MITx offerings:

- https://learn.mit.edu/terms (was /terms-of-service/)
- https://learn.mit.edu/privacy (was /privacy-policy/)
- https://learn.mit.edu/honor_code (was /honor-code/)

Updated in 6 places:

- main/templates/footer.html — site-wide footer (all three links)
- frontend/public/src/lib/urls.js — informationLinks route constants consumed by the React signup form (all three links)
- mail/templates/email_base.html — base transactional email footer (ToS + Privacy)
- ecommerce/templates/mail/product_order_receipt/body.html — order receipt email (ToS + Privacy)
- courses/templates/mail/partials/_uai_footer.html — B2B/partner-branded email footer (ToS + Privacy)
- cms/templates/certificate_page.html — public certificate page footer (ToS + Privacy)

No honor code link exists in any of the email templates or the certificate page, so those two files only needed the ToS/Privacy changes.

### Screenshots (if appropriate):
No visual/layout changes — link text and placement are unchanged, only the href destinations changed.

### How can this be tested?

1. On mitxonline, load any page and check the site footer — Terms of Service, Privacy Policy, and Honor Code links should all point to learn.mit.edu and load the correct page.
2. Go through the account registration/signup flow and confirm the same three consent links in the signup form point to Learn.
3. Trigger (or inspect a rendered copy of) the order receipt email, and any B2B/partner-branded course email, and confirm the footer's Terms of Service / Privacy Policy links point to Learn.
4. View a public certificate page and confirm its footer links point to Learn.
5. yarn lint and yarn fmt:check pass clean on frontend/public (only urls.js is JS/lintable — the Django templates have no linter configured in this repo).

### Additional Context

- Confirmed the exact Learn destination paths (/terms, /privacy, /honor_code) against Learn's actual Next.js routes rather than assuming a naming pattern — note /honor_code uses an underscore, not a hyphen, unlike mitxonline's original /honor-code/.
- No trailing slashes on the new URLs — Learn's Next.js app uses the default trailingSlash: false, so these are the canonical forms.
- RegisterEmailForm.js (the component that renders the signup-form links) needed no changes — it reads the fixed constants from urls.js directly.
- Checked for tests asserting on these link values; found none (the only similarly-named test, openedx/api_test.py, covers an unrelated Open edX enrollment API field also named honor_code).
- Scope is limited to ToS/Privacy/Honor Code links only — other mitxonline→Learn redirect work (product pages, catalog, home page) is tracked in separate tickets under the parent epic (#12027).


### Checklist:
- [ ] Confirm with @pdpinch that privacy policy should not link to honor code

