### PR TITLE
fix: allow 0 as minimum # of value

### DIFF
--- a/courses/forms.py
+++ b/courses/forms.py
@@ -141,7 +141,7 @@ def program_requirements_schema():
                                 "format": "number",
                                 "title": "Value",
                                 "default": 1,
-                                "minimum": 1,
+                                "minimum": 0,
                                 "options": {
                                     "dependencies": {
                                         "node_type": ProgramRequirementNodeType.OPERATOR.value,
@@ -305,13 +305,13 @@ class ProgramAdminForm(ModelForm):
                 # Ensure the value is not negative
                 try:
                     value = int(operator["data"]["operator_value"])
-                    if value < 1:
+                    if value < 0:
                         raise ValidationError(
-                            '"Minimum # of" operator must have Value equal to 1 or more.'  # noqa: EM101
+                            '"Minimum # of" operator must have Value equal to 0 or more.'  # noqa: EM101
                         )
                 except (ValueError, TypeError):
                     raise ValidationError(
-                        '"Minimum # of" operator must have a valid numeric Value equal to 1 or more.'  # noqa: EM101
+                        '"Minimum # of" operator must have a valid numeric Value equal to 0 or more.'  # noqa: EM101
                     ) from None
 
         def _validate_operator_title(operator):

--- a/courses/models.py
+++ b/courses/models.py
@@ -2598,9 +2598,9 @@ class ProgramRequirement(MP_Node):
         ):
             try:
                 value = int(self.operator_value)
-                if value < 1:
+                if value < 0:
                     raise ValidationError(
-                        {"operator_value": "Minimum # of value must be 1 or greater."}
+                        {"operator_value": "Minimum # of value must be 0 or greater."}
                     )
             except (ValueError, TypeError):
                 raise ValidationError(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/12498

### Description (What does it do?)
<!--- Describe your changes in detail -->
Allows 0 as the value for minimum # operator. It is a regression introduced in https://github.com/mitodl/mitxonline/pull/3531

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Add program requirements with minimum operator and use 0 as value. It should allow to save.