### PR TITLE
Speed up pytest: fast password hasher, drop unused coverage html report

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -327,6 +327,10 @@ if ZEAL_ENABLE or ENVIRONMENT == "pytest":
 ZEAL_RAISE = False
 ZEAL_ALLOWLIST = []
 
+# use a fast, insecure password hasher under pytest - tests don't need real hashing strength
+if ENVIRONMENT == "pytest":
+    PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
 MITXONLINE_NEW_USER_LOGIN_URL = get_string(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,7 @@ fixture-parentheses = false
 
 
 [tool.pytest.ini_options]
-addopts = "--cov . --cov-report xml --cov-report term --cov-report html --ds=main.settings --reuse-db --color=yes"
+addopts = "--cov . --cov-report xml --cov-report term --ds=main.settings --reuse-db --color=yes"
 norecursedirs = [
   "node_modules",
   ".git",


### PR DESCRIPTION
## Summary
- Use `MD5PasswordHasher` under pytest instead of the real (slow) production hasher - tests don't need real hashing strength.
- Drop `--cov-report html` from pytest addopts - nothing in CI uploads or otherwise consumes `htmlcov/`, and `.gitignore` already excludes it.

Validated locally against a fresh test DB (`-n 4`, matching CI's runner size): no correctness regressions, and a representative slice (`users/ openedx/ authentication/ cms/`) ran noticeably faster with the fast hasher alone.

Two other candidate changes were tried and dropped after local validation surfaced real problems, noted here for the record:
- `--no-migrations`: breaks Wagtail's own `RunPython` data migrations (seeds the default `Locale`/root `Page`/`Collection`/`Workflow`). Selectively skipping only this project's own app migrations doesn't work either - the custom `User` model is referenced by third-party app migrations (wagtail, oauth2_provider), so Django can't resolve migration state when `users` has no migration history but its dependents do.
- `--dist worksteal`: intermittently flaky - reproduced a real test-isolation failure (`Locale.DoesNotExist`, `Page.DoesNotExist`) on one of three otherwise-identical runs that doesn't occur under the default `load` scheduler.

CI on this branch already completed in **16m24s**, down from the ~20m baseline.

Stacked on top of this: #see nl/faster-tests-sharded, which adds CI matrix sharding + drops `--cov` from CI entirely.

## Test plan
- [x] CI green on this branch (16m24s, `pytest -n logical`, all tests passing)
- [x] Local validation: `users/models_test.py::test_create_user` (password hasher) passes
- [x] Local validation: broad slice (`users/ openedx/ authentication/ cms/`) passes cleanly with fast hasher against a fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)