### PR TITLE
fix: count each B2B program enrollment once in backfill

### DIFF
--- a/b2b/management/commands/backfill_b2b_program_enrollments.py
+++ b/b2b/management/commands/backfill_b2b_program_enrollments.py
@@ -76,11 +76,12 @@ matches are reported and skipped."""
         already_enrolled = 0
         no_program = 0
         ambiguous = []
-        # A user can be enrolled in several course runs that all belong to the
-        # same program (within the same contract). Those collapse to one program
-        # enrollment, so track the (user, program) pairs we've already accounted
-        # for this run to avoid double-counting - this also keeps the dry-run
-        # count consistent with what a --commit run would actually create.
+        # A user can be enrolled in several course runs that all map to the same
+        # program. ProgramEnrollment is unique on (user, program), so those
+        # collapse to a single enrollment regardless of contract. Track the
+        # (user, program) pairs already accounted for this run to avoid
+        # double-counting - this keeps the dry-run count consistent with what a
+        # --commit run would actually create.
         planned = set()
 
         self.stdout.write(

--- a/b2b/management/commands/backfill_b2b_program_enrollments.py
+++ b/b2b/management/commands/backfill_b2b_program_enrollments.py
@@ -76,6 +76,12 @@ matches are reported and skipped."""
         already_enrolled = 0
         no_program = 0
         ambiguous = []
+        # A user can be enrolled in several course runs that all belong to the
+        # same program (within the same contract). Those collapse to one program
+        # enrollment, so track the (user, program) pairs we've already accounted
+        # for this run to avoid double-counting - this also keeps the dry-run
+        # count consistent with what a --commit run would actually create.
+        planned = set()
 
         self.stdout.write(
             f"Scanning {enrollments.count()} active B2B course-run enrollment(s)..."
@@ -106,11 +112,16 @@ matches are reported and skipped."""
 
             program = candidate_programs[0]
 
-            if ProgramEnrollment.all_objects.filter(
+            # Skip if the user is already enrolled in this program, or if another
+            # course run for the same user+program was already handled this run.
+            # The latter keeps the dry-run count consistent with what a --commit
+            # run would create (each program enrollment counted exactly once).
+            if (user.id, program.id) in planned or ProgramEnrollment.all_objects.filter(
                 user=user, program=program
             ).exists():
                 already_enrolled += 1
                 continue
+            planned.add((user.id, program.id))
 
             self.stdout.write(
                 f"\t{user.email}: enrolling in program {program.readable_id} "

--- a/b2b/management/tests/backfill_b2b_program_enrollments_test.py
+++ b/b2b/management/tests/backfill_b2b_program_enrollments_test.py
@@ -173,6 +173,4 @@ def test_backfill_counts_each_program_enrollment_once():
     out = io.StringIO()
     call_command(COMMAND, "--commit", stdout=out)
     assert "Created 1 program enrollment(s)." in out.getvalue()
-    assert (
-        ProgramEnrollment.all_objects.filter(user=user, program=program).count() == 1
-    )
+    assert ProgramEnrollment.all_objects.filter(user=user, program=program).count() == 1

--- a/b2b/management/tests/backfill_b2b_program_enrollments_test.py
+++ b/b2b/management/tests/backfill_b2b_program_enrollments_test.py
@@ -1,5 +1,7 @@
 """Tests for the backfill_b2b_program_enrollments command."""
 
+import io
+
 import pytest
 from django.core.management import call_command
 
@@ -131,3 +133,46 @@ def test_backfill_ignores_non_b2b_enrollments():
     call_command(COMMAND, "--commit")
 
     assert not ProgramEnrollment.objects.filter(user=enrollment.user).exists()
+
+
+def test_backfill_counts_each_program_enrollment_once():
+    """Multiple runs mapping to one program collapse to a single enrollment.
+
+    Regression: a user enrolled in several B2B course runs that all belong to
+    the same program used to inflate the dry-run "Would create" count (one per
+    run) even though a --commit run only ever creates a single ProgramEnrollment.
+    The dry-run count must match what --commit actually creates.
+    """
+
+    contract = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_MANAGED,
+    )
+    program = ProgramFactory.create()
+    user = None
+
+    for _ in range(3):
+        course = CourseFactory.create()
+        program.add_requirement(course)
+        ContractProgramItem.objects.get_or_create(
+            contract=contract, program=program, defaults={"sort_order": 0}
+        )
+        run = CourseRunFactory.create(course=course, b2b_contract=contract)
+        # Reuse the same user across all three runs.
+        enrollment = CourseRunEnrollmentFactory.create(
+            run=run, **({"user": user} if user else {})
+        )
+        user = enrollment.user
+
+    # Dry run: reports a single planned enrollment, not one per course run.
+    out = io.StringIO()
+    call_command(COMMAND, stdout=out)
+    assert "Would create 1 program enrollment(s)." in out.getvalue()
+    assert not ProgramEnrollment.objects.filter(user=user, program=program).exists()
+
+    # Commit: creates exactly one ProgramEnrollment, matching the dry-run count.
+    out = io.StringIO()
+    call_command(COMMAND, "--commit", stdout=out)
+    assert "Created 1 program enrollment(s)." in out.getvalue()
+    assert (
+        ProgramEnrollment.all_objects.filter(user=user, program=program).count() == 1
+    )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11333

### Description (What does it do?)
Fixes an over-counting bug in the `backfill_b2b_program_enrollments` management command.

A user can be enrolled in several B2B course runs that all belong to the **same** program within one contract. Those collapse to a single `ProgramEnrollment`, but the command was processing each course run independently. In dry-run mode nothing is persisted, so the "already enrolled" check never fired for the repeats and the **"Would create"** total was inflated (e.g. a user in 18 course runs of one program was reported as 18 program enrollments instead of 1). This also meant the dry-run count disagreed with what a `--commit` run actually creates.

The command now tracks the `(user, program)` pairs already handled during the run and skips repeats, so:
- the dry-run "Would create" count matches the committed result,
- each program enrollment is counted once (repeats fall under "already enrolled"), and
- the enrolling log line is emitted once per program rather than once per course run.

### How can this be tested?

**1. Seed a user enrolled in several course runs that all map to the same program** in one contract:

    docker compose run --rm web python manage.py shell <<'PY'
    import uuid
    from b2b.factories import ContractPageFactory
    from b2b.models import ContractPage, ContractProgramItem
    from courses.factories import CourseFactory, CourseRunEnrollmentFactory, CourseRunFactory, ProgramFactory
    from courses.models import CourseRun
    from users.factories import UserFactory

    TAG, SUF = "deduptest", uuid.uuid4().hex[:8]
    old = ContractPage.objects.filter(name__startswith=TAG)
    if old.exists():
        CourseRun.objects.filter(b2b_contract__in=old).delete(); old.delete()

    contract = ContractPageFactory.create(name=f"{TAG} Contract")
    prog = ProgramFactory.create(title=f"{TAG} Prog", readable_id=f"program-v1:{TAG}+P+{SUF}")
    ContractProgramItem(contract=contract, program=prog).save(skip_run_creation=True)
    user = UserFactory.create(username=f"{TAG}_{SUF}", email=f"{TAG}_{SUF}@example.com")
    for i in range(3):
        c = CourseFactory.create(readable_id=f"course-v1:{TAG}+C{i}{SUF}")
        r = CourseRunFactory.create(course=c, b2b_contract=contract)
        prog.add_requirement(c); prog.refresh_from_db()
        CourseRunEnrollmentFactory.create(user=user, run=r)
    print(f"\nSeeded {user.email}: 3 runs, all in {prog.readable_id}")
    print(f"Test with: --user {user.email}")
    PY

**2. Run a dry run** scoped to that user — it should report **`Would create 1`** (not 3), with the 2 repeats under "Already enrolled":

    docker compose run --rm web python manage.py backfill_b2b_program_enrollments --user <email>

**3. Commit** — confirm exactly **one** `ProgramEnrollment` is created (`Created 1`), matching the dry-run count:

    docker compose run --rm web python manage.py backfill_b2b_program_enrollments --user <email> --commit

**4. Verify idempotency** — re-run with `--commit`; it now reports `Created 0` / `Already enrolled 3`.

> Before this fix, step 2 reported `Would create 3` — one per course run — even though a `--commit` run only ever created one enrollment.

### Additional Context
The dry-run vs `--commit` mismatch was purely a **counting/reporting** issue — `create_program_enrollments` uses `get_or_create`, so no duplicate `ProgramEnrollment` rows were ever created even before this fix. This change makes the dry-run preview trustworthy so it can be relied on before committing a large prod backfill.
