### PR TITLE
Fix OAS comment generation

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -38,11 +38,6 @@ jobs:
             fi
           done
           echo "EOF" >> $GITHUB_OUTPUT
-      - name: Get summary
-        id: oasdif_summary
-        run: |
-          echo summary=$(echo "${{ steps.oasdif_changelog.outputs.changelog }}" | head -1 ) \
-          >> $GITHUB_OUTPUT
       - name: Find existing comment
         id: find_comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
@@ -54,7 +49,6 @@ jobs:
       - name: Post changes as comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         # Even if no changes, make sure to update old comment if it was found.
-        if: steps.oasdif_summary.outputs.summary || steps.find_comment.outputs.comment-id
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           edit-mode: "replace"
@@ -65,7 +59,7 @@ jobs:
             ## OpenAPI Changes
 
             <details>
-            <summary>Show/hide ${{ steps.oasdif_summary.outputs.summary || 'No detectable change.' }}</summary>
+            <summary>Show/hide changes</summary>
 
             ```
             ${{ steps.oasdif_changelog.outputs.changelog }}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The OAS diff sometimes fails (see https://github.com/mitodl/mitxonline/actions/runs/30037342589/job/89308503010) because the get summary step can't parse the summary. That said, the summary _always_ ends up being "## Changes for v0.yaml:" because that's always the first line and this isn't helpful and in fact misleading because the contents that are hidden include changes for _all_ the specs. So I'm just getting rid of the summary.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass and an OAS comment should get left on this PR.