### PR TITLE
feat(b2b): look up managed orgs by sso_organization_id; expose the org UUID

### DIFF
--- a/b2b/serializers/v0/__init__.py
+++ b/b2b/serializers/v0/__init__.py
@@ -97,6 +97,7 @@ class OrganizationPageSerializer(serializers.ModelSerializer):
             "description",
             "logo",
             "slug",
+            "sso_organization_id",
             "contracts",
         ]
         read_only_fields = [
@@ -105,6 +106,7 @@ class OrganizationPageSerializer(serializers.ModelSerializer):
             "description",
             "logo",
             "slug",
+            "sso_organization_id",
             "contracts",
         ]
 

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 from django.db.models import Count, Prefetch, Q
 from django.shortcuts import get_object_or_404
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
     extend_schema,
@@ -194,7 +195,7 @@ class ManagerOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
         parameters=[
             OpenApiParameter(
                 name="sso_organization_id",
-                type=str,
+                type=OpenApiTypes.UUID,
                 location=OpenApiParameter.QUERY,
                 required=False,
                 description=(

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -147,9 +147,17 @@ class ManagerOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ManagerContractOrgPagination
 
     def get_queryset(self):
-        """Filter to organizations where the user is a manager."""
+        """Filter to organizations where the user is a manager.
 
-        return (
+        An optional ``sso_organization_id`` query param narrows the result to a
+        single org by its Keycloak organization UUID. This is what
+        ol-analytics-api uses to ask "does this user manage the org with this
+        UUID?" (a non-empty response means yes) without dereferencing the
+        internal PK. An unparseable UUID yields an empty queryset (fail-safe:
+        reads as "not a manager"), never a 500.
+        """
+
+        queryset = (
             OrganizationPage.objects.prefetch_related(
                 Prefetch(
                     "contracts",
@@ -170,9 +178,32 @@ class ManagerOrganizationViewSet(viewsets.ReadOnlyModelViewSet):
             .distinct()
         )
 
+        sso_organization_id = self.request.query_params.get("sso_organization_id")
+        if sso_organization_id:
+            try:
+                org_uuid = uuid.UUID(sso_organization_id)
+            except (ValueError, TypeError):
+                return queryset.none()
+            queryset = queryset.filter(sso_organization_id=org_uuid)
+
+        return queryset
+
     @extend_schema(
         operation_id="b2b_manager_organizations_list",
         description="List managed organizations",
+        parameters=[
+            OpenApiParameter(
+                name="sso_organization_id",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Narrow the result to the single org with this Keycloak "
+                    "organization UUID (sso_organization_id). A non-empty "
+                    "response means the caller manages that org."
+                ),
+            ),
+        ],
     )
     def list(self, request, *args, **kwargs):
         """List the orgs."""

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -1,5 +1,7 @@
 """Tests for the B2B Manager views"""
 
+import uuid
+
 import pytest
 import reversion
 from django.urls import reverse
@@ -2009,6 +2011,74 @@ def test_manager_org_list_multiple_managed_orgs():
     result_ids = {r["id"] for r in resp.json()["results"]}
     assert org_1.id in result_ids
     assert org_2.id in result_ids
+
+
+def test_manager_org_list_filters_by_sso_organization_id():
+    """?sso_organization_id=<uuid> narrows the managed-org list to that one org --
+    the lookup ol-analytics-api uses to ask "does this user manage org UUID X?".
+    The org's UUID is also serialized in the response.
+    """
+    manager = UserFactory.create()
+    org_1 = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE
+    ).organization
+    org_2 = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE
+    ).organization
+    org_1.sso_organization_id = uuid.uuid4()
+    org_1.save()
+    org_2.sso_organization_id = uuid.uuid4()
+    org_2.save()
+    UserOrganization.objects.create(user=manager, organization=org_1, is_manager=True)
+    UserOrganization.objects.create(user=manager, organization=org_2, is_manager=True)
+    client = APIClient()
+    client.force_login(manager)
+    url = reverse("b2b:b2b-manager-organization-list")
+
+    resp = client.get(url, {"sso_organization_id": str(org_1.sso_organization_id)})
+    assert resp.status_code == status.HTTP_200_OK
+    results = resp.json()["results"]
+    assert {r["id"] for r in results} == {org_1.id}
+    assert results[0]["sso_organization_id"] == str(org_1.sso_organization_id)
+
+
+def test_manager_org_list_sso_filter_excludes_orgs_the_user_does_not_manage():
+    """The filter only narrows the manager-scoped queryset -- filtering by an org
+    the user does NOT manage returns empty, never that org.
+    """
+    manager = UserFactory.create()
+    managed = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE
+    ).organization
+    other = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE
+    ).organization
+    other.sso_organization_id = uuid.uuid4()
+    other.save()
+    UserOrganization.objects.create(user=manager, organization=managed, is_manager=True)
+    client = APIClient()
+    client.force_login(manager)
+    url = reverse("b2b:b2b-manager-organization-list")
+
+    resp = client.get(url, {"sso_organization_id": str(other.sso_organization_id)})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == []
+
+
+def test_manager_org_list_invalid_sso_uuid_returns_empty_not_500():
+    """An unparseable sso_organization_id yields an empty result, not a 500."""
+    manager = UserFactory.create()
+    org = ContractPageFactory.create(
+        membership_type=CONTRACT_MEMBERSHIP_CODE
+    ).organization
+    UserOrganization.objects.create(user=manager, organization=org, is_manager=True)
+    client = APIClient()
+    client.force_login(manager)
+    url = reverse("b2b:b2b-manager-organization-list")
+
+    resp = client.get(url, {"sso_organization_id": "not-a-uuid"})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -262,6 +262,13 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
+      - in: query
+        name: sso_organization_id
+        schema:
+          type: string
+        description: Narrow the result to the single org with this Keycloak organization
+          UUID (sso_organization_id). A non-empty response means the caller manages
+          that org.
       tags:
       - b2b
       responses:
@@ -7465,6 +7472,13 @@ components:
           readOnly: true
           description: The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/
           pattern: ^[-\w]+$
+        sso_organization_id:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Organization SSO ID
+          description: The UUID for the organization in the SSO provider.
         contracts:
           type: array
           items:
@@ -7477,6 +7491,7 @@ components:
       - logo
       - name
       - slug
+      - sso_organization_id
     Override:
       type: object
       description: Serializer for overrides used in certificate pages.

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -266,6 +266,7 @@ paths:
         name: sso_organization_id
         schema:
           type: string
+          format: uuid
         description: Narrow the result to the single org with this Keycloak organization
           UUID (sso_organization_id). A non-empty response means the caller manages
           that org.

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -262,6 +262,13 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
+      - in: query
+        name: sso_organization_id
+        schema:
+          type: string
+        description: Narrow the result to the single org with this Keycloak organization
+          UUID (sso_organization_id). A non-empty response means the caller manages
+          that org.
       tags:
       - b2b
       responses:
@@ -7465,6 +7472,13 @@ components:
           readOnly: true
           description: The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/
           pattern: ^[-\w]+$
+        sso_organization_id:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Organization SSO ID
+          description: The UUID for the organization in the SSO provider.
         contracts:
           type: array
           items:
@@ -7477,6 +7491,7 @@ components:
       - logo
       - name
       - slug
+      - sso_organization_id
     Override:
       type: object
       description: Serializer for overrides used in certificate pages.

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -266,6 +266,7 @@ paths:
         name: sso_organization_id
         schema:
           type: string
+          format: uuid
         description: Narrow the result to the single org with this Keycloak organization
           UUID (sso_organization_id). A non-empty response means the caller manages
           that org.

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -262,6 +262,13 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
+      - in: query
+        name: sso_organization_id
+        schema:
+          type: string
+        description: Narrow the result to the single org with this Keycloak organization
+          UUID (sso_organization_id). A non-empty response means the caller manages
+          that org.
       tags:
       - b2b
       responses:
@@ -7465,6 +7472,13 @@ components:
           readOnly: true
           description: The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/
           pattern: ^[-\w]+$
+        sso_organization_id:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Organization SSO ID
+          description: The UUID for the organization in the SSO provider.
         contracts:
           type: array
           items:
@@ -7477,6 +7491,7 @@ components:
       - logo
       - name
       - slug
+      - sso_organization_id
     Override:
       type: object
       description: Serializer for overrides used in certificate pages.

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -266,6 +266,7 @@ paths:
         name: sso_organization_id
         schema:
           type: string
+          format: uuid
         description: Narrow the result to the single org with this Keycloak organization
           UUID (sso_organization_id). A non-empty response means the caller manages
           that org.

--- a/users/models.py
+++ b/users/models.py
@@ -361,9 +361,9 @@ class User(
     def b2b_organization_sso_ids(self):
         """Just the UUIDs for the organizations the user is in."""
         return list(
-            self.organizations.filter(sso_organization_id__isnull=False).values_list(
-                "sso_organization_id", flat=True
-            )
+            self.b2b_organizations.filter(
+                sso_organization_id__isnull=False
+            ).values_list("sso_organization_id", flat=True)
         )
 
     @property

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -69,6 +69,9 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, has_orgs):
                     "description": contract.organization.description,
                     "logo": None,
                     "slug": contract.organization.slug,
+                    "sso_organization_id": str(
+                        contract.organization.sso_organization_id
+                    ),
                     "contracts": [
                         {
                             "id": contract.id,


### PR DESCRIPTION
## Why

The B2B analytics stack (ol-analytics-api / the mit-learn org-manager dashboard) keys organizations on the **Keycloak org UUID** (`sso_organization_id`) — the one identifier stable across the JWT, MITx Online, and StarRocks (see mitodl/ol-analytics-api#13 and the identifier analysis on mitodl/hq#11845). MITx Online is the authority on org-manager status, but there was no way to ask *"does this user manage the org with UUID X?"*, and the UUID never left the DB.

## What

- **`ManagerOrganizationViewSet.get_queryset`**: optional `?sso_organization_id=<uuid>` filter that narrows the already-manager-scoped queryset to a single org. This is exactly what ol-analytics-api calls — a non-empty response means the caller manages that org. An unparseable UUID returns an empty queryset (fail-safe), never a 500. The filter is **additive and only narrows** — absent param preserves current behavior, so the existing mit-learn manager dashboard is unaffected.
- **`OrganizationPageSerializer`**: expose `sso_organization_id` (read-only), so the org UUID round-trips through the API (e.g. `/users/me` `b2b_organizations`) for mit-learn to build analytics URLs.
- **Fix `User.b2b_organization_sso_ids`**: it referenced a nonexistent `self.organizations` accessor (the M2M is `self.b2b_organizations`), so any call raised `AttributeError`. Dead code today, but it's the natural hook for the UUID list.
- Regenerated the committed OpenAPI specs (v0/v1/v2).

## Tests
New `manager_test.py` cases: filter narrows to the matching managed org (and serializes its UUID), the filter can't surface an org the user doesn't manage, and an invalid UUID returns empty (not 500). Ran locally against Postgres+Redis: 4 passed; ruff + DRF-ORM pre-commit clean.

## Rollout
This is the piece the org-UUID work depends on — **deploy this before ol-analytics-api#13**, since an older manager endpoint would ignore the filter and return all managed orgs (fail-open). Data-side MVs: mitodl/ol-data-platform `feat/b2b-mv-sso-organization-id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)