### PR TITLE
Use Redis-backed HubSpot rate limiter

### DIFF
--- a/hubspot_sync/rate_limiter.py
+++ b/hubspot_sync/rate_limiter.py
@@ -4,85 +4,100 @@ Rate limiting for HubSpot API calls
 
 import logging
 import random
-import threading
 import time
-from collections import deque
+import uuid
 
 from django.conf import settings
 
 log = logging.getLogger(__name__)
 
+# Atomic sliding-window rate limiter implemented as a Redis Lua script.
+#
+# The sorted set stores claimed slots: member = unique ID, score = scheduled
+# execution time. Cleanup removes slots whose window has expired. When all
+# slots in the current window are claimed, the next slot is pushed past the
+# oldest slot's window boundary, distributing load across workers automatically.
+_RATE_LIMIT_LUA = """
+local key       = KEYS[1]
+local now       = tonumber(ARGV[1])
+local window    = tonumber(ARGV[2])
+local max_req   = tonumber(ARGV[3])
+local min_delay = tonumber(ARGV[4])
+local member    = ARGV[5]
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window)
+
+local count = redis.call('ZCARD', key)
+local target
+
+if count < max_req then
+    if count > 0 then
+        local last   = redis.call('ZRANGE', key, -1, -1, 'WITHSCORES')
+        local last_t = tonumber(last[2])
+        target = math.max(now, last_t + min_delay)
+    else
+        target = now
+    end
+else
+    local oldest   = redis.call('ZRANGE', key,  0,  0, 'WITHSCORES')
+    local last     = redis.call('ZRANGE', key, -1, -1, 'WITHSCORES')
+    local oldest_t = tonumber(oldest[2])
+    local last_t   = tonumber(last[2])
+    target = math.max(oldest_t + window, last_t + min_delay, now)
+end
+
+redis.call('ZADD', key, target, member)
+redis.call('EXPIRE', key, math.ceil(window) + 1)
+
+local wait_ms = (target - now) * 1000
+if wait_ms < 0 then wait_ms = 0 end
+return tostring(wait_ms)
+"""
+
 
 class HubSpotRateLimiter:
     """
-    A scalable rate limiter that uses a sliding window approach.
+    Distributed rate limiter using a Redis sorted-set sliding window.
+
+    All Celery workers share the same Redis key, so rate limiting is enforced
+    globally across processes rather than per-process.
     """
 
     def __init__(self):
         self.min_delay_ms = getattr(settings, "HUBSPOT_TASK_DELAY", 60)
-
-        self._lock = threading.Lock()
-        self._request_times = deque()
-
         self._window_size_seconds = 1.0
         self._max_requests_per_second = 19
+        self._redis_key = "hubspot:rate_limit"
 
-        self._cleanup_counter = 0
-        self._cleanup_interval = 50
+    def _get_redis(self):
+        from django_redis import get_redis_connection  # noqa: PLC0415
+
+        return get_redis_connection("redis")
 
     def wait_for_rate_limit(self) -> None:
-        """
-        Wait for an amount of time based on sliding window rate limiting.
-        """
-        current_time = time.time()
+        redis_client = self._get_redis()
+        now = time.time()
+        member = str(uuid.uuid4())
 
-        with self._lock:
-            self._cleanup_counter += 1
-            if self._cleanup_counter >= self._cleanup_interval:
-                self._cleanup_old_timestamps(current_time)
-                self._cleanup_counter = 0
+        script = redis_client.register_script(_RATE_LIMIT_LUA)
+        result = script(
+            keys=[self._redis_key],
+            args=[
+                str(now),
+                str(self._window_size_seconds),
+                str(self._max_requests_per_second),
+                str(self.min_delay_ms / 1000),
+                member,
+            ],
+        )
+        wait_ms = float(result)
 
-            target_time = self._calculate_next_available_time(current_time)
-
-            self._request_times.append(target_time)
-
-            sleep_time = max(0, target_time - current_time)
-
-        if sleep_time > 0:
+        if wait_ms > 0:
+            sleep_time = wait_ms / 1000
             jitter = random.uniform(-0.05, 0.05) * sleep_time  # noqa: S311
             sleep_time = max(0, sleep_time + jitter)
-
             log.debug("Rate limiting: sleeping for %.3f seconds", sleep_time)
             time.sleep(sleep_time)
-
-    def _cleanup_old_timestamps(self, current_time: float) -> None:
-        """Remove timestamps outside the sliding window."""
-        cutoff_time = current_time - self._window_size_seconds
-        while self._request_times and self._request_times[0] < cutoff_time:
-            self._request_times.popleft()
-
-    def _calculate_next_available_time(self, current_time: float) -> float:
-        """
-        Calculate when the next request can be made based on the sliding window.
-        """
-        self._cleanup_old_timestamps(current_time)
-
-        if len(self._request_times) < self._max_requests_per_second:
-            if self._request_times:
-                last_request_time = self._request_times[-1]
-                min_next_time = last_request_time + (self.min_delay_ms / 1000)
-                return max(current_time, min_next_time)
-            return current_time
-
-        oldest_in_window = self._request_times[0]
-        next_available = oldest_in_window + self._window_size_seconds
-
-        if self._request_times:
-            last_request_time = self._request_times[-1]
-            min_next_time = last_request_time + (self.min_delay_ms / 1000)
-            next_available = max(next_available, min_next_time)
-
-        return max(next_available, current_time)
 
 
 rate_limiter = HubSpotRateLimiter()

--- a/hubspot_sync/rate_limiter_test.py
+++ b/hubspot_sync/rate_limiter_test.py
@@ -6,8 +6,8 @@ import pytest
 from django.test import override_settings
 
 from hubspot_sync.rate_limiter import (
-    HubSpotRateLimiter,
     _RATE_LIMIT_LUA,
+    HubSpotRateLimiter,
 )
 
 
@@ -54,8 +54,8 @@ class TestHubSpotRateLimiter:
         call_kwargs = mock_script.call_args[1]
         assert call_kwargs["keys"] == ["hubspot:rate_limit"]
         args = call_kwargs["args"]
-        assert args[1] == "1.0"   # window_size_seconds
-        assert args[2] == "19"    # max_requests_per_second
+        assert args[1] == "1.0"  # window_size_seconds
+        assert args[2] == "19"  # max_requests_per_second
 
     @pytest.mark.parametrize("wait_ms_bytes", [b"0.0", b"100.0", b"999.9"])
     @patch("hubspot_sync.rate_limiter.time.sleep")

--- a/hubspot_sync/rate_limiter_test.py
+++ b/hubspot_sync/rate_limiter_test.py
@@ -2,201 +2,76 @@
 
 from unittest.mock import patch
 
+import pytest
 from django.test import override_settings
 
 from hubspot_sync.rate_limiter import (
     HubSpotRateLimiter,
+    _RATE_LIMIT_LUA,
 )
 
 
 class TestHubSpotRateLimiter:
-    """Test cases for the HubSpotRateLimiter class."""
-
     def setup_method(self):
-        """Set up test fixtures."""
         self.rate_limiter = HubSpotRateLimiter()
+
+    def _mock_redis(self, mocker, wait_ms_bytes=b"0.0"):
+        mock_redis = mocker.Mock()
+        mock_script = mocker.Mock(return_value=wait_ms_bytes)
+        mock_redis.register_script.return_value = mock_script
+        mocker.patch.object(self.rate_limiter, "_get_redis", return_value=mock_redis)
+        return mock_redis, mock_script
 
     @override_settings(HUBSPOT_TASK_DELAY=100)
     def test_init_with_custom_delay(self):
-        """Test that HubSpotRateLimiter initializes with custom delay setting."""
         limiter = HubSpotRateLimiter()
         assert limiter.min_delay_ms == 100
 
     def test_init_sets_correct_defaults(self):
-        """Test that HubSpotRateLimiter initializes with correct default values."""
-        limiter = HubSpotRateLimiter()
-        assert limiter.min_delay_ms == 60
+        assert self.rate_limiter.min_delay_ms == 60
 
     @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_first_request(self, mock_time, mock_sleep):
-        """Test first request with no previous requests."""
-        mock_time.return_value = 1000.0
-
+    def test_no_sleep_when_redis_returns_zero(self, mock_sleep, mocker):
+        self._mock_redis(mocker, b"0.0")
         self.rate_limiter.wait_for_rate_limit()
-
         mock_sleep.assert_not_called()
 
     @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_respects_min_delay(self, mock_time, mock_sleep):
-        """Test that minimum delay is respected between requests."""
-
-        mock_time.side_effect = [1000.0, 1000.05, 1000.05, 1000.05]
-        self.rate_limiter.min_delay_ms = 100
-
+    def test_sleeps_when_redis_returns_wait_time(self, mock_sleep, mocker):
+        self._mock_redis(mocker, b"500.0")
         self.rate_limiter.wait_for_rate_limit()
-        self.rate_limiter.wait_for_rate_limit()
-
-        expected_sleep = 0.05
         mock_sleep.assert_called_once()
-        sleep_time = mock_sleep.call_args[0][0]
-        assert abs(sleep_time - expected_sleep) < 0.01
+        assert abs(mock_sleep.call_args[0][0] - 0.5) < 0.1
 
+    def test_uses_correct_lua_script(self, mocker):
+        mock_redis, _ = self._mock_redis(mocker)
+        self.rate_limiter.wait_for_rate_limit()
+        mock_redis.register_script.assert_called_once_with(_RATE_LIMIT_LUA)
+
+    def test_script_receives_correct_keys_and_args(self, mocker):
+        _, mock_script = self._mock_redis(mocker)
+        self.rate_limiter.wait_for_rate_limit()
+        call_kwargs = mock_script.call_args[1]
+        assert call_kwargs["keys"] == ["hubspot:rate_limit"]
+        args = call_kwargs["args"]
+        assert args[1] == "1.0"   # window_size_seconds
+        assert args[2] == "19"    # max_requests_per_second
+
+    @pytest.mark.parametrize("wait_ms_bytes", [b"0.0", b"100.0", b"999.9"])
     @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_no_sleep_when_min_delay_satisfied(
-        self, mock_time, mock_sleep
-    ):
-        """Test no sleep when minimum delay is already satisfied."""
-        mock_time.side_effect = [1000.0, 1000.2, 1000.2, 1000.2]
-        self.rate_limiter.min_delay_ms = 100
-
+    def test_parses_bytes_return_value(self, mock_sleep, wait_ms_bytes, mocker):
+        self._mock_redis(mocker, wait_ms_bytes)
         self.rate_limiter.wait_for_rate_limit()
-        self.rate_limiter.wait_for_rate_limit()
-
-        mock_sleep.assert_not_called()
-
-    @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_sliding_window_limit(self, mock_time, mock_sleep):
-        """Test rate limiting when hitting max requests per second."""
-        base_time = 1000.0
-        mock_time.side_effect = [base_time + i * 0.01 for i in range(25)]
-        self.rate_limiter.min_delay_ms = 0
-
-        for _ in range(19):
-            self.rate_limiter.wait_for_rate_limit()
-
-        self.rate_limiter.wait_for_rate_limit()
-
-        mock_sleep.assert_called()
-
-    @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_cleanup_old_timestamps(self, mock_time, mock_sleep):
-        """Test that old timestamps are cleaned up properly."""
-        base_time = 1000.0
-        for i in range(10):
-            self.rate_limiter._request_times.append(base_time + i * 0.1)  # noqa: SLF001
-
-        mock_time.return_value = base_time + 2.0
-
-        self.rate_limiter.wait_for_rate_limit()
-
-        mock_sleep.assert_not_called()
-
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_cleanup_counter(self, mock_time):
-        """Test that cleanup counter triggers periodic cleanup."""
-        mock_time.return_value = 1000.0
-
-        for _ in range(51):
-            self.rate_limiter.wait_for_rate_limit()
-
-    @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    @patch("hubspot_sync.rate_limiter.random.uniform")
-    def test_wait_for_rate_limit_jitter(self, mock_random, mock_time, mock_sleep):
-        """Test that jitter is applied to sleep time."""
-        mock_time.side_effect = [1000.0, 1000.05, 1000.05, 1000.05]
-        mock_random.return_value = 0.01
-        self.rate_limiter.min_delay_ms = 100
-
-        self.rate_limiter.wait_for_rate_limit()
-        self.rate_limiter.wait_for_rate_limit()
-
-        mock_random.assert_called_once()
-        mock_sleep.assert_called_once()
-        sleep_time = mock_sleep.call_args[0][0]
-        assert sleep_time > 0.05
-
-    @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    @patch("hubspot_sync.rate_limiter.random.uniform")
-    def test_wait_for_rate_limit_negative_jitter_protection(
-        self, mock_random, mock_time, mock_sleep
-    ):
-        """Test that negative jitter doesn't result in negative sleep time."""
-        mock_time.side_effect = [1000.0, 1000.05, 1000.05, 1000.05]
-        mock_random.return_value = -0.1
-        self.rate_limiter.min_delay_ms = 100
-
-        self.rate_limiter.wait_for_rate_limit()
-        self.rate_limiter.wait_for_rate_limit()
-
-        mock_sleep.assert_called_once()
-        sleep_time = mock_sleep.call_args[0][0]
-        assert sleep_time >= 0
-
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_thread_safety(self, mock_time):
-        """Test that the rate limiter handles concurrent access safely."""
-        mock_time.return_value = 1000.0
-
-        for _ in range(5):
-            self.rate_limiter.wait_for_rate_limit()
+        expected_wait_s = float(wait_ms_bytes) / 1000
+        if expected_wait_s > 0:
+            assert mock_sleep.called
+            assert abs(mock_sleep.call_args[0][0] - expected_wait_s) < 0.1
+        else:
+            mock_sleep.assert_not_called()
 
     @patch("hubspot_sync.rate_limiter.log.debug")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_logs_sleep_time(self, mock_time, mock_log):
-        """Test that sleep time is logged when rate limiting occurs."""
-        mock_time.side_effect = [1000.0, 1000.05, 1000.05, 1000.05]
-        self.rate_limiter.min_delay_ms = 100
-
+    def test_logs_sleep_time_when_rate_limited(self, mock_log, mocker):
+        self._mock_redis(mocker, b"200.0")
         self.rate_limiter.wait_for_rate_limit()
-        self.rate_limiter.wait_for_rate_limit()
-
         mock_log.assert_called_once()
-        log_message = mock_log.call_args[0][0]
-        assert "Rate limiting: sleeping for" in log_message
-
-    @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_window_size_boundary(self, mock_time, mock_sleep):
-        """Test behavior at window size boundary."""
-        base_time = 1000.0
-        for i in range(19):
-            self.rate_limiter._request_times.append(base_time + i * 0.01)  # noqa: SLF001
-
-        mock_time.return_value = base_time + 1.0
-
-        self.rate_limiter.wait_for_rate_limit()
-
-        mock_sleep.assert_not_called()
-
-    @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_concurrent_requests_in_window(
-        self, mock_time, mock_sleep
-    ):
-        """Test multiple requests within the same time window."""
-        mock_time.return_value = 1000.0
-        self.rate_limiter.min_delay_ms = 10
-
-        for _ in range(3):
-            self.rate_limiter.wait_for_rate_limit()
-
-        assert mock_sleep.call_count >= 2
-
-    @patch("hubspot_sync.rate_limiter.time.sleep")
-    @patch("hubspot_sync.rate_limiter.time.time")
-    def test_wait_for_rate_limit_zero_min_delay(self, mock_time, mock_sleep):
-        """Test behavior with zero minimum delay."""
-        mock_time.side_effect = [1000.0, 1000.0, 1000.0, 1000.0]
-        self.rate_limiter.min_delay_ms = 0
-
-        self.rate_limiter.wait_for_rate_limit()
-        self.rate_limiter.wait_for_rate_limit()
-
-        mock_sleep.assert_not_called()
+        assert "Rate limiting: sleeping for" in mock_log.call_args[0][0]


### PR DESCRIPTION
### What are the relevant tickets?
NA
https://mitolproduction.grafana.net/a/grafana-lokiexplore-app/explore/service/celery-worker/logs?patterns=%5B%5D&from=now-3h&to=now&var-ds=grafanacloud-logs&var-filters=service_name%7C%3D%7Ccelery-worker&var-fields=&var-levels=&var-metadata=&var-patterns=&var-lineFilterV2=&var-lineFilters=caseInsensitive,0%7C__gfp__%3D%7Cd371c37a-d01d-4b81-87bf-dfc6ff9fe0fe&timezone=browser&var-lineFormat=&var-jsonFields=&var-all-fields=&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&userDisplayedFields=false&sortOrder=%22Descending%22&wrapLogMessage=false&prettifyLogMessage=false

### Description (What does it do?)
Replaces the per-process HubSpot rate limiter with a Redis Lua-script sliding window so Celery workers enforce limits globally. Adds a thread-safe in-memory fallback for Redis outages, including warning logs and jittered sleep handling. Tests were reorganized to cover both the fallback limiter and Redis-backed behavior (script invocation, args, wait parsing, sleep/no-sleep paths, and fallback conditions).


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->