### PR TITLE
fix: hard purge Fastly surrogate keys instead of soft purge

### DIFF
--- a/cms/tasks.py
+++ b/cms/tasks.py
@@ -111,6 +111,15 @@ def queue_fastly_surrogate_key_purge(surrogate_key, service_id=None):
 
     Key format: mitxonline:course:<readable_id> or mitxonline:program:<readable_id>
 
+    This is a *hard* purge. A soft purge would only mark the objects stale, and
+    MIT Learn pages are served with a long stale-while-revalidate window, so
+    every cache node would serve the outdated page at least once more before
+    refreshing. That is the wrong trade for the changes this task reacts to:
+    publishing, unpublishing, or flipping `live` means the cached response is
+    not merely stale but wrong -- a cached 404 for a page that now exists, or a
+    page that should no longer be reachable. A hard purge evicts instead, so the
+    next request is a guaranteed miss through to origin.
+
     Args:
         surrogate_key (str): The surrogate key to purge, e.g.
             "mitxonline:course:course-v1:MITx+6.00.1x"
@@ -144,10 +153,7 @@ def queue_fastly_surrogate_key_purge(surrogate_key, service_id=None):
         settings.FASTLY_URL,
         f"/service/{service_id}/purge/{surrogate_key}",
     )
-    headers = {
-        "Fastly-Key": settings.FASTLY_AUTH_TOKEN,
-        "fastly-soft-purge": "1",
-    }
+    headers = {"Fastly-Key": settings.FASTLY_AUTH_TOKEN}
 
     resp = requests.post(api_url, headers=headers, timeout=10)
 

--- a/cms/tasks.py
+++ b/cms/tasks.py
@@ -111,14 +111,11 @@ def queue_fastly_surrogate_key_purge(surrogate_key, service_id=None):
 
     Key format: mitxonline:course:<readable_id> or mitxonline:program:<readable_id>
 
-    This is a *hard* purge. A soft purge would only mark the objects stale, and
-    MIT Learn pages are served with a long stale-while-revalidate window, so
-    every cache node would serve the outdated page at least once more before
-    refreshing. That is the wrong trade for the changes this task reacts to:
-    publishing, unpublishing, or flipping `live` means the cached response is
-    not merely stale but wrong -- a cached 404 for a page that now exists, or a
-    page that should no longer be reachable. A hard purge evicts instead, so the
-    next request is a guaranteed miss through to origin.
+    This is a *hard* purge. A soft purge only marks objects stale, so each cache
+    node serves the outdated page once more before refreshing. For the events
+    this task reacts to -- publishing, unpublishing, flipping `live` -- that
+    response is not merely stale but wrong: a cached 404 for a page that now
+    exists, or a page that should no longer be reachable.
 
     Args:
         surrogate_key (str): The surrogate key to purge, e.g.

--- a/cms/tasks_test.py
+++ b/cms/tasks_test.py
@@ -49,6 +49,28 @@ def test_queue_fastly_surrogate_key_purge_targets_given_service(fastly_settings)
 
 
 @responses.activate
+def test_queue_fastly_surrogate_key_purge_sends_hard_purge(fastly_settings):
+    """
+    The surrogate key purge must be a hard purge -- no Fastly-Soft-Purge header.
+
+    A soft purge only marks objects stale, and MIT Learn serves pages with a long
+    stale-while-revalidate window, so each cache node would serve the outdated
+    page at least once more instead of refetching from origin.
+    """
+    responses.add(
+        responses.POST,
+        f"{FASTLY_URL}/service/{LEARN_SERVICE_ID}/purge/{SURROGATE_KEY}",
+        json={"status": "ok"},
+        status=200,
+    )
+
+    assert queue_fastly_surrogate_key_purge(SURROGATE_KEY, LEARN_SERVICE_ID) is True
+
+    sent_headers = responses.calls[0].request.headers
+    assert "fastly-soft-purge" not in {key.lower() for key in sent_headers}
+
+
+@responses.activate
 def test_queue_fastly_surrogate_key_purge_falls_back_to_settings(fastly_settings):
     """
     Called with the surrogate key alone, the task purges Learn's service anyway.

--- a/cms/tasks_test.py
+++ b/cms/tasks_test.py
@@ -53,9 +53,8 @@ def test_queue_fastly_surrogate_key_purge_sends_hard_purge(fastly_settings):
     """
     The surrogate key purge must be a hard purge -- no Fastly-Soft-Purge header.
 
-    A soft purge only marks objects stale, and MIT Learn serves pages with a long
-    stale-while-revalidate window, so each cache node would serve the outdated
-    page at least once more instead of refetching from origin.
+    A soft purge only marks objects stale, so each cache node would serve the
+    outdated page once more instead of refetching from origin.
     """
     responses.add(
         responses.POST,


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/12381

That issue was reopened to track hard vs. soft purge specifically, and [this comment](https://github.com/mitodl/hq/issues/12381#issuecomment-5106102226) splits it into two halves:

1. **Soft purge doesn't work at all right now** — after a soft purge, the shield serves stale content that the edge caches as fresh for a full TTL. Fixed in https://github.com/mitodl/ol-infrastructure/pull/5143, which applies [Fastly's documented shielding fix](https://www.fastly.com/documentation/guides/concepts/cache/stale/#shielding-considerations) and has sequence diagrams for the mechanism.
2. **For MITxOnline, soft purge is the wrong semantics anyway** — this PR.

The two are independent. This one is what makes publish/unpublish correct; #5143 is a guard rail that becomes inert once this lands.

### Description (What does it do?)

Drops the `Fastly-Soft-Purge` header from `queue_fastly_surrogate_key_purge`, so MITxOnline product-page invalidation is a **hard** purge.

```diff
-    headers = {
-        "Fastly-Key": MITX_ONLINE_FASTLY_AUTH_TOKEN,
-        "fastly-soft-purge": "1",
-    }
+    headers = {"Fastly-Key": MITX_ONLINE_FASTLY_AUTH_TOKEN}
```

**Why.** MIT Learn serves every page route with `Cache-Control: s-maxage=7200, stale-if-error=86400, stale-while-revalidate=86400`. A soft purge does not evict anything — it marks the object stale, and `stale-while-revalidate` then means each cache node answers the next request from its stale copy and refreshes in the background. So a soft purge guarantees at least one more outdated response per cache node, per object variant.

That is the wrong trade for the events this task fires on. Publishing, unpublishing, or flipping `live` doesn't make the cached response slightly old, it makes it **wrong**:

- A cached `404` for a page that now exists. Confirmed cacheable — MIT Learn returns 404s with the same 2-hour `s-maxage`, which is the "404s when new verticals are published for UAI" symptom in the issue.
- A page that should no longer be reachable, still being served after an unpublish.

A hard purge evicts, so the next request is a guaranteed miss through to origin. This also brings per-item purges in line with deploy-time purges, which already use a hard surrogate-key purge (`{"mode": "surrogate_key", "surrogate_key": "html-pages"}` in `ol-infrastructure`).

The origin-load argument for soft purge is weak here: Fastly collapses concurrent requests per object, and MIT Learn has shielding enabled, so a single product page going cold costs roughly one Next.js render regardless of how many POPs were holding it.

### How can this be tested?

Adds `cms/tasks_test.py` — `cms/tasks.py` had no test file previously. The test pins the absence of the soft-purge header, which is the behaviour that regressed silently before:

```bash
# Repo-standard workflow
docker compose exec web pytest cms/tasks_test.py courses/signals_test.py
```

I verified against the `ol-infrastructure` local-dev Kubernetes stack rather than docker compose:

```bash
kubectl exec -n mitxonline deploy/mitxonline-webapp -c app -- \
  pytest cms/tasks_test.py courses/signals_test.py cms/commands_test.py -n0 -q
# 10 passed
```

`pre-commit run --files cms/tasks.py cms/tasks_test.py` passes (ruff format, ruff, detect-secrets).

**The new test was confirmed failing before the fix** — re-adding the header produces:

```
FAILED cms/tasks_test.py::test_queue_fastly_surrogate_key_purge_sends_hard_purge
  - AssertionError: assert 'fastly-soft-purge' not in {'accept', 'accept-encodi...
```

One thing worth knowing if you extend these tests: `cms/tasks.py` imports the Fastly settings from `main.settings` at module import time, so they are attributes of `cms.tasks`, not live settings lookups. Django's `settings` fixture does not reach them — the test monkeypatches `cms.tasks.MITX_ONLINE_FASTLY_*` instead.

**End-to-end validation after deploy:** publish a MITxOnline course or program page, then load the corresponding `learn.mit.edu/courses/<readable_id>` page. It should reflect the change on the first request, with `age: 0`.

### Additional Context

**Deliberately left out of scope**, both from the same issue and both worth their own PRs:

- `queue_fastly_full_purge` is broken. It builds `urljoin("https://api.fastly.com", "*")` and sends `PURGE` to `api.fastly.com/*`, which is neither the site nor Fastly's purge-all endpoint (`POST /service/{id}/purge_all`). Reachable only via the `purge_fastly_cache` management command.
- `queue_fastly_purge_url` and `call_fastly_purge_api` appear to be dead code — nothing in the repo calls `queue_fastly_purge_url`, and `call_fastly_purge_api`'s only live caller is the broken full-purge task above.

**Also worth a follow-up:** the `post_save` receivers in `courses/signals.py` fire a purge on *every* save of a `Course`, `CourseRun`, or `Program`, unconditionally. With hard purges each of those is a genuine origin miss, so a bulk edX sync or `backpopulate` run will fan out into a burst of Next.js renders. Shielding bounds this to roughly one render per changed product rather than one per POP, so it should be tolerable, but narrowing those receivers to changes that actually affect the rendered page would be a real improvement.
