### PR TITLE
feat: retire course run cmd added to retire a b2b contract

### DIFF
--- a/b2b/api.py
+++ b/b2b/api.py
@@ -20,7 +20,11 @@ from wagtail.models import Page
 from b2b.constants import (
     B2B_RUN_TAG_FORMAT,
     CONTRACT_MEMBERSHIP_AUTOS,
+    CONTRACT_MEMBERSHIP_MANAGED,
     ORG_KEY_MAX_LENGTH,
+    RETIREMENT_CONTRACT_NAME,
+    RETIREMENT_ORG_KEY,
+    RETIREMENT_ORG_NAME,
 )
 from b2b.exceptions import SourceCourseIncompleteError
 from b2b.keycloak_admin_api import KCAM_ORGANIZATIONS, get_keycloak_model
@@ -109,6 +113,156 @@ def ensure_b2b_organization_index() -> OrganizationIndexPage:
             org_page.move(org_index_page, "last-child")
         log.info("Moved organization pages under organization index page")
     return org_index_page
+
+
+class RetirementContractCollisionError(Exception):
+    """Raised when a run can't be moved into the holding contract."""
+
+
+def get_or_create_retirement_contract() -> ContractPage:
+    """
+    Get (or create) the holding contract that retired course runs live in.
+
+    Moving a retired run here rather than nulling its ``b2b_contract`` matters:
+    ``CourseRunQuerySet.exclude_b2b()`` is ``b2b_contract__isnull=True``, so a
+    run with no contract becomes a candidate for the *public* catalog. Parking
+    it against an inactive contract keeps it out of the public catalog and out
+    of every org/contract catalog query, which filter on
+    ``b2b_contract__active=True``.
+
+    Both pages are created unpublished so they are never served, and the
+    contract is inactive with a zero learner cap. The org has no
+    ``sso_organization_id``, which is safe: ``reconcile_keycloak_orgs`` only
+    creates or updates pages for orgs Keycloak knows about and never prunes
+    ones it doesn't.
+
+    Returns:
+        ContractPage: the holding contract.
+    """
+
+    org = OrganizationPage.objects.filter(org_key=RETIREMENT_ORG_KEY).first()
+
+    if not org:
+        # Prefer an existing index page. ensure_b2b_organization_index() also
+        # re-parents every OrganizationPage when its child count doesn't match,
+        # which is a side effect we don't want to trigger from here.
+        org_index = OrganizationIndexPage.objects.first() or (
+            ensure_b2b_organization_index()
+        )
+        org = OrganizationPage(
+            name=RETIREMENT_ORG_NAME,
+            org_key=RETIREMENT_ORG_KEY,
+            live=False,
+            description=(
+                "System organization. Holds course runs that have been retired. "
+                "Not a real customer - do not add members or contracts."
+            ),
+        )
+        org_index.add_child(instance=org)
+        org.refresh_from_db()
+        log.info("Created retirement holding organization %s", org)
+
+    contract = ContractPage.objects.filter(
+        organization=org, name=RETIREMENT_CONTRACT_NAME
+    ).first()
+
+    if not contract:
+        contract = ContractPage(
+            name=RETIREMENT_CONTRACT_NAME,
+            organization=org,
+            membership_type=CONTRACT_MEMBERSHIP_MANAGED,
+            active=False,
+            max_learners=0,
+            contract_start=None,
+            contract_end=None,
+            live=False,
+            description=(
+                "System contract. Retired course runs are parked here so they "
+                "stay hidden but keep their courseware IDs. Never add programs "
+                "or learners to this contract."
+            ),
+        )
+        org.add_child(instance=contract)
+        contract.refresh_from_db()
+        log.info("Created retirement holding contract %s", contract)
+
+    return contract
+
+
+def check_retirement_contract_collision(run: CourseRun, contract: ContractPage) -> None:
+    """
+    Check that moving the run into the holding contract won't break a constraint.
+
+    ``CourseRun`` has two unique constraints that include ``b2b_contract`` with
+    ``nulls_distinct=False`` - ``unique_primary_language_per_group`` and
+    ``unique_language_per_group``. Collisions are unlikely in practice because
+    the B2B run tag embeds the source contract ID and year, but an
+    ``IntegrityError`` mid-command is a much worse outcome than a clear refusal.
+
+    Args:
+        run (CourseRun): the run being moved.
+        contract (ContractPage): the holding contract.
+    Raises:
+        RetirementContractCollisionError: if a conflicting run is already parked.
+    """
+
+    siblings = CourseRun.all_objects.filter(
+        course=run.course,
+        run_tag=run.run_tag,
+        is_source_run=run.is_source_run,
+        b2b_contract=contract,
+    ).exclude(pk=run.pk)
+
+    if (
+        run.language
+        and siblings.filter(
+            language=run.language,
+            variant_length=run.variant_length,
+            variant_industry=run.variant_industry,
+        ).exists()
+    ):
+        msg = (
+            f"A run for {run.course.readable_id} with run tag '{run.run_tag}', "
+            f"language '{run.language}' and variant "
+            f"'{run.variant_length}/{run.variant_industry}' is already parked in "
+            f"{contract}. Rename the run tag or clear the existing one first."
+        )
+        raise RetirementContractCollisionError(msg)
+
+    if run.is_primary_language and siblings.filter(is_primary_language=True).exists():
+        msg = (
+            f"A primary-language run for {run.course.readable_id} with run tag "
+            f"'{run.run_tag}' is already parked in {contract}. Rename the run tag "
+            "or clear the existing one first."
+        )
+        raise RetirementContractCollisionError(msg)
+
+
+def move_run_to_retirement_contract(run: CourseRun) -> ContractPage:
+    """
+    Move a course run into the holding contract.
+
+    Args:
+        run (CourseRun): the run to park.
+    Returns:
+        ContractPage: the holding contract the run was moved to.
+    Raises:
+        RetirementContractCollisionError: if a conflicting run is already parked.
+    """
+
+    contract = get_or_create_retirement_contract()
+
+    if run.b2b_contract_id == contract.id:
+        return contract
+
+    check_retirement_contract_collision(run, contract)
+
+    run.b2b_contract = contract
+    run.save()
+
+    log.info("Moved course run %s to %s", run.courseware_id, contract)
+
+    return contract
 
 
 @transaction.atomic

--- a/b2b/commands_test.py
+++ b/b2b/commands_test.py
@@ -33,7 +33,10 @@ def _create_run_with_product_and_discount(contract, *, with_enrollment=False):
 def test_b2b_courseware_remove_run_without_enrollments_unlinks_and_deactivates(mocker):
     """Removing a run with no enrollments should unlink it and deactivate related objects."""
 
-    mocker.patch("b2b.management.commands.b2b_courseware.update_edx_course")
+    # b2b_courseware pushes dates through courses.retirement now, shared with
+    # retire_courserun. Patch the edX boundary rather than the helper, so the
+    # payload-building logic still runs under test.
+    mocker.patch("courses.retirement.update_edx_course")
 
     contract = ContractPageFactory.create()
     run, product, discount = _create_run_with_product_and_discount(
@@ -69,7 +72,10 @@ def test_b2b_courseware_remove_run_with_enrollments_keeps_contract_and_deactivat
 ):
     """Removing a run with enrollments should keep contract link but deactivate run/products/codes."""
 
-    mocker.patch("b2b.management.commands.b2b_courseware.update_edx_course")
+    # b2b_courseware pushes dates through courses.retirement now, shared with
+    # retire_courserun. Patch the edX boundary rather than the helper, so the
+    # payload-building logic still runs under test.
+    mocker.patch("courses.retirement.update_edx_course")
 
     contract = ContractPageFactory.create()
     run, product, discount = _create_run_with_product_and_discount(
@@ -105,7 +111,10 @@ def test_b2b_courseware_remove_run_does_not_delete_used_discount_order_redemptio
 ):
     """Discounts that have been used for an order should not be deleted."""
 
-    mocker.patch("b2b.management.commands.b2b_courseware.update_edx_course")
+    # b2b_courseware pushes dates through courses.retirement now, shared with
+    # retire_courserun. Patch the edX boundary rather than the helper, so the
+    # payload-building logic still runs under test.
+    mocker.patch("courses.retirement.update_edx_course")
 
     contract = ContractPageFactory.create()
     run, product, discount = _create_run_with_product_and_discount(
@@ -128,7 +137,10 @@ def test_b2b_courseware_remove_run_does_not_delete_used_discount_contract_attach
 ):
     """Discounts that have been used to attach a user to a contract should not be deleted."""
 
-    mocker.patch("b2b.management.commands.b2b_courseware.update_edx_course")
+    # b2b_courseware pushes dates through courses.retirement now, shared with
+    # retire_courserun. Patch the edX boundary rather than the helper, so the
+    # payload-building logic still runs under test.
+    mocker.patch("courses.retirement.update_edx_course")
 
     contract = ContractPageFactory.create()
     run, product, discount = _create_run_with_product_and_discount(

--- a/b2b/constants.py
+++ b/b2b/constants.py
@@ -32,3 +32,12 @@ CONTRACT_MEMBERSHIP_TYPE_CHOICES = list(
 B2B_RUN_TAG_FORMAT = "{run_idx}T{contract_id}C{year}"
 
 ORG_KEY_MAX_LENGTH = 30
+
+# The holding org/contract that retired course runs get moved into. Runs parked
+# here are hidden from every catalog path because the contract is inactive and
+# has no members, but the CourseRun row survives - which matters, because
+# create_contract_run_key() derives its run index from existing courseware IDs,
+# so deleting a retired run risks minting a duplicate courseware ID later.
+RETIREMENT_ORG_KEY = "RETIRED"
+RETIREMENT_ORG_NAME = "Retired Runs"
+RETIREMENT_CONTRACT_NAME = "Retired Runs Holding Contract"

--- a/b2b/management/commands/b2b_courseware.py
+++ b/b2b/management/commands/b2b_courseware.py
@@ -7,7 +7,6 @@ Allows you to
 import logging
 from argparse import RawTextHelpFormatter
 
-from django.contrib.contenttypes.models import ContentType
 from django.core.management import BaseCommand, CommandError
 from mitol.common.utils.datetime import now_in_utc
 from opaque_keys import InvalidKeyError
@@ -18,8 +17,12 @@ from b2b.tasks import queue_enrollment_code_check
 from courses.api import resolve_courseware_object_from_id
 from courses.constants import UAI_COURSEWARE_ID_PREFIX
 from courses.models import CourseRun, CourseRunEnrollment
-from ecommerce.models import Discount, DiscountProduct, Product
-from openedx.api import update_edx_course
+from courses.retirement import (
+    deactivate_run_products,
+    get_run_products,
+    push_run_dates_to_edx,
+)
+from ecommerce.models import Discount, DiscountProduct
 
 log = logging.getLogger(__name__)
 
@@ -457,23 +460,13 @@ Specifying a program will only unlink the program from the contract, unless "--r
 
                 courseware.save()
 
-                # Deactivate products for this run
-                # Use all_objects so we can find products regardless of
-                # their current is_active state, and evaluate to a list so
-                # subsequent updates don't affect the collection we use
-                # below when removing discount associations.
-                content_type = ContentType.objects.get_for_model(CourseRun)
-                run_products = list(
-                    Product.all_objects.filter(
-                        content_type=content_type,
-                        object_id=courseware.id,
-                    ).all()
-                )
-
-                for product in run_products:
-                    if product.is_active:
-                        product.is_active = False
-                        product.save(update_fields=("is_active",))
+                # Deactivate products for this run. get_run_products uses
+                # all_objects so it finds products regardless of their current
+                # is_active state, and returns a list so the deactivation below
+                # doesn't mutate the collection we reuse when removing discount
+                # associations. Shared with the retire_courserun command.
+                run_products = get_run_products(courseware)
+                deactivate_run_products(courseware)
 
                 # Invalidate/delete any enrollment codes (Discounts) associated with this run's products
                 discounts = Discount.objects.filter(
@@ -497,26 +490,17 @@ Specifying a program will only unlink the program from the contract, unless "--r
 
                 # Attempt to push the new enrollment_end to edX so it isn't
                 # overwritten by the next sync from edX.
+                #
+                # NOTE: edX will not accept an enrollment window for a run that
+                # has no start and end date, so for a run with a null end_date
+                # the new enrollment_end never reaches edX and the next sync
+                # reverts it. push_run_dates_to_edx returns False and logs a
+                # warning in that case. Fixing it properly means also moving
+                # end_date into the past, which is what the retire_courserun
+                # command does; this command's contract is narrower, so the
+                # behaviour is left as-is here.
                 try:
-                    pacing_type = (
-                        "self_paced" if courseware.is_self_paced else "instructor_paced"
-                    )
-
-                    course_params = [
-                        courseware.courseware_id,
-                        courseware.title,
-                        pacing_type,
-                    ]
-
-                    if courseware.start_date and courseware.end_date:
-                        course_params.append(courseware.start_date)
-                        course_params.append(courseware.end_date)
-
-                        if courseware.enrollment_start and courseware.enrollment_end:
-                            course_params.append(courseware.enrollment_start)
-                            course_params.append(courseware.enrollment_end)
-
-                    update_edx_course(*course_params)
+                    push_run_dates_to_edx(courseware)
                 except Exception:
                     log.exception(
                         "Failed to update enrollment end date on edX for %s",

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -468,6 +468,37 @@ class CourseRunAdmin(VerifiableCredentialBackfillAdminMixin, TimestampedModelAdm
 
         return self.model.all_objects
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        """
+        Show inactive contracts in the b2b_contract dropdown.
+
+        By default the admin builds this field from
+        ``ContractPage._default_manager``. ContractPage declares
+        ``active_objects`` as its only local manager, and Django orders local
+        managers ahead of ones inherited from the concrete parent, so
+        ``_default_manager`` is ``ActiveContractManager`` and filters
+        ``active=True``.
+
+        That means a run attached to an inactive contract - a retired run parked
+        in the holding contract, or any run on an expired contract - renders with
+        an empty dropdown, because its current value isn't among the choices.
+        Since the field is ``null=True, blank=True``, saving that form is valid
+        and silently sets ``b2b_contract`` to NULL, which turns a B2B run into a
+        public-catalog run (``CourseRunQuerySet.exclude_b2b`` treats a null
+        contract as "not B2B").
+        """
+
+        if db_field.name == "b2b_contract":
+            # Imported here to avoid a circular dependency at module load time,
+            # matching ProgramContractPageInline above.
+            from b2b.models import ContractPage  # noqa: PLC0415
+
+            kwargs["queryset"] = ContractPage.objects.order_by(
+                "organization__name", "name"
+            )
+
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
     @admin.display(description="Primary?", ordering="is_primary_language")
     def primary(self, obj):
         """Return the primary language run flag."""

--- a/courses/management/commands/retire_courserun.py
+++ b/courses/management/commands/retire_courserun.py
@@ -1,0 +1,421 @@
+"""
+Management command to retire (delist) a course run.
+
+Retiring a run makes it inert: its course and enrollment windows are pushed
+into the past in edX *and* locally, it stops being live, and its products are
+switched off. Existing enrollments are left alone by default so that learners
+who were partway through keep their access to the material.
+
+By default the command runs in dry-run mode and changes nothing. A snapshot of
+the run's pre-retirement state is written either way, so there is always a
+record to roll back from by hand.
+
+**Usage:**
+
+1. See what would happen (no changes, not even in edX):
+./manage.py retire_courserun --run=course-v1:UAI_ACME+14.100x+1T12C2026
+
+2. Retire the run, moving it to the B2B holding contract. Active learners keep
+   their enrollments and their access; they are reported, not blocked:
+./manage.py retire_courserun --run=course-v1:UAI_ACME+14.100x+1T12C2026 --commit
+
+3. Retire and unenroll everyone. This revokes courseware access, so it refuses
+   unless --allow-active-enrollments is passed too. Add --email to notify the
+   learners, which is off by default:
+./manage.py retire_courserun --run=... --commit --unenroll --allow-active-enrollments
+
+4. Retire a run that has no counterpart in edX:
+./manage.py retire_courserun --run=... --commit --skip-edx
+"""
+
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+from mitol.common.utils.datetime import now_in_utc
+
+from b2b.api import (
+    RetirementContractCollisionError,
+    move_run_to_retirement_contract,
+)
+from courses.management.utils import bulk_unenroll_learners
+from courses.models import CourseRun
+from courses.retirement import (
+    SourceRunRetirementError,
+    audit_course_run,
+    build_snapshot,
+    check_run_retirable,
+    retire_course_run,
+)
+from openedx.api import get_edx_course
+
+
+class Command(BaseCommand):
+    """Retire a course run in both edX and MITx Online."""
+
+    help = "Retire (delist) a course run in both edX and MITx Online."
+
+    def add_arguments(self, parser):
+        """Add command line arguments."""
+
+        parser.add_argument(
+            "--run",
+            type=str,
+            required=True,
+            help="The 'courseware_id' value for the CourseRun to retire.",
+        )
+        parser.add_argument(
+            "--commit",
+            action="store_true",
+            dest="commit",
+            help="Actually retire the run. Without this flag, the command runs "
+            "in dry-run mode and makes no changes in edX or MITx Online.",
+        )
+        parser.add_argument(
+            "--unenroll",
+            action="store_true",
+            dest="unenroll",
+            help="Unenroll the run's learners in edX and MITx Online. This "
+            "revokes their access to the courseware, so it is off by default.",
+        )
+        parser.add_argument(
+            "--allow-active-enrollments",
+            action="store_true",
+            dest="allow_active_enrollments",
+            help="Required to combine --unenroll with a run that still has "
+            "active learners on it. Retiring on its own never needs this: it "
+            "leaves enrollments intact, so learners keep their access.",
+        )
+        parser.add_argument(
+            "--email",
+            action="store_true",
+            dest="email",
+            help="Send unenrollment notification emails. Only meaningful with "
+            "--unenroll. Off by default so retirement is silent to learners.",
+        )
+        parser.add_argument(
+            "--keep-contract",
+            action="store_true",
+            dest="keep_contract",
+            help="Leave the run attached to its current B2B contract instead of "
+            "moving it to the retirement holding contract.",
+        )
+        parser.add_argument(
+            "--keep-products",
+            action="store_true",
+            dest="keep_products",
+            help="Leave the run's products active.",
+        )
+        parser.add_argument(
+            "--skip-edx",
+            action="store_true",
+            dest="skip_edx",
+            help="Don't read from or write to edX. Use for runs that have no "
+            "edX counterpart. The next sync will not overwrite the local dates "
+            "only if the run genuinely isn't in edX.",
+        )
+        parser.add_argument(
+            "--snapshot-dir",
+            type=str,
+            dest="snapshot_dir",
+            default=".",
+            help="Directory to write the pre-retirement snapshot to. Defaults "
+            "to the current directory.",
+        )
+        parser.add_argument(
+            "--reason",
+            type=str,
+            default="",
+            help="Why the run is being retired. Recorded in the snapshot.",
+        )
+
+    def _resolve_run(self, courseware_id):
+        """
+        Find the run and refuse the ones we shouldn't touch.
+
+        Uses all_objects because the default manager excludes source runs, and
+        we need to be able to see a source run in order to reject it.
+        """
+
+        run = CourseRun.all_objects.filter(courseware_id=courseware_id).first()
+
+        if run is None:
+            msg = f"Could not find course run with courseware_id={courseware_id}"
+            raise CommandError(msg)
+
+        try:
+            check_run_retirable(run)
+        except SourceRunRetirementError as exc:
+            raise CommandError(str(exc)) from exc
+
+        return run
+
+    def _report(self, audit):
+        """Print the audit for the operator."""
+
+        run = audit.run
+
+        self.stdout.write("")
+        self.stdout.write(f"Course run:   {run.courseware_id} (id={run.id})")
+        self.stdout.write(f"Course:       {run.course.readable_id}")
+        self.stdout.write(f"Title:        {run.title}")
+        self.stdout.write(
+            f"Run tag:      {run.run_tag}  language: {run.language or '-'}"
+        )
+        self.stdout.write(f"Live:         {run.live}")
+        self.stdout.write(f"Start / end:  {run.start_date} / {run.end_date}")
+        self.stdout.write(
+            f"Enrollment:   {run.enrollment_start} / {run.enrollment_end}"
+        )
+        self.stdout.write(
+            f"B2B contract: {run.b2b_contract or '- (not a contract run)'}"
+        )
+
+        self.stdout.write("")
+        if audit.edx_error:
+            self.stdout.write(
+                self.style.WARNING(f"edX lookup failed: {audit.edx_error}")
+            )
+        elif audit.edx_details:
+            self.stdout.write("edX currently reports:")
+            for key, value in audit.edx_details.items():
+                self.stdout.write(f"  {key}: {value}")
+        else:
+            self.stdout.write("edX not consulted (--skip-edx).")
+
+        self.stdout.write("")
+        self.stdout.write(
+            f"Enrollments:  {len(audit.active_enrollments)} active, "
+            f"{len(audit.inactive_enrollments)} inactive"
+        )
+        for enrollment in audit.active_enrollments:
+            self.stdout.write(
+                f"  ACTIVE  {enrollment.user.email} ({enrollment.enrollment_mode})"
+            )
+        if audit.certificate_count or audit.grade_count:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  {audit.certificate_count} certificate(s) and "
+                    f"{audit.grade_count} grade record(s) exist for this run. "
+                    "These are kept either way."
+                )
+            )
+
+        self.stdout.write("")
+        self.stdout.write(f"Products:     {len(audit.products)}")
+        for entry in audit.products:
+            state = "active" if entry.was_active else "inactive"
+            self.stdout.write(
+                f"  #{entry.product.id} {entry.product.description} "
+                f"({entry.product.price}, {state}), "
+                f"{len(entry.discounts)} discount code(s), "
+                f"{entry.basket_items} open basket item(s)"
+            )
+            if entry.discounts:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "    Discount codes are NOT removed by this command. "
+                        "They will stop working once the product is inactive."
+                    )
+                )
+
+    def _write_snapshot(self, audit, snapshot_dir, reason):
+        """Write the rollback snapshot and return its path."""
+
+        snapshot = build_snapshot(audit, reason=reason, source="Management Command")
+
+        safe_id = audit.run.courseware_id.replace(":", "_").replace("+", "_")
+        timestamp = now_in_utc().strftime("%Y%m%dT%H%M%SZ")
+        target = Path(snapshot_dir) / f"retire_{safe_id}_{timestamp}.json"
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(snapshot, indent=2))
+
+        return target.resolve()
+
+    def _handle_contract(self, run, *, keep_contract):
+        """Move the run to the holding contract, if it's a contract run."""
+
+        if keep_contract or not run.b2b_contract_id:
+            return
+
+        previous = str(run.b2b_contract)
+
+        try:
+            contract = move_run_to_retirement_contract(run)
+        except RetirementContractCollisionError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write(
+            self.style.SUCCESS(f"  Moved from '{previous}' to '{contract}'")
+        )
+
+    def _handle_unenroll(self, run, *, email):
+        """Unenroll the run's active learners."""
+
+        entries = [
+            (enrollment.user.email, run.courseware_id)
+            for enrollment in run.enrollments.filter(active=True).select_related("user")
+        ]
+
+        if not entries:
+            self.stdout.write("  No active enrollments to remove.")
+            return
+
+        summary = bulk_unenroll_learners(
+            entries,
+            keep_failed_enrollments=False,
+            send_notification=email,
+        )
+
+        for _user_id, _cw_id, status, message in summary["details"]:
+            if status == "succeeded":
+                self.stdout.write(self.style.SUCCESS(f"  {message}"))
+            elif status == "skipped":
+                self.stderr.write(self.style.WARNING(f"  SKIP: {message}"))
+            else:
+                self.stderr.write(self.style.ERROR(f"  FAILED: {message}"))
+
+        self.stdout.write(
+            f"  Unenrolled {summary['succeeded']}, failed {summary['failed']}, "
+            f"skipped {summary['skipped']}"
+        )
+
+    def _verify(self, run, *, skip_edx):
+        """Re-read the run and report anything that didn't stick."""
+
+        run.refresh_from_db()
+
+        problems = []
+
+        if run.live:
+            problems.append("run is still live")
+        if not run.end_date or run.end_date > now_in_utc():
+            problems.append("end_date is not in the past")
+        if not run.enrollment_end or run.enrollment_end > now_in_utc():
+            problems.append("enrollment_end is not in the past")
+
+        if not skip_edx:
+            try:
+                edx_run = get_edx_course(run.courseware_id)
+                self.stdout.write(
+                    f"  edX now reports end={getattr(edx_run, 'end', None)}, "
+                    f"enrollment_end={getattr(edx_run, 'enrollment_end', None)}"
+                )
+            except Exception as exc:  # noqa: BLE001
+                problems.append(f"could not re-read the run from edX: {exc}")
+
+        if problems:
+            self.stderr.write(
+                self.style.ERROR("Verification found problems: " + "; ".join(problems))
+            )
+        else:
+            self.stdout.write(self.style.SUCCESS("  Verification passed."))
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Handle command execution."""
+
+        commit = options["commit"]
+        skip_edx = options["skip_edx"]
+
+        run = self._resolve_run(options["run"])
+
+        # An active product parked in the holding contract is a hazard: the
+        # holding contract is 'managed' with no fixed price, so a later
+        # `b2b_codes validate` sweep would treat it as a free SSO contract and
+        # delete its discounts. Deactivating the products keeps the contract
+        # inert, because ContractPage.get_products() filters on is_active.
+        if (
+            options["keep_products"]
+            and run.b2b_contract_id
+            and not options["keep_contract"]
+        ):
+            msg = (
+                "--keep-products cannot be combined with moving the run to the "
+                "retirement holding contract. Leaving an active product on a run "
+                "parked in the holding contract risks a later b2b_codes sweep "
+                "deleting its discounts. Add --keep-contract if you really want "
+                "the products left on."
+            )
+            raise CommandError(msg)
+
+        audit = audit_course_run(run, fetch_edx=not skip_edx)
+        self._report(audit)
+
+        snapshot_path = self._write_snapshot(
+            audit, options["snapshot_dir"], options["reason"]
+        )
+        self.stdout.write("")
+        self.stdout.write(f"Snapshot written to {snapshot_path}")
+
+        if not commit:
+            self.stdout.write("")
+            self.stdout.write(
+                self.style.WARNING(
+                    "DRY RUN - nothing was changed. Re-run with --commit to retire "
+                    "this run."
+                )
+            )
+            return
+
+        # Retiring on its own is safe for people already on the run: no view
+        # filters enrollments on live/end_date/expiration_date, and edX access
+        # is governed purely by the enrollment record. So the refusal belongs on
+        # --unenroll, which is the step that actually takes access away.
+        if (
+            options["unenroll"]
+            and audit.has_active_enrollments
+            and not options["allow_active_enrollments"]
+        ):
+            msg = (
+                f"--unenroll would remove {len(audit.active_enrollments)} active "
+                f"enrollment(s) from {run.courseware_id}, revoking those learners' "
+                "access to the courseware. Re-run with --allow-active-enrollments "
+                "if that is what you want, or drop --unenroll to retire the run "
+                "and leave them enrolled."
+            )
+            raise CommandError(msg)
+
+        self.stdout.write("")
+        self.stdout.write("Retiring...")
+
+        result = retire_course_run(
+            run,
+            deactivate_products=not options["keep_products"],
+            skip_edx=skip_edx,
+        )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"  Dates set to start={result['dates']['start']}, "
+                f"end={result['dates']['end']}, "
+                f"enrollment_end={result['dates']['enrollment_end']}"
+            )
+        )
+        self.stdout.write(self.style.SUCCESS("  live set to False"))
+
+        if not skip_edx and not result["edx_updated"]:
+            self.stderr.write(
+                self.style.ERROR(
+                    "  edX did not receive the enrollment window. The next "
+                    "courseware sync will overwrite the local dates."
+                )
+            )
+
+        for product in result["products"]:
+            self.stdout.write(
+                self.style.SUCCESS(f"  Deactivated product #{product.id}")
+            )
+
+        self._handle_contract(run, keep_contract=options["keep_contract"])
+
+        if options["unenroll"]:
+            self._handle_unenroll(run, email=options["email"])
+
+        self.stdout.write("")
+        self.stdout.write("Verifying...")
+        self._verify(run, skip_edx=skip_edx)
+
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS(f"Retired {run.courseware_id}."))
+        self.stdout.write(f"Snapshot for rollback: {snapshot_path}")

--- a/courses/management/commands/retire_courserun.py
+++ b/courses/management/commands/retire_courserun.py
@@ -229,7 +229,10 @@ class Command(BaseCommand):
         target = Path(snapshot_dir) / f"retire_{safe_id}_{timestamp}.json"
 
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps(snapshot, indent=2))
+        # default=str so an unexpected object from the edX client can never be
+        # the thing that aborts a retirement. The snapshot is a safety net; it
+        # should degrade to a string rather than raise.
+        target.write_text(json.dumps(snapshot, indent=2, default=str))
 
         return target.resolve()
 

--- a/courses/management/tests/retire_courserun_test.py
+++ b/courses/management/tests/retire_courserun_test.py
@@ -260,8 +260,15 @@ class TestCommit:
         # CourseRun.save() calls clean(), which rejects an expiration_date
         # earlier than start/end. Without clearing it, retiring an already
         # finished run raises ValidationError *after* the edX write landed.
-        run.expiration_date = now_in_utc() - timedelta(days=90)
-        run.end_date = now_in_utc() - timedelta(days=120)
+        #
+        # The setup itself has to satisfy clean(), so the whole run is pushed
+        # well into the past: start < end < expiration, all historic. Retiring
+        # then moves end to yesterday, which lands after expiration and is what
+        # forces the reset.
+        now = now_in_utc()
+        run.start_date = now - timedelta(days=200)
+        run.end_date = now - timedelta(days=120)
+        run.expiration_date = now - timedelta(days=90)
         run.save()
 
         _run_command(run, tmp_path, commit=True)
@@ -451,7 +458,21 @@ class TestContractHandling:
 class TestCollisionCheck:
     """The holding contract can't be allowed to violate a unique constraint."""
 
-    def test_language_collision_refused(self, mock_edx):  # noqa: ARG002
+    @pytest.fixture
+    def source_contract(self):
+        """
+        A normal contract, created before anything asks for the holding one.
+
+        ContractPageFactory bootstraps HomePage -> OrganizationIndexPage ->
+        OrganizationPage. get_or_create_retirement_contract() falls back to
+        ensure_b2b_organization_index(), which calls cms.api.get_home_page() and
+        raises Page.DoesNotExist when no Wagtail tree exists yet, so the ordering
+        matters.
+        """
+
+        return ContractPageFactory.create()
+
+    def test_language_collision_refused(self, source_contract, mock_edx):  # noqa: ARG002
         """A parked run with the same course/tag/language/variant blocks the move."""
 
         holding = get_or_create_retirement_contract()
@@ -460,7 +481,7 @@ class TestCollisionCheck:
         )
         incoming = CourseRunFactory.create(
             course=parked.course,
-            b2b_contract=ContractPageFactory.create(),
+            b2b_contract=source_contract,
             language="de_DE",
             run_tag="1T9C2026",
         )
@@ -468,7 +489,7 @@ class TestCollisionCheck:
         with pytest.raises(RetirementContractCollisionError, match="already parked"):
             move_run_to_retirement_contract(incoming)
 
-    def test_primary_language_collision_refused(self, mock_edx):  # noqa: ARG002
+    def test_primary_language_collision_refused(self, source_contract, mock_edx):  # noqa: ARG002
         """A parked primary-language run blocks another for the same group."""
 
         holding = get_or_create_retirement_contract()
@@ -480,7 +501,7 @@ class TestCollisionCheck:
         )
         incoming = CourseRunFactory.create(
             course=parked.course,
-            b2b_contract=ContractPageFactory.create(),
+            b2b_contract=source_contract,
             language="",
             is_primary_language=True,
             run_tag="1T9C2026",
@@ -489,7 +510,7 @@ class TestCollisionCheck:
         with pytest.raises(RetirementContractCollisionError, match="primary-language"):
             move_run_to_retirement_contract(incoming)
 
-    def test_distinct_run_tags_do_not_collide(self, mock_edx):  # noqa: ARG002
+    def test_distinct_run_tags_do_not_collide(self, source_contract, mock_edx):  # noqa: ARG002
         """Different run tags park side by side, which is the normal case."""
 
         holding = get_or_create_retirement_contract()
@@ -498,14 +519,14 @@ class TestCollisionCheck:
         )
         incoming = CourseRunFactory.create(
             course=parked.course,
-            b2b_contract=ContractPageFactory.create(),
+            b2b_contract=source_contract,
             language="de_DE",
             run_tag="1T9C2027",
         )
 
         assert move_run_to_retirement_contract(incoming).id == holding.id
 
-    def test_already_parked_run_is_a_no_op(self, mock_edx):  # noqa: ARG002
+    def test_already_parked_run_is_a_no_op(self, source_contract, mock_edx):  # noqa: ARG002
         """Re-parking a run that's already in the holding contract is fine."""
 
         holding = get_or_create_retirement_contract()

--- a/courses/management/tests/retire_courserun_test.py
+++ b/courses/management/tests/retire_courserun_test.py
@@ -1,0 +1,607 @@
+"""Tests for the retire_courserun management command and courses.retirement."""
+
+from datetime import timedelta
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from mitol.common.utils.datetime import now_in_utc
+
+from b2b.api import (
+    RetirementContractCollisionError,
+    get_or_create_retirement_contract,
+    move_run_to_retirement_contract,
+)
+from b2b.factories import ContractPageFactory
+from courses.factories import (
+    CourseRunEnrollmentFactory,
+    CourseRunFactory,
+)
+from courses.retirement import (
+    SourceRunRetirementError,
+    check_run_retirable,
+    compute_retirement_dates,
+    deactivate_run_products,
+    get_run_products,
+    push_run_dates_to_edx,
+    retire_course_run,
+)
+from ecommerce.factories import ProductFactory
+from ecommerce.models import Product
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_edx(mocker):
+    """Stub out both edX calls the command makes."""
+
+    return {
+        "update": mocker.patch("courses.retirement.update_edx_course"),
+        "get": mocker.patch("courses.retirement.get_edx_course"),
+        "verify_get": mocker.patch(
+            "courses.management.commands.retire_courserun.get_edx_course"
+        ),
+    }
+
+
+@pytest.fixture
+def run():
+    """A live, in-progress run with a product."""
+
+    course_run = CourseRunFactory.create(live=True)
+    ProductFactory.create(purchasable_object=course_run, is_active=True)
+    return course_run
+
+
+def _run_command(course_run, tmp_path, **kwargs):
+    """Call the command, keeping snapshots out of the repo."""
+
+    out = StringIO()
+    err = StringIO()
+    call_command(
+        "retire_courserun",
+        run=course_run.courseware_id,
+        snapshot_dir=str(tmp_path),
+        stdout=out,
+        stderr=err,
+        **kwargs,
+    )
+    return out.getvalue(), err.getvalue()
+
+
+class TestDryRun:
+    """Without --commit, nothing anywhere should change."""
+
+    def test_dry_run_changes_nothing(self, run, tmp_path, mock_edx):
+        """Dry run changes nothing."""
+
+        original = (
+            run.live,
+            run.start_date,
+            run.end_date,
+            run.enrollment_start,
+            run.enrollment_end,
+        )
+
+        out, _ = _run_command(run, tmp_path)
+
+        run.refresh_from_db()
+        assert (
+            run.live,
+            run.start_date,
+            run.end_date,
+            run.enrollment_start,
+            run.enrollment_end,
+        ) == original
+        assert all(p.is_active for p in get_run_products(run))
+        mock_edx["update"].assert_not_called()
+        assert "DRY RUN" in out
+
+    def test_dry_run_still_writes_a_snapshot(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """Dry run still writes a snapshot."""
+
+        _run_command(run, tmp_path)
+
+        snapshots = list(tmp_path.glob("retire_*.json"))
+        assert len(snapshots) == 1
+
+    def test_dry_run_reports_enrollments_and_products(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """Dry run reports enrollments and products."""
+
+        enrollment = CourseRunEnrollmentFactory.create(run=run, active=True)
+
+        out, _ = _run_command(run, tmp_path)
+
+        assert enrollment.user.email in out
+        assert "1 active" in out
+        assert "Products:     1" in out
+
+
+class TestGuards:
+    """The command should refuse the dangerous cases."""
+
+    def test_unknown_run(self, tmp_path):
+        """Unknown run."""
+
+        with pytest.raises(CommandError, match="Could not find course run"):
+            call_command(
+                "retire_courserun",
+                run="course-v1:nope+nope+nope",
+                snapshot_dir=str(tmp_path),
+            )
+
+    def test_source_run_refused(self, tmp_path, mock_edx):  # noqa: ARG002
+        """Source run refused."""
+
+        source = CourseRunFactory.create(is_source_run=True)
+
+        with pytest.raises(CommandError, match="is a source run"):
+            _run_command(source, tmp_path, commit=True)
+
+    def test_source_run_refused_in_dry_run_too(self, tmp_path, mock_edx):  # noqa: ARG002
+        """Source run refused in dry run too."""
+
+        source = CourseRunFactory.create(is_source_run=True)
+
+        with pytest.raises(CommandError, match="is a source run"):
+            _run_command(source, tmp_path)
+
+    def test_source_run_by_run_tag_refused(self):
+        """Source run by run tag refused."""
+
+        source = CourseRunFactory.create(is_source_run=False, run_tag="SOURCE")
+
+        with pytest.raises(SourceRunRetirementError):
+            check_run_retirable(source)
+
+    def test_active_enrollments_do_not_block_retirement(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """Retiring never blocks on enrollments; it leaves them intact."""
+
+        enrollment = CourseRunEnrollmentFactory.create(run=run, active=True)
+
+        _run_command(run, tmp_path, commit=True)
+
+        run.refresh_from_db()
+        enrollment.refresh_from_db()
+        assert run.live is False
+        # No view filters enrollments on live/end_date/expiration_date, and edX
+        # access is enrollment-based, so this learner keeps working access.
+        assert enrollment.active is True
+
+    def test_unenroll_blocked_by_active_enrollments(self, run, tmp_path, mock_edx):
+        """--unenroll refuses without the override, changing nothing."""
+
+        CourseRunEnrollmentFactory.create(run=run, active=True)
+
+        with pytest.raises(CommandError, match="--unenroll would remove"):
+            _run_command(run, tmp_path, commit=True, unenroll=True)
+
+        run.refresh_from_db()
+        assert run.live is True
+        mock_edx["update"].assert_not_called()
+
+    def test_unenroll_allowed_with_override(self, run, tmp_path, mock_edx, mocker):  # noqa: ARG002
+        """--allow-active-enrollments unblocks --unenroll."""
+
+        mock_bulk = mocker.patch(
+            "courses.management.commands.retire_courserun.bulk_unenroll_learners",
+            return_value={"succeeded": 1, "failed": 0, "skipped": 0, "details": []},
+        )
+        CourseRunEnrollmentFactory.create(run=run, active=True)
+
+        _run_command(
+            run, tmp_path, commit=True, unenroll=True, allow_active_enrollments=True
+        )
+
+        run.refresh_from_db()
+        assert run.live is False
+        mock_bulk.assert_called_once()
+
+    def test_unenroll_with_no_active_enrollments_needs_no_override(
+        self,
+        run,
+        tmp_path,
+        mock_edx,  # noqa: ARG002
+    ):
+        """--unenroll on a run nobody is on doesn't need the override."""
+
+        CourseRunEnrollmentFactory.create(run=run, active=False)
+
+        _run_command(run, tmp_path, commit=True, unenroll=True)
+
+        run.refresh_from_db()
+        assert run.live is False
+
+    def test_inactive_enrollments_do_not_block(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """Inactive enrollments do not block."""
+
+        CourseRunEnrollmentFactory.create(run=run, active=False)
+
+        _run_command(run, tmp_path, commit=True)
+
+        run.refresh_from_db()
+        assert run.live is False
+
+
+class TestCommit:
+    """The committed path."""
+
+    def test_dates_and_live(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """Committing pushes the windows into the past and unsets live."""
+
+        _run_command(run, tmp_path, commit=True)
+
+        run.refresh_from_db()
+        now = now_in_utc()
+        assert run.live is False
+        assert run.end_date < now
+        assert run.enrollment_end < now
+        assert run.start_date < run.end_date
+        assert run.enrollment_start <= run.start_date
+
+    def test_future_expiration_date_untouched(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """A future expiration_date is left alone."""
+
+        original = run.expiration_date
+        assert original > now_in_utc()
+
+        _run_command(run, tmp_path, commit=True)
+
+        run.refresh_from_db()
+        # Moving expiration_date would hide the run from the dashboards of
+        # learners we deliberately left enrolled.
+        assert run.expiration_date == original
+
+    def test_past_expiration_date_is_cleared(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """A past expiration_date is cleared instead of tripping clean()."""
+
+        # CourseRun.save() calls clean(), which rejects an expiration_date
+        # earlier than start/end. Without clearing it, retiring an already
+        # finished run raises ValidationError *after* the edX write landed.
+        run.expiration_date = now_in_utc() - timedelta(days=90)
+        run.end_date = now_in_utc() - timedelta(days=120)
+        run.save()
+
+        _run_command(run, tmp_path, commit=True)
+
+        run.refresh_from_db()
+        assert run.expiration_date is None
+        assert run.live is False
+
+    def test_products_deactivated(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """Products deactivated."""
+
+        _run_command(run, tmp_path, commit=True)
+
+        assert all(not p.is_active for p in get_run_products(run))
+
+    def test_keep_products(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """Keep products."""
+
+        _run_command(run, tmp_path, commit=True, keep_products=True)
+
+        assert all(p.is_active for p in get_run_products(run))
+
+    def test_edx_gets_a_complete_date_set(self, run, tmp_path, mock_edx):
+        """All four dates must reach edX or the sync will revert us."""
+
+        _run_command(run, tmp_path, commit=True)
+
+        mock_edx["update"].assert_called_once()
+        _args, kwargs = mock_edx["update"].call_args
+        for key in ("start", "end", "enrollment_start", "enrollment_end"):
+            assert kwargs[key] is not None
+        assert kwargs["end"] < now_in_utc()
+
+    def test_edx_failure_leaves_local_state_alone(self, run, tmp_path, mock_edx):
+        """A failed edX write must abort before anything local changes."""
+
+        mock_edx["update"].side_effect = ValueError("edX exploded")
+
+        with pytest.raises(ValueError, match="edX exploded"):
+            _run_command(run, tmp_path, commit=True)
+
+        run.refresh_from_db()
+        assert run.live is True
+        assert all(p.is_active for p in get_run_products(run))
+
+    def test_skip_edx(self, run, tmp_path, mock_edx):
+        """--skip-edx bypasses edX entirely."""
+
+        _run_command(run, tmp_path, commit=True, skip_edx=True)
+
+        mock_edx["update"].assert_not_called()
+        run.refresh_from_db()
+        assert run.live is False
+
+    def test_unenroll(self, run, tmp_path, mock_edx, mocker):  # noqa: ARG002
+        """--unenroll defaults to sending no email."""
+
+        mock_bulk = mocker.patch(
+            "courses.management.commands.retire_courserun.bulk_unenroll_learners",
+            return_value={"succeeded": 1, "failed": 0, "skipped": 0, "details": []},
+        )
+        enrollment = CourseRunEnrollmentFactory.create(run=run, active=True)
+
+        _run_command(
+            run,
+            tmp_path,
+            commit=True,
+            allow_active_enrollments=True,
+            unenroll=True,
+        )
+
+        mock_bulk.assert_called_once_with(
+            [(enrollment.user.email, run.courseware_id)],
+            keep_failed_enrollments=False,
+            send_notification=False,
+        )
+
+    def test_unenroll_with_email(self, run, tmp_path, mock_edx, mocker):  # noqa: ARG002
+        """--email opts into notifying learners."""
+
+        mock_bulk = mocker.patch(
+            "courses.management.commands.retire_courserun.bulk_unenroll_learners",
+            return_value={"succeeded": 1, "failed": 0, "skipped": 0, "details": []},
+        )
+        CourseRunEnrollmentFactory.create(run=run, active=True)
+
+        _run_command(
+            run,
+            tmp_path,
+            commit=True,
+            allow_active_enrollments=True,
+            unenroll=True,
+            email=True,
+        )
+
+        assert mock_bulk.call_args.kwargs["send_notification"] is True
+
+
+class TestContractHandling:
+    """Retired B2B runs get parked, not orphaned."""
+
+    def test_moved_to_holding_contract(self, tmp_path, mock_edx):  # noqa: ARG002
+        """A retired B2B run is parked, never orphaned."""
+
+        contract = ContractPageFactory.create()
+        course_run = CourseRunFactory.create(live=True, b2b_contract=contract)
+
+        _run_command(course_run, tmp_path, commit=True)
+
+        course_run.refresh_from_db()
+        holding = get_or_create_retirement_contract()
+        assert course_run.b2b_contract_id == holding.id
+        # Never nulled - a null contract FK would make this a public-catalog run.
+        assert course_run.b2b_contract_id is not None
+        assert holding.active is False
+        assert holding.live is False
+
+    def test_holding_contract_is_reused(self, tmp_path, mock_edx):  # noqa: ARG002
+        """The holding contract is created once and reused."""
+
+        contract = ContractPageFactory.create()
+        first = CourseRunFactory.create(live=True, b2b_contract=contract)
+        second = CourseRunFactory.create(live=True, b2b_contract=contract)
+
+        _run_command(first, tmp_path, commit=True)
+        _run_command(second, tmp_path, commit=True)
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.b2b_contract_id == second.b2b_contract_id
+
+    def test_keep_contract(self, tmp_path, mock_edx):  # noqa: ARG002
+        """Keep contract."""
+
+        contract = ContractPageFactory.create()
+        course_run = CourseRunFactory.create(live=True, b2b_contract=contract)
+
+        _run_command(course_run, tmp_path, commit=True, keep_contract=True)
+
+        course_run.refresh_from_db()
+        assert course_run.b2b_contract_id == contract.id
+
+    def test_non_b2b_run_needs_no_contract(self, run, tmp_path, mock_edx):  # noqa: ARG002
+        """A non-B2B run retires fine with no contract step."""
+
+        _run_command(run, tmp_path, commit=True)
+
+        run.refresh_from_db()
+        assert run.b2b_contract_id is None
+        assert run.live is False
+
+    def test_keep_products_refused_when_parking_the_run(self, tmp_path, mock_edx):  # noqa: ARG002
+        """--keep-products can't be combined with the contract move."""
+
+        contract = ContractPageFactory.create()
+        course_run = CourseRunFactory.create(live=True, b2b_contract=contract)
+        ProductFactory.create(purchasable_object=course_run, is_active=True)
+
+        with pytest.raises(CommandError, match="--keep-products cannot be combined"):
+            _run_command(course_run, tmp_path, commit=True, keep_products=True)
+
+        course_run.refresh_from_db()
+        assert course_run.b2b_contract_id == contract.id
+        assert course_run.live is True
+
+    def test_keep_products_allowed_with_keep_contract(self, tmp_path, mock_edx):  # noqa: ARG002
+        """--keep-contract makes --keep-products safe again."""
+
+        contract = ContractPageFactory.create()
+        course_run = CourseRunFactory.create(live=True, b2b_contract=contract)
+        ProductFactory.create(purchasable_object=course_run, is_active=True)
+
+        _run_command(
+            course_run,
+            tmp_path,
+            commit=True,
+            keep_products=True,
+            keep_contract=True,
+        )
+
+        course_run.refresh_from_db()
+        assert course_run.live is False
+        assert course_run.b2b_contract_id == contract.id
+        assert all(p.is_active for p in get_run_products(course_run))
+
+
+class TestCollisionCheck:
+    """The holding contract can't be allowed to violate a unique constraint."""
+
+    def test_language_collision_refused(self, mock_edx):  # noqa: ARG002
+        """A parked run with the same course/tag/language/variant blocks the move."""
+
+        holding = get_or_create_retirement_contract()
+        parked = CourseRunFactory.create(
+            b2b_contract=holding, language="de_DE", run_tag="1T9C2026"
+        )
+        incoming = CourseRunFactory.create(
+            course=parked.course,
+            b2b_contract=ContractPageFactory.create(),
+            language="de_DE",
+            run_tag="1T9C2026",
+        )
+
+        with pytest.raises(RetirementContractCollisionError, match="already parked"):
+            move_run_to_retirement_contract(incoming)
+
+    def test_primary_language_collision_refused(self, mock_edx):  # noqa: ARG002
+        """A parked primary-language run blocks another for the same group."""
+
+        holding = get_or_create_retirement_contract()
+        parked = CourseRunFactory.create(
+            b2b_contract=holding,
+            language="",
+            is_primary_language=True,
+            run_tag="1T9C2026",
+        )
+        incoming = CourseRunFactory.create(
+            course=parked.course,
+            b2b_contract=ContractPageFactory.create(),
+            language="",
+            is_primary_language=True,
+            run_tag="1T9C2026",
+        )
+
+        with pytest.raises(RetirementContractCollisionError, match="primary-language"):
+            move_run_to_retirement_contract(incoming)
+
+    def test_distinct_run_tags_do_not_collide(self, mock_edx):  # noqa: ARG002
+        """Different run tags park side by side, which is the normal case."""
+
+        holding = get_or_create_retirement_contract()
+        parked = CourseRunFactory.create(
+            b2b_contract=holding, language="de_DE", run_tag="1T9C2026"
+        )
+        incoming = CourseRunFactory.create(
+            course=parked.course,
+            b2b_contract=ContractPageFactory.create(),
+            language="de_DE",
+            run_tag="1T9C2027",
+        )
+
+        assert move_run_to_retirement_contract(incoming).id == holding.id
+
+    def test_already_parked_run_is_a_no_op(self, mock_edx):  # noqa: ARG002
+        """Re-parking a run that's already in the holding contract is fine."""
+
+        holding = get_or_create_retirement_contract()
+        parked = CourseRunFactory.create(b2b_contract=holding, run_tag="1T9C2026")
+
+        assert move_run_to_retirement_contract(parked).id == holding.id
+
+
+class TestRetirementHelpers:
+    """Unit coverage for the shared util."""
+
+    def test_compute_dates_puts_everything_in_the_past(self):
+        """Every computed date lands in the past, in a valid order."""
+
+        course_run = CourseRunFactory.build(
+            start_date=None, end_date=None, enrollment_start=None, enrollment_end=None
+        )
+
+        dates = compute_retirement_dates(course_run)
+
+        now = now_in_utc()
+        assert dates["end"] < now
+        assert dates["enrollment_end"] < now
+        assert dates["start"] < dates["end"]
+        assert dates["enrollment_start"] <= dates["start"]
+
+    def test_compute_dates_preserves_an_early_start(self):
+        """An already-past start date is left alone."""
+
+        # Pinned rather than left to the factory: its upper bound is now-1d,
+        # which is exactly the cutoff compute_retirement_dates compares against.
+        original_start = now_in_utc() - timedelta(days=10)
+        course_run = CourseRunFactory.build(start_date=original_start)
+
+        dates = compute_retirement_dates(course_run)
+
+        assert dates["start"] == original_start
+
+    def test_push_dates_reports_incomplete_sets(self, run, mock_edx):
+        """A run with no end_date can't have its enrollment window set in edX."""
+
+        run.end_date = None
+        run.save()
+
+        assert push_run_dates_to_edx(run) is False
+
+        kwargs = mock_edx["update"].call_args.kwargs
+        assert "enrollment_end" not in kwargs
+
+    def test_push_dates_sends_a_complete_set(self, run, mock_edx):
+        """A complete date set reaches edX intact."""
+
+        dates = compute_retirement_dates(run)
+
+        assert push_run_dates_to_edx(run, dates) is True
+
+        kwargs = mock_edx["update"].call_args.kwargs
+        assert kwargs["enrollment_end"] == dates["enrollment_end"]
+
+    def test_get_run_products_sees_inactive_products(self, run):
+        """get_run_products must see products the default manager hides."""
+
+        product = get_run_products(run)[0]
+        product.is_active = False
+        product.save()
+
+        assert len(get_run_products(run)) == 1
+        assert not Product.objects.filter(id=product.id).exists()
+
+    def test_deactivate_run_products_is_idempotent(self, run):
+        """Deactivate run products is idempotent."""
+
+        assert len(deactivate_run_products(run)) == 1
+        assert deactivate_run_products(run) == []
+
+    def test_retire_leaves_enrollments_alone(self, run, mock_edx):  # noqa: ARG002
+        """Retire leaves enrollments alone."""
+
+        enrollment = CourseRunEnrollmentFactory.create(run=run, active=True)
+
+        retire_course_run(run)
+
+        enrollment.refresh_from_db()
+        assert enrollment.active is True
+        assert enrollment.change_status is None
+
+    def test_retire_returns_what_it_changed(self, run, mock_edx):  # noqa: ARG002
+        """Retire returns what it changed."""
+
+        result = retire_course_run(run)
+
+        assert result["edx_updated"] is True
+        assert len(result["products"]) == 1
+        assert set(result["dates"]) == {
+            "start",
+            "end",
+            "enrollment_start",
+            "enrollment_end",
+        }

--- a/courses/retirement.py
+++ b/courses/retirement.py
@@ -282,12 +282,21 @@ def audit_course_run(
     if fetch_edx:
         try:
             edx_run = get_edx_course(run.courseware_id, client=client)
+
+            def _edx_value(attr, edx_run=edx_run):
+                """Stringify an edX attribute, keeping None as None."""
+                value = getattr(edx_run, attr, None)
+                return None if value is None else str(value)
+
             audit.edx_details = {
-                "title": getattr(edx_run, "title", None),
-                "start": str(getattr(edx_run, "start", None)),
-                "end": str(getattr(edx_run, "end", None)),
-                "enrollment_start": str(getattr(edx_run, "enrollment_start", None)),
-                "enrollment_end": str(getattr(edx_run, "enrollment_end", None)),
+                attr: _edx_value(attr)
+                for attr in (
+                    "title",
+                    "start",
+                    "end",
+                    "enrollment_start",
+                    "enrollment_end",
+                )
             }
         except Exception as exc:  # noqa: BLE001
             audit.edx_error = str(exc)

--- a/courses/retirement.py
+++ b/courses/retirement.py
@@ -1,0 +1,472 @@
+"""
+Shared logic for retiring (delisting) course runs.
+
+A "retired" run is one that has been made inert: it is no longer live, its
+enrollment window and course window are in the past, and its products are
+switched off. Existing enrollments are deliberately left alone by default so
+that learners who were partway through the material keep their access.
+
+The date changes are pushed to edX as well as written locally, because
+``courses.api.sync_course_runs`` overwrites ``start_date``, ``end_date``,
+``enrollment_start``, ``enrollment_end``, ``title``, ``is_self_paced`` and
+``certificate_available_date`` from edX on every sync. ``live`` is the only
+one of these fields that is not synced, which makes it the durable local lever.
+
+This module is intentionally free of any B2B imports so that it can be used for
+non-B2B runs. The B2B holding-contract behaviour lives in ``b2b.api``.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from django.contrib.contenttypes.models import ContentType
+from mitol.common.utils.datetime import now_in_utc
+
+from courses.models import (
+    CourseRun,
+    CourseRunCertificate,
+    CourseRunEnrollment,
+    CourseRunGrade,
+)
+from ecommerce.models import BasketItem, Discount, Product
+from openedx.api import get_edx_course, update_edx_course
+
+log = logging.getLogger(__name__)
+
+# How far into the past to push the retired dates. A day is enough to put the
+# run unambiguously in the past without looking like a data-entry error.
+RETIREMENT_DATE_OFFSET = timedelta(days=1)
+
+
+class SourceRunRetirementError(Exception):
+    """Raised when the run being retired is a source run."""
+
+
+@dataclass
+class ProductAudit:
+    """What we know about a product attached to the run."""
+
+    product: Product
+    was_active: bool
+    discounts: list = field(default_factory=list)
+    basket_items: int = 0
+
+
+@dataclass
+class RunAudit:
+    """Everything the operator should see before a run is retired."""
+
+    run: CourseRun
+    active_enrollments: list = field(default_factory=list)
+    inactive_enrollments: list = field(default_factory=list)
+    products: list = field(default_factory=list)
+    certificate_count: int = 0
+    grade_count: int = 0
+    edx_details: dict | None = None
+    edx_error: str | None = None
+
+    @property
+    def has_active_enrollments(self):
+        """Whether anybody is currently enrolled."""
+
+        return len(self.active_enrollments) > 0
+
+
+def get_run_products(run: CourseRun) -> list[Product]:
+    """
+    Return every product attached to the run, active or not.
+
+    ``Product.objects`` is an ``ActiveUndeleteManager`` and filters out
+    ``is_active=False``, so already-deactivated products are invisible through
+    it. We want to see them, so this uses ``all_objects``.
+
+    Args:
+        run (CourseRun): the run to inspect.
+    Returns:
+        list of Product: the run's products, evaluated so that later updates
+        don't mutate the collection out from under the caller.
+    """
+
+    return list(
+        Product.all_objects.filter(
+            content_type=ContentType.objects.get_for_model(CourseRun),
+            object_id=run.id,
+        ).all()
+    )
+
+
+def deactivate_run_products(run: CourseRun) -> list[Product]:
+    """
+    Switch off every active product attached to the run.
+
+    Uses ``save()`` rather than a queryset ``update()`` so that the
+    ``ecommerce.signals.sync_product`` post-save receiver still fires and
+    HubSpot stays consistent. That means one HubSpot task per product.
+
+    Args:
+        run (CourseRun): the run whose products should be deactivated.
+    Returns:
+        list of Product: the products that were actually changed.
+    """
+
+    deactivated = []
+
+    for product in get_run_products(run):
+        if product.is_active:
+            product.is_active = False
+            product.save(update_fields=("is_active",))
+            deactivated.append(product)
+
+    return deactivated
+
+
+def compute_retirement_dates(run: CourseRun, *, now: datetime | None = None) -> dict:
+    """
+    Work out the set of dates that put the run in the past.
+
+    ``end_date`` and ``enrollment_end`` are the fields that actually delist a
+    run: ``end_date`` drives ``CourseRun.is_past`` and
+    ``CourseRunQuerySet.available()``, and ``enrollment_end`` drives
+    ``CourseRun.is_enrollable``. The start dates are only moved if they aren't
+    already early enough, because edX refuses to set enrollment dates unless
+    the run has both a start and an end date, so we must always send a
+    coherent set of four.
+
+    Args:
+        run (CourseRun): the run being retired.
+    Keyword Args:
+        now (datetime|None): override for the current time, for tests.
+    Returns:
+        dict: keys ``start``, ``end``, ``enrollment_start``, ``enrollment_end``.
+    """
+
+    now = now or now_in_utc()
+    cutoff = now - RETIREMENT_DATE_OFFSET
+
+    start = (
+        run.start_date
+        if run.start_date and run.start_date < cutoff
+        else cutoff - RETIREMENT_DATE_OFFSET
+    )
+    enrollment_start = (
+        run.enrollment_start
+        if run.enrollment_start and run.enrollment_start < start
+        else start
+    )
+
+    return {
+        "start": start,
+        "end": cutoff,
+        "enrollment_start": enrollment_start,
+        "enrollment_end": cutoff,
+    }
+
+
+def push_run_dates_to_edx(
+    run: CourseRun, dates: dict | None = None, *, client=None
+) -> bool:
+    """
+    Push a run's schedule to edX.
+
+    edX will only accept enrollment dates for a run that has both a start and
+    an end date, so if any of the four dates is missing this sends the title
+    and pacing only and returns False. Callers that need the dates to stick
+    should pass a complete set (see ``compute_retirement_dates``).
+
+    Any error from the edX client propagates; it is up to the caller to decide
+    whether that should abort the operation.
+
+    Args:
+        run (CourseRun): the run to update in edX.
+        dates (dict|None): the dates to send. Defaults to the run's current
+            local values.
+    Keyword Args:
+        client (EdxApi|None): edX client, if you want to reuse one.
+    Returns:
+        bool: True if the dates were included in the payload, False if only
+        the title and pacing were sent.
+    """
+
+    if dates is None:
+        dates = {
+            "start": run.start_date,
+            "end": run.end_date,
+            "enrollment_start": run.enrollment_start,
+            "enrollment_end": run.enrollment_end,
+        }
+
+    complete = all(dates.get(key) for key in ("start", "end"))
+    enrollment_complete = complete and all(
+        dates.get(key) for key in ("enrollment_start", "enrollment_end")
+    )
+
+    payload = {
+        "title": run.title,
+        "pacing_type": "self_paced" if run.is_self_paced else "instructor_paced",
+    }
+
+    if complete:
+        payload["start"] = dates["start"]
+        payload["end"] = dates["end"]
+
+        if enrollment_complete:
+            payload["enrollment_start"] = dates["enrollment_start"]
+            payload["enrollment_end"] = dates["enrollment_end"]
+
+    if not enrollment_complete:
+        log.warning(
+            "push_run_dates_to_edx: %s has an incomplete date set %s, so edX will "
+            "not accept the enrollment window and the next sync will overwrite "
+            "the local values",
+            run.courseware_id,
+            dates,
+        )
+
+    update_edx_course(run.courseware_id, client=client, **payload)
+
+    return enrollment_complete
+
+
+def audit_course_run(
+    run: CourseRun, *, fetch_edx: bool = True, client=None
+) -> RunAudit:
+    """
+    Collect everything an operator needs to see before retiring a run.
+
+    Makes no changes. Safe to call in dry-run mode.
+
+    Args:
+        run (CourseRun): the run to inspect.
+    Keyword Args:
+        fetch_edx (bool): whether to read the run's current state from edX.
+        client (EdxApi|None): edX client, if you want to reuse one.
+    Returns:
+        RunAudit
+    """
+
+    audit = RunAudit(run=run)
+
+    enrollments = (
+        CourseRunEnrollment.all_objects.filter(run=run)
+        .select_related("user")
+        .order_by("user__email")
+    )
+
+    for enrollment in enrollments:
+        if enrollment.active:
+            audit.active_enrollments.append(enrollment)
+        else:
+            audit.inactive_enrollments.append(enrollment)
+
+    # all_objects, because CourseRunCertificate.objects hides revoked
+    # certificates and ones with a future issue date. Under-reporting here would
+    # be exactly the wrong direction for a warning.
+    audit.certificate_count = CourseRunCertificate.all_objects.filter(
+        course_run=run
+    ).count()
+    audit.grade_count = CourseRunGrade.objects.filter(course_run=run).count()
+
+    for product in get_run_products(run):
+        audit.products.append(
+            ProductAudit(
+                product=product,
+                was_active=product.is_active,
+                discounts=list(
+                    Discount.objects.filter(products__product=product).distinct().all()
+                ),
+                basket_items=BasketItem.objects.filter(product=product).count(),
+            )
+        )
+
+    if fetch_edx:
+        try:
+            edx_run = get_edx_course(run.courseware_id, client=client)
+            audit.edx_details = {
+                "title": getattr(edx_run, "title", None),
+                "start": str(getattr(edx_run, "start", None)),
+                "end": str(getattr(edx_run, "end", None)),
+                "enrollment_start": str(getattr(edx_run, "enrollment_start", None)),
+                "enrollment_end": str(getattr(edx_run, "enrollment_end", None)),
+            }
+        except Exception as exc:  # noqa: BLE001
+            audit.edx_error = str(exc)
+
+    return audit
+
+
+def check_run_retirable(run: CourseRun) -> None:
+    """
+    Refuse to retire runs that other machinery depends on.
+
+    Source runs are the templates ``b2b.api.create_contract_run`` clones from,
+    so retiring one quietly breaks every future contract run for the course.
+    There is deliberately no override flag.
+
+    Args:
+        run (CourseRun): the run to check.
+    Raises:
+        SourceRunRetirementError: if the run is a source run.
+    """
+
+    if run.is_source_run or run.run_tag == "SOURCE":
+        msg = (
+            f"{run.courseware_id} is a source run. Retiring it would break future "
+            "contract runs for this course. Retire the contract runs instead."
+        )
+        raise SourceRunRetirementError(msg)
+
+
+def build_snapshot(audit: RunAudit, *, reason: str = "", source: str = "") -> dict:
+    """
+    Build a JSON-serialisable record of the run's pre-retirement state.
+
+    This is the rollback source of truth. There is no automated rollback; the
+    snapshot exists so that a human can put things back by hand.
+
+    Args:
+        audit (RunAudit): the audit to serialise.
+    Keyword Args:
+        reason (str): why the run is being retired.
+        source (str): what produced the snapshot, e.g. "Management Command".
+    Returns:
+        dict
+    """
+
+    run = audit.run
+
+    def _dt(value):
+        return value.isoformat() if value else None
+
+    return {
+        "snapshot_taken": now_in_utc().isoformat(),
+        "reason": reason,
+        "source": source,
+        "run": {
+            "id": run.id,
+            "courseware_id": run.courseware_id,
+            "course": run.course.readable_id,
+            "run_tag": run.run_tag,
+            "title": run.title,
+            "live": run.live,
+            "is_self_paced": run.is_self_paced,
+            "is_source_run": run.is_source_run,
+            "language": run.language,
+            "start_date": _dt(run.start_date),
+            "end_date": _dt(run.end_date),
+            "enrollment_start": _dt(run.enrollment_start),
+            "enrollment_end": _dt(run.enrollment_end),
+            "expiration_date": _dt(run.expiration_date),
+            "upgrade_deadline": _dt(run.upgrade_deadline),
+            "b2b_contract_id": run.b2b_contract_id,
+        },
+        "edx": audit.edx_details,
+        "edx_error": audit.edx_error,
+        "products": [
+            {
+                "id": entry.product.id,
+                "description": entry.product.description,
+                "price": str(entry.product.price),
+                "is_active": entry.was_active,
+                "basket_items": entry.basket_items,
+                "discounts": [
+                    {"id": discount.id, "code": discount.discount_code}
+                    for discount in entry.discounts
+                ],
+            }
+            for entry in audit.products
+        ],
+        "enrollments": {
+            "active": [
+                {"id": e.id, "user": e.user.email, "mode": e.enrollment_mode}
+                for e in audit.active_enrollments
+            ],
+            "inactive": [
+                {
+                    "id": e.id,
+                    "user": e.user.email,
+                    "mode": e.enrollment_mode,
+                    "change_status": e.change_status,
+                }
+                for e in audit.inactive_enrollments
+            ],
+        },
+        "certificate_count": audit.certificate_count,
+        "grade_count": audit.grade_count,
+    }
+
+
+def retire_course_run(
+    run: CourseRun,
+    *,
+    deactivate_products: bool = True,
+    skip_edx: bool = False,
+    edx_client=None,
+    now: datetime | None = None,
+) -> dict:
+    """
+    Retire a course run: past dates in edX and locally, not live, products off.
+
+    edX is written first, deliberately. edX is the effective source of truth
+    for the date fields, so if the edX call fails after we've written locally
+    the next ``sync_course_runs`` pass would silently revert us. Writing edX
+    first means a failure aborts with nothing changed, and a local failure
+    after a successful edX write is self-healing on the next sync.
+
+    Enrollments are not touched. Unenrolling is a separate, explicit step
+    (see ``courses.management.utils.bulk_unenroll_learners``) because it
+    revokes courseware access and emails learners.
+
+    Args:
+        run (CourseRun): the run to retire.
+    Keyword Args:
+        deactivate_products (bool): switch off the run's products.
+        skip_edx (bool): don't call edX at all, for runs with no edX counterpart.
+        edx_client (EdxApi|None): edX client, if you want to reuse one.
+        now (datetime|None): override for the current time, for tests.
+    Returns:
+        dict: ``dates`` applied, ``products`` deactivated, and ``edx_updated``.
+    """
+
+    dates = compute_retirement_dates(run, now=now)
+    edx_updated = False
+
+    if not skip_edx:
+        edx_updated = push_run_dates_to_edx(run, dates, client=edx_client)
+
+    # CourseRun.save() runs clean(), which rejects an expiration_date earlier
+    # than the start or end date. Pushing the run into the past would trip that
+    # for any run whose expiration_date has already passed - which is the most
+    # likely thing to be retiring. Clear it so it goes back to being derived,
+    # exactly as sync_course_runs does when the dates change under it.
+    if run.expiration_date and (
+        run.expiration_date < dates["end"] or run.expiration_date < dates["start"]
+    ):
+        log.info(
+            "Clearing expiration_date %s on %s; it predates the retired end date",
+            run.expiration_date,
+            run.courseware_id,
+        )
+        run.expiration_date = None
+
+    run.start_date = dates["start"]
+    run.end_date = dates["end"]
+    run.enrollment_start = dates["enrollment_start"]
+    run.enrollment_end = dates["enrollment_end"]
+    run.live = False
+    run.save()
+
+    products = deactivate_run_products(run) if deactivate_products else []
+
+    log.info(
+        "Retired course run %s (edx_updated=%s, products_deactivated=%s)",
+        run.courseware_id,
+        edx_updated,
+        len(products),
+    )
+
+    return {
+        "dates": dates,
+        "products": products,
+        "edx_updated": edx_updated,
+    }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12106

### Description (What does it do?)
This pull request introduces a system for "retiring" course runs by moving them into a special holding contract, ensuring they remain hidden from catalogs while preserving their courseware IDs. This prevents accidental exposure in the public catalog and avoids potential duplicate courseware IDs. The changes also refactor product deactivation and enrollment sync logic, and improve admin usability for managing inactive contracts.

**Retired Runs Handling:**

* Added constants and logic for a dedicated retirement organization and contract (`RETIREMENT_ORG_KEY`, `RETIREMENT_ORG_NAME`, `RETIREMENT_CONTRACT_NAME`) to hold retired course runs. This ensures retired runs are hidden but not deleted, preventing courseware ID duplication. [[1]](diffhunk://#diff-c61146f84bbc9370783c035a706a63deb7a17ff99e46f65efcd794013b4bead2R35-R43) [[2]](diffhunk://#diff-ddca35b1a4cd22ffe1105e0a657ecb4172ecd513777b360d9e75e624f5098bc1R23-R27)
* Implemented `get_or_create_retirement_contract`, `check_retirement_contract_collision`, and `move_run_to_retirement_contract` in `b2b/api.py` to safely move runs to the retirement contract, including collision checks to avoid unique constraint violations.

**Product Deactivation and Enrollment Sync:**

* Refactored product deactivation in the `b2b_courseware` management command to use shared utilities (`get_run_products`, `deactivate_run_products`), ensuring consistent handling across commands. [[1]](diffhunk://#diff-39c0bfe36a15bf3bcf186309c80d25dd6065f81bb5267f0236169fa3f0e4c214L21-R25) [[2]](diffhunk://#diff-39c0bfe36a15bf3bcf186309c80d25dd6065f81bb5267f0236169fa3f0e4c214L460-R469)
* Replaced direct edX course updates with the new `push_run_dates_to_edx` utility, which handles edge cases and logs warnings appropriately.

**Admin Usability Improvements:**

* Updated the Django admin for `CourseRun` to show inactive contracts in the `b2b_contract` dropdown, preventing accidental removal of B2B associations when editing retired or expired runs.

### How can this be tested?
1. Make sure the setup is working fine and wagtail is setup `docker compose exec web ./manage.py configure_wagtail`
2. A course with a local SOURCE run. create_courseware makes no edX calls.
```python
docker compose exec web ./manage.py create_courseware course \
  course-v1:MITxT+14.100x "B2B Retire Test" \
  --live --dept "Economics" --create-depts --create-page \
  --create-run SOURCE --create-run-as-sourcerun \
  --set-courserun-dates-automatically
```
3. Org + contract.
```python
docker compose exec web ./manage.py b2b_contract create \
  "Retire Test Org" "Retire Test Contract" managed \
  --create --org-key TESTRETIRE --max-learners 10 --price 0
```
4. Get the contract ID:
```python
docker compose exec web ./manage.py b2b_list contracts --org TESTRETIRE
```
5. Now attach the course twice, so you have two contract runs to work with
```python
docker compose exec web ./manage.py b2b_courseware add --no-create-runs <CONTRACT_ID> \
  course-v1:MITxT+14.100x
```
6. Export so the rest of the commands are copy-paste:
```bash
export B2B_RUN=course-v1:UAI_TESTRETIRE+14.100x+1T<CONTRACT_ID>C2026
```
7.  **Dry run** must change nothing and Verify nothing moved.
```python
docker compose exec web ./manage.py retire_courserun \
  --run=$B2B_RUN --skip-edx
```
8. **Commit**
```python
docker compose exec web ./manage.py retire_courserun \
  --run=$B2B_RUN --skip-edx --reason="QA run"
```
9. Expect **Verification passed**. at the end.