### PR TITLE
fix: dirty-check edX sync and ProductPage saves to cut Fastly purges

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1320,7 +1320,11 @@ class ProductPage(VideoPlayerConfigMixin, MetadataPageMixin):
             courseware_object = self.course
         elif self.is_program_page:
             courseware_object = self.program
-        if courseware_object:
+        # Only push the title down (and save) when it actually changed. An
+        # unconditional save here fires the courseware object's post_save
+        # Fastly purge signal on every page save, so publishing one page
+        # would otherwise emit several redundant purges of the same key.
+        if courseware_object and courseware_object.title != self.title:
             courseware_object.title = self.title
             courseware_object.save()
 

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -664,6 +664,21 @@ def test_courseware_title_synced_with_product_page_title(test_course):
     assert courseware.title == updated_title
 
 
+@pytest.mark.parametrize("test_course", [True, False])
+def test_product_page_save_skips_courseware_save_when_title_unchanged(test_course):
+    """
+    Saving a product page without changing its title must not re-save the
+    linked courseware object, so it fires no redundant Fastly purge signal.
+    """
+    product_page = CoursePageFactory() if test_course else ProgramPageFactory()
+    courseware = product_page.course if test_course else product_page.program
+
+    with patch.object(type(courseware), "save") as mock_courseware_save:
+        product_page.save()
+
+    mock_courseware_save.assert_not_called()
+
+
 @pytest.mark.parametrize("flex_form_for_course", [True, False])
 def test_flexible_pricing_request_form_context(flex_form_for_course):
     """

--- a/courses/api.py
+++ b/courses/api.py
@@ -667,6 +667,52 @@ def _filter_valid_course_keys(runs):
     return valid_course_keys, runs_by_course_id
 
 
+def _sync_course_run_from_edx(run, course_detail):
+    """
+    Apply edX course detail values to a CourseRun, saving only when something
+    actually changed.
+
+    Skipping the save when nothing differs avoids a pointless full-column
+    UPDATE and, more importantly, the Fastly purge that the run's post_save
+    signal would otherwise trigger for its parent course on every sync pass.
+
+    Args:
+        run (CourseRun): the run to update.
+        course_detail (CourseDetail): the incoming edX course detail.
+
+    Returns:
+        bool: True if the run was changed and saved, False if it was unchanged.
+    """
+    # Only sync the certificate date if it's set in edX, otherwise fall back
+    # to the course's end date.
+    certificate_available_date = (
+        course_detail.certificate_available_date or course_detail.end
+    )
+    incoming_values = {
+        "title": course_detail.name,
+        "start_date": course_detail.start,
+        "end_date": course_detail.end,
+        "enrollment_start": course_detail.enrollment_start,
+        "enrollment_end": course_detail.enrollment_end,
+        "is_self_paced": course_detail.is_self_paced(),
+        "certificate_available_date": certificate_available_date,
+    }
+
+    if all(getattr(run, field) == value for field, value in incoming_values.items()):
+        return False
+
+    # Reset the expiration_date so it is calculated automatically and does not
+    # raise a validation error now that the start or end date has changed.
+    if run.start_date != course_detail.start or run.end_date != course_detail.end:
+        run.expiration_date = None
+
+    for field, value in incoming_values.items():
+        setattr(run, field, value)
+
+    run.save()
+    return True
+
+
 def sync_course_runs(runs):
     """
     Sync course run dates and title from Open edX using course list API
@@ -706,32 +752,11 @@ def sync_course_runs(runs):
             run = runs_by_course_id[course_detail.course_id]
 
             try:
-                # Reset the expiration_date so it is calculated automatically and
-                # does not raise a validation error now that the start or end date
-                # has changed.
-                if (
-                    run.start_date != course_detail.start
-                    or run.end_date != course_detail.end
-                ):
-                    run.expiration_date = None
-
-                run.title = course_detail.name
-                run.start_date = course_detail.start
-                run.end_date = course_detail.end
-                run.enrollment_start = course_detail.enrollment_start
-                run.enrollment_end = course_detail.enrollment_end
-                run.is_self_paced = course_detail.is_self_paced()
-                # Only sync the date if it's set in edX, Otherwise set it to course's end date
-                if course_detail.certificate_available_date:
-                    run.certificate_available_date = (
-                        course_detail.certificate_available_date
-                    )
+                if _sync_course_run_from_edx(run, course_detail):
+                    success_count += 1
+                    log.info("Updated course run: %s", run.courseware_id)
                 else:
-                    run.certificate_available_date = course_detail.end
-
-                run.save()
-                success_count += 1
-                log.info("Updated course run: %s", run.courseware_id)
+                    log.debug("No changes for course run: %s", run.courseware_id)
 
             except Exception as e:  # pylint: disable=broad-except  # noqa: BLE001
                 # Report any validation or otherwise model errors

--- a/courses/api.py
+++ b/courses/api.py
@@ -721,7 +721,10 @@ def sync_course_runs(runs):
         runs ([CourseRun]): list of CourseRun objects.
 
     Returns:
-        tuple: (success_count, failure_count) - counts of successful and failed syncs
+        tuple: (success_count, failure_count) where success_count is the number
+        of runs that had changed edX values and were saved (runs already in sync
+        are skipped and counted as neither success nor failure), and
+        failure_count is the number of runs that errored while syncing.
     """
     api_client = get_edx_api_course_list_client()
 

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1262,16 +1262,20 @@ def test_sync_course_runs_skips_unchanged(
     mock_course_list = mocker.patch("courses.api.get_edx_api_course_list_client")
     mock_course_list.return_value.get_courses.return_value = [course_detail]
 
-    # First pass writes the edX values and enqueues one purge.
+    # Ignore any purges enqueued by the factory setup above so we only measure
+    # purges caused by the sync calls themselves.
+    mock_purge_delay.reset_mock()
+
+    # First pass writes the edX values and enqueues exactly one purge.
     success_count, failure_count = sync_course_runs([course_run])
     assert (success_count, failure_count) == (1, 0)
-    purge_calls_after_first = mock_purge_delay.call_count
-    assert purge_calls_after_first >= 1
+    assert mock_purge_delay.call_count == 1
 
     # Second pass with identical edX data is a no-op: no save, no new purge.
+    mock_purge_delay.reset_mock()
     success_count, failure_count = sync_course_runs([course_run])
     assert (success_count, failure_count) == (0, 0)
-    assert mock_purge_delay.call_count == purge_calls_after_first
+    assert mock_purge_delay.call_count == 0
 
 
 @pytest.mark.parametrize(

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1235,6 +1235,45 @@ def test_sync_course_runs(settings, mocker, mocked_api_response, expect_success)
         assert failure_count == 1
 
 
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("cms.tasks.queue_fastly_surrogate_key_purge.delay")
+def test_sync_course_runs_skips_unchanged(
+    mock_purge_delay, mock_on_commit, settings, mocker
+):
+    """
+    A run whose edX values match what's already stored is not re-saved, so it
+    triggers no additional full-column UPDATE and no additional Fastly purge.
+    """
+    settings.OPENEDX_SERVICE_WORKER_API_TOKEN = "mock_api_token"  # noqa: S105
+
+    course_run = CourseRunFactory.create(courseware_id="course-v1:MITx+6.00.1x+3T2015")
+    course_detail = CourseDetail(
+        {
+            "id": "course-v1:MITx+6.00.1x+3T2015",
+            "start": "2015-09-15T05:00:00Z",
+            "end": "2015-12-31T05:00:00Z",
+            "enrollment_start": "2015-09-01T00:00:00Z",
+            "enrollment_end": None,
+            "name": "Introduction to Computer Science",
+            "pacing": "instructor",
+        }
+    )
+
+    mock_course_list = mocker.patch("courses.api.get_edx_api_course_list_client")
+    mock_course_list.return_value.get_courses.return_value = [course_detail]
+
+    # First pass writes the edX values and enqueues one purge.
+    success_count, failure_count = sync_course_runs([course_run])
+    assert (success_count, failure_count) == (1, 0)
+    purge_calls_after_first = mock_purge_delay.call_count
+    assert purge_calls_after_first >= 1
+
+    # Second pass with identical edX data is a no-op: no save, no new purge.
+    success_count, failure_count = sync_course_runs([course_run])
+    assert (success_count, failure_count) == (0, 0)
+    assert mock_purge_delay.call_count == purge_calls_after_first
+
+
 @pytest.mark.parametrize(
     "mocked_api_response, expect_success",  # noqa: PT006
     [


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12614

### Description (What does it do?)
Fastly surrogate-key purges were firing hundreds of times a day for changes that never happened. Root cause: two code paths call `.save()` unconditionally, and every `CourseRun`/`Course` save triggers a `post_save` purge signal.

This PR adds dirty checks so those saves (and their purges) only happen when something actually changed:

- **`sync_course_runs`** (hourly edX sync): compares incoming edX values against the stored run and skips `save()` when nothing differs. This eliminates the bulk of the purges (a course with 8 live runs was emitting ~192 identical purges/day, none reflecting a change) and a pointless full-column `UPDATE`.
- **`ProductPage.save()`**: only pushes the title down to the linked `Course`/`Program` (and saves it) when the title actually changed, removing the redundant purges emitted on every page save.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

### How can this be tested?
The goal is to confirm that a purge is only scheduled when data actually changes. We do this in a Django shell by watching the purge task and running the sync twice — the second run should schedule **zero** purges.

1. Make sure your local stack is up and migrations are applied:
   ```bash
   docker compose up -d
   docker compose run --rm web python manage.py migrate
   ```
2. Open a Django shell:
   ```bash
   docker compose run --rm web python manage.py shell
   ```
3. Paste the following into the shell. It creates a throwaway course run, feeds it fake edX data, and runs the sync twice. Everything is rolled back at the end, so nothing is saved to your DB:
   ```python
   import uuid
   from unittest.mock import patch
   from django.db import transaction
   from edx_api.course_detail import CourseDetail
   from courses.factories import CourseRunFactory
   from courses.api import sync_course_runs

   suffix = uuid.uuid4().hex[:8]
   cid = f"course-v1:Demo+Purge+{suffix}"

   with patch("courses.signals.transaction.on_commit", side_effect=lambda cb: cb()), \
        patch("cms.tasks.queue_fastly_surrogate_key_purge.delay") as purge, \
        patch("courses.api.get_edx_api_course_list_client") as client:
       try:
           with transaction.atomic():
               run = CourseRunFactory.create(
                   courseware_id=cid,
                   course__readable_id=f"course-v1:Demo+Purge{suffix}",
               )
               client.return_value.get_courses.return_value = [CourseDetail({
                   "id": cid, "start": "2015-09-15T05:00:00Z", "end": "2015-12-31T05:00:00Z",
                   "enrollment_start": "2015-09-01T00:00:00Z", "enrollment_end": None,
                   "name": "Demo Course", "pacing": "instructor",
               })]

               purge.reset_mock()
               s, f = sync_course_runs([run])
               print(f"1st sync (data changed):   saved={s}  purges={purge.call_count}  -> expect saved=1 purges=1")

               purge.reset_mock()
               s, f = sync_course_runs([run])
               print(f"2nd sync (nothing changed): saved={s}  purges={purge.call_count}  -> expect saved=0 purges=0")

               raise RuntimeError("rollback")  # discard the throwaway data
       except RuntimeError:
           pass
   ```
4. Expected output:
   ```
   1st sync (data changed):   saved=1  purges=1  -> expect saved=1 purges=1
   2nd sync (nothing changed): saved=0  purges=0  -> expect saved=0 purges=0
   ```
   The second line is the fix in action: identical data → no save → no Fastly purge. Before this PR, the second line would show `purges=1` for a change that didn't happen.

New regression tests covering both fixes are included and run automatically in CI, so no extra steps are needed for those.

### Additional Context
<!--- optional - delete if empty --->
- Kept `.save()` in the sync path (didn't switch to `.update()`) so `CourseRun.clean()` still runs — the `expiration_date` logic depends on it.
- The dirty check stops bumping `CourseRun.updated_on` (`auto_now`). Nothing reads it (no admin `list_display`/serializer), so this is safe to lose.
- Surrogate-key dedup and narrowing the receiver to MIT-Learn-rendered fields were considered but left out — they're largely redundant once the unnecessary saves are stopped at the source (dedup also carries a rollback footgun since Django has no `on_rollback`).
