### PR TITLE
feat(b2b): add a service-scoped org-manager check endpoint

### DIFF
--- a/b2b/serializers/v0/service.py
+++ b/b2b/serializers/v0/service.py
@@ -13,3 +13,19 @@ class OrganizationManagerCheckSerializer(serializers.Serializer):
     is_manager = serializers.BooleanField(
         help_text="True if the user manages the organization.",
     )
+
+
+class ServiceDetailErrorSerializer(serializers.Serializer):
+    """Response shape for the 400 error responses below.
+
+    Same shape as b2b.serializers.v0.manager.DetailErrorSerializer, but
+    duplicated rather than imported (and distinctly named, since
+    drf-spectacular keys its component registry on class identity, not
+    structural equality -- reusing the same name for a different class
+    produces a "components with identical names" warning and an
+    unpredictable schema) so this module stays self-contained and its
+    deletion remains a plain file removal (see the module docstring in
+    b2b/views/v0/service.py).
+    """
+
+    detail = serializers.CharField()

--- a/b2b/serializers/v0/service.py
+++ b/b2b/serializers/v0/service.py
@@ -1,0 +1,15 @@
+"""Service-to-service B2B serializers.
+
+TEMPORARY -- delete alongside b2b/views/v0/service.py when org-manager status
+becomes visible in Keycloak (mitodl/hq#10594).
+"""
+
+from rest_framework import serializers
+
+
+class OrganizationManagerCheckSerializer(serializers.Serializer):
+    """Response shape for the org-manager check."""
+
+    is_manager = serializers.BooleanField(
+        help_text="True if the user manages the organization.",
+    )

--- a/b2b/views/v0/service.py
+++ b/b2b/views/v0/service.py
@@ -33,7 +33,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from b2b.models import OrganizationPage, is_organization_manager
-from b2b.serializers.v0.service import OrganizationManagerCheckSerializer
+from b2b.serializers.v0.service import (
+    OrganizationManagerCheckSerializer,
+    ServiceDetailErrorSerializer,
+)
 from users.models import User
 
 # Distinct from the user-facing scopes in OAUTH2_PROVIDER["SCOPES"]: this one
@@ -81,7 +84,10 @@ class OrganizationManagerCheckView(APIView):
                 description="The user's Keycloak subject (User.global_id).",
             ),
         ],
-        responses=OrganizationManagerCheckSerializer,
+        responses={
+            200: OrganizationManagerCheckSerializer,
+            400: ServiceDetailErrorSerializer,
+        },
     )
     def get(self, request, *args, **kwargs):  # noqa: ARG002
         """Return the manager status for the (user, organization) pair."""

--- a/b2b/views/v0/service.py
+++ b/b2b/views/v0/service.py
@@ -1,0 +1,131 @@
+"""Service-to-service B2B views.
+
+TEMPORARY -- delete this module when org-manager status becomes visible in
+Keycloak (mitodl/hq#10594).
+
+Unlike everything in manager.py, these endpoints answer questions *about* a
+named user rather than about the caller. They exist because `is_manager`
+(b2b.models.UserOrganization) is curated only here, in the Django admin, and
+never reaches the Keycloak token -- so a downstream service that needs the
+flag has no way to learn it except by asking MITx Online.
+
+The one consumer today is ol-analytics-api, which gates its B2B analytics
+endpoints on org-manager status. It cannot reuse
+ManagerOrganizationViewSet: that viewset scopes its queryset to
+`self.request.user`, so a service-authenticated call would always answer
+"manages nothing". Nor can it forward the end user's identity -- the APISIX
+openid-connect plugin strips client-supplied X-Userinfo/X-Access-Token
+headers before they reach an upstream, by design, so a forwarded identity
+never survives the gateway.
+
+Hence a service credential plus an explicit subject parameter. Kept in its
+own module, off the user-facing manager surface, so that the deletion in
+mitodl/hq#10594 is a file removal rather than an unpicking of a live
+authorization path.
+"""
+
+import uuid
+
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication, TokenHasScope
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from b2b.models import OrganizationPage, is_organization_manager
+from b2b.serializers.v0.service import OrganizationManagerCheckSerializer
+from users.models import User
+
+# Distinct from the user-facing scopes in OAUTH2_PROVIDER["SCOPES"]: this one
+# is only ever granted to a service Application, never to a user-facing client.
+MANAGER_CHECK_SCOPE = "b2b:manager-check"
+
+
+class OrganizationManagerCheckView(APIView):
+    """Answer whether a given user manages a given organization.
+
+    Deliberately fails closed: an unknown user, an unknown organization, or a
+    user with no membership row all return `is_manager: false` rather than a
+    404. A 404 would let a caller enumerate which Keycloak organization UUIDs
+    and user IDs exist here, which is more than this endpoint needs to reveal
+    to answer its one question.
+    """
+
+    authentication_classes = [OAuth2Authentication]
+    permission_classes = [TokenHasScope]
+    required_scopes = [MANAGER_CHECK_SCOPE]
+
+    @extend_schema(
+        operation_id="b2b_service_organization_manager_check",
+        description=(
+            "Check whether a user is a manager of an organization. "
+            "Service-to-service only; requires the "
+            f"`{MANAGER_CHECK_SCOPE}` scope."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="sso_organization_id",
+                type=OpenApiTypes.UUID,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description=(
+                    "The organization's Keycloak UUID "
+                    "(OrganizationPage.sso_organization_id)."
+                ),
+            ),
+            OpenApiParameter(
+                name="user_global_id",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="The user's Keycloak subject (User.global_id).",
+            ),
+        ],
+        responses=OrganizationManagerCheckSerializer,
+    )
+    def get(self, request, *args, **kwargs):  # noqa: ARG002
+        """Return the manager status for the (user, organization) pair."""
+
+        sso_organization_id = request.query_params.get("sso_organization_id")
+        user_global_id = request.query_params.get("user_global_id")
+
+        missing = [
+            name
+            for name, value in (
+                ("sso_organization_id", sso_organization_id),
+                ("user_global_id", user_global_id),
+            )
+            if not value
+        ]
+        if missing:
+            return Response(
+                {
+                    "detail": f"Missing required query parameter(s): {', '.join(missing)}"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # sso_organization_id maps to a UUIDField. Rejecting a malformed value
+        # here keeps a bad request a 400 rather than letting the ORM raise on
+        # the lookup and turn it into a 500.
+        try:
+            uuid.UUID(sso_organization_id)
+        except ValueError:
+            return Response(
+                {"detail": "sso_organization_id must be a UUID"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        organization = OrganizationPage.objects.filter(
+            sso_organization_id=sso_organization_id
+        ).first()
+        user = User.objects.filter(global_id=user_global_id).first()
+
+        is_manager = bool(
+            organization and user and is_organization_manager(user, organization.id)
+        )
+
+        return Response(
+            OrganizationManagerCheckSerializer({"is_manager": is_manager}).data,
+            status=status.HTTP_200_OK,
+        )

--- a/b2b/views/v0/service_test.py
+++ b/b2b/views/v0/service_test.py
@@ -187,10 +187,10 @@ def test_requires_authentication(api_client, url, org):
         },
     )
 
-    assert response.status_code in (
-        status.HTTP_401_UNAUTHORIZED,
-        status.HTTP_403_FORBIDDEN,
-    )
+    # No authenticator succeeds, so DRF's permission_denied() raises
+    # NotAuthenticated (401) rather than PermissionDenied (403) -- see
+    # rest_framework.views.APIView.permission_denied.
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_requires_the_manager_check_scope(api_client, url, service_application, org):
@@ -232,10 +232,12 @@ def test_expired_token_is_rejected(api_client, url, service_application, org):
         },
     )
 
-    assert response.status_code in (
-        status.HTTP_401_UNAUTHORIZED,
-        status.HTTP_403_FORBIDDEN,
-    )
+    # OAuth2Authentication.authenticate() returns None for an expired token
+    # (same as no token at all), so this hits the same NotAuthenticated (401)
+    # path as test_requires_authentication above -- it never reaches
+    # TokenHasScope, which is what produces 403 in
+    # test_requires_the_manager_check_scope below.
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.parametrize(

--- a/b2b/views/v0/service_test.py
+++ b/b2b/views/v0/service_test.py
@@ -1,0 +1,265 @@
+"""Tests for the service-to-service B2B views.
+
+TEMPORARY -- delete alongside b2b/views/v0/service.py when org-manager status
+becomes visible in Keycloak (mitodl/hq#10594).
+"""
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from mitol.common.utils.datetime import now_in_utc
+from oauth2_provider.models import AccessToken, Application, get_application_model
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from b2b.factories import OrganizationPageFactory
+from b2b.models import UserOrganization
+from b2b.views.v0.service import MANAGER_CHECK_SCOPE
+from users.factories import UserFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+def generate_token():
+    """Return a unique opaque token value."""
+
+    return uuid.uuid4().hex
+
+
+@pytest.fixture
+def api_client():
+    """Unauthenticated API client."""
+
+    return APIClient()
+
+
+@pytest.fixture
+def url():
+    """The org-manager-check endpoint URL."""
+
+    return reverse("b2b:service-organization-manager-check")
+
+
+@pytest.fixture
+def service_application():
+    """A confidential client-credentials Application, as a service would use."""
+
+    return get_application_model().objects.create(
+        name="ol-analytics-api",
+        client_type=Application.CLIENT_CONFIDENTIAL,
+        authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+    )
+
+
+def _token(application, scope):
+    """Mint an access token for the application with the given scope."""
+
+    return AccessToken.objects.create(
+        user=None,
+        application=application,
+        token=generate_token(),
+        scope=scope,
+        expires=now_in_utc() + timedelta(hours=1),
+    )
+
+
+@pytest.fixture
+def scoped_token(service_application):
+    """A token carrying the manager-check scope."""
+
+    return _token(service_application, MANAGER_CHECK_SCOPE)
+
+
+@pytest.fixture
+def org():
+    """An organization with a known sso_organization_id."""
+
+    return OrganizationPageFactory.create(sso_organization_id=uuid.uuid4())
+
+
+def _auth(client, token):
+    """Attach a bearer token to the client."""
+
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+    return client
+
+
+def test_manager_returns_true(api_client, url, scoped_token, org):
+    """A user with is_manager=True on the org is reported as a manager."""
+
+    user = UserFactory.create()
+    UserOrganization.objects.create(user=user, organization=org, is_manager=True)
+
+    response = _auth(api_client, scoped_token).get(
+        url,
+        {
+            "sso_organization_id": str(org.sso_organization_id),
+            "user_global_id": user.global_id,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"is_manager": True}
+
+
+def test_member_but_not_manager_returns_false(api_client, url, scoped_token, org):
+    """Plain membership is not enough -- is_manager must be set.
+
+    This is the whole reason the endpoint exists: the Keycloak token carries
+    membership but not the manager flag.
+    """
+
+    user = UserFactory.create()
+    UserOrganization.objects.create(user=user, organization=org, is_manager=False)
+
+    response = _auth(api_client, scoped_token).get(
+        url,
+        {
+            "sso_organization_id": str(org.sso_organization_id),
+            "user_global_id": user.global_id,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"is_manager": False}
+
+
+def test_manager_of_a_different_org_returns_false(api_client, url, scoped_token, org):
+    """Managing one org must not confer manager status on another."""
+
+    other_org = OrganizationPageFactory.create(sso_organization_id=uuid.uuid4())
+    user = UserFactory.create()
+    UserOrganization.objects.create(user=user, organization=other_org, is_manager=True)
+
+    response = _auth(api_client, scoped_token).get(
+        url,
+        {
+            "sso_organization_id": str(org.sso_organization_id),
+            "user_global_id": user.global_id,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"is_manager": False}
+
+
+@pytest.mark.parametrize(
+    "unknown",
+    [("user",), ("org",), ("user", "org")],
+    ids=["unknown-user", "unknown-org", "both-unknown"],
+)
+def test_unknown_subject_fails_closed(api_client, url, scoped_token, org, unknown):
+    """An unknown user or org answers false rather than 404.
+
+    Fails closed, and avoids letting a caller enumerate which org UUIDs and
+    user IDs exist here.
+    """
+
+    user = UserFactory.create()
+    UserOrganization.objects.create(user=user, organization=org, is_manager=True)
+
+    response = _auth(api_client, scoped_token).get(
+        url,
+        {
+            "sso_organization_id": (
+                str(uuid.uuid4()) if "org" in unknown else str(org.sso_organization_id)
+            ),
+            "user_global_id": (
+                "no-such-global-id" if "user" in unknown else user.global_id
+            ),
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"is_manager": False}
+
+
+def test_requires_authentication(api_client, url, org):
+    """An unauthenticated call is rejected."""
+
+    response = api_client.get(
+        url,
+        {
+            "sso_organization_id": str(org.sso_organization_id),
+            "user_global_id": "anything",
+        },
+    )
+
+    assert response.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+def test_requires_the_manager_check_scope(api_client, url, service_application, org):
+    """A valid token without the scope is rejected.
+
+    The scope is the only thing standing between a service credential and the
+    ability to ask about any user, so this is the load-bearing check.
+    """
+
+    wrong_scope_token = _token(service_application, "user:read")
+
+    response = _auth(api_client, wrong_scope_token).get(
+        url,
+        {
+            "sso_organization_id": str(org.sso_organization_id),
+            "user_global_id": "anything",
+        },
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_expired_token_is_rejected(api_client, url, service_application, org):
+    """An expired token does not authenticate."""
+
+    expired = AccessToken.objects.create(
+        user=None,
+        application=service_application,
+        token=generate_token(),
+        scope=MANAGER_CHECK_SCOPE,
+        expires=now_in_utc() - timedelta(hours=1),
+    )
+
+    response = _auth(api_client, expired).get(
+        url,
+        {
+            "sso_organization_id": str(org.sso_organization_id),
+            "user_global_id": "anything",
+        },
+    )
+
+    assert response.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},
+        {"sso_organization_id": "11111111-1111-1111-1111-111111111111"},
+        {"user_global_id": "abc"},
+    ],
+)
+def test_missing_parameters_are_a_400(api_client, url, scoped_token, params):
+    """Both query parameters are required."""
+
+    response = _auth(api_client, scoped_token).get(url, params)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_malformed_organization_id_is_a_400(api_client, url, scoped_token):
+    """A non-UUID sso_organization_id is a 400, not a 500 from the ORM."""
+
+    response = _auth(api_client, scoped_token).get(
+        url,
+        {"sso_organization_id": "not-a-uuid", "user_global_id": "abc"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/b2b/views/v0/urls.py
+++ b/b2b/views/v0/urls.py
@@ -12,6 +12,7 @@ from b2b.views.v0.manager import (
     ManagerContractViewSet,
     ManagerOrganizationViewSet,
 )
+from b2b.views.v0.service import OrganizationManagerCheckView
 from main.routers import SimpleRouterWithNesting
 
 app_name = "b2b"
@@ -50,5 +51,12 @@ urlpatterns = [
         r"attach/<str:enrollment_code>/",
         AttachContractApi.as_view(),
         name="attach-user",
+    ),
+    # Service-to-service; delete along with b2b/views/v0/service.py once
+    # org-manager status is visible in Keycloak (mitodl/hq#10594).
+    path(
+        r"service/organization-manager-check/",
+        OrganizationManagerCheckView.as_view(),
+        name="service-organization-manager-check",
     ),
 ]

--- a/main/settings.py
+++ b/main/settings.py
@@ -1093,6 +1093,10 @@ OAUTH2_PROVIDER = {
         "write": "Write scope",
         "openid": "OpenID Connect scope",
         "user:read": "Can read user and profile data",
+        # Service-to-service only, never granted to a user-facing client.
+        # Remove with b2b/views/v0/service.py once org-manager status is
+        # visible in Keycloak (mitodl/hq#10594).
+        "b2b:manager-check": "Can check whether a user manages an organization",
         # "digitalcredentials": "Can read and write Digital Credentials data",  # noqa: ERA001
     },
     "DEFAULT_SCOPES": ["user:read"],

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -876,6 +876,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationManagerCheck'
           description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceDetailError'
+          description: ''
   /api/v0/baskets/:
     get:
       operationId: baskets_list
@@ -8824,6 +8830,24 @@ components:
           minLength: 1
       required:
       - email
+    ServiceDetailError:
+      type: object
+      description: |-
+        Response shape for the 400 error responses below.
+
+        Same shape as b2b.serializers.v0.manager.DetailErrorSerializer, but
+        duplicated rather than imported (and distinctly named, since
+        drf-spectacular keys its component registry on class identity, not
+        structural equality -- reusing the same name for a different class
+        produces a "components with identical names" warning and an
+        unpredictable schema) so this module stays self-contained and its
+        deletion remains a plain file removal (see the module docstring in
+        b2b/views/v0/service.py).
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     SignatoryItem:
       type: object
       description: Serializer for signatory items used in certificate pages.

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -848,6 +848,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationPage'
           description: ''
+  /api/v0/b2b/service/organization-manager-check/:
+    get:
+      operationId: b2b_service_organization_manager_check
+      description: Check whether a user is a manager of an organization. Service-to-service
+        only; requires the `b2b:manager-check` scope.
+      parameters:
+      - in: query
+        name: sso_organization_id
+        schema:
+          type: string
+          format: uuid
+        description: The organization's Keycloak UUID (OrganizationPage.sso_organization_id).
+        required: true
+      - in: query
+        name: user_global_id
+        schema:
+          type: string
+        description: The user's Keycloak subject (User.global_id).
+        required: true
+      tags:
+      - b2b
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationManagerCheck'
+          description: ''
   /api/v0/baskets/:
     get:
       operationId: baskets_list
@@ -7447,6 +7475,15 @@ components:
       required:
       - state
       - total_price_paid
+    OrganizationManagerCheck:
+      type: object
+      description: Response shape for the org-manager check.
+      properties:
+        is_manager:
+          type: boolean
+          description: True if the user manages the organization.
+      required:
+      - is_manager
     OrganizationPage:
       type: object
       description: Serializer for the OrganizationPage model.

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -876,6 +876,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationManagerCheck'
           description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceDetailError'
+          description: ''
   /api/v0/baskets/:
     get:
       operationId: baskets_list
@@ -8824,6 +8830,24 @@ components:
           minLength: 1
       required:
       - email
+    ServiceDetailError:
+      type: object
+      description: |-
+        Response shape for the 400 error responses below.
+
+        Same shape as b2b.serializers.v0.manager.DetailErrorSerializer, but
+        duplicated rather than imported (and distinctly named, since
+        drf-spectacular keys its component registry on class identity, not
+        structural equality -- reusing the same name for a different class
+        produces a "components with identical names" warning and an
+        unpredictable schema) so this module stays self-contained and its
+        deletion remains a plain file removal (see the module docstring in
+        b2b/views/v0/service.py).
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     SignatoryItem:
       type: object
       description: Serializer for signatory items used in certificate pages.

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -848,6 +848,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationPage'
           description: ''
+  /api/v0/b2b/service/organization-manager-check/:
+    get:
+      operationId: b2b_service_organization_manager_check
+      description: Check whether a user is a manager of an organization. Service-to-service
+        only; requires the `b2b:manager-check` scope.
+      parameters:
+      - in: query
+        name: sso_organization_id
+        schema:
+          type: string
+          format: uuid
+        description: The organization's Keycloak UUID (OrganizationPage.sso_organization_id).
+        required: true
+      - in: query
+        name: user_global_id
+        schema:
+          type: string
+        description: The user's Keycloak subject (User.global_id).
+        required: true
+      tags:
+      - b2b
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationManagerCheck'
+          description: ''
   /api/v0/baskets/:
     get:
       operationId: baskets_list
@@ -7447,6 +7475,15 @@ components:
       required:
       - state
       - total_price_paid
+    OrganizationManagerCheck:
+      type: object
+      description: Response shape for the org-manager check.
+      properties:
+        is_manager:
+          type: boolean
+          description: True if the user manages the organization.
+      required:
+      - is_manager
     OrganizationPage:
       type: object
       description: Serializer for the OrganizationPage model.

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -876,6 +876,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationManagerCheck'
           description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceDetailError'
+          description: ''
   /api/v0/baskets/:
     get:
       operationId: baskets_list
@@ -8824,6 +8830,24 @@ components:
           minLength: 1
       required:
       - email
+    ServiceDetailError:
+      type: object
+      description: |-
+        Response shape for the 400 error responses below.
+
+        Same shape as b2b.serializers.v0.manager.DetailErrorSerializer, but
+        duplicated rather than imported (and distinctly named, since
+        drf-spectacular keys its component registry on class identity, not
+        structural equality -- reusing the same name for a different class
+        produces a "components with identical names" warning and an
+        unpredictable schema) so this module stays self-contained and its
+        deletion remains a plain file removal (see the module docstring in
+        b2b/views/v0/service.py).
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     SignatoryItem:
       type: object
       description: Serializer for signatory items used in certificate pages.

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -848,6 +848,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationPage'
           description: ''
+  /api/v0/b2b/service/organization-manager-check/:
+    get:
+      operationId: b2b_service_organization_manager_check
+      description: Check whether a user is a manager of an organization. Service-to-service
+        only; requires the `b2b:manager-check` scope.
+      parameters:
+      - in: query
+        name: sso_organization_id
+        schema:
+          type: string
+          format: uuid
+        description: The organization's Keycloak UUID (OrganizationPage.sso_organization_id).
+        required: true
+      - in: query
+        name: user_global_id
+        schema:
+          type: string
+        description: The user's Keycloak subject (User.global_id).
+        required: true
+      tags:
+      - b2b
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationManagerCheck'
+          description: ''
   /api/v0/baskets/:
     get:
       operationId: baskets_list
@@ -7447,6 +7475,15 @@ components:
       required:
       - state
       - total_price_paid
+    OrganizationManagerCheck:
+      type: object
+      description: Response shape for the org-manager check.
+      properties:
+        is_manager:
+          type: boolean
+          description: True if the user manages the organization.
+      required:
+      - is_manager
     OrganizationPage:
       type: object
       description: Serializer for the OrganizationPage model.


### PR DESCRIPTION
### What are the relevant tickets?
Related: https://github.com/mitodl/hq/issues/10594 (this endpoint is deleted once that lands)

### Description (What does it do?)
Adds a small, service-scoped endpoint that answers one question: **does user X manage organization Y?**

```
GET /api/v0/b2b/service/organization-manager-check/
    ?sso_organization_id=<keycloak org uuid>&user_global_id=<keycloak sub>
→ 200 {"is_manager": true}
```

`OAuth2Authentication` + `TokenHasScope`, requiring a new `b2b:manager-check` scope that is only ever granted to a service Application. Backed by the existing `is_organization_manager()` in `b2b/models.py`.

#### Why this is needed

`ol-analytics-api` serves the B2B analytics dashboard and gates every endpoint on org-manager status. It currently gets that status by calling `/api/v0/b2b/manager/organizations/` and forwarding the end user's `X-Userinfo` header. **That has never worked** — in QA every request 502s, because MITx Online sees the call as anonymous and returns 403.

Two independent reasons a lighter fix isn't available:

1. **It can't reuse `ManagerOrganizationViewSet`.** `get_queryset` filters on `self.request.user`, so a service-authenticated call answers "manages nothing" and every user is denied.
2. **It can't forward the user's identity.** Our APISIX build's `openid-connect` plugin strips client-supplied identity headers before they reach an upstream, by design:

   ```lua
   -- Snapshot the client-supplied X-Access-Token (it doubles as a bearer
   -- input via get_bearer_access_token) and clear the four headers this
   -- plugin advertises as outputs so client-supplied values cannot bleed
   -- through to the upstream.
   ctx.openid_connect_client_x_access_token = core.request.header(ctx, "X-Access-Token")
   core.request.set_header(ctx, "X-Access-Token", nil)
   core.request.set_header(ctx, "X-Userinfo", nil)
   ```

   Bearer tokens aren't an alternative either: the plugin's bearer path is gated on `bearer_only or introspection_endpoint or public_key or use_jwks`, and the mitxonline route sets none of them, so a bearer token is never inspected at all. (Verified by probing the live RC endpoint — a bogus bearer token returns the identical 403 to sending no header.)

So the only remaining option is a service credential plus an explicit subject parameter.

#### Design notes

- **Its own module** (`b2b/views/v0/service.py`), not folded into `manager.py`. The user-facing dashboard path is completely untouched — no risk of regressing the live manager UI — and the eventual removal is a file deletion rather than unpicking a conditional out of a live authorization path.
- **Fails closed.** Unknown user, unknown org, or no membership row all return `is_manager: false` rather than 404. Besides being the safe default, a 404 would let a caller enumerate which org UUIDs and user IDs exist here.
- **A malformed `sso_organization_id` is a 400,** not a 500 from the ORM rejecting a non-UUID on a `UUIDField` lookup.
- **Marked temporary in three places** — module docstring, URL comment, and the scope entry in settings — each pointing at mitodl/hq#10594.

### How can this be tested?

```bash
pytest b2b/views/v0/service_test.py
```

13 tests covering: manager → true; member-but-not-manager → false (the case that motivates the whole endpoint, since the Keycloak token carries membership but not the manager flag); manager of a *different* org → false; unknown user/org/both → false; unauthenticated → rejected; **valid token without the scope → 403**; expired token → rejected; missing params → 400; malformed UUID → 400.

Verified locally against Postgres 15.16:
- `pytest b2b/views/v0/service_test.py` → 13 passed
- `pytest b2b/` → **510 passed, 1 skipped** (the skip is pre-existing), so nothing existing regressed
- `ruff check` and `ruff format --check` clean; pre-commit hooks pass
- `./manage.py generate_openapi_spec --fail-on-warn` regenerated; the spec diff is included

### Additional Context

**This is one of three PRs.** It can merge independently and is inert until a service Application is granted the scope:
- this PR — the endpoint
- mitodl/ol-analytics-api — consumes it via client-credentials (stacked on https://github.com/mitodl/ol-analytics-api/pull/21)
- mitodl/ol-infrastructure — Vault secret + Pulumi env wiring

**Pre-merge step:** an OAuth2 `Application` (confidential, `client-credentials`) needs creating per environment with the `b2b:manager-check` scope, and its client id/secret stored in Vault for ol-analytics-api. No migration or fixture is included — say the word if you'd prefer one over doing it through the admin.

The scope appears in all three of `openapi/specs/v{0,1,2}.yaml` because the generator emits every path into each version's spec; `v1.yaml` already contained 20 other `/api/v0/b2b/` paths before this change, so that's the existing convention rather than something introduced here.

### Checklist:
- [ ] Create the OAuth2 Application + `b2b:manager-check` scope grant in each environment, and store its credentials in Vault, before the ol-analytics-api side deploys
