### PR TITLE
Guarantee enrollment fixture covers programs with and without run enrollments

### DIFF
--- a/courses/conftest.py
+++ b/courses/conftest.py
@@ -331,6 +331,76 @@ class UserWithEnrollmentsAndCerts(NamedTuple):
     program_certificates: list[ProgramCertificate]
 
 
+def _sample_runs_for_programs(fake, course_runs, programs, length):
+    """
+    Sample `length` course runs, split so that at least one of `programs` has a
+    run among its courses and at least one has none.
+
+    Enrolling in a program does not imply enrolling in any of its courses, so
+    both cases are real and both are worth generating. Sampling runs
+    independently of the programs leaves the split to chance instead: it happens
+    to produce full coverage about 97.6% of the time, which makes the uncovered
+    case effectively untested and makes any test asserting full coverage fail
+    the rest of the time.
+
+    Runs are returned in the order they should be enrolled in -- consumers
+    compare positionally against responses ordered by enrollment id.
+    """
+    if len(programs) < 2:  # noqa: PLR2004
+        return pytest.fail("Need at least 2 program enrollments to cover only some")
+    if length < 1:
+        return pytest.fail("Need at least 1 run enrollment to cover a program")
+
+    course_ids_by_program_id = {
+        program.id: {course.id for course in program.courses_qset}
+        for program in programs
+    }
+    runs_by_course_id = defaultdict(list)
+    for run in course_runs:
+        runs_by_course_id[run.course_id].append(run)
+
+    # Whichever program is left uncovered, some other program has to keep a run
+    # outside it, or there is nothing left that can be covered.
+    for uncovered in fake.random_sample(programs, length=len(programs)):
+        uncovered_course_ids = course_ids_by_program_id[uncovered.id]
+        runs_outside_uncovered = {
+            program.id: [
+                run
+                for course_id in course_ids_by_program_id[program.id]
+                - uncovered_course_ids
+                for run in runs_by_course_id[course_id]
+            ]
+            for program in programs
+            if program.id != uncovered.id
+        }
+        coverable = [
+            program for program in programs if runs_outside_uncovered.get(program.id)
+        ]
+        if coverable:
+            break
+    else:
+        return pytest.fail(
+            "No program has a course run outside another program's courses; "
+            "cannot cover one program and leave another uncovered"
+        )
+
+    eligible = [run for run in course_runs if run.course_id not in uncovered_course_ids]
+    if length > len(eligible):
+        return pytest.fail(
+            f"Cannot enroll in {length} runs outside {uncovered.readable_id}'s "
+            f"courses; only {len(eligible)} of {len(course_runs)} runs are eligible"
+        )
+
+    covered = fake.random_element(coverable)
+    covering_run = fake.random_element(runs_outside_uncovered[covered.id])
+    return [
+        covering_run,
+        *fake.random_sample(
+            [run for run in eligible if run.id != covering_run.id], length=length - 1
+        ),
+    ]
+
+
 @pytest.fixture
 def user_with_enrollments_and_certificates(
     fake,
@@ -350,8 +420,11 @@ def user_with_enrollments_and_certificates(
         programs_to_enroll_in, length=user_enrollment_config.program_enrollment_count
     )
 
-    runs_to_enroll_in = fake.random_sample(
-        course_runs, length=user_enrollment_config.run_enrollment_count
+    runs_to_enroll_in = _sample_runs_for_programs(
+        fake,
+        course_runs,
+        programs_to_enroll_in,
+        user_enrollment_config.run_enrollment_count,
     )
     runs_with_certificate = fake.random_sample(
         runs_to_enroll_in, length=user_enrollment_config.run_certificate_count

--- a/courses/views/v1/views_test.py
+++ b/courses/views/v1/views_test.py
@@ -815,10 +815,14 @@ def test_program_enrollments(user_drf_client, user_with_enrollments_and_certific
         for program_enrollment in program_enrollments
     }
 
-    # assert that we ended up with data
+    # Assert that we ended up with data, covering both cases: a program the user
+    # has course run enrollments in, and one they have none in. Enrolling in a
+    # program does not imply enrolling in its courses, so the response has to be
+    # right either way.
     assert len(program_enrollments) > 0
-    for runs in run_enrollments_by_program_id.values():
-        assert len(runs) > 0
+    runs_per_program = list(run_enrollments_by_program_id.values())
+    assert [runs for runs in runs_per_program if len(runs) > 0]
+    assert [runs for runs in runs_per_program if len(runs) == 0]
 
     resp = user_drf_client.get(reverse("v1:user_program_enrollments_api-list"))
 

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -1664,10 +1664,14 @@ def test_program_enrollments(user_drf_client, user_with_enrollments_and_certific
         for program_enrollment in program_enrollments
     }
 
-    # assert that we ended up with data
+    # Assert that we ended up with data, covering both cases: a program the user
+    # has course run enrollments in, and one they have none in. Enrolling in a
+    # program does not imply enrolling in its courses, so the response has to be
+    # right either way.
     assert len(program_enrollments) > 0
-    for runs in run_enrollments_by_program_id.values():
-        assert len(runs) > 0
+    runs_per_program = list(run_enrollments_by_program_id.values())
+    assert [runs for runs in runs_per_program if len(runs) > 0]
+    assert [runs for runs in runs_per_program if len(runs) == 0]
 
     resp = user_drf_client.get(reverse("v2:user_program_enrollments_api-list"))
 

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -100,7 +100,7 @@ def test_admin_settings(settings_sandbox, settings):
 def test_csrf_cookie_domain(settings_sandbox):
     """Verify that we can configure CSRF_COOKIE_DOMAIN with a var"""
     # Test the default
-    settings_vars = settings_sandbox.get()
+    settings_vars = settings_sandbox.reload()
     assert settings_vars.get("CSRF_COOKIE_DOMAIN") is None
 
     # Verify the env var works
@@ -111,7 +111,7 @@ def test_csrf_cookie_domain(settings_sandbox):
 def test_csrf_trusted_origins(settings_sandbox):
     """Verify that we can configure CSRF_TRUSTED_ORIGINS with a var"""
     # Test the default
-    settings_vars = settings_sandbox.get()
+    settings_vars = settings_sandbox.reload()
     assert settings_vars.get("CSRF_TRUSTED_ORIGINS") == []
 
     # Verify the env var works
@@ -129,7 +129,7 @@ def test_csrf_trusted_origins(settings_sandbox):
 def test_mitol_apigateway_allowed_redirect_hosts(settings_sandbox):
     """Verify that we can configure MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS with a var"""
     # Test the default
-    settings_vars = settings_sandbox.get()
+    settings_vars = settings_sandbox.reload()
     assert settings_vars.get("MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS") == [
         "localhost",
         "mitxonline.odl.local",


### PR DESCRIPTION
### What are the relevant tickets?

None.

### Description (What does it do?)

`user_with_enrollments_and_certificates` now guarantees that one enrolled program has course run enrollments and another has none, instead of sampling programs and runs independently — the source of `test_program_enrollments`'s roughly 1-in-42 failure rate. Enrolling in a program no longer implies enrolling in its courses, so the v1 and v2 guards now assert both shapes.

Also fixes three `main/settings_test.py` tests that asserted a default by reading the live `main.settings` globals without reloading, so they passed only when a sibling in the file had already reloaded — guaranteed sequentially, not under `-n logical`.

### How can this be tested?

```bash
pytest courses/views/v1/views_test.py::test_program_enrollments \
       courses/views/v2/views_test.py::test_program_enrollments \
       courses/views/v3/views_test.py main/settings_test.py
```

To confirm the fixture flake is gone, loop it — `main` fails roughly 1 in 42, this branch 0 in 120:

```bash
for i in $(seq 1 120); do
  pytest courses/views/v1/views_test.py::test_program_enrollments \
         courses/views/v2/views_test.py::test_program_enrollments -q --no-cov || echo "FAILED $i"
done
```

The settings flake only reproduces with `CSRF_TRUSTED_ORIGINS` set in the environment, which CI does not do. With it set, `pytest main/settings_test.py::test_csrf_trusted_origins` fails on `main` and passes here.

### Additional Context

Guaranteeing an uncovered program excludes that program's runs from the eligible pool, so the 7 run enrollments now come from about 5 of the 10 courses rather than all 10.
