### PR TITLE
Adding missing profile fields to profile api

### DIFF
--- a/compliance/api.py
+++ b/compliance/api.py
@@ -95,8 +95,22 @@ def _normalize_administrative_area(
     return normalized_state
 
 
-def _validate_bill_to_fields(user, bill_to: dict[str, str]) -> None:
-    """Raise a clear error when required CyberSource bill-to fields are missing."""
+# Maps CyberSource bill-to field names to the profile field names an API
+# consumer should show the user as missing.
+BILL_TO_FIELD_TO_PROFILE_FIELD = {
+    "first_name": "first_name",
+    "last_name": "last_name",
+    "email": "email",
+    "address1": "street_address_1",
+    "locality": "city",
+    "country": "country",
+    "administrative_area": "state",
+    "postal_code": "postal_code",
+}
+
+
+def _missing_bill_to_fields(bill_to: dict[str, str]) -> list[str]:
+    """Return the CyberSource bill-to field names missing from the given data."""
     missing_fields = []
 
     if not bill_to.get("first_name"):
@@ -110,12 +124,18 @@ def _validate_bill_to_fields(user, bill_to: dict[str, str]) -> None:
 
     missing_fields.extend(field for field in required_fields if not bill_to.get(field))
 
+    return missing_fields
+
+
+def _validate_bill_to_fields(user, bill_to: dict[str, str]) -> None:
+    """Raise a clear error when required CyberSource bill-to fields are missing."""
+    missing_fields = _missing_bill_to_fields(bill_to)
     if missing_fields:
         raise ExportComplianceDataError(user, missing_fields)
 
 
-def _build_export_payload(user) -> Any:
-    """Build the CyberSource export compliance REST request payload."""
+def _build_bill_to(user) -> dict[str, str]:
+    """Build the CyberSource bill-to fields from a user's legal address."""
     try:
         legal_address = user.legal_address
     except ObjectDoesNotExist:
@@ -145,6 +165,24 @@ def _build_export_payload(user) -> Any:
     if legal_address and legal_address.postal_code:
         bill_to["postal_code"] = legal_address.postal_code
 
+    return bill_to
+
+
+def get_missing_export_compliance_fields(user) -> list[str]:
+    """Return the profile field names required for an export compliance check that are missing."""
+    bill_to = _build_bill_to(user)
+    missing_bill_to_fields = _missing_bill_to_fields(bill_to)
+    return sorted(
+        {
+            BILL_TO_FIELD_TO_PROFILE_FIELD[field]
+            for field in missing_bill_to_fields
+        }
+    )
+
+
+def _build_export_payload(user) -> Any:
+    """Build the CyberSource export compliance REST request payload."""
+    bill_to = _build_bill_to(user)
     _validate_bill_to_fields(user, bill_to)
 
     return ValidateExportComplianceRequest(

--- a/compliance/api.py
+++ b/compliance/api.py
@@ -173,10 +173,7 @@ def get_missing_export_compliance_fields(user) -> list[str]:
     bill_to = _build_bill_to(user)
     missing_bill_to_fields = _missing_bill_to_fields(bill_to)
     return sorted(
-        {
-            BILL_TO_FIELD_TO_PROFILE_FIELD[field]
-            for field in missing_bill_to_fields
-        }
+        {BILL_TO_FIELD_TO_PROFILE_FIELD[field] for field in missing_bill_to_fields}
     )
 
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9208,8 +9208,15 @@ components:
           readOnly: true
           nullable: true
           description: The SSO ID (usually a Keycloak UUID) for the user.
+        compliance_missing_fields:
+          type: array
+          items:
+            type: string
+          description: Get the profile fields missing for an export compliance check
+          readOnly: true
       required:
       - b2b_organizations
+      - compliance_missing_fields
       - created_on
       - global_id
       - grants

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -9208,8 +9208,15 @@ components:
           readOnly: true
           nullable: true
           description: The SSO ID (usually a Keycloak UUID) for the user.
+        compliance_missing_fields:
+          type: array
+          items:
+            type: string
+          description: Get the profile fields missing for an export compliance check
+          readOnly: true
       required:
       - b2b_organizations
+      - compliance_missing_fields
       - created_on
       - global_id
       - grants

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -9208,8 +9208,15 @@ components:
           readOnly: true
           nullable: true
           description: The SSO ID (usually a Keycloak UUID) for the user.
+        compliance_missing_fields:
+          type: array
+          items:
+            type: string
+          description: Get the profile fields missing for an export compliance check
+          readOnly: true
       required:
       - b2b_organizations
+      - compliance_missing_fields
       - created_on
       - global_id
       - grants

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -12,6 +12,7 @@ from rest_framework import serializers
 
 from b2b.api import get_user_b2b_organizations
 from b2b.serializers.v0 import OrganizationPageSerializer
+from compliance.api import get_missing_export_compliance_fields
 from hubspot_sync.task_helpers import sync_hubspot_user
 
 # from ecommerce.api import fetch_and_serialize_unused_coupons  # noqa: ERA001
@@ -218,6 +219,7 @@ class UserSerializer(serializers.ModelSerializer):
     b2b_organizations = serializers.SerializerMethodField()
     is_anonymous = serializers.BooleanField(read_only=True)
     is_authenticated = serializers.BooleanField(read_only=True)
+    compliance_missing_fields = serializers.SerializerMethodField()
 
     def validate_email(self, value):
         if (
@@ -247,6 +249,14 @@ class UserSerializer(serializers.ModelSerializer):
         return OrganizationPageSerializer(
             get_user_b2b_organizations(instance), many=True
         ).data
+
+    @extend_schema_field(list[str])
+    def get_compliance_missing_fields(self, instance):
+        """Get the profile fields missing for an export compliance check"""
+        if instance.is_anonymous:
+            return []
+
+        return get_missing_export_compliance_fields(instance)
 
     def validate(self, data):
         request = self.context.get("request", None)
@@ -409,6 +419,7 @@ class UserSerializer(serializers.ModelSerializer):
             "is_active",
             "b2b_organizations",
             "global_id",
+            "compliance_missing_fields",
         )
         read_only_fields = (
             "is_anonymous",
@@ -421,6 +432,7 @@ class UserSerializer(serializers.ModelSerializer):
             "grants",
             "global_id",
             "b2b_organizations",
+            "compliance_missing_fields",
         )
 
 

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -10,6 +10,7 @@ from mitol.common.utils import now_in_utc
 from rest_framework import status
 
 from b2b.factories import ContractPageFactory
+from compliance.api import get_missing_export_compliance_fields
 from main.test_utils import drf_datetime
 from users.api import User
 from users.factories import UserFactory
@@ -127,6 +128,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, has_orgs):
             "user_profile": None,
             "is_active": False,
             "b2b_organizations": b2b_orgs,
+            "compliance_missing_fields": [],
         }
     else:
         assert resp.json() == {
@@ -163,6 +165,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous, has_orgs):
             "grants": list(user.get_all_permissions()),
             "is_active": True,
             "b2b_organizations": b2b_orgs,
+            "compliance_missing_fields": get_missing_export_compliance_fields(user),
         }
 
 
@@ -310,6 +313,7 @@ def test_get_userinfo(client, user, is_anonymous, has_openedx_user, has_edx_user
             "grants": list(user.get_all_permissions()),
             "is_active": True,
             "b2b_organizations": b2b_orgs,
+            "compliance_missing_fields": get_missing_export_compliance_fields(user),
         }
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/12528

### Description (What does it do?)
 - Expose a compliance_missing_fields read-only field on the users/me (profile) API, listing which profile fields still need to be filled in before a CyberSource export compliance check can run for the 
  user (e.g. first_name, country, state, postal_code).                                                                                                                                                     
  - Refactor compliance/api.py to share the missing-field logic between the existing validation path (_validate_bill_to_fields, which raises ExportComplianceDataError) and a new public                   
  get_missing_export_compliance_fields(user) helper, so both stay in sync with a single source of truth.                                                                                                   
  - Map CyberSource's internal bill-to field names (address1, locality, administrative_area) back to the corresponding LegalAddress/User field names (street_address_1, city, state) via                   
  BILL_TO_FIELD_TO_PROFILE_FIELD, so the API returns names the frontend can map directly to profile form fields.                                                                                           
  - Regenerate openapi/specs/{v0,v1,v2}.yaml to include the new field.       
  


### How can this be tested?
Go to  http://mitxonline.odl.local:8013/api/users/me 

