### PR TITLE
Strip angle brackets

### DIFF
--- a/b2b/mail.py
+++ b/b2b/mail.py
@@ -56,7 +56,14 @@ def send_email_helper(  # noqa: PLR0913
                 == "anymail.backends.mailgun.EmailBackend"
             ):
                 recipient_status = message.anymail_status.recipients.get(email)
-                message_id = recipient_status.message_id if recipient_status else None
+                # Message ID is in the following format when pulled from anymail
+                # '<20260806133209.67c51081a4f1c478@mitxonline-rc-mail.mitxonline.mit.edu>'
+                # The webhook doesn't have the leading or trailing angle brackets, so we'll remove those
+                message_id = (
+                    recipient_status.message_id.strip("<>")
+                    if recipient_status
+                    else None
+                )
             else:
                 message_id = str(uuid.uuid4())
 


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/7656349183/events/394cbee32c4048f3a318b1b3c6cf8dd8/?environment=rc&project=5864687&query=is%3Aunresolved&referrer=previous-event

### Description (What does it do?)
Just strips some formatting from the message ID given back by anymail. This means that it'll match what we get back from mailgun in the webhooks.

If you're using something like mailpit locally, this change has no effect.

### How can this be tested?
Tests should pass - this is otherwise not feasible to test w/o a bunch of finagling and a mailgun account.