### PR TITLE
Add failed filter to /codes

### DIFF
--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -438,7 +438,15 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                     contract_redemptions__redeemed_on__isnull=True
                 )
             elif status_filter == EMAIL_STATUS_FAILED:
-                filter_q &= Q(contract_redemptions__email_status=EMAIL_STATUS_FAILED)
+                # A failed invite email only matters if the code hasn't since
+                # been redeemed some other way - exclude redeemed codes here.
+                # We shouldn't really be in this state under normal operation,
+                # but it could happen if we give a user their code out of band.
+                filter_q &= (
+                    Q(contract_redemptions__email_status=EMAIL_STATUS_FAILED)
+                    & Q(contract_redemptions__user__isnull=True)
+                    & Q(contract_redemptions__redeemed_on__isnull=True)
+                )
 
             discounts = (
                 contract.get_discounts()

--- a/b2b/views/v0/manager.py
+++ b/b2b/views/v0/manager.py
@@ -26,6 +26,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from b2b.api import _create_discount_with_product, is_potentially_valid_mailgun_webhook
 from b2b.constants import CONTRACT_MEMBERSHIP_AUTOS
 from b2b.models import (
+    EMAIL_STATUS_FAILED,
     EMAIL_STATUS_PENDING,
     REDEMPTION_STATUS_ASSIGNED,
     REDEMPTION_STATUS_REDEEMED,
@@ -377,9 +378,13 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 name="status",
                 type=str,
                 location=OpenApiParameter.QUERY,
-                description="Filter codes by status. Supported values are assigned and redeemed.",
+                description="Filter codes by status. Supported values are assigned, redeemed, and failed.",
                 required=False,
-                enum=[REDEMPTION_STATUS_ASSIGNED, REDEMPTION_STATUS_REDEEMED],
+                enum=[
+                    REDEMPTION_STATUS_ASSIGNED,
+                    REDEMPTION_STATUS_REDEEMED,
+                    EMAIL_STATUS_FAILED,
+                ],
             ),
         ],
     )
@@ -432,6 +437,9 @@ class ManagerContractViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 filter_q &= Q(contract_redemptions__user__isnull=True) & Q(
                     contract_redemptions__redeemed_on__isnull=True
                 )
+            elif status_filter == EMAIL_STATUS_FAILED:
+                filter_q &= Q(contract_redemptions__email_status=EMAIL_STATUS_FAILED)
+
             discounts = (
                 contract.get_discounts()
                 .filter(filter_q)

--- a/b2b/views/v0/manager_test.py
+++ b/b2b/views/v0/manager_test.py
@@ -13,6 +13,8 @@ from b2b.api import ensure_enrollment_codes_exist
 from b2b.constants import CONTRACT_MEMBERSHIP_CODE
 from b2b.factories import ContractPageFactory
 from b2b.models import (
+    EMAIL_STATUS_DELIVERED,
+    EMAIL_STATUS_FAILED,
     EMAIL_STATUS_PENDING,
     REDEMPTION_STATUS_ASSIGNED,
     REDEMPTION_STATUS_REDEEMED,
@@ -723,6 +725,61 @@ def test_org_contract_codes_status_filter(org_setup, manager_drf_client):
     ) == {
         discounts[1].discount_code,
         discounts[2].discount_code,
+    }
+
+
+def test_org_contract_codes_status_filter_failed(org_setup, manager_drf_client):
+    """
+    The "failed" status filters on email_status, but only for codes that
+    haven't since been redeemed - a redeemed code shouldn't show up as
+    "failed" since the code has been consumed.
+    """
+    _, _, (contract_1, *_), *_ = org_setup
+
+    discounts = list(contract_1.get_discounts().order_by("id")[:4])
+
+    user_a = UserFactory.create(email="alice@example.com")
+
+    # assigned, invite email delivered successfully - not "failed"
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[0],
+        assigned_email="carol@example.com",
+        email_status=EMAIL_STATUS_DELIVERED,
+        contract=contract_1,
+    )
+    # assigned, invite email failed to send
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[1],
+        assigned_email="dave@example.com",
+        email_status=EMAIL_STATUS_FAILED,
+        contract=contract_1,
+    )
+    # redeemed (has user), invite email delivered - not "failed"
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[2],
+        user=user_a,
+        email_status=EMAIL_STATUS_DELIVERED,
+        contract=contract_1,
+    )
+    # redeemed (has redeemed_on but no user), but the invite email had failed
+    # before the code was redeemed some other way - should NOT count as "failed"
+    DiscountContractAttachmentRedemption.objects.create(
+        discount=discounts[3],
+        redeemed_on=now_in_utc(),
+        email_status=EMAIL_STATUS_FAILED,
+        contract=contract_1,
+    )
+
+    url = reverse(
+        "b2b:b2b-manager-org-contract-codes",
+        kwargs={
+            "parent_lookup_organization": contract_1.organization.id,
+            "pk": contract_1.id,
+        },
+    )
+
+    assert _get_codes_for_status(manager_drf_client, url, EMAIL_STATUS_FAILED) == {
+        discounts[1].discount_code
     }
 
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -386,8 +386,10 @@ paths:
           type: string
           enum:
           - assigned
+          - failed
           - redeemed
-        description: Filter codes by status. Supported values are assigned and redeemed.
+        description: Filter codes by status. Supported values are assigned, redeemed,
+          and failed.
       tags:
       - b2b
       responses:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -386,8 +386,10 @@ paths:
           type: string
           enum:
           - assigned
+          - failed
           - redeemed
-        description: Filter codes by status. Supported values are assigned and redeemed.
+        description: Filter codes by status. Supported values are assigned, redeemed,
+          and failed.
       tags:
       - b2b
       responses:

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -386,8 +386,10 @@ paths:
           type: string
           enum:
           - assigned
+          - failed
           - redeemed
-        description: Filter codes by status. Supported values are assigned and redeemed.
+        description: Filter codes by status. Supported values are assigned, redeemed,
+          and failed.
       tags:
       - b2b
       responses:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12722

### Description (What does it do?)
Adds a new status filter value. This value allows callers to filter down to records which are unredeemed and have received a permanent failure status event from mailgun.

### How can this be tested?
- Create a b2b contract w/ one or more codes and set yourself as a manager of the corresponding organization.
- Preassign a least one code. Find the DiscountContractAttachmentRedemption for this code.
- Run `./manage.py b2b_send_mailgun_webhook <record_id> failed --host='http://<local_mitxonline_host>:<port>'`
- Visit `/api/schema/swagger-ui/#/b2b/b2b_manager_organizations_contracts_codes_list` and specify your contract and `status=failed` as args. You should only get the record you just recorded a webhook for.

<img width="1406" height="505" alt="Screenshot 2026-08-07 at 11 16 23 AM" src="https://github.com/user-attachments/assets/c6b94e73-5431-431d-a1ff-0ab018893ad6" />

