### PR TITLE
Fix duplicate ECOMMERCE_DEFAULT_PAYMENT_GATEWAY env var declaration

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -1652,11 +1652,5 @@ MIT_LEARN_ATTACH_URL = get_string(
     description="The URL to use for generating contract attachment URLs for B2B.",
 )
 
-ECOMMERCE_DEFAULT_PAYMENT_GATEWAY = get_string(
-    name="ECOMMERCE_DEFAULT_PAYMENT_GATEWAY",
-    default=MITOL_PAYMENT_GATEWAY_CYBERSOURCE,
-    description="The default payment gateway to use. Must match the value of the constant in the mitol.payment_gateway library.",
-)
-
-if ECOMMERCE_DEFAULT_PAYMENT_GATEWAY == "None":
+if ECOMMERCE_DEFAULT_PAYMENT_GATEWAY == "None":  # noqa: F405
     ECOMMERCE_DEFAULT_PAYMENT_GATEWAY = MITOL_PAYMENT_GATEWAY_CYBERSOURCE

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -2354,6 +2354,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/Order'
           description: ''
+  /api/v0/orders/refund-requests/:
+    post:
+      operationId: orders_refund_requests_create
+      description: Submit a refund request for a fulfilled order. Only the order's
+        purchaser may submit a request, and B2B contract orders are excluded.
+      tags:
+      - orders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundRequest'
+          description: ''
   /api/v0/orders/status/{order_id}/:
     get:
       operationId: orders_status_retrieve
@@ -7528,12 +7554,16 @@ components:
             country:
               type: string
           readOnly: true
+        refund_eligible:
+          type: boolean
+          readOnly: true
       required:
       - created_on
       - discounts
       - id
       - lines
       - purchaser
+      - refund_eligible
       - refunds
       - state
       - street_address
@@ -7573,11 +7603,15 @@ components:
           type: string
           format: date-time
           readOnly: true
+        refund_eligible:
+          type: boolean
+          readOnly: true
       required:
       - created_on
       - id
       - lines
       - purchaser
+      - refund_eligible
       - state
       - titles
       - total_price_paid
@@ -8930,6 +8964,58 @@ components:
       - one-time
       - one-time-per-user
       - unlimited
+    RefundReasonEnum:
+      enum:
+      - enrolled_in_another_course
+      - course_not_as_expected
+      - technical_difficulties
+      - financial_reasons
+      - other
+      type: string
+      description: |-
+        * `enrolled_in_another_course` - I enrolled in another course
+        * `course_not_as_expected` - Course is not what I expected
+        * `technical_difficulties` - Technical difficulties
+        * `financial_reasons` - Financial reasons
+        * `other` - Other
+      x-enum-descriptions:
+      - I enrolled in another course
+      - Course is not what I expected
+      - Technical difficulties
+      - Financial reasons
+      - Other
+    RefundRequest:
+      type: object
+      description: Serializer for creating learner-submitted refund requests.
+      properties:
+        order:
+          type: integer
+        refund_reason:
+          oneOf:
+          - $ref: '#/components/schemas/RefundReasonEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        refund_reason_text:
+          type: string
+        consent_given:
+          type: boolean
+      required:
+      - order
+    RefundRequestRequest:
+      type: object
+      description: Serializer for creating learner-submitted refund requests.
+      properties:
+        order:
+          type: integer
+        refund_reason:
+          oneOf:
+          - $ref: '#/components/schemas/RefundReasonEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        refund_reason_text:
+          type: string
+        consent_given:
+          type: boolean
+      required:
+      - order
     ResultEnum:
       enum:
       - b2b-disallowed

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2354,6 +2354,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/Order'
           description: ''
+  /api/v0/orders/refund-requests/:
+    post:
+      operationId: orders_refund_requests_create
+      description: Submit a refund request for a fulfilled order. Only the order's
+        purchaser may submit a request, and B2B contract orders are excluded.
+      tags:
+      - orders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundRequest'
+          description: ''
   /api/v0/orders/status/{order_id}/:
     get:
       operationId: orders_status_retrieve
@@ -7528,12 +7554,16 @@ components:
             country:
               type: string
           readOnly: true
+        refund_eligible:
+          type: boolean
+          readOnly: true
       required:
       - created_on
       - discounts
       - id
       - lines
       - purchaser
+      - refund_eligible
       - refunds
       - state
       - street_address
@@ -7573,11 +7603,15 @@ components:
           type: string
           format: date-time
           readOnly: true
+        refund_eligible:
+          type: boolean
+          readOnly: true
       required:
       - created_on
       - id
       - lines
       - purchaser
+      - refund_eligible
       - state
       - titles
       - total_price_paid
@@ -8930,6 +8964,58 @@ components:
       - one-time
       - one-time-per-user
       - unlimited
+    RefundReasonEnum:
+      enum:
+      - enrolled_in_another_course
+      - course_not_as_expected
+      - technical_difficulties
+      - financial_reasons
+      - other
+      type: string
+      description: |-
+        * `enrolled_in_another_course` - I enrolled in another course
+        * `course_not_as_expected` - Course is not what I expected
+        * `technical_difficulties` - Technical difficulties
+        * `financial_reasons` - Financial reasons
+        * `other` - Other
+      x-enum-descriptions:
+      - I enrolled in another course
+      - Course is not what I expected
+      - Technical difficulties
+      - Financial reasons
+      - Other
+    RefundRequest:
+      type: object
+      description: Serializer for creating learner-submitted refund requests.
+      properties:
+        order:
+          type: integer
+        refund_reason:
+          oneOf:
+          - $ref: '#/components/schemas/RefundReasonEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        refund_reason_text:
+          type: string
+        consent_given:
+          type: boolean
+      required:
+      - order
+    RefundRequestRequest:
+      type: object
+      description: Serializer for creating learner-submitted refund requests.
+      properties:
+        order:
+          type: integer
+        refund_reason:
+          oneOf:
+          - $ref: '#/components/schemas/RefundReasonEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        refund_reason_text:
+          type: string
+        consent_given:
+          type: boolean
+      required:
+      - order
     ResultEnum:
       enum:
       - b2b-disallowed

--- a/openapi/specs/v2.yaml
+++ b/openapi/specs/v2.yaml
@@ -2354,6 +2354,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/Order'
           description: ''
+  /api/v0/orders/refund-requests/:
+    post:
+      operationId: orders_refund_requests_create
+      description: Submit a refund request for a fulfilled order. Only the order's
+        purchaser may submit a request, and B2B contract orders are excluded.
+      tags:
+      - orders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RefundRequestRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundRequest'
+          description: ''
   /api/v0/orders/status/{order_id}/:
     get:
       operationId: orders_status_retrieve
@@ -7528,12 +7554,16 @@ components:
             country:
               type: string
           readOnly: true
+        refund_eligible:
+          type: boolean
+          readOnly: true
       required:
       - created_on
       - discounts
       - id
       - lines
       - purchaser
+      - refund_eligible
       - refunds
       - state
       - street_address
@@ -7573,11 +7603,15 @@ components:
           type: string
           format: date-time
           readOnly: true
+        refund_eligible:
+          type: boolean
+          readOnly: true
       required:
       - created_on
       - id
       - lines
       - purchaser
+      - refund_eligible
       - state
       - titles
       - total_price_paid
@@ -8930,6 +8964,58 @@ components:
       - one-time
       - one-time-per-user
       - unlimited
+    RefundReasonEnum:
+      enum:
+      - enrolled_in_another_course
+      - course_not_as_expected
+      - technical_difficulties
+      - financial_reasons
+      - other
+      type: string
+      description: |-
+        * `enrolled_in_another_course` - I enrolled in another course
+        * `course_not_as_expected` - Course is not what I expected
+        * `technical_difficulties` - Technical difficulties
+        * `financial_reasons` - Financial reasons
+        * `other` - Other
+      x-enum-descriptions:
+      - I enrolled in another course
+      - Course is not what I expected
+      - Technical difficulties
+      - Financial reasons
+      - Other
+    RefundRequest:
+      type: object
+      description: Serializer for creating learner-submitted refund requests.
+      properties:
+        order:
+          type: integer
+        refund_reason:
+          oneOf:
+          - $ref: '#/components/schemas/RefundReasonEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        refund_reason_text:
+          type: string
+        consent_given:
+          type: boolean
+      required:
+      - order
+    RefundRequestRequest:
+      type: object
+      description: Serializer for creating learner-submitted refund requests.
+      properties:
+        order:
+          type: integer
+        refund_reason:
+          oneOf:
+          - $ref: '#/components/schemas/RefundReasonEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        refund_reason_text:
+          type: string
+        consent_given:
+          type: boolean
+      required:
+      - order
     ResultEnum:
       enum:
       - b2b-disallowed


### PR DESCRIPTION
Closes #3831
Closes #3833

## Summary

`main`'s CI has two independent, pre-existing breakages, both traced back to #3810 ("Add learner refund request workflow"), fixed together here:

### 1. Duplicate `ECOMMERCE_DEFAULT_PAYMENT_GATEWAY` env var declaration (#3831)

`main/settings.py:1655` re-declares `ECOMMERCE_DEFAULT_PAYMENT_GATEWAY` via `get_string(...)`, but that name is already registered a few hundred lines earlier through `import_settings_modules("mitol.payment_gateway.settings", ...)` (which itself calls `get_string(name="ECOMMERCE_DEFAULT_PAYMENT_GATEWAY", ...)`).

`mitol.common.envs`'s registry raises if a name is declared twice in the same process, so **every** Django management command crashes:

```
ValueError: Environment variable 'ECOMMERCE_DEFAULT_PAYMENT_GATEWAY' was used more than once
```

Fix: remove the redundant declaration, keep only the `"None"` → CyberSource normalization that existed before #3810.

### 2. Stale OpenAPI specs (#3833)

#3810 added the refund-request endpoint, `RefundRequest`/`RefundRequestRequest`/`RefundReasonEnum` schemas, and the `refund_eligible` field, but never regenerated `openapi/specs/{v0,v1,v2}.yaml`, so `scripts/test/openapi_spec_check.sh` fails in CI's `python-checks` job.

Fix: regenerated via `manage.py generate_openapi_spec`.

Both issues currently fail CI on every open PR based on `main`, including #3802.

## Test plan

- [x] `python manage.py check` passes (previously crashed with the ValueError above)
- [x] `python manage.py migrate` / `makemigrations --check --dry-run` pass
- [x] Confirmed `settings.ECOMMERCE_DEFAULT_PAYMENT_GATEWAY` still resolves to `CyberSource` by default
- [x] `pytest ecommerce/api_test.py -k "gateway or payment"` passes
- [x] `pytest main/settings_test.py` passes
- [x] Regenerated OpenAPI spec diffs clean against the committed specs (`diff` exit 0)
- [x] `ruff check` / `ruff format --check` clean

## CI status

All checks green: `python-checks`, all 4 `python-tests` shards, `javascript-tests`, `openapi-diff`, CodeQL, and pre-commit.ci all pass on this branch.