### PR TITLE
fix(scim): send name.givenName/familyName in outbound SCIM payload

### DIFF
--- a/users/adapters.py
+++ b/users/adapters.py
@@ -140,13 +140,16 @@ class LearnUserAdapter(UserAdapter):
         # Inbound name.givenName/familyName always writes to legal_address
         # directly - this is real data from an external SCIM client, never
         # a derived guess (see _resolve_name's tier 2, which is outbound-only).
+        # An explicit JSON null (as opposed to an absent key) is treated the
+        # same as absent - legal_address.first_name/last_name are non-nullable
+        # CharFields, so assigning None would raise an IntegrityError on save.
         name = d.get("name") or {}
-        self.legal_address.first_name = name.get(
-            "givenName", self.legal_address.first_name
-        )
-        self.legal_address.last_name = name.get(
-            "familyName", self.legal_address.last_name
-        )
+        given_name = name.get("givenName")
+        if given_name is not None:
+            self.legal_address.first_name = given_name
+        family_name = name.get("familyName")
+        if family_name is not None:
+            self.legal_address.last_name = family_name
 
     def _save_related(self):
         self.user_profile.user = self.obj

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -140,15 +140,17 @@ class LearnUserAdapter(UserAdapter):
         # Inbound name.givenName/familyName always writes to legal_address
         # directly - this is real data from an external SCIM client, never
         # a derived guess (see _resolve_name's tier 2, which is outbound-only).
-        # An explicit JSON null (as opposed to an absent key) is treated the
-        # same as absent - legal_address.first_name/last_name are non-nullable
-        # CharFields, so assigning None would raise an IntegrityError on save.
+        # An absent key, an explicit JSON null, or a blank/whitespace-only
+        # string are all treated as "no value provided" and leave the
+        # existing value alone - legal_address feeds SDN compliance
+        # screening, so a client silently sending an empty name should not
+        # be able to blank out a previously-valid one.
         name = d.get("name") or {}
-        given_name = name.get("givenName")
-        if given_name is not None:
+        given_name = (name.get("givenName") or "").strip()
+        if given_name:
             self.legal_address.first_name = given_name
-        family_name = name.get("familyName")
-        if family_name is not None:
+        family_name = (name.get("familyName") or "").strip()
+        if family_name:
             self.legal_address.last_name = family_name
 
     def _save_related(self):

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -21,6 +21,10 @@ class LearnUserAdapter(UserAdapter):
         ("active", None, None): "is_active",
         ("userName", None, None): "username",
         ("fullName", None, None): "name",
+        ("name", "givenName", None): "legal_address__first_name",
+        ("givenName", None, None): "legal_address__first_name",
+        ("name", "familyName", None): "legal_address__last_name",
+        ("familyName", None, None): "legal_address__last_name",
     }
 
     obj: "User"
@@ -52,16 +56,59 @@ class LearnUserAdapter(UserAdapter):
         """
         return self.obj.name
 
+    def _resolve_name(self) -> tuple[str, str]:
+        """
+        Resolve (given_name, family_name) for the SCIM ``name`` attribute.
+
+        Keycloak has no combined "full name" field - it only stores split
+        firstName/lastName, fed by SCIM's name.givenName/name.familyName. So
+        whatever single name string we have has to be split into two pieces
+        before it's sent; there's no way to hand Keycloak one string and have
+        it split for us. Tiers, in order of confidence:
+
+        1. legal_address.first_name/last_name, if both are set - real
+           structured data.
+        2. self.obj.name, split heuristically (last whitespace-separated
+           token = family name, remainder = given name) - no naive split is
+           correct for every name (breaks on single-name accounts,
+           multi-word surnames, non-Western conventions), but it's the best
+           data available for users who only came through the edX migration
+           and never had a legal_address name recorded.
+        3. Neither available - both empty strings.
+
+        This is deliberately never persisted back onto legal_address, which
+        is used for SDN compliance screening - writing a heuristic guess into
+        a field that compliance screening may rely on for an accurate legal
+        name would be a real risk, not just a data-quality nitpick.
+        """
+        if self.legal_address.first_name and self.legal_address.last_name:
+            return self.legal_address.first_name, self.legal_address.last_name
+
+        given_and_family_name_parts = 2
+        full_name = (self.obj.name or "").strip()
+        if full_name:
+            parts = full_name.rsplit(None, 1)
+            if len(parts) == given_and_family_name_parts:
+                return parts[0], parts[1]
+            return parts[0], ""
+
+        return "", ""
+
     def to_dict(self):
         """
         Return a ``dict`` conforming to the SCIM User Schema,
         ready for conversion to a JSON object.
         """
+        given_name, family_name = self._resolve_name()
         return {
             "id": self.id,
             "externalId": self.obj.scim_external_id,
             "schemas": [SchemaURI.USER],
             "userName": self.obj.username,
+            "name": {
+                "givenName": given_name,
+                "familyName": family_name,
+            },
             "displayName": self.display_name,
             "emails": self.emails,
             "active": self.obj.is_active,
@@ -89,6 +136,17 @@ class LearnUserAdapter(UserAdapter):
         self.obj.scim_external_id = d.get("externalId")
         self.obj.global_id = self.obj.scim_external_id or ""
         self.obj.name = d.get("fullName", self.obj.name)
+
+        # Inbound name.givenName/familyName always writes to legal_address
+        # directly - this is real data from an external SCIM client, never
+        # a derived guess (see _resolve_name's tier 2, which is outbound-only).
+        name = d.get("name") or {}
+        self.legal_address.first_name = name.get(
+            "givenName", self.legal_address.first_name
+        )
+        self.legal_address.last_name = name.get(
+            "familyName", self.legal_address.last_name
+        )
 
     def _save_related(self):
         self.user_profile.user = self.obj

--- a/users/adapters_test.py
+++ b/users/adapters_test.py
@@ -100,7 +100,8 @@ def test_learn_user_adapter_from_dict_writes_legal_address():
 def test_learn_user_adapter_from_dict_explicit_null_name_does_not_blank_out():
     """An explicit JSON null for givenName/familyName is treated the same as an
     absent key - it must not overwrite legal_address with None, since those
-    are non-nullable CharFields and would raise an IntegrityError on save"""
+    are non-nullable CharFields and would raise an IntegrityError on save
+    """
     user = UserFactory.create(name="Joe Smith")
     user.legal_address.first_name = "Joe"
     user.legal_address.last_name = "Smith"

--- a/users/adapters_test.py
+++ b/users/adapters_test.py
@@ -124,6 +124,32 @@ def test_learn_user_adapter_from_dict_explicit_null_name_does_not_blank_out():
     assert user.legal_address.last_name == "Smith"
 
 
+def test_learn_user_adapter_from_dict_blank_name_does_not_blank_out():
+    """An empty or whitespace-only string for givenName/familyName is treated
+    the same as absent/null - it must not silently overwrite a previously
+    valid legal_address name with blank data"""
+    user = UserFactory.create(name="Joe Smith")
+    user.legal_address.first_name = "Joe"
+    user.legal_address.last_name = "Smith"
+    user.legal_address.save()
+
+    adapter = LearnUserAdapter(user)
+    adapter.from_dict(
+        {
+            "active": True,
+            "userName": "jsmith",
+            "externalId": "1",
+            "name": {"givenName": "", "familyName": "   "},
+        }
+    )
+    adapter.save()
+
+    user.refresh_from_db()
+
+    assert user.legal_address.first_name == "Joe"
+    assert user.legal_address.last_name == "Smith"
+
+
 def test_learn_user_adapter_blank_fields():
     """An incoming request with no name data doesn't blank out existing fields"""
     user = UserFactory.create(name="Joe Smith")

--- a/users/adapters_test.py
+++ b/users/adapters_test.py
@@ -127,7 +127,8 @@ def test_learn_user_adapter_from_dict_explicit_null_name_does_not_blank_out():
 def test_learn_user_adapter_from_dict_blank_name_does_not_blank_out():
     """An empty or whitespace-only string for givenName/familyName is treated
     the same as absent/null - it must not silently overwrite a previously
-    valid legal_address name with blank data"""
+    valid legal_address name with blank data
+    """
     user = UserFactory.create(name="Joe Smith")
     user.legal_address.first_name = "Joe"
     user.legal_address.last_name = "Smith"

--- a/users/adapters_test.py
+++ b/users/adapters_test.py
@@ -97,6 +97,32 @@ def test_learn_user_adapter_from_dict_writes_legal_address():
     assert user.legal_address.last_name == "Name"
 
 
+def test_learn_user_adapter_from_dict_explicit_null_name_does_not_blank_out():
+    """An explicit JSON null for givenName/familyName is treated the same as an
+    absent key - it must not overwrite legal_address with None, since those
+    are non-nullable CharFields and would raise an IntegrityError on save"""
+    user = UserFactory.create(name="Joe Smith")
+    user.legal_address.first_name = "Joe"
+    user.legal_address.last_name = "Smith"
+    user.legal_address.save()
+
+    adapter = LearnUserAdapter(user)
+    adapter.from_dict(
+        {
+            "active": True,
+            "userName": "jsmith",
+            "externalId": "1",
+            "name": {"givenName": None, "familyName": None},
+        }
+    )
+    adapter.save()
+
+    user.refresh_from_db()
+
+    assert user.legal_address.first_name == "Joe"
+    assert user.legal_address.last_name == "Smith"
+
+
 def test_learn_user_adapter_blank_fields():
     """An incoming request with no name data doesn't blank out existing fields"""
     user = UserFactory.create(name="Joe Smith")

--- a/users/adapters_test.py
+++ b/users/adapters_test.py
@@ -1,18 +1,110 @@
 import pytest
+from mitol.scim.requests import InMemoryHttpRequest
 
-from users.adapters import UserAdapter
+from users.adapters import LearnUserAdapter
 from users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
 
-def test_user_adapter_blank_fields():
-    """Test that an incoming request with no name data doesn't blank out fields"""
-    user = UserFactory.create(
-        name="Joe Smith",
-    )
+def _adapter(user):
+    """LearnUserAdapter needs a request for to_dict()'s meta/location, same as
+    the real sync code (mitol.scim.api._get_sync_operations) provides.
+    """
+    return LearnUserAdapter(user, InMemoryHttpRequest.stub())
 
-    adapter = UserAdapter(user)
+
+def test_learn_user_adapter_to_dict_uses_legal_address_name():
+    """to_dict() should use legal_address first/last name when both are set"""
+    user = UserFactory.create(name="Joe Smith")
+    user.legal_address.first_name = "Given"
+    user.legal_address.last_name = "Family"
+    user.legal_address.save()
+
+    assert _adapter(user).to_dict()["name"] == {
+        "givenName": "Given",
+        "familyName": "Family",
+    }
+
+
+def test_learn_user_adapter_to_dict_falls_back_to_split_name():
+    """to_dict() splits User.name when legal_address has no name on file"""
+    user = UserFactory.create(name="Joe Middle Smith")
+    user.legal_address.first_name = ""
+    user.legal_address.last_name = ""
+    user.legal_address.save()
+
+    assert _adapter(user).to_dict()["name"] == {
+        "givenName": "Joe Middle",
+        "familyName": "Smith",
+    }
+
+
+def test_learn_user_adapter_to_dict_single_token_name():
+    """A single-token name can't be split; givenName gets it, familyName is blank"""
+    user = UserFactory.create(name="Madonna")
+    user.legal_address.first_name = ""
+    user.legal_address.last_name = ""
+    user.legal_address.save()
+
+    assert _adapter(user).to_dict()["name"] == {
+        "givenName": "Madonna",
+        "familyName": "",
+    }
+
+
+def test_learn_user_adapter_to_dict_no_name_data():
+    """No legal_address and no User.name results in a blank given/family name"""
+    user = UserFactory.create(name="")
+    user.legal_address.first_name = ""
+    user.legal_address.last_name = ""
+    user.legal_address.save()
+
+    assert _adapter(user).to_dict()["name"] == {"givenName": "", "familyName": ""}
+
+
+def test_learn_user_adapter_to_dict_partial_legal_address_falls_back():
+    """A half-filled legal_address isn't trusted; falls back to splitting name"""
+    user = UserFactory.create(name="Joe Smith")
+    user.legal_address.first_name = "OnlyGiven"
+    user.legal_address.last_name = ""
+    user.legal_address.save()
+
+    assert _adapter(user).to_dict()["name"] == {
+        "givenName": "Joe",
+        "familyName": "Smith",
+    }
+
+
+def test_learn_user_adapter_from_dict_writes_legal_address():
+    """from_dict() writes incoming name.givenName/familyName onto legal_address"""
+    user = UserFactory.create(name="Joe Smith")
+    adapter = LearnUserAdapter(user)
+
+    adapter.from_dict(
+        {
+            "active": True,
+            "userName": "jsmith",
+            "externalId": "1",
+            "name": {"givenName": "New", "familyName": "Name"},
+        }
+    )
+    adapter.save()
+
+    user.refresh_from_db()
+
+    assert user.legal_address.first_name == "New"
+    assert user.legal_address.last_name == "Name"
+
+
+def test_learn_user_adapter_blank_fields():
+    """An incoming request with no name data doesn't blank out existing fields"""
+    user = UserFactory.create(name="Joe Smith")
+    user.legal_address.first_name = "Joe"
+    user.legal_address.last_name = "Smith"
+    user.legal_address.save()
+
+    adapter = LearnUserAdapter(user)
     adapter.from_dict(
         {
             "active": True,
@@ -25,3 +117,5 @@ def test_user_adapter_blank_fields():
     user.refresh_from_db()
 
     assert user.name == "Joe Smith"
+    assert user.legal_address.first_name == "Joe"
+    assert user.legal_address.last_name == "Smith"

--- a/users/management/commands/remediate_keycloak_user_names.py
+++ b/users/management/commands/remediate_keycloak_user_names.py
@@ -126,11 +126,26 @@ class Command(BaseCommand):
         )
 
     def _mitxonline_users_by_scim_id(self):
-        users = User.objects.filter(is_active=True).exclude(
-            scim_external_id__isnull=True
+        # LearnUserAdapter.__init__ touches user_profile and openedx_user on
+        # every instantiation (not just legal_address), so both need to be
+        # covered here too or the loop in handle() does 2 extra queries per
+        # user. user_profile is a real OneToOneField, so select_related
+        # covers it. openedx_user is a cached_property backed by
+        # self.openedx_users.first() - select_related can't target it
+        # (openedx_users is the real FK), and prefetch_related alone doesn't
+        # help either, since .first() re-queries instead of using the
+        # prefetch cache. So we prefetch openedx_users and manually prime the
+        # cached_property's cache from it below.
+        users = (
+            User.objects.filter(is_active=True)
+            .exclude(scim_external_id__isnull=True)
+            .select_related("legal_address", "user_profile")
+            .prefetch_related("openedx_users")
         )
         by_id = {}
-        for user in users.select_related("legal_address"):
+        for user in users:
+            prefetched = list(user.openedx_users.all())
+            user.__dict__["openedx_user"] = prefetched[0] if prefetched else None
             if user.scim_external_id:
                 by_id[user.scim_external_id] = user
         return by_id

--- a/users/management/commands/remediate_keycloak_user_names.py
+++ b/users/management/commands/remediate_keycloak_user_names.py
@@ -79,8 +79,8 @@ class Command(BaseCommand):
                 continue
 
             if (
-                keycloak_user.firstName == given_name
-                and keycloak_user.lastName == family_name
+                (keycloak_user.firstName or "") == given_name
+                and (keycloak_user.lastName or "") == family_name
             ):
                 up_to_date.append(
                     self._row(keycloak_user, user, given_name, family_name)
@@ -104,7 +104,8 @@ class Command(BaseCommand):
             # verify - don't just trust a 2xx
             refetched = client.retrieve(f"users/{keycloak_user.id}", UserRepresentation)
             row["verified"] = (
-                refetched.firstName == given_name and refetched.lastName == family_name
+                (refetched.firstName or "") == given_name
+                and (refetched.lastName or "") == family_name
             )
             patched.append(row)
             patch_count += 1

--- a/users/management/commands/remediate_keycloak_user_names.py
+++ b/users/management/commands/remediate_keycloak_user_names.py
@@ -78,10 +78,9 @@ class Command(BaseCommand):
                 )
                 continue
 
-            if (
-                (keycloak_user.firstName or "") == given_name
-                and (keycloak_user.lastName or "") == family_name
-            ):
+            if (keycloak_user.firstName or "") == given_name and (
+                keycloak_user.lastName or ""
+            ) == family_name:
                 up_to_date.append(
                     self._row(keycloak_user, user, given_name, family_name)
                 )
@@ -103,10 +102,9 @@ class Command(BaseCommand):
             )
             # verify - don't just trust a 2xx
             refetched = client.retrieve(f"users/{keycloak_user.id}", UserRepresentation)
-            row["verified"] = (
-                (refetched.firstName or "") == given_name
-                and (refetched.lastName or "") == family_name
-            )
+            row["verified"] = (refetched.firstName or "") == given_name and (
+                refetched.lastName or ""
+            ) == family_name
             patched.append(row)
             patch_count += 1
 

--- a/users/management/commands/remediate_keycloak_user_names.py
+++ b/users/management/commands/remediate_keycloak_user_names.py
@@ -102,12 +102,9 @@ class Command(BaseCommand):
                 {"firstName": given_name, "lastName": family_name},
             )
             # verify - don't just trust a 2xx
-            refetched = client.retrieve(
-                f"users/{keycloak_user.id}", UserRepresentation
-            )
+            refetched = client.retrieve(f"users/{keycloak_user.id}", UserRepresentation)
             row["verified"] = (
-                refetched.firstName == given_name
-                and refetched.lastName == family_name
+                refetched.firstName == given_name and refetched.lastName == family_name
             )
             patched.append(row)
             patch_count += 1
@@ -142,9 +139,7 @@ class Command(BaseCommand):
     def _paginate_keycloak_users(self, client):
         first = 0
         while True:
-            page = client.list(
-                "users", UserRepresentation, first=first, max=PAGE_SIZE
-            )
+            page = client.list("users", UserRepresentation, first=first, max=PAGE_SIZE)
             if not page:
                 return
             yield from page

--- a/users/management/commands/remediate_keycloak_user_names.py
+++ b/users/management/commands/remediate_keycloak_user_names.py
@@ -1,0 +1,172 @@
+"""
+Find and (optionally) fix Keycloak users whose firstName/lastName are blank
+or stale, for users that were already synced before the LearnUserAdapter fix
+that adds name.givenName/name.familyName to the outbound SCIM payload.
+
+sync_users_to_scim_remote only ever creates users that don't already exist
+remotely - it has no update/PATCH path - so re-running the sync does nothing
+for users that are already in Keycloak. This command talks to Keycloak's
+Admin API directly instead, bypassing SCIM entirely.
+
+Default mode is dry-run: report every candidate and what would change,
+write nothing. Pass --apply to actually patch Keycloak.
+"""
+
+import json
+
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+from b2b.keycloak_admin_api import bootstrap_client
+from b2b.keycloak_admin_dataclasses import UserRepresentation
+from users.adapters import LearnUserAdapter
+
+User = get_user_model()
+
+PAGE_SIZE = 100
+
+
+class Command(BaseCommand):
+    """Find and (optionally) patch already-migrated Keycloak users' names."""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        """Define the command's CLI flags."""
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually PUT the corrected firstName/lastName to Keycloak. "
+            "Without this flag, only reports what would change.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Cap how many users get patched in a single --apply run. "
+            "Ignored in dry-run mode (the report always covers everyone).",
+        )
+        parser.add_argument(
+            "--report-path",
+            type=str,
+            help="Write the JSON report to this path instead of stdout.",
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Paginate Keycloak users, resolve the correct name, patch or report."""
+        apply_changes = options.get("apply", False)
+        limit = options.get("limit")
+        report_path = options.get("report_path")
+
+        client = bootstrap_client(verify_realm=True)
+
+        mitxonline_users_by_scim_id = self._mitxonline_users_by_scim_id()
+
+        patched, would_patch, unpatchable, up_to_date = [], [], [], []
+        patch_count = 0
+
+        for keycloak_user in self._paginate_keycloak_users(client):
+            user = mitxonline_users_by_scim_id.get(keycloak_user.id)
+            if user is None:
+                continue  # not a user we can trace back to mitxonline
+
+            adapter = LearnUserAdapter(user)
+            given_name, family_name = adapter._resolve_name()  # noqa: SLF001
+
+            if not given_name and not family_name:
+                unpatchable.append(
+                    self._row(keycloak_user, user, given_name, family_name)
+                )
+                continue
+
+            if (
+                keycloak_user.firstName == given_name
+                and keycloak_user.lastName == family_name
+            ):
+                up_to_date.append(
+                    self._row(keycloak_user, user, given_name, family_name)
+                )
+                continue
+
+            row = self._row(keycloak_user, user, given_name, family_name)
+
+            if not apply_changes:
+                would_patch.append(row)
+                continue
+
+            if limit is not None and patch_count >= limit:
+                would_patch.append(row)
+                continue
+
+            client.save(
+                f"users/{keycloak_user.id}",
+                {"firstName": given_name, "lastName": family_name},
+            )
+            # verify - don't just trust a 2xx
+            refetched = client.retrieve(
+                f"users/{keycloak_user.id}", UserRepresentation
+            )
+            row["verified"] = (
+                refetched.firstName == given_name
+                and refetched.lastName == family_name
+            )
+            patched.append(row)
+            patch_count += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{len(patched)} patched, {len(would_patch)} would-patch, "
+                f"{len(unpatchable)} unpatchable (no name data anywhere), "
+                f"{len(up_to_date)} already up to date"
+            )
+        )
+        self._write_report(
+            {
+                "patched": patched,
+                "would_patch": would_patch,
+                "unpatchable": unpatchable,
+                "up_to_date": up_to_date,
+            },
+            report_path,
+        )
+
+    def _mitxonline_users_by_scim_id(self):
+        users = User.objects.filter(is_active=True).exclude(
+            scim_external_id__isnull=True
+        )
+        by_id = {}
+        for user in users.select_related("legal_address"):
+            if user.scim_external_id:
+                by_id[user.scim_external_id] = user
+        return by_id
+
+    def _paginate_keycloak_users(self, client):
+        first = 0
+        while True:
+            page = client.list(
+                "users", UserRepresentation, first=first, max=PAGE_SIZE
+            )
+            if not page:
+                return
+            yield from page
+            first += PAGE_SIZE
+
+    @staticmethod
+    def _row(keycloak_user, user, given_name, family_name):
+        return {
+            "keycloak_id": keycloak_user.id,
+            "user_id": user.id,
+            "email": user.email,
+            "keycloak_first_name": keycloak_user.firstName,
+            "keycloak_last_name": keycloak_user.lastName,
+            "resolved_given_name": given_name,
+            "resolved_family_name": family_name,
+        }
+
+    def _write_report(self, report, report_path):
+        output = json.dumps(report, indent=2, default=str)
+        if report_path:
+            with open(report_path, "w") as f:  # noqa: PTH123
+                f.write(output)
+            self.stdout.write(f"Report written to {report_path}")
+        else:
+            self.stdout.write(output)

--- a/users/management/tests/remediate_keycloak_user_names_test.py
+++ b/users/management/tests/remediate_keycloak_user_names_test.py
@@ -97,6 +97,49 @@ def test_up_to_date_user_is_skipped(mocker):
 
 
 @pytest.mark.django_db
+def test_single_name_user_with_null_keycloak_field_is_up_to_date(mocker):
+    """A mononym user (resolved family_name == "") whose Keycloak record has
+    lastName=None, not "", must still be treated as up to date - None and ""
+    both mean "no last name", and Keycloak may return either representation"""
+    user = UserFactory.create(name="Madonna", scim_external_id="kc-1")
+    user.legal_address.first_name = ""
+    user.legal_address.last_name = ""
+    user.legal_address.save()
+
+    kc_user = UserRepresentation(id="kc-1", firstName="Madonna", lastName=None)
+    client = _mock_client(mocker, [[kc_user]])
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    COMMAND.handle(apply=True, limit=None, report_path=None)
+
+    client.save.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_single_name_user_patch_verified_when_refetch_returns_null(mocker, tmp_path):
+    """After patching a mononym user's lastName to "", the verify step must
+    still pass if Keycloak's re-fetch normalizes the empty string back to
+    None"""
+    user = UserFactory.create(name="Madonna", scim_external_id="kc-1")
+    user.legal_address.first_name = ""
+    user.legal_address.last_name = ""
+    user.legal_address.save()
+
+    kc_user = UserRepresentation(id="kc-1", firstName="", lastName="")
+    client = _mock_client(mocker, [[kc_user]])
+    client.retrieve.return_value = UserRepresentation(
+        id="kc-1", firstName="Madonna", lastName=None
+    )
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    report = _run(tmp_path, apply=True, limit=None)
+    patched_row = report["patched"][0]
+
+    assert patched_row["verified"] is True
+    client.retrieve.assert_called_once()
+
+
+@pytest.mark.django_db
 def test_unpatchable_user_has_no_name_data(mocker, tmp_path):
     """A user with no name data anywhere in mitxonline is reported separately,
     never patched even with --apply

--- a/users/management/tests/remediate_keycloak_user_names_test.py
+++ b/users/management/tests/remediate_keycloak_user_names_test.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from b2b.keycloak_admin_dataclasses import UserRepresentation
+from users.adapters import LearnUserAdapter
 from users.factories import UserFactory
 from users.management.commands import remediate_keycloak_user_names
 
@@ -35,6 +36,24 @@ def mock_bootstrap(mocker):
     return mocker.patch(
         "users.management.commands.remediate_keycloak_user_names.bootstrap_client"
     )
+
+
+@pytest.mark.django_db
+def test_mitxonline_users_lookup_query_count_is_flat(django_assert_max_num_queries):
+    """_mitxonline_users_by_scim_id() plus constructing a LearnUserAdapter per
+    user (as handle() does) must not issue extra queries per user - the fixed
+    query count covers select_related(legal_address, user_profile) plus one
+    bulk prefetch for openedx_users, regardless of how many users there are"""
+    for i in range(5):
+        user = UserFactory.create(scim_external_id=f"kc-{i}")
+        user.legal_address.first_name = "Joe"
+        user.legal_address.last_name = "Smith"
+        user.legal_address.save()
+
+    with django_assert_max_num_queries(3):
+        by_id = COMMAND._mitxonline_users_by_scim_id()  # noqa: SLF001
+        for user in by_id.values():
+            LearnUserAdapter(user)._resolve_name()  # noqa: SLF001
 
 
 @pytest.mark.django_db

--- a/users/management/tests/remediate_keycloak_user_names_test.py
+++ b/users/management/tests/remediate_keycloak_user_names_test.py
@@ -1,0 +1,175 @@
+"""Tests for remediate_keycloak_user_names management command"""
+
+import json
+
+import pytest
+
+from b2b.keycloak_admin_dataclasses import UserRepresentation
+from users.factories import UserFactory
+from users.management.commands import remediate_keycloak_user_names
+
+COMMAND = remediate_keycloak_user_names.Command()
+
+
+def _mock_client(mocker, pages):
+    """pages: list of lists of UserRepresentation, terminated by an empty list"""
+    client = mocker.Mock()
+    client.list.side_effect = [*pages, []]
+    return client
+
+
+def _run(tmp_path, **options):
+    """Run the command and return its parsed JSON report - reading the report
+    file, rather than scraping stdout, avoids Command()'s stdout reference
+    being grabbed at module-import time (before pytest's capture fixtures are
+    active for the current test).
+    """
+    report_path = tmp_path / "report.json"
+    COMMAND.handle(report_path=str(report_path), **options)
+    return json.loads(report_path.read_text())
+
+
+@pytest.fixture(autouse=True)
+def mock_bootstrap(mocker):
+    """Every test needs bootstrap_client mocked before it can set a return value."""
+    return mocker.patch(
+        "users.management.commands.remediate_keycloak_user_names.bootstrap_client"
+    )
+
+
+@pytest.mark.django_db
+def test_dry_run_reports_without_patching(mocker, tmp_path):
+    """A mismatched user is reported as would-patch; client.save is never called"""
+    user = UserFactory.create(name="Joe Smith", scim_external_id="kc-1")
+    user.legal_address.first_name = "Joe"
+    user.legal_address.last_name = "Smith"
+    user.legal_address.save()
+
+    kc_user = UserRepresentation(id="kc-1", firstName="", lastName="")
+    client = _mock_client(mocker, [[kc_user]])
+    mock_bootstrap = remediate_keycloak_user_names.bootstrap_client
+    mock_bootstrap.return_value = client
+
+    report = _run(tmp_path, apply=False, limit=None)
+
+    client.save.assert_not_called()
+    assert [row["user_id"] for row in report["would_patch"]] == [user.id]
+
+
+@pytest.mark.django_db
+def test_apply_patches_and_verifies(mocker):
+    """--apply calls client.save with the resolved name, then re-fetches to verify"""
+    user = UserFactory.create(name="Joe Smith", scim_external_id="kc-1")
+    user.legal_address.first_name = "Joe"
+    user.legal_address.last_name = "Smith"
+    user.legal_address.save()
+
+    kc_user = UserRepresentation(id="kc-1", firstName="", lastName="")
+    client = _mock_client(mocker, [[kc_user]])
+    client.retrieve.return_value = UserRepresentation(
+        id="kc-1", firstName="Joe", lastName="Smith"
+    )
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    COMMAND.handle(apply=True, limit=None, report_path=None)
+
+    client.save.assert_called_once_with(
+        "users/kc-1", {"firstName": "Joe", "lastName": "Smith"}
+    )
+    client.retrieve.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_up_to_date_user_is_skipped(mocker):
+    """A user whose Keycloak record already matches isn't touched"""
+    user = UserFactory.create(name="Joe Smith", scim_external_id="kc-1")
+    user.legal_address.first_name = "Joe"
+    user.legal_address.last_name = "Smith"
+    user.legal_address.save()
+
+    kc_user = UserRepresentation(id="kc-1", firstName="Joe", lastName="Smith")
+    client = _mock_client(mocker, [[kc_user]])
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    COMMAND.handle(apply=True, limit=None, report_path=None)
+
+    client.save.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_unpatchable_user_has_no_name_data(mocker, tmp_path):
+    """A user with no name data anywhere in mitxonline is reported separately,
+    never patched even with --apply
+    """
+    user = UserFactory.create(name="", scim_external_id="kc-1")
+    user.legal_address.first_name = ""
+    user.legal_address.last_name = ""
+    user.legal_address.save()
+
+    kc_user = UserRepresentation(id="kc-1", firstName="", lastName="")
+    client = _mock_client(mocker, [[kc_user]])
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    report = _run(tmp_path, apply=True, limit=None)
+
+    client.save.assert_not_called()
+    assert [row["user_id"] for row in report["unpatchable"]] == [user.id]
+
+
+@pytest.mark.django_db
+def test_limit_caps_writes_in_apply_mode(mocker):
+    """--limit caps how many get patched; the rest fall back to would-patch"""
+    users = []
+    kc_users = []
+    for i in range(3):
+        user = UserFactory.create(name="Joe Smith", scim_external_id=f"kc-{i}")
+        user.legal_address.first_name = "Joe"
+        user.legal_address.last_name = "Smith"
+        user.legal_address.save()
+        users.append(user)
+        kc_users.append(UserRepresentation(id=f"kc-{i}", firstName="", lastName=""))
+
+    client = _mock_client(mocker, [kc_users])
+    client.retrieve.return_value = UserRepresentation(
+        id="kc-0", firstName="Joe", lastName="Smith"
+    )
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    COMMAND.handle(apply=True, limit=1, report_path=None)
+
+    assert client.save.call_count == 1
+
+
+@pytest.mark.django_db
+def test_unmatched_keycloak_user_is_ignored(mocker):
+    """A Keycloak user with no corresponding mitxonline scim_external_id is
+    skipped entirely - not counted in any bucket
+    """
+    kc_user = UserRepresentation(id="kc-orphan", firstName="", lastName="")
+    client = _mock_client(mocker, [[kc_user]])
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    COMMAND.handle(apply=False, limit=None, report_path=None)
+
+    client.save.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_paginates_across_multiple_pages(mocker):
+    """The command keeps paging until it gets an empty page back"""
+    user = UserFactory.create(name="Joe Smith", scim_external_id="kc-page2")
+    user.legal_address.first_name = "Joe"
+    user.legal_address.last_name = "Smith"
+    user.legal_address.save()
+
+    page1 = [
+        UserRepresentation(id=f"kc-filler-{i}", firstName="x", lastName="y")
+        for i in range(remediate_keycloak_user_names.PAGE_SIZE)
+    ]
+    page2 = [UserRepresentation(id="kc-page2", firstName="", lastName="")]
+    client = _mock_client(mocker, [page1, page2])
+    remediate_keycloak_user_names.bootstrap_client.return_value = client
+
+    COMMAND.handle(apply=False, limit=None, report_path=None)
+
+    assert client.list.call_count == 3  # page1, page2, empty terminator

--- a/users/management/tests/remediate_keycloak_user_names_test.py
+++ b/users/management/tests/remediate_keycloak_user_names_test.py
@@ -43,7 +43,8 @@ def test_mitxonline_users_lookup_query_count_is_flat(django_assert_max_num_queri
     """_mitxonline_users_by_scim_id() plus constructing a LearnUserAdapter per
     user (as handle() does) must not issue extra queries per user - the fixed
     query count covers select_related(legal_address, user_profile) plus one
-    bulk prefetch for openedx_users, regardless of how many users there are"""
+    bulk prefetch for openedx_users, regardless of how many users there are
+    """
     for i in range(5):
         user = UserFactory.create(scim_external_id=f"kc-{i}")
         user.legal_address.first_name = "Joe"

--- a/users/management/tests/remediate_keycloak_user_names_test.py
+++ b/users/management/tests/remediate_keycloak_user_names_test.py
@@ -100,7 +100,8 @@ def test_up_to_date_user_is_skipped(mocker):
 def test_single_name_user_with_null_keycloak_field_is_up_to_date(mocker):
     """A mononym user (resolved family_name == "") whose Keycloak record has
     lastName=None, not "", must still be treated as up to date - None and ""
-    both mean "no last name", and Keycloak may return either representation"""
+    both mean "no last name", and Keycloak may return either representation
+    """
     user = UserFactory.create(name="Madonna", scim_external_id="kc-1")
     user.legal_address.first_name = ""
     user.legal_address.last_name = ""
@@ -119,7 +120,8 @@ def test_single_name_user_with_null_keycloak_field_is_up_to_date(mocker):
 def test_single_name_user_patch_verified_when_refetch_returns_null(mocker, tmp_path):
     """After patching a mononym user's lastName to "", the verify step must
     still pass if Keycloak's re-fetch normalizes the empty string back to
-    None"""
+    None
+    """
     user = UserFactory.create(name="Madonna", scim_external_id="kc-1")
     user.legal_address.first_name = ""
     user.legal_address.last_name = ""


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Users migrated into Keycloak via SCIM ended up with blank `firstName`/`lastName` ("General" section in the Keycloak admin console) — and, downstream, blank names in Learn too, since Keycloak's own outbound sync just propagates whatever it has.

Root cause: `LearnUserAdapter.to_dict()` (`users/adapters.py`) never included a `name` object in the SCIM payload — only `displayName`, `userName`, `emails`, `active`. Confirmed by decompiling the installed `scim-for-keycloak` Keycloak plugin jar that:
- `name.givenName`/`name.familyName` on an inbound SCIM request map directly (hardcoded) to Keycloak's core `firstName`/`lastName` attributes.
- `displayName` is never read by the plugin for that purpose at all — sending it has zero effect on Keycloak's stored name.

So the only fix is sending the structured `name.givenName`/`name.familyName` fields, which requires splitting whatever combined name data we have (Keycloak has no "full name" field to hand a single string to).

**Fix**: `LearnUserAdapter._resolve_name()` resolves `(given_name, family_name)` with three tiers of confidence:
1. `legal_address.first_name`/`last_name`, if both are set — real structured data.
2. `User.name`, split heuristically (last whitespace token = family name, remainder = given name) — a fallback for users who only came through the edX migration and never had a `legal_address` name recorded. No naive split is correct for every name (breaks on single-name accounts, multi-word surnames, non-Western conventions), but it's the best data available.
3. Neither available — blank, same as today.

The tier-2 derived split is **never persisted back** onto `legal_address` — that model is used for SDN/denied-persons compliance screening, and writing a heuristic guess into a field compliance may rely on for an accurate legal name is a real risk, not just a data-quality nitpick. It's computed fresh in `to_dict()` for the outbound payload only.

`ATTR_MAP` also gained entries for `name.givenName`/`name.familyName` (and flat `givenName`/`familyName`, matching upstream `django_scim`'s own default `UserFilterQuery.attr_map` convention) so SCIM filter/PATCH path resolution works for the new fields, and `from_dict()` writes inbound `name.givenName`/`name.familyName` directly to `legal_address` (real data from an external SCIM client, never a derived guess).

**Also included**: `remediate_keycloak_user_names`, a standalone management command for accounts that were already migrated before this fix and are stuck with blank/stale names in Keycloak. `sync_users_to_scim_remote` only ever *creates* users that don't already exist remotely — it has no update/PATCH path — so re-running the sync does nothing for already-existing accounts. This command talks to Keycloak's Admin API directly instead (reusing the existing `b2b/keycloak_admin_api.py` `KeycloakAdminClient`, paginating users 100 at a time rather than one request per user):

- Default mode is dry-run: reports every candidate and what would change, writes nothing.
- `--apply` performs the actual `PUT` of `firstName`/`lastName`, using the same `_resolve_name()` tiers as the adapter so a backfill and a fresh migration always agree on what a user's name should be.
- `--limit` caps how many get patched in a single `--apply` run, for a cautious first pass against production.
- After each patch, re-fetches the user to confirm the stored value now matches, rather than trusting a 2xx.
- Users with no name data anywhere in mitxonline are reported separately as unpatchable, left untouched.

### How can this be tested?
`users/adapters_test.py` was rewritten — the existing test imported the base `mitol.scim.adapters.UserAdapter` (a re-export), not the actual `LearnUserAdapter` subclass used in production, so it never exercised the real adapter at all. New tests cover all three `_resolve_name()` tiers in `to_dict()`, and `from_dict()` writing tier-1 data back to `legal_address`.

`users/management/tests/remediate_keycloak_user_names_test.py` covers: dry-run reporting without patching, `--apply` patching + re-verification, already-up-to-date users being skipped, unpatchable (no name data) users being reported separately, `--limit` capping writes, unmatched Keycloak users being ignored, and pagination across multiple pages.

Ran the full `users/` suite locally with a fresh test DB (`uv run pytest users/ --create-db`): 138 passed, no regressions. Ran `ruff check` on all changed files with no findings (aside from one pre-existing, unrelated missing-module-docstring lint on `users/adapters.py` that predates this change).

### Additional Context
This is the independent, mergeable half of a larger fix. A companion PR in `mitodl/ol-django` (https://github.com/mitodl/ol-django/pull/544) makes `sync_users_to_scim_remote` return its results instead of `None`, which a follow-up mitxonline PR (a new `migrate_and_sync_users` orchestrator command, replacing the old manual `migrate_edx_data` + ad hoc sync script process) depends on for post-sync verification. That follow-up isn't included here since it would call code that doesn't exist yet in the currently-published `mitol-django-scim` — it'll be opened as a draft PR blocked on the ol-django release.