### PR TITLE
Fix duplicate ECOMMERCE_DEFAULT_PAYMENT_GATEWAY setting registration

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -1652,11 +1652,9 @@ MIT_LEARN_ATTACH_URL = get_string(
     description="The URL to use for generating contract attachment URLs for B2B.",
 )
 
-ECOMMERCE_DEFAULT_PAYMENT_GATEWAY = get_string(
-    name="ECOMMERCE_DEFAULT_PAYMENT_GATEWAY",
-    default=MITOL_PAYMENT_GATEWAY_CYBERSOURCE,
-    description="The default payment gateway to use. Must match the value of the constant in the mitol.payment_gateway library.",
-)
-
+# mitol.payment_gateway.settings (imported above via import_settings_modules)
+# already declares ECOMMERCE_DEFAULT_PAYMENT_GATEWAY, defaulting to "None" if
+# unset. Coerce that default to CyberSource, since this app always expects a
+# real gateway to be configured.
 if ECOMMERCE_DEFAULT_PAYMENT_GATEWAY == "None":
     ECOMMERCE_DEFAULT_PAYMENT_GATEWAY = MITOL_PAYMENT_GATEWAY_CYBERSOURCE


### PR DESCRIPTION

### What are the relevant tickets?
N/A
### Description (What does it do?)
 The `mitol-django-payment-gateway` version currently pinned in `pyproject.toml` (`2026.8.5`) restructured its settings module: it now declares `ECOMMERCE_DEFAULT_PAYMENT_GATEWAY` itself (defaulting  
  to `"None"`), and `import_settings_modules()` injects that directly into `main.settings`'s namespace.                                                                                                    
  - `main/settings.py` still had its own `get_string(name="ECOMMERCE_DEFAULT_PAYMENT_GATEWAY", ...)` call declaring the same env var name, which `mitol.common.envs` rejects as a duplicate registration — 
  crashing Django at import time with `ValueError: Environment variable 'ECOMMERCE_DEFAULT_PAYMENT_GATEWAY' was used more than once`.                                                                      
  - This currently blocks Django from booting at all (`manage.py check`, `migrate`, and the full test suite all fail immediately on settings import).                                                      
                                                                                                                                                                             

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
