### PR TITLE
fix: reject enrollments in course runs whose enrollment window has closed

### DIFF
--- a/courses/serializers/v1/courses.py
+++ b/courses/serializers/v1/courses.py
@@ -175,6 +175,19 @@ class CourseRunEnrollmentSerializer(BaseCourseRunEnrollmentWithFlexiblePriceSeri
         if run.b2b_contract is not None:
             raise ValidationError({"run_id": f"Invalid course run id: {run_id}"})
 
+        # The enrollment window governs getting into a run. An existing active
+        # enrollment is exempt so that mode changes and idempotent retries for
+        # already-enrolled learners keep working after the window closes.
+        if (
+            not run.is_enrollable
+            and not models.CourseRunEnrollment.objects.filter(
+                run=run, user=user, active=True
+            ).exists()
+        ):
+            raise ValidationError(
+                {"run_id": f"Course run is not open for enrollment: {run_id}"}
+            )
+
         successful_enrollments, _ = create_run_enrollments(
             user,
             [run],

--- a/courses/serializers/v2/courses.py
+++ b/courses/serializers/v2/courses.py
@@ -340,6 +340,20 @@ class CourseRunEnrollmentSerializer(BaseCourseRunEnrollmentWithFlexiblePriceSeri
 
         if run.b2b_contract is not None:
             raise ValidationError({"run_id": f"Invalid course run id: {run_id}"})
+
+        # The enrollment window governs getting into a run. An existing active
+        # enrollment is exempt so that mode changes and idempotent retries for
+        # already-enrolled learners keep working after the window closes.
+        if (
+            not run.is_enrollable
+            and not models.CourseRunEnrollment.objects.filter(
+                run=run, user=user, active=True
+            ).exists()
+        ):
+            raise ValidationError(
+                {"run_id": f"Course run is not open for enrollment: {run_id}"}
+            )
+
         successful_enrollments, _ = create_run_enrollments(
             user,
             [run],

--- a/courses/views/v1/views_test.py
+++ b/courses/views/v1/views_test.py
@@ -555,6 +555,22 @@ def test_user_enrollments_create_b2b_run_invalid(user_drf_client, user):
     assert resp.json() == {"errors": {"run_id": f"Invalid course run id: {run.id}"}}
 
 
+def test_user_enrollments_create_closed_run_invalid(user_drf_client, user):
+    """Creating an enrollment for a run outside its enrollment window should be rejected."""
+    course = CourseFactory.create()
+    run = CourseRunFactory.create(course=course, past_enrollment_end=True)
+
+    resp = user_drf_client.post(
+        reverse("v1:user-enrollments-api-list"), data={"run_id": run.id}
+    )
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json() == {
+        "errors": {"run_id": f"Course run is not open for enrollment: {run.id}"}
+    }
+    assert not CourseRunEnrollment.objects.filter(user=user, run=run).exists()
+
+
 @pytest.mark.parametrize(
     "deactivate_fail, exp_success, exp_status_code",  # noqa: PT006
     [

--- a/courses/views/v2/__init__.py
+++ b/courses/views/v2/__init__.py
@@ -752,6 +752,27 @@ def _create_course_enrollment_from_program(request, courserun_id, program_enroll
 
     run = CourseRun.objects.filter(courseware_id=courserun_id).get()
 
+    # A program enrollment doesn't entitle the learner to bypass the run's
+    # enrollment window. This guards both the audit and the verified paths
+    # below, neither of which checks the window itself.
+    #
+    # The window only governs getting into a run in the first place. A learner
+    # who already holds a seat may still change mode (e.g. an audit enrollment
+    # upgrading because they bought the program), which is gated by
+    # is_upgradable further down rather than by the window.
+    if (
+        not run.is_enrollable
+        and not CourseRunEnrollment.objects.filter(
+            run=run, user=request.user, active=True
+        ).exists()
+    ):
+        log.warning(
+            "_create_course_enrollment_from_program: user %s tried to enroll in %s, which is outside its enrollment window",
+            request.user,
+            courserun_id,
+        )
+        return Response(status=status.HTTP_400_BAD_REQUEST)
+
     in_program = run.course in [
         *program_enrollment.program.required_courses,
         *program_enrollment.program.elective_courses,

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -1156,6 +1156,47 @@ def test_user_enrollments_create_b2b_run_invalid_v2(user_drf_client, user):
     assert resp.json() == {"errors": {"run_id": f"Invalid course run id: {run.id}"}}
 
 
+def test_user_enrollments_create_closed_run_invalid_v2(user_drf_client, user):
+    """v2 enrollments API should reject runs that are outside their enrollment window."""
+    course = CourseFactory.create()
+    run = CourseRunFactory.create(course=course, past_enrollment_end=True)
+
+    resp = user_drf_client.post(
+        reverse("v2:user-enrollments-api-list"), data={"run_id": run.id}
+    )
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json() == {
+        "errors": {"run_id": f"Course run is not open for enrollment: {run.id}"}
+    }
+    assert not CourseRunEnrollment.objects.filter(user=user, run=run).exists()
+
+
+def test_user_enrollments_create_closed_run_existing_enrollment_v2(
+    mocker, user_drf_client, user
+):
+    """
+    A learner who already holds an active seat isn't blocked by a closed window.
+
+    The window governs getting into a run; mode changes and idempotent retries
+    for an existing enrollment must keep working after it closes.
+    """
+    course = CourseFactory.create()
+    run = CourseRunFactory.create(course=course, past_enrollment_end=True)
+    enrollment = CourseRunEnrollmentFactory.create(user=user, run=run, active=True)
+    patched_enroll = mocker.patch(
+        "courses.serializers.v2.courses.create_run_enrollments",
+        return_value=([enrollment], True),
+    )
+
+    resp = user_drf_client.post(
+        reverse("v2:user-enrollments-api-list"), data={"run_id": run.id}
+    )
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    patched_enroll.assert_called_once()
+
+
 def test_program_filter_for_b2b_org(user, mock_course_run_clone):
     """Test that filtering programs by org works as expected."""
 
@@ -1980,6 +2021,165 @@ def test_add_verified_program_course_enrollment_audit_only_run_falls_back_to_aud
     assert resp.json()["run"]["id"] == course_run.id
     assert resp.json()["enrollment_mode"] == EDX_ENROLLMENT_AUDIT_MODE
     assert user.orders.count() == initial_order_count
+
+
+def _verified_program_enrollment_with_product(user):
+    """Set up a verified program enrollment whose program has a product."""
+
+    prog_enrollment = ProgramEnrollmentFactory.create(
+        user=user, enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE
+    )
+    program = prog_enrollment.program
+
+    program_content_type = ContentType.objects.get_for_model(program)
+    with reversion.create_revision():
+        Product.objects.create(
+            price=10,
+            is_active=True,
+            object_id=program.id,
+            content_type=program_content_type,
+        )
+
+    return program
+
+
+@pytest.mark.skip_nplusone_check
+@responses.activate
+def test_add_verified_program_course_enrollment_rejects_closed_non_upgradable_run(
+    user_drf_client, user
+):
+    """
+    A run whose enrollment window has closed must be rejected on the audit
+    fallback path, even for a learner enrolled in the program.
+
+    This is the shape reported in #12813: the run is closed and not upgradable
+    (no product), so it used to fall through to the audit branch and enroll the
+    learner with no enrollment-window check at all.
+    """
+
+    responses.add(
+        responses.GET,
+        f"{settings.OPENEDX_API_BASE_URL}/api/enrollment/v1/enrollments",
+        json={"results": [{"mode": EDX_ENROLLMENT_VERIFIED_MODE, "is_active": True}]},
+        status=status.HTTP_200_OK,
+    )
+
+    program = _verified_program_enrollment_with_product(user)
+
+    # No product for the run, so it is not upgradable -> audit fallback branch.
+    course_run = CourseRunFactory.create(past_enrollment_end=True)
+    program.add_requirement(course_run.course)
+
+    assert not course_run.is_upgradable
+    assert not course_run.is_enrollable
+
+    resp = user_drf_client.post(
+        reverse(
+            "v2:add_verified_program_course_enrollment",
+            kwargs={"courserun_id": course_run.courseware_id},
+        ),
+        data=[program.readable_id],
+    )
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert not CourseRunEnrollment.objects.filter(user=user, run=course_run).exists()
+
+
+@pytest.mark.skip_nplusone_check
+@responses.activate
+def test_add_verified_program_course_enrollment_rejects_closed_upgradable_run(
+    user_drf_client, user
+):
+    """
+    A closed run must also be rejected on the verified path, and no order should
+    be generated for it.
+
+    is_upgradable guards upgrade_deadline while is_enrollable guards
+    enrollment_end, so a run can be closed for enrollment and still upgradable.
+    That combination reaches the verified branch, which creates an order.
+    """
+
+    responses.add(
+        responses.GET,
+        f"{settings.OPENEDX_API_BASE_URL}/api/enrollment/v1/enrollments",
+        json={"results": [{"mode": EDX_ENROLLMENT_VERIFIED_MODE, "is_active": True}]},
+        status=status.HTTP_200_OK,
+    )
+
+    program = _verified_program_enrollment_with_product(user)
+
+    course_run = CourseRunFactory.create(past_enrollment_end=True)
+    program.add_requirement(course_run.course)
+
+    course_run_content_type = ContentType.objects.get_for_model(course_run)
+    with reversion.create_revision():
+        Product.objects.create(
+            price=10,
+            is_active=True,
+            object_id=course_run.id,
+            content_type=course_run_content_type,
+        )
+
+    # Closed for enrollment, but still upgradable, so this exercises the
+    # verified branch rather than the audit fallback.
+    assert course_run.is_upgradable
+    assert not course_run.is_enrollable
+
+    initial_order_count = user.orders.count()
+
+    resp = user_drf_client.post(
+        reverse(
+            "v2:add_verified_program_course_enrollment",
+            kwargs={"courserun_id": course_run.courseware_id},
+        ),
+        data=[program.readable_id],
+    )
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert not CourseRunEnrollment.objects.filter(user=user, run=course_run).exists()
+    assert user.orders.count() == initial_order_count
+
+
+@pytest.mark.skip_nplusone_check
+@responses.activate
+def test_add_verified_program_course_enrollment_closed_run_existing_enrollment(
+    user_drf_client, user
+):
+    """
+    A learner already holding a seat in a closed run still gets the idempotent
+    no-op rather than being rejected by the new window check.
+    """
+
+    responses.add(
+        responses.GET,
+        f"{settings.OPENEDX_API_BASE_URL}/api/enrollment/v1/enrollments",
+        json={"results": [{"mode": EDX_ENROLLMENT_AUDIT_MODE, "is_active": True}]},
+        status=status.HTTP_200_OK,
+    )
+
+    prog_enrollment = ProgramEnrollmentFactory.create(
+        user=user, enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE
+    )
+    program = prog_enrollment.program
+
+    course_run = CourseRunFactory.create(past_enrollment_end=True)
+    program.add_requirement(course_run.course)
+    CourseRunEnrollmentFactory.create(
+        user=user,
+        run=course_run,
+        active=True,
+        enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
+    )
+
+    resp = user_drf_client.post(
+        reverse(
+            "v2:add_verified_program_course_enrollment",
+            kwargs={"courserun_id": course_run.courseware_id},
+        ),
+        data=[program.readable_id],
+    )
+
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
 @pytest.mark.skip_nplusone_check


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/12828

### Description (What does it do?)

We never checked whether a course run was still open for enrollment before creating one, so any logged-in learner could POST a closed run's id and get in. Three endpoints were affected:

- `POST /api/v2/verified_program_enrollments/<courserun_id>/` — a learner holding a program enrollment got into a closed run. A non-upgradable run produced a free audit enrollment; an upgradable one also produced a zero-value **order**, which is messier to undo.
- `POST /api/v2/enrollments/` and `POST /api/v1/enrollments/` — same gap, no program involved.

`is_enrollable` already existed but was only enforced on the deferral path in `courses/api.py`. Closed runs were kept out of reach by product-listing filters and by a client-side check in mit-learn (mitodl/mit-learn#3508), not by the API, so the endpoints stayed callable directly.

This adds the check to all three entry points. In the program view it sits right after the run is loaded, before the audit/verified mode logic, so one check covers both branches. Gating only the audit branch would leave the verified branch open — and that is the branch that creates an order.

**Existing enrollments are exempt.** The check applies only when the learner has no active enrollment in the run:

```python
if not run.is_enrollable and not CourseRunEnrollment.objects.filter(
    run=run, user=request.user, active=True
).exists():
```

The enrollment window controls *getting into* a run; the upgrade deadline (`is_upgradable`) controls *changing mode* once in. Without the exemption, a learner who bought the program could no longer upgrade an audit seat after `enrollment_end` passed, and repeat POSTs from already-enrolled learners would return 400 instead of today's 204/201. Inactive (unenrolled) rows do not count, so re-entering a closed run stays blocked.

**No `force` flag needed.** Management commands, deferrals and order fulfillment all call `create_run_enrollments` directly and never pass through these three entry points. That is also why the check does not live in `create_run_enrollments` — those callers legitimately enroll into closed runs.

**One correction to the issue.** #3450 and #3451 widened this rather than causing it: the audit branch never checked the window, so audit-mode program learners could already get into closed runs before April 2026. What #3451 changed is that a verified learner on a closed, non-upgradable run used to hit a 500 (missing product) and now silently succeeds. This matters for the backfill — it needs to cover dates before April 2026 and the plain `/enrollments/` endpoint, not just `_create_course_enrollment_from_program` in the `call_stack`.

Six tests added. No migrations, and the v2 OpenAPI spec is unchanged (the endpoint already declared a 400 response).

### How can this be tested?

No working Open edX needed — every run below uses a `run_tag` starting with `fake`, so `create_run_enrollments` skips the edX call.

**1. Create the data.** Save as `/tmp/window_data.py`, then `docker compose exec -T web python manage.py shell < /tmp/window_data.py`:

```python
from datetime import timedelta
from uuid import uuid4

import reversion
from django.contrib.contenttypes.models import ContentType
from mitol.common.utils import now_in_utc

from courses.factories import (
    CourseRunEnrollmentFactory,
    CourseRunFactory,
    ProgramEnrollmentFactory,
)
from ecommerce.models import Product
from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE

# Factory readable_id sequences restart every shell session, so ids are built
# here: keeps this re-runnable and clear of whatever is in your dev database.
TOKEN = uuid4().hex[:8]
now = now_in_utc()
past, long_past, future = (
    now - timedelta(days=30), now - timedelta(days=90), now + timedelta(days=365),
)


def add_product(obj, price=10):
    with reversion.create_revision():  # without a revision, no order can be made
        Product.objects.create(
            price=price, is_active=True, object_id=obj.id,
            content_type=ContentType.objects.get_for_model(obj),
        )


pe = ProgramEnrollmentFactory.create(
    enrollment_mode=EDX_ENROLLMENT_VERIFIED_MODE, active=True,
    program__readable_id=f"program-v1:wintest-{TOKEN}",
    program__title=f"Window test {TOKEN}",
)
learner, program = pe.user, pe.program
learner.set_password("testpass123")
learner.is_staff = True  # so you can sign in at /admin/
learner.save()
add_product(program, price=100)


def make_run(slug, *, closed, in_program=True):
    run = CourseRunFactory.create(
        course__readable_id=f"course-v1:wintest-{TOKEN}+{slug}",
        course__title=f"Window test {TOKEN} {slug}",
        courseware_id=f"course-v1:wintest-{TOKEN}+{slug}+3T2026",
        run_tag=f"fake{slug}", live=True, start_date=past, end_date=future,
        enrollment_start=long_past,
        enrollment_end=past if closed else future, upgrade_deadline=future,
    )
    if in_program:
        program.add_requirement(run.course)
    return run


runs = {
    "A": make_run("A", closed=True),                  # closed, not upgradable
    "B": make_run("B", closed=True),                  # closed, upgradable
    "C": make_run("C", closed=False),                 # open
    "D": make_run("D", closed=True),                  # closed, already enrolled
    "E": make_run("E", closed=False, in_program=False),  # open, outside program
}
add_product(runs["B"])
add_product(runs["C"])
CourseRunEnrollmentFactory.create(
    user=learner, run=runs["D"], active=True, edx_enrolled=True,
    enrollment_mode=EDX_ENROLLMENT_AUDIT_MODE,
)

BASE = "http://mitxonline.odl.local:8013"
want = {
    "A": "400  audit branch (the reported shape)",
    "B": "400  verified branch, and no order",
    "C": "201  verified (control)",
    "D": "204  no-op (exemption)",
    "E": "201  control, plain endpoint only",
}
print(f"\nlearner {learner.email} / testpass123\nprogram {program.readable_id}\n")
for slug, run in runs.items():
    print(f"{slug} enrollable={str(run.is_enrollable):<5} "
          f"upgradable={str(run.is_upgradable):<5} -> {want[slug]}")
    if slug != "E":
        print(f"  {BASE}/api/v2/verified_program_enrollments/{run.courseware_id}/")
    print(f'  {BASE}/api/v2/enrollments/  body: {{"run_id": {run.id}}}')
```

It prints the learner, the program readable id, and a ready-to-paste URL for every case:

```
A enrollable=False upgradable=False -> 400  audit branch (the reported shape)
B enrollable=False upgradable=True  -> 400  verified branch, and no order
C enrollable=True  upgradable=True  -> 201  verified (control)
D enrollable=False upgradable=False -> 204  no-op (exemption)
E enrollable=True  upgradable=False -> 201  control, plain endpoint only
```

**2. Sign in** at `http://mitxonline.odl.local:8013/admin/login/` as the printed learner, password `testpass123`.

Use `/admin/`, not the app's normal login. `ApisixUserMiddleware` logs out any session whose backend is a `RemoteUserBackend` when the APISIX header is missing, so signing in another way gives `403 Authentication credentials were not provided` on the API.

**3. Program endpoint.** `DEBUG` is on locally, so DRF's browsable API gives you a real POST form. Open each printed `verified_program_enrollments` URL, put `["<program readable_id>"]` in the content box, choose `application/json`, click POST. Expect **A → 400**, **B → 400** (and check no new order), **C → 201** with `enrollment_mode: verified`, **D → 204**.

The page loads as `HTTP 405` because the endpoint is POST-only; the form still works. POST C only once — a second time returns 204 because the enrollment now exists.

**4. Plain endpoint.** Open `/api/v2/enrollments/` (loads as 200 with a POST form) and POST the `run_id` bodies the script printed. Expect **A → 400** `Course run is not open for enrollment`, **E → 201**. Same for `/api/v1/enrollments/`.

**5. Confirm the check is what is doing the work.**

```bash
git stash push -- courses/views/v2/__init__.py courses/serializers/v1/courses.py courses/serializers/v2/courses.py
# recreate the data, repeat steps 3-4: A and B now return 201, and B also makes an order
git stash pop
```

Prefer `fetch` from the console? Note this project renames the CSRF cookie to `csrf_mitxonline`, and the header is `X-CSRFTOKEN`.

#### Testing through the MIT Learn UI (optional)
The click that hits the program endpoint is the enroll CTA on the Dashboard module rows of an enrolled program (ModuleCard.tsx, useCreateVerifiedProgramEnrollment). [mitodl/mit-learn#3508](https://github.com/mitodl/mit-learn/pull/3508) disables that CTA for closed runs, so you cannot reach it by clicking in the normal case. To test through the UI, temporarily set disableEnrollment = false in ModuleCard.tsx.

Separately, ModuleCard calls getBestRun(data, { contractId }) without enrollableOnly, while DashboardCard passes enrollableOnly: true, and ModuleCard's guard is course-level (courseruns.some(...)) while the run it enrolls is chosen per-run. Those can disagree. Worth aligning on the mit-learn side; not needed for this fix.
