### PR TITLE
Enforce one product per purchasable object

### DIFF
--- a/ecommerce/migrations/0044_alter_product_unique_purchasable_object.py
+++ b/ecommerce/migrations/0044_alter_product_unique_purchasable_object.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ecommerce", "0043_refund_request_status"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="product",
+            name="unique_purchasable_object",
+        ),
+        migrations.AddConstraint(
+            model_name="product",
+            constraint=models.UniqueConstraint(
+                fields=("object_id", "content_type"),
+                name="unique_purchasable_object",
+            ),
+        ),
+    ]

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -102,8 +102,7 @@ class Product(TimestampedModel):
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["object_id", "is_active", "content_type"],
-                condition=models.Q(is_active=True),
+                fields=["object_id", "content_type"],
                 name="unique_purchasable_object",
             )
         ]

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -329,15 +329,25 @@ def test_product_managers():
     )
 
 
-def test_product_multiple_active_for_single_purchasable_object():
-    """Test that creating multiple Products with the same course/program
-    and are active is not allowed
+def test_product_multiple_for_single_purchasable_object():
+    """Test that creating multiple Products with the same course/program is not allowed,
+    regardless of active state.
     """
     first_product = ProductFactory.create()
     try:
         with transaction.atomic():
             ProductFactory.create(purchasable_object=first_product.purchasable_object)
         pytest.fail("Two active Products for the same purchasable_object were allowed.")
+    except IntegrityError:
+        pass
+
+    first_product.delete()
+    try:
+        with transaction.atomic():
+            ProductFactory.create(purchasable_object=first_product.purchasable_object)
+        pytest.fail(
+            "A Product was created for a purchasable_object that already has an inactive Product."
+        )
     except IntegrityError:
         pass
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11729

### Description (What does it do?)
Updates `Product` uniqueness to always enforce a single product per `(object_id, content_type)` pair, instead of allowing duplicates when one is inactive. Adds a migration to replace the old conditional constraint and updates the model test to cover both active and inactive duplicate creation attempts.

### How can this be tested?
Create a product, then attempt to create a second active product for the same object.  This should not work even if the first product is deactivated.