### PR TITLE
Recurse into the program if the program doesn't have a verified mode when generating certificates

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -53,6 +53,7 @@ def payment_gateway_settings(settings):
     settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_REST_API_ENVIRONMENT = (
         "apitest.cybersource.com"
     )
+    settings.MITOL_PAYMENT_GATEWAY_STRIPE_API_KEY = uuid.uuid4()
 
 
 @pytest.fixture

--- a/courses/api.py
+++ b/courses/api.py
@@ -1268,10 +1268,18 @@ def _has_earned_program_cert(user, program):
             # has passed the referenced course
             return node.course in [*cert_courses, *grade_courses]
         elif node.is_program:
-            # has earned certificate for the required sub-program
-            return ProgramCertificate.all_objects.filter(
-                user=user, program=node.required_program, is_revoked=False
-            ).exists()
+            # If the program has a verified mode (requires_payment=True), then
+            # check for a certificate. If not, then recurse; if the learner would
+            # have earned a certificate, we should count that.
+            if (
+                node.is_program
+                and node.program.enrollment_modes.filter(requires_payment=True).exists()
+            ):
+                return ProgramCertificate.all_objects.filter(
+                    user=user, program=node.required_program, is_revoked=False
+                ).exists()
+
+            return _has_earned_program_cert(user, node.program)
         return False
 
     return _has_earned(root)

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -2367,15 +2367,56 @@ def test_generate_program_certificate_failure_not_all_passed_nested_elective_sti
 
 
 @pytest.mark.parametrize(
-    ("has_main_enroll", "has_sub_enroll"),
+    (
+        "has_main_enroll",
+        "has_sub_enroll",
+        "sub_is_audit_only",
+        "sub_course_passed",
+    ),
     [
         (
             True,
             True,
+            False,
+            True,
         ),
-        (True, False),
-        (False, True),
-        (False, False),
+        (
+            True,
+            True,
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+            False,
+            True,
+        ),
+        (
+            True,
+            False,
+            False,
+            False,
+        ),
+        (False, True, False, True),
+        (
+            False,
+            False,
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+            True,
+            True,
+        ),
+        (
+            True,
+            True,
+            True,
+            False,
+        ),
     ],
 )
 @patch("courses.signals.upsert_custom_properties")
@@ -2386,10 +2427,12 @@ def test_generate_program_certificate_with_subprogram_requirement(  # noqa: PLR0
     default_mode_records,
     has_main_enroll,
     has_sub_enroll,
+    sub_is_audit_only,
+    sub_course_passed,
 ):
     """
-    Test that generate_program_certificate considers sub-program (nested program) requirements
-    when determining if a user has earned a program certificate.
+    Test that generate_program_certificate considers sub-program (nested program)
+    requirements when determining if a user has earned a program certificate.
     """
     patched_sync_hubspot_user = mocker.patch(
         "hubspot_sync.task_helpers.sync_hubspot_user",
@@ -2399,7 +2442,12 @@ def test_generate_program_certificate_with_subprogram_requirement(  # noqa: PLR0
     )
 
     # Create a sub-program that the user will complete
-    sub_program = ProgramFactory.create()
+    modes = (
+        [EnrollmentModeFactory(mode_slug=EDX_ENROLLMENT_AUDIT_MODE)]
+        if sub_is_audit_only
+        else []
+    )
+    sub_program = ProgramFactory.create(enrollment_modes=modes)
     sub_course = CourseFactory.create()
     sub_program.add_requirement(sub_course)
 
@@ -2446,8 +2494,9 @@ def test_generate_program_certificate_with_subprogram_requirement(  # noqa: PLR0
     main_certificate, main_created = generate_program_certificate(
         user=user, program=main_program
     )
-    if has_main_enroll and has_sub_enroll:
-        # Should only get a certificate if we had a cert in the sub
+    if has_main_enroll and has_sub_enroll and sub_course_passed:
+        # Should only get a certificate if we had a cert (or a passing grade!)
+        # in the sub
         # So, we'd have to have been enrolled there, too
         assert main_created is True
         assert isinstance(main_certificate, ProgramCertificate)

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -87,6 +87,29 @@ class ProgramFactory(DjangoModelFactory):
             return
         self.departments.set(extracted)
 
+    @factory.post_generation
+    def enrollment_modes(self, create, extracted, **kwargs):  # noqa: ARG002
+        """
+        Post-generation method to add enrollment modes to the course run.
+        By default, adds the audit and verified modes if no modes are provided.
+
+        Args:
+            create: Whether the instance is being created (as opposed to just built).
+            extracted: The enrollment modes to add, if any were provided when the factory was called.
+            **kwargs: Additional keyword arguments (not used here).
+        """
+        if not create:
+            return
+        if extracted is not None and len(extracted) > 0:
+            self.enrollment_modes.set(extracted)
+        else:
+            self.enrollment_modes.add(
+                EnrollmentModeFactory(mode_slug=EDX_ENROLLMENT_AUDIT_MODE)
+            )
+            self.enrollment_modes.add(
+                EnrollmentModeFactory(mode_slug=EDX_ENROLLMENT_VERIFIED_MODE)
+            )
+
     class Meta:
         model = Program
 

--- a/courses/serializers/v1/programs_test.py
+++ b/courses/serializers/v1/programs_test.py
@@ -24,6 +24,7 @@ from courses.factories import (
     program_with_requirements,  # noqa: F401
 )
 from courses.models import Department, ProgramRequirement, ProgramRequirementNodeType
+from courses.serializers.v1.base import EnrollmentModeSerializer
 from courses.serializers.v1.courses import CourseWithCourseRunsSerializer
 from courses.serializers.v1.programs import (
     LearnerRecordSerializer,
@@ -140,7 +141,9 @@ def test_serialize_program(mock_context, remove_tree, program_with_empty_require
             "program_type": "Series",
             "departments": [],
             "live": True,
-            "enrollment_modes": [],
+            "enrollment_modes": EnrollmentModeSerializer(
+                program_with_empty_requirements.enrollment_modes, many=True
+            ).data,
         },
     )
 

--- a/courses/serializers/v2/programs_test.py
+++ b/courses/serializers/v2/programs_test.py
@@ -12,7 +12,6 @@ from cms.serializers import ProgramPageSerializer
 from courses.factories import (  # noqa: F401
     CourseFactory,
     CourseRunFactory,
-    EnrollmentModeFactory,
     ProgramCollectionFactory,
     ProgramFactory,
     program_with_empty_requirements,
@@ -25,6 +24,7 @@ from courses.models import (
     ProgramCollectionItem,
     ProgramRequirement,
 )
+from courses.serializers.v1.base import EnrollmentModeSerializer
 from courses.serializers.v1.departments import DepartmentSerializer
 from courses.serializers.v2.programs import (
     ProgramDetailSerializer,
@@ -164,8 +164,10 @@ def test_serialize_program(
             "min_weekly_hours": program_with_empty_requirements.page.min_weekly_hours,
             "min_price": program_with_empty_requirements.page.min_price,
             "max_price": program_with_empty_requirements.page.max_price,
-            "certificate_available": False,
-            "enrollment_modes": [],
+            "certificate_available": True,
+            "enrollment_modes": EnrollmentModeSerializer(
+                program_with_empty_requirements.enrollment_modes, many=True
+            ).data,
             "display_mode": None,
         },
     )
@@ -340,11 +342,10 @@ def test_serialize_program_certificate_available(
     expected,
 ):
     """Test that certificate_available reflects whether any enrollment mode requires payment."""
-    mode = EnrollmentModeFactory.create(
-        mode_slug="verified" if has_paid_mode else "audit",
-        requires_payment=has_paid_mode,
-    )
-    program_with_empty_requirements.enrollment_modes.add(mode)
+    if not has_paid_mode:
+        program_with_empty_requirements.enrollment_modes.filter(
+            requires_payment=True
+        ).delete()
 
     data = ProgramSerializer(
         instance=program_with_empty_requirements, context=mock_context

--- a/courses/views/v1/views_test.py
+++ b/courses/views/v1/views_test.py
@@ -47,6 +47,7 @@ from courses.models import (
     Program,
     ProgramEnrollment,
 )
+from courses.serializers.v1.base import EnrollmentModeSerializer
 from courses.serializers.v1.courses import (
     CourseRunEnrollmentSerializer,
     CourseRunSerializer,
@@ -836,7 +837,9 @@ def test_program_enrollments(user_drf_client, user_with_enrollments_and_certific
                 "title": program_enrollment.program.title,
                 "live": program_enrollment.program.live,
                 "departments": [],
-                "enrollment_modes": [],
+                "enrollment_modes": EnrollmentModeSerializer(
+                    program_enrollment.program.enrollment_modes, many=True
+                ).data,
                 "readable_id": program_enrollment.program.readable_id,
                 "req_tree": list(
                     ProgramRequirementTreeSerializer(

--- a/courses/views/v2/views_test.py
+++ b/courses/views/v2/views_test.py
@@ -49,6 +49,7 @@ from courses.models import (
     Program,
     ProgramEnrollment,
 )
+from courses.serializers.v1.base import EnrollmentModeSerializer
 from courses.serializers.v2.certificates import (
     CourseRunCertificateSerializer,
     ProgramCertificateSerializer,
@@ -1699,7 +1700,7 @@ def test_program_enrollments(user_drf_client, user_with_enrollments_and_certific
                 "collections": [],
                 "availability": "anytime",
                 "certificate_type": "Certificate of Completion",
-                "certificate_available": False,
+                "certificate_available": True,
                 "required_prerequisites": _get_page_prop(
                     program_enrollment, "prerequisites", ""
                 )
@@ -1711,7 +1712,9 @@ def test_program_enrollments(user_drf_client, user_with_enrollments_and_certific
                 "end_date": None,
                 "enrollment_end": None,
                 "enrollment_start": None,
-                "enrollment_modes": [],
+                "enrollment_modes": EnrollmentModeSerializer(
+                    program_enrollment.program.enrollment_modes, many=True
+                ).data,
                 "duration": _get_page_prop(program_enrollment, "length"),
                 "time_commitment": _get_page_prop(program_enrollment, "effort"),
                 "min_price": _get_page_prop(program_enrollment, "min_price"),


### PR DESCRIPTION

### What are the relevant tickets?

Closes mitodl/hq#12823

### Description (What does it do?)

When determining if the user is eligible for a certificate for a program, recurse into sub-programs if the sub-program only offers audit-mode enrollments.

This also updates the ProgramFactory to generate course modes and updates the affected tests. Also adds a Stripe key to the ecommerce defaults factory - I was getting test errors for that.

### How can this be tested?

Automated tests should pass. Note that several tests have changed to accommodate the ProgramFactory changes.

Create a program that only offers audit-mode enrollments. Then, create another program that supports verified-mode enrollments (including a certificate page) and add the first program as a requirement. Create course runs as necessary for these programs as well (you should probably have at least one course in the audit-only program).

Enroll a user in the verified-track program as a verified-track user, in the audit-only program as audit, and the other courses in the appropriate mode (best between verified and audit). Create grades for courses such that the user has a passing grade in everything.

Generate certificates for any course that you've enrolled your user in that has a verified mode. Do this manually (using the Django Admin) because the tasks/commands for this will try to pull grade info from edX. Don't generate a certificate for your verified-mode program yet.

Finally, run `_has_earned_program_certificate` from `courses/api.py` in a Django shell with the user and verified-mode program. It should indicate that the user has earned the program certificate. Running the program certificate generation task/etc. should generate a certificate as well.
